### PR TITLE
[monorepo] fix: code coverage does not show for all packages.

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -36,19 +36,19 @@ flags:
   rest-gateway:
     paths:
       - client/rest
-    carryforward: false
+    carryforward: true
 
   catbuffer-parser:
     paths:
       - catbuffer/parser
-    carryforward: false
+    carryforward: true
 
   sdk-python:
     paths:
       - sdk/python
-    carryforward: false
+    carryforward: true
 
   sdk-javascript:
     paths:
       - sdk/javascript
-    carryforward: false
+    carryforward: true

--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -187,7 +187,8 @@ void call(Closure body) {
 						when {
 							allOf {
 								expression {
-									return env.TEST_MODE == 'code-coverage'
+									// The branch indexing build TEST_MODE = null
+									return env.TEST_MODE == null || env.TEST_MODE == 'code-coverage'
 								}
 								expression {
 									return params.codeCoverageTool != null


### PR DESCRIPTION
Codecov seems to evaluate code coverage for each commit for the entire repo and not per flags.  Need to set ``carryforward: true`` to allow code coverage from previous commits.