### PR TITLE
[client/rest] fix: Add MongoDB to Dockerfile

### DIFF
--- a/client/rest/scripts/ci/setup_test.sh
+++ b/client/rest/scripts/ci/setup_test.sh
@@ -5,13 +5,11 @@ set -ex
 mongod --fork --logpath /data/mongod.log
 
 wait_period=10
-while ! /usr/bin/mongo --eval "printjson(db.version())" > /dev/null 2>&1;
-do
-    sleep 1;
-    let "wait_period-=1"
-    if [ $wait_period -le 1 ];
-    then
-        echo "Waiting for monogo timed out, exiting now.."
-        exit 1
-    fi
+while ! /usr/bin/mongo --eval "printjson(db.version())" >/dev/null 2>&1; do
+	sleep 1
+	((--wait_period))
+	if [ "$wait_period" -le 1 ]; then
+		echo "Waiting for monogo timed out, exiting now.."
+		exit 1
+	fi
 done

--- a/client/rest/scripts/ci/setup_test.sh
+++ b/client/rest/scripts/ci/setup_test.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -ex
+
+mongod --fork --logpath /data/mongod.log
+
+wait_period=10
+while ! /usr/bin/mongo --eval "printjson(db.version())" > /dev/null 2>&1;
+do
+    sleep 1;
+    let "wait_period-=1"
+    if [ $wait_period -le 1 ];
+    then
+        echo "Waiting for monogo timed out, exiting now.."
+        exit 1
+    fi
+done

--- a/jenkins/docker/javascript.Dockerfile
+++ b/jenkins/docker/javascript.Dockerfile
@@ -35,4 +35,3 @@ WORKDIR /home/ubuntu
 # Create the MongoDB data directory
 RUN mkdir -p /data/db \
 	&& chown -R ubuntu:ubuntu /data
-EXPOSE 27017 

--- a/jenkins/docker/javascript.Dockerfile
+++ b/jenkins/docker/javascript.Dockerfile
@@ -5,6 +5,14 @@ RUN apt-get update >/dev/null \
 	&& apt-get install -y tzdata \
 	&& apt-get install -y git curl
 
+# mongodb
+RUN apt-get install -y wget gnupg \
+	&& wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add - \
+	&& echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" \
+	| tee /etc/apt/sources.list.d/mongodb-org-5.0.list \
+	&& apt-get update \
+	&& apt-get install -y mongodb-org
+
 # nodejs
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
 	&& apt-get install -y nodejs
@@ -23,3 +31,8 @@ RUN apt-get install -y shellcheck \
 RUN useradd --uid 1000 -ms /bin/bash ubuntu
 
 WORKDIR /home/ubuntu
+
+# Create the MongoDB data directory
+RUN mkdir -p /data/db \
+	&& chown -R ubuntu:ubuntu /data
+EXPOSE 27017 


### PR DESCRIPTION
Rest tests that required MongoDB were failing due to MongoDB not available in the image.
Added MongoDB and start the process in the setup test staged.