### PR TITLE
[Jenkins] fix: First build failed with missing property

### DIFF
--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -28,7 +28,8 @@ void call(Closure body) {
 
 		agent {
 			dockerfile {
-				label "${PLATFORM}-agent"
+				// PLATFORM can be null on first job due to https://issues.jenkins.io/browse/JENKINS-41929
+				label env.PLATFORM == null ? "${params.platform[0]}-agent" : "${env.PLATFORM}-agent" 
 
 				dir 'jenkins/docker'
 				filename "${params.ciBuildDockerfile}"


### PR DESCRIPTION
The first build with parameters on a multibranch job fails due to no parameters getting included.  Add a check for this condition to workaround the bug below.
https://issues.jenkins.io/browse/JENKINS-41929