### PR TITLE
[monorepo] fix: init file not run.

### DIFF
--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -304,6 +304,6 @@ void runInitializeScriptIfPresent() {
 	String initFile = 'init.sh'
 	if (fileExists(initFile)) {
 		println 'Running initialize script'
-		sh initFile
+		sh "bash ${initFile}"
 	}
 }


### PR DESCRIPTION

Run the script file directly with bash.

## What is the current behavior?
The ``init.sh`` was found but failed to run.

## What's the issue?
The script was not found when executed directly by the shell.

## How have you changed the behavior?
The script will run with bash.
