### PR TITLE
[monorepo] task: create CODEOWNERS.md to automatically assign reviewers

### DIFF
--- a/.github/CODEOWNERS.md
+++ b/.github/CODEOWNERS.md
@@ -1,0 +1,10 @@
+# Hi! Welcome to the CODEOWNERS file. Don't want manual reviews anymore? No worries, this will automatically assign it. 
+# These owners are the default reviewers for any change made to the respect subdirectories.  
+
+catbuffer/parser/		@Jaguar0625 @gimre-xymcity
+catbuffer/schemas/		@Jaguar0625 @gimre-xymcity
+client/catapult/		@Jaguar0625 @gimre-xymcity @wayonb @0x6861746366574
+client/rest/			@Jaguar0625 @gimre-xymcity @wayonb @0x6861746366574
+linters/				@wayonb
+sdk/python/				@Jaguar0625 @gimre-xymcity @0x6861746366574
+sdk/javascript/			@Jaguar0625 @gimre-xymcity @0x6861746366574


### PR DESCRIPTION
See [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) for more configuration options. We can also enforce per-language reviewers, but for now, I think it is saner to keep to subdirectories.