### PR TITLE
[sdk/python]: fix serialization of signed integers

### DIFF
--- a/catbuffer/schemas/nem/multisig/multisig.cats
+++ b/catbuffer/schemas/nem/multisig/multisig.cats
@@ -9,7 +9,7 @@ struct Cosignature
 	inline Transaction
 
 	# multisig transaction hash outer size
-	multisig_transaction_hash_outer_size = make_reserved(int32, 36)
+	multisig_transaction_hash_outer_size = make_reserved(uint32, 36)
 
 	# [__value__] multisig transaction hash
 	#

--- a/sdk/python/examples/descriptors/symbol_metadata.py
+++ b/sdk/python/examples/descriptors/symbol_metadata.py
@@ -6,30 +6,35 @@ def descriptor_factory():
 	value2 = 'Once upon a midnight dreary'
 	value3 = 'while I pondered, weak and weary'
 
-	return [
+	templates = [
 		{
 			'type': 'account_metadata',
 			'target_address': sample_address,
-			'scoped_metadata_key': 0xC0FFE,
-			'value_size_delta': len(value1),
-			'value': value1
+			'scoped_metadata_key': 0xC0FFE
 		},
 
 		{
 			'type': 'mosaic_metadata',
 			'target_mosaic_id': sample_mosaic_id,
 			'target_address': sample_address,
-			'scoped_metadata_key': 0xFACADE,
-			'value_size_delta': len(value2),
-			'value': value2
+			'scoped_metadata_key': 0xFACADE
 		},
 
 		{
 			'type': 'namespace_metadata',
 			'target_namespace_id': sample_namespace_id,
 			'target_address': sample_address,
-			'scoped_metadata_key': 0xC1CADA,
-			'value_size_delta': len(value3),
-			'value': value3
+			'scoped_metadata_key': 0xC1CADA
 		}
+	]
+
+	return [
+		{**templates[0], 'value_size_delta': len(value1), 'value': value1},
+		{**templates[0], 'value_size_delta': -5, 'value': value1[:-5]},
+
+		{**templates[1], 'value_size_delta': len(value2), 'value': value2},
+		{**templates[1], 'value_size_delta': -5, 'value': value2[:-5]},
+
+		{**templates[2], 'value_size_delta': len(value3), 'value': value3},
+		{**templates[2], 'value_size_delta': -5, 'value': value3[:-5]}
 	]

--- a/sdk/python/generator/printers.py
+++ b/sdk/python/generator/printers.py
@@ -34,7 +34,12 @@ class IntPrinter(Printer):
 		return self.get_size()
 
 	def store(self, field_name):
-		return f'{field_name}.to_bytes({self.get_size()}, byteorder="little", signed=False)'
+		is_signed = False
+
+		if hasattr(self.descriptor.ast_model, 'field_type') and isinstance(self.descriptor.ast_model.field_type, FixedSizeInteger):
+			is_signed = not self.descriptor.ast_model.field_type.is_unsigned
+
+		return f'{field_name}.to_bytes({self.get_size()}, byteorder="little", signed={is_signed})'
 
 	@staticmethod
 	def assign(value):

--- a/sdk/python/symbolchain/nc/__init__.py
+++ b/sdk/python/symbolchain/nc/__init__.py
@@ -3494,7 +3494,7 @@ class MultisigAccountModificationTransaction:
 		buffer_ += len(self._modifications).to_bytes(4, byteorder="little", signed=False)  # modifications_count
 		buffer_ += ArrayHelpers.write_array(self._modifications)
 		buffer_ += self._min_approval_delta_size.to_bytes(4, byteorder="little", signed=False)
-		buffer_ += self._min_approval_delta.to_bytes(4, byteorder="little", signed=False)
+		buffer_ += self._min_approval_delta.to_bytes(4, byteorder="little", signed=True)
 		return buffer_
 
 	def __str__(self) -> str:
@@ -3688,7 +3688,7 @@ class NonVerifiableMultisigAccountModificationTransaction:
 		buffer_ += len(self._modifications).to_bytes(4, byteorder="little", signed=False)  # modifications_count
 		buffer_ += ArrayHelpers.write_array(self._modifications)
 		buffer_ += self._min_approval_delta_size.to_bytes(4, byteorder="little", signed=False)
-		buffer_ += self._min_approval_delta.to_bytes(4, byteorder="little", signed=False)
+		buffer_ += self._min_approval_delta.to_bytes(4, byteorder="little", signed=True)
 		return buffer_
 
 	def __str__(self) -> str:

--- a/sdk/python/symbolchain/sc/__init__.py
+++ b/sdk/python/symbolchain/sc/__init__.py
@@ -10508,7 +10508,7 @@ class AccountMetadataTransaction:
 		buffer_ += self._deadline.serialize()
 		buffer_ += self._target_address.serialize()
 		buffer_ += self._scoped_metadata_key.to_bytes(8, byteorder="little", signed=False)
-		buffer_ += self._value_size_delta.to_bytes(2, byteorder="little", signed=False)
+		buffer_ += self._value_size_delta.to_bytes(2, byteorder="little", signed=True)
 		buffer_ += len(self._value).to_bytes(2, byteorder="little", signed=False)  # value_size
 		buffer_ += self._value
 		return buffer_
@@ -10687,7 +10687,7 @@ class EmbeddedAccountMetadataTransaction:
 		buffer_ += self._type_.serialize()
 		buffer_ += self._target_address.serialize()
 		buffer_ += self._scoped_metadata_key.to_bytes(8, byteorder="little", signed=False)
-		buffer_ += self._value_size_delta.to_bytes(2, byteorder="little", signed=False)
+		buffer_ += self._value_size_delta.to_bytes(2, byteorder="little", signed=True)
 		buffer_ += len(self._value).to_bytes(2, byteorder="little", signed=False)  # value_size
 		buffer_ += self._value
 		return buffer_
@@ -10923,7 +10923,7 @@ class MosaicMetadataTransaction:
 		buffer_ += self._target_address.serialize()
 		buffer_ += self._scoped_metadata_key.to_bytes(8, byteorder="little", signed=False)
 		buffer_ += self._target_mosaic_id.serialize()
-		buffer_ += self._value_size_delta.to_bytes(2, byteorder="little", signed=False)
+		buffer_ += self._value_size_delta.to_bytes(2, byteorder="little", signed=True)
 		buffer_ += len(self._value).to_bytes(2, byteorder="little", signed=False)  # value_size
 		buffer_ += self._value
 		return buffer_
@@ -11118,7 +11118,7 @@ class EmbeddedMosaicMetadataTransaction:
 		buffer_ += self._target_address.serialize()
 		buffer_ += self._scoped_metadata_key.to_bytes(8, byteorder="little", signed=False)
 		buffer_ += self._target_mosaic_id.serialize()
-		buffer_ += self._value_size_delta.to_bytes(2, byteorder="little", signed=False)
+		buffer_ += self._value_size_delta.to_bytes(2, byteorder="little", signed=True)
 		buffer_ += len(self._value).to_bytes(2, byteorder="little", signed=False)  # value_size
 		buffer_ += self._value
 		return buffer_
@@ -11355,7 +11355,7 @@ class NamespaceMetadataTransaction:
 		buffer_ += self._target_address.serialize()
 		buffer_ += self._scoped_metadata_key.to_bytes(8, byteorder="little", signed=False)
 		buffer_ += self._target_namespace_id.serialize()
-		buffer_ += self._value_size_delta.to_bytes(2, byteorder="little", signed=False)
+		buffer_ += self._value_size_delta.to_bytes(2, byteorder="little", signed=True)
 		buffer_ += len(self._value).to_bytes(2, byteorder="little", signed=False)  # value_size
 		buffer_ += self._value
 		return buffer_
@@ -11550,7 +11550,7 @@ class EmbeddedNamespaceMetadataTransaction:
 		buffer_ += self._target_address.serialize()
 		buffer_ += self._scoped_metadata_key.to_bytes(8, byteorder="little", signed=False)
 		buffer_ += self._target_namespace_id.serialize()
-		buffer_ += self._value_size_delta.to_bytes(2, byteorder="little", signed=False)
+		buffer_ += self._value_size_delta.to_bytes(2, byteorder="little", signed=True)
 		buffer_ += len(self._value).to_bytes(2, byteorder="little", signed=False)  # value_size
 		buffer_ += self._value
 		return buffer_
@@ -12900,8 +12900,8 @@ class MultisigAccountModificationTransaction:
 		buffer_ += self._type_.serialize()
 		buffer_ += self._fee.serialize()
 		buffer_ += self._deadline.serialize()
-		buffer_ += self._min_removal_delta.to_bytes(1, byteorder="little", signed=False)
-		buffer_ += self._min_approval_delta.to_bytes(1, byteorder="little", signed=False)
+		buffer_ += self._min_removal_delta.to_bytes(1, byteorder="little", signed=True)
+		buffer_ += self._min_approval_delta.to_bytes(1, byteorder="little", signed=True)
 		buffer_ += len(self._address_additions).to_bytes(1, byteorder="little", signed=False)  # address_additions_count
 		buffer_ += len(self._address_deletions).to_bytes(1, byteorder="little", signed=False)  # address_deletions_count
 		buffer_ += self._multisig_account_modification_transaction_body_reserved_1.to_bytes(4, byteorder="little", signed=False)
@@ -13089,8 +13089,8 @@ class EmbeddedMultisigAccountModificationTransaction:
 		buffer_ += self._version.to_bytes(1, byteorder="little", signed=False)
 		buffer_ += self._network.serialize()
 		buffer_ += self._type_.serialize()
-		buffer_ += self._min_removal_delta.to_bytes(1, byteorder="little", signed=False)
-		buffer_ += self._min_approval_delta.to_bytes(1, byteorder="little", signed=False)
+		buffer_ += self._min_removal_delta.to_bytes(1, byteorder="little", signed=True)
+		buffer_ += self._min_approval_delta.to_bytes(1, byteorder="little", signed=True)
 		buffer_ += len(self._address_additions).to_bytes(1, byteorder="little", signed=False)  # address_additions_count
 		buffer_ += len(self._address_deletions).to_bytes(1, byteorder="little", signed=False)  # address_deletions_count
 		buffer_ += self._multisig_account_modification_transaction_body_reserved_1.to_bytes(4, byteorder="little", signed=False)


### PR DESCRIPTION
problem:

generator is currently serializing all integers as unsigned but

solution:

int* types should be serialized with signed=True

issue: #7