### PR TITLE
[sdk/python] allow descriptor-inlined cosignatures

### DIFF
--- a/sdk/python/symbolchain/nem/TransactionFactory.py
+++ b/sdk/python/symbolchain/nem/TransactionFactory.py
@@ -71,9 +71,9 @@ class TransactionFactory:
 		factory.autodetect()
 
 		struct_names = [
-			'Message', 'NamespaceId', 'MosaicId', 'Mosaic', 'SizePrefixedMosaic', 'MosaicLevy',
+			'Cosignature', 'Message', 'NamespaceId', 'MosaicId', 'Mosaic', 'SizePrefixedMosaic', 'MosaicLevy',
 			'MosaicProperty', 'SizePrefixedMosaicProperty', 'MosaicDefinition',
-			'MultisigAccountModification', 'SizePrefixedMultisigAccountModification'
+			'MultisigAccountModification', 'SizePrefixedMultisigAccountModification', 'SizePrefixedCosignature'
 		]
 		for name in struct_names:
 			factory.add_struct_parser(name)
@@ -86,7 +86,8 @@ class TransactionFactory:
 		for name, typename in sdk_type_mapping.items():
 			factory.add_pod_parser(name, typename)
 
-		for name in ['struct:SizePrefixedMosaic', 'struct:SizePrefixedMosaicProperty', 'struct:SizePrefixedMultisigAccountModification']:
-			factory.add_array_parser(name)
+		array_names = ['SizePrefixedMosaic', 'SizePrefixedMosaicProperty', 'SizePrefixedMultisigAccountModification', 'SizePrefixedCosignature']
+		for name in array_names:
+			factory.add_array_parser(f'struct:{name}')
 
 		return factory

--- a/sdk/python/tests/nem/test_TransactionFactory.py
+++ b/sdk/python/tests/nem/test_TransactionFactory.py
@@ -51,13 +51,26 @@ class TransactionFactoryTest(BasicTransactionFactoryTest, unittest.TestCase):
 			'BlockType', 'LinkAction', 'MessageType', 'MosaicSupplyChangeAction', 'MosaicTransferFeeType',
 			'MultisigAccountModificationType', 'NetworkType', 'TransactionType',
 
-			'struct:Message', 'struct:NamespaceId', 'struct:MosaicId', 'struct:Mosaic', 'struct:SizePrefixedMosaic', 'struct:MosaicLevy',
-			'struct:MosaicProperty', 'struct:SizePrefixedMosaicProperty', 'struct:MosaicDefinition',
-			'struct:MultisigAccountModification', 'struct:SizePrefixedMultisigAccountModification',
+			'struct:Cosignature',
+			'struct:Message',
+			'struct:Mosaic',
+			'struct:MosaicDefinition',
+			'struct:MosaicId',
+			'struct:MosaicLevy',
+			'struct:MosaicProperty',
+			'struct:MultisigAccountModification',
+			'struct:NamespaceId',
+			'struct:SizePrefixedCosignature',
+			'struct:SizePrefixedMosaic',
+			'struct:SizePrefixedMosaicProperty',
+			'struct:SizePrefixedMultisigAccountModification',
 
 			'Address', 'Hash256', 'PublicKey',
 
-			'array[SizePrefixedMosaic]', 'array[SizePrefixedMosaicProperty]', 'array[SizePrefixedMultisigAccountModification]'
+			'array[SizePrefixedCosignature]',
+			'array[SizePrefixedMosaic]',
+			'array[SizePrefixedMosaicProperty]',
+			'array[SizePrefixedMultisigAccountModification]'
 		]
 		self.assertEqual(set(expected_rule_names), set(factory.factory.rules.keys()))
 


### PR DESCRIPTION
## What's the issue?
Right now cosignatures in nem can't be used, when transaction  is created via descriptors

## How have you changed the behavior?
Added processing of `Cosignature` and `SizePrefixedCosignature` in nem's TransactionFactory

## How was this change tested?

Tested using upcoming PR, since this work the same as any other structs, separate unittests are not needed.
