### PR TITLE
 feat: Add seed job for monorepo layout.

### DIFF
--- a/jenkins/shared-library/vars/createMonorepoMultibranchJobs.groovy
+++ b/jenkins/shared-library/vars/createMonorepoMultibranchJobs.groovy
@@ -13,6 +13,7 @@ String appendFilter(String path) {
 void generateMultibranchJobs(Object buildConfiguration, String gitUrl, String rootFolder, String credentialsId) {
 	final String pathSeparator = '/'
 	Map jobConfiguration = [:]
+
 	jobConfiguration.gitUrl = gitUrl
 	jobConfiguration.rootFolder = rootFolder
 	jobConfiguration.credentialsId = credentialsId
@@ -21,7 +22,7 @@ void generateMultibranchJobs(Object buildConfiguration, String gitUrl, String ro
 	jobConfiguration.repositoryOwner = tokens[2]
 	jobConfiguration.repositoryName = tokens.last().split('\\.')[0]
 
-	String fullFolderName = ''
+	String fullFolderName = pathSeparator
 	rootFolder.tokenize(pathSeparator).each { folderName ->
 		fullFolderName += folderName
 		createJenkinsFolder(fullFolderName, "${folderName}")
@@ -39,15 +40,13 @@ void generatePackageMultibranchJobs(Object buildConfiguration, Map jobConfigurat
 	final String pathSeparator = '/'
 
 	buildConfiguration.builds.each { build ->
+		jobConfiguration.packageExcludePaths = '**/*'
 		String pipelineName = build.path.tokenize(pathSeparator).last()
-		jobConfiguration.with {
-			jobName = Paths.get(jobConfiguration.fullBranchFolder.toString()).resolve(pipelineName).toString()
-			jenkinsfilePath = Paths.get(build.path).resolve('Jenkinsfile').toString()
-			packageIncludePaths = addPathAndDependsOnFolder(build).join('\n')
-			packageExcludePaths = '**/*'
-			path = build.path
-			packageFolder = Paths.get(jobConfiguration.repositoryName.toString()).resolve(build.path).toString()
-		}
+		jobConfiguration.jobName = Paths.get(jobConfiguration.fullBranchFolder.toString()).resolve(pipelineName).toString()
+		jobConfiguration.jenkinsfilePath = Paths.get(build.path).resolve('Jenkinsfile').toString()
+		jobConfiguration.packageIncludePaths = addPathAndDependsOnFolder(build).join('\n')
+		jobConfiguration.displayName = build.name
+		jobConfiguration.packageFolder = Paths.get(jobConfiguration.repositoryName.toString()).resolve(build.path).toString()
 		createMultibranchJob(jobConfiguration)
 	}
 }
@@ -60,13 +59,13 @@ void generateRepoMultibranchJob(Object buildConfiguration, Map jobConfiguration)
 		excludePaths += addPathAndDependsOnFolder(build)
 	}
 	jobConfiguration.packageExcludePaths = excludePaths.unique().join('\n')
+
 	String pipelineName = 'RootJob'
-	jobConfiguration.with {
-		jobName = Paths.get(jobConfiguration.fullBranchFolder).resolve(pipelineName).toString()
-		jenkinsfilePath = 'Jenkinsfile'
-		packageIncludePaths = ''
-		packageFolder = Paths.get(jobConfiguration.repositoryName).resolve(pipelineName).toString()
-	}
+	jobConfiguration.jobName = Paths.get(jobConfiguration.fullBranchFolder).resolve(pipelineName).toString()
+	jobConfiguration.jenkinsfilePath = 'Jenkinsfile'
+	jobConfiguration.packageIncludePaths = ''
+	jobConfiguration.displayName = pipelineName
+	jobConfiguration.packageFolder = Paths.get(jobConfiguration.repositoryName).resolve(pipelineName).toString()
 	createMultibranchJob(jobConfiguration)
 }
 

--- a/jenkins/shared-library/vars/createMultibranchJob.groovy
+++ b/jenkins/shared-library/vars/createMultibranchJob.groovy
@@ -9,6 +9,8 @@ void call(Map jobConfiguration) {
 			final int USE_CURRENT_SOURCE_STRATEGY_ID = 2
 
 			multibranchPipelineJob(jobName) {
+				displayName(displayName)
+
 				branchSources {
 					branchSource {
 						source {
@@ -82,6 +84,7 @@ void call(Map jobConfiguration) {
 			packageIncludePaths: jobConfiguration.packageIncludePaths.toString(),
 			packageExcludePaths: jobConfiguration.packageExcludePaths.toString(),
 			credentialsId: jobConfiguration.credentialsId.toString(),
-			notificationContextLabel: "continuous-integration/jenkins/${jobConfiguration.packageFolder}"
+			notificationContextLabel: "continuous-integration/jenkins/${jobConfiguration.packageFolder}",
+			displayName: jobConfiguration.displayName.toString()
 	]
 }

--- a/jenkins/shared-library/vars/monorepoSeedPipeline.groovy
+++ b/jenkins/shared-library/vars/monorepoSeedPipeline.groovy
@@ -26,7 +26,7 @@ void call(Closure body) {
 
 		environment {
 			JENKINS_ROOT_FOLDER	  = "${params.organizationName}/generated"
-			BUILD_CONFIGURATION_FILE = 'buildConfiguration.yaml'
+			BUILD_CONFIGURATION_FILE = 'seed-job/buildConfiguration.yaml'
 			GITHUB_CREDENTIALS_ID = "${params.gitHubId}"
 		}
 

--- a/linters/groovy/.groovylintrc.json
+++ b/linters/groovy/.groovylintrc.json
@@ -10,6 +10,8 @@
 
     "dry.DuplicateStringLiteral": { "ignoreStrings": ",/,\n,Jenkinsfile" },
 
-    "unnecessary.UnnecessaryGetter": { "checkIsMethods": false }
+    "unnecessary.UnnecessaryGetter": { "checkIsMethods": false },
+
+    "UnnecessaryObjectReferences": { "enabled": false }
   }
 }

--- a/seed-job/Jenkinsfile
+++ b/seed-job/Jenkinsfile
@@ -1,0 +1,5 @@
+monorepoSeedPipeline {
+	platform = ['ubuntu']
+	organizationName = 'Symbol'
+	gitHubId = 'Symbol-Github-app'
+}

--- a/seed-job/buildConfiguration.yaml
+++ b/seed-job/buildConfiguration.yaml
@@ -1,0 +1,22 @@
+builds:
+  - name: Rest Gateway
+    path: client/rest
+
+  - name: Catbuffer Parser
+    path: catbuffer/parser
+
+  - name: Sdk Python
+    path: sdk/python
+    dependsOn:
+      - catbuffer/parser
+
+  - name: Sdk Javascript
+    path: sdk/javascript
+    dependsOn:
+      - catbuffer/parser
+
+  - name: Jenkins
+    path: jenkins
+
+  - name: Linters
+    path: linters


### PR DESCRIPTION
Add the seed job which can be used to automatically create the other package jobs.
The seed job can be configured to update the package jobs if changes are made to the buildConfiguration.yaml file.
The ``buildConfiguration.yaml`` has layout of each package and their dependencies.