### PR TITLE
test(sdk/python): fix tests with hardcoded yaml inputs after tabification

### DIFF
--- a/sdk/python/tests/core/facade/test_BatchOperations.py
+++ b/sdk/python/tests/core/facade/test_BatchOperations.py
@@ -25,7 +25,7 @@ ACCOUNTS_YAML_INPUT = f'''
 
 - address: {ALICE_ADDRESS}
 	name: ALICE
-'''
+'''.replace('\t', '  ')
 
 TRANSACTIONS_YAML_INPUT = f'''
 - type: transfer
@@ -38,7 +38,7 @@ TRANSACTIONS_YAML_INPUT = f'''
 	signer_public_key: TEST
 	recipient_address: {BOB_ADDRESS}
 	amount: 1000000
-'''
+'''.replace('\t', '  ')
 
 
 class BatchOperationsTest(unittest.TestCase):

--- a/sdk/python/tests/core/facade/test_NemFacade.py
+++ b/sdk/python/tests/core/facade/test_NemFacade.py
@@ -10,7 +10,7 @@ from ...test.NemTestUtils import NemTestUtils
 YAML_INPUT = '''
 - public_key: A59277D56E9F4FA46854F5EFAAA253B09F8AE69A473565E01FD9E6A738E4AB74
 	name: TEST
-'''
+'''.replace('\t', '  ')
 
 
 class NemFacadeTest(unittest.TestCase):

--- a/sdk/python/tests/core/facade/test_SymbolFacade.py
+++ b/sdk/python/tests/core/facade/test_SymbolFacade.py
@@ -11,7 +11,7 @@ from ...test.NemTestUtils import NemTestUtils
 YAML_INPUT = '''
 - public_key: 87DA603E7BE5656C45692D5FC7F6D0EF8F24BB7A5C10ED5FDA8C5CFBC49FCBC8
 	name: TEST
-'''
+'''.replace('\t', '  ')
 
 
 class SymbolFacadeTest(unittest.TestCase):

--- a/sdk/python/tests/core/test_AccountDescriptorRepository.py
+++ b/sdk/python/tests/core/test_AccountDescriptorRepository.py
@@ -28,7 +28,7 @@ YAML_INPUT = f'''
 
 - address: {ENCODED_ADDRESS_2}
 	name: charlie
-'''
+'''.replace('\t', '  ')
 
 
 # nem style address to avoid circular import

--- a/sdk/python/tests/core/test_BlockchainSettings.py
+++ b/sdk/python/tests/core/test_BlockchainSettings.py
@@ -26,7 +26,7 @@ accounts:
 	- public_key: {PUBLIC_KEY_2}
 		name: TEST1
 		roles: [red, test]
-'''
+'''.replace('\t', '  ')
 
 
 class BlockchainSettingsTest(unittest.TestCase):

--- a/sdk/python/tests/core/test_NodeDescriptorRepository.py
+++ b/sdk/python/tests/core/test_NodeDescriptorRepository.py
@@ -15,7 +15,7 @@ YAML_INPUT = '''
 
 - host: mercury
 	roles: [super]
-'''
+'''.replace('\t', '  ')
 
 
 class NodeDescriptorRepositoryTest(unittest.TestCase):


### PR DESCRIPTION
problem:

- yaml does not support tab indent

- pycodestyle does not allow python tab indent and yaml space indent

solution:

- replace yaml tabs with spaces