### PR TITLE
fix: Update paths for docker build scripts

### DIFF
--- a/jenkins/catapult/runDockerBuild.py
+++ b/jenkins/catapult/runDockerBuild.py
@@ -74,7 +74,7 @@ def get_volume_mappings(ccache_path, conan_path, source_path, script_path):
 	return [f'--volume={str(key)}:{value}' for key, value in sorted(mappings)]
 
 
-def create_docker_run_command(options, compiler_configuration_filepath, build_configuration_filepath, user, source_path, script_path):
+def create_docker_run_command(options, args, source_path, script_path):
 	docker_run_settings = options.docker_run_settings()
 	volume_mappings = get_volume_mappings(options.ccache_path, options.conan_path, source_path, script_path)
 
@@ -82,13 +82,13 @@ def create_docker_run_command(options, compiler_configuration_filepath, build_co
 	docker_args = [
 		'docker', 'run',
 		'--rm',
-		f'--user={user}',
+		f'--user={args.user}',
 	] + docker_run_settings + volume_mappings + [
 		options.build_base_image_name,
 		'python3', '/scripts/runDockerBuildInnerBuild.py',
 		# assume paths are relative to workdir
-		f'--compiler-configuration={inner_configuration_path}/{get_base_from_path(compiler_configuration_filepath)}',
-		f'--build-configuration={inner_configuration_path}/{get_base_from_path(build_configuration_filepath)}'
+		f'--compiler-configuration={inner_configuration_path}/{get_base_from_path(args.compiler_configuration_filepath)}',
+		f'--build-configuration={inner_configuration_path}/{get_base_from_path(args.build_configuration_filepath)}'
 	]
 
 	return docker_args
@@ -165,7 +165,7 @@ def main():
 		return
 
 	source_path = Path(args.source_path).resolve()
-	docker_run = create_docker_run_command(options, args.compiler_configuration, args.build_configuration, args.user, source_path, script_path)
+	docker_run = create_docker_run_command(options, args, source_path, script_path)
 
 	environment_manager = EnvironmentManager(args.dry_run)
 	environment_manager.rmtree(OUTPUT_DIR)

--- a/jenkins/catapult/runDockerTests.py
+++ b/jenkins/catapult/runDockerTests.py
@@ -48,14 +48,6 @@ def prepare_docker_compose_file(input_filepath, prepare_replacements, outfile):
 		outfile.write(contents)
 
 
-def get_script_path():
-	return os.path.abspath(os.path.dirname(sys.argv[0]))
-
-
-def get_base_from_path(filepath):
-	return os.path.basename(filepath)
-
-
 def main():
 	parser = argparse.ArgumentParser(description='catapult tests runner')
 	parser.add_argument('--image', help='docker tests image', required=True)
@@ -79,11 +71,11 @@ def main():
 	print(f'processing template from {compose_template_filepath}')
 	prepare_replacements = {
 		'image_name': args.image,
-		'compiler_configuration': '/scripts/configurations/' + get_base_from_path(args.compiler_configuration),
+		'compiler_configuration': '/scripts/configurations/' + os.path.basename(args.compiler_configuration),
 		'user': args.user,
 		'verbosity': args.verbosity,
 		'src_dir': str(Path(args.source_path).resolve().absolute()),
-		'script_path': get_script_path(),
+		'script_path': os.path.abspath(os.path.dirname(sys.argv[0])),
 		'linter_path': str(Path(args.linter_path).resolve().absolute()) if args.mode == 'lint' else ''
 	}
 	prepare_docker_compose_file(compose_template_filepath, prepare_replacements, sys.stdout)

--- a/jenkins/catapult/runDockerTestsInnerLint.py
+++ b/jenkins/catapult/runDockerTestsInnerLint.py
@@ -9,6 +9,7 @@ OUTPUT_DIR = Path('catapult-data')
 SRC_DIR = Path('/catapult-src')
 LINTER_DIR = Path('/linters')
 
+
 def print_linter_status(name, return_code):
 	return_code_description = 'succeeded' if not return_code else 'FAILED'
 	print(f'{name} {return_code_description}')

--- a/jenkins/catapult/runDockerTestsInnerLint.py
+++ b/jenkins/catapult/runDockerTestsInnerLint.py
@@ -6,8 +6,8 @@ from environment import EnvironmentManager
 from process import ProcessManager
 
 OUTPUT_DIR = Path('catapult-data')
-SRC_DIR = Path('catapult-src')
-
+SRC_DIR = Path('/catapult-src')
+LINTER_DIR = Path('/linters')
 
 def print_linter_status(name, return_code):
 	return_code_description = 'succeeded' if not return_code else 'FAILED'
@@ -19,7 +19,7 @@ def find_files_with_extension(environment_manager, extension):
 
 
 def run_cpp_linters(process_manager, dest_dir):
-	cpp_lint_args = ['python3', 'scripts/lint/checkProjectStructure.py']
+	cpp_lint_args = ['python3', str(LINTER_DIR.joinpath('cpp/checkProjectStructure.py').resolve())]
 	for directory in ['src', 'extensions', 'plugins']:
 		cpp_lint_args.extend(['--dep-check-dir', directory])
 
@@ -45,9 +45,6 @@ class LinterRunner:
 		linter_result = self.process_manager.dispatch_subprocess(args, handle_error=False, redirect_filename=self.output_filepath)
 		print_linter_status(self.scope, linter_result)
 
-	def fixup_source_path(self):
-		self.fixup(lambda line: line.replace(f'/{SRC_DIR}', str(SRC_DIR)))
-
 	def fixup(self, modifier):
 		if self.dry_run:
 			return
@@ -67,7 +64,6 @@ class LinterRunner:
 def run_shell_linters(linter_runner, shell_files):
 	linter_runner.set_scope('shellcheck')
 	linter_runner.run(['shellcheck', '--format=gcc'] + shell_files)
-	linter_runner.fixup_source_path()
 
 
 def run_python_linters(linter_runner, python_files):
@@ -76,15 +72,14 @@ def run_python_linters(linter_runner, python_files):
 	linter_runner.set_scope('pylint')
 	linter_runner.run([
 		'pylint',
-		'--rcfile', '.pylintrc',
+		'--rcfile', str(LINTER_DIR.joinpath('python/.pylintrc').resolve()),
 		'--load-plugins', 'pylint_quotes',
 		'--output-format', 'parseable'
 	] + python_files)
 	linter_runner.fixup(lambda line: line if not pylint_warning_pattern.match(line) else f'{SRC_DIR}/scripts/{line}')
 
 	linter_runner.set_scope('pycodestyle')
-	linter_runner.run(['pycodestyle', '--config', '.pycodestyle'] + python_files)
-	linter_runner.fixup_source_path()
+	linter_runner.run(['pycodestyle', '--config', str(LINTER_DIR.joinpath('python/.pycodestyle').resolve())] + python_files)
 
 	isort_warning_pattern = re.compile('([A-Z]+): ([a-zA-Z\\-/]+\\.py) (.*)')
 
@@ -93,7 +88,6 @@ def run_python_linters(linter_runner, python_files):
 	linter_runner.fixup(lambda line: isort_warning_pattern.sub(
 		lambda match: f'{match.group(2)}:1:1 {match.group(1).lower()}: {match.group(3)}',
 		line))
-	linter_runner.fixup_source_path()
 
 
 def main():
@@ -108,7 +102,7 @@ def main():
 
 	run_cpp_linters(process_manager, args.out_dir)
 
-	environment_manager.chdir('scripts')
+	environment_manager.chdir(SRC_DIR.joinpath('scripts').resolve())
 
 	linter_runner = LinterRunner(process_manager, args.out_dir, args.dry_run)
 	run_shell_linters(linter_runner, find_files_with_extension(environment_manager, '.sh'))

--- a/jenkins/catapult/templates/RunBench.yaml
+++ b/jenkins/catapult/templates/RunBench.yaml
@@ -6,9 +6,10 @@ services:
     working_dir: /catapult-data/workdir
     cap_add:
       - SYS_PTRACE
-    command: python3 /catapult-src/scripts/build/runDockerTestsInnerBench.py --exe-path /usr/catapult/bin  --out-dir /catapult-data/logs
+    command: python3 /scripts/runDockerTestsInnerBench.py --exe-path /usr/catapult/bin  --out-dir /catapult-data/logs
     environment:
       - LD_LIBRARY_PATH=/usr/catapult/lib:/usr/catapult/deps
     volumes:
       - ./catapult-data:/catapult-data
-      - ./catapult-src:/catapult-src
+      - {{CATAPULT_SRC}}:/catapult-src
+      - {{SCRIPT_PATH}}:/scripts

--- a/jenkins/catapult/templates/RunLint.yaml
+++ b/jenkins/catapult/templates/RunLint.yaml
@@ -6,7 +6,9 @@ services:
     working_dir: /catapult-src
     cap_add:
       - SYS_PTRACE
-    command: python3 /catapult-src/scripts/build/runDockerTestsInnerLint.py --out-dir /catapult-data/logs
+    command: python3 /scripts/runDockerTestsInnerLint.py --out-dir /catapult-data/logs
     volumes:
       - ./catapult-data:/catapult-data
-      - ./catapult-src:/catapult-src
+      - {{CATAPULT_SRC}}:/catapult-src
+      - {{SCRIPT_PATH}}:/scripts
+      - {{LINTER_PATH}}:/linters

--- a/jenkins/catapult/templates/RunTest.yaml
+++ b/jenkins/catapult/templates/RunTest.yaml
@@ -27,14 +27,15 @@ services:
     ulimits:
       core: -1
     command: >-
-      python3 /catapult-src/scripts/build/runDockerTestsInnerTest.py
+      python3 /scripts/runDockerTestsInnerTest.py
         --compiler-configuration /{{COMPILER_CONFIGURATION}}
         --exe-path /usr/catapult/tests
         --out-dir /catapult-data/logs
         --verbosity {{VERBOSITY}}
     volumes:
       - ./catapult-data:/catapult-data
-      - ./catapult-src:/catapult-src
+      - {{CATAPULT_SRC}}:/catapult-src
+      - {{SCRIPT_PATH}}:/scripts
     depends_on:
       - db
 


### PR DESCRIPTION
With the move to monorepo, the path for linters, scripts and code are in different folders.

Update the python scripts to now take a ``--source-path`` which points to where the catapult source is located.
Linters and scripts also have different mount points in the docker container.