### PR TITLE
[monorepo] fix: Manual build branch list incorrect

### DIFF
--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -16,7 +16,10 @@ void call(Closure body) {
 			gitParameter branchFilter: 'origin/(.*)',
 				defaultValue: "${env.GIT_BRANCH}",
 				name: 'MANUAL_GIT_BRANCH',
-				type: 'PT_BRANCH'
+				type: 'PT_BRANCH',
+				selectedValue: 'TOP',
+				sortMode: 'ASCENDING',
+				useRepository: "${helper.resolveRepoName()}"
 			choice name: 'PLATFORM',
 				choices: params.platform ?: 'ubuntu',
 				description: 'Run on specific platform'

--- a/jenkins/shared-library/vars/helper.groovy
+++ b/jenkins/shared-library/vars/helper.groovy
@@ -9,3 +9,8 @@ String resolveBranchName(String manualBranch) {
 Boolean isPublicBuild(String buildConfiguration) {
 	return buildConfiguration == 'release-public'
 }
+
+String resolveRepoName() {
+	// groovylint-disable-next-line UnnecessaryGetter
+	return scm.getUserRemoteConfigs()[0].getUrl().tokenize('/').last()
+}

--- a/jenkins/shared-library/vars/monorepoSeedPipeline.groovy
+++ b/jenkins/shared-library/vars/monorepoSeedPipeline.groovy
@@ -9,7 +9,10 @@ void call(Closure body) {
 			gitParameter branchFilter: 'origin/(.*)',
 				defaultValue: "${env.GIT_BRANCH}",
 				name: 'MANUAL_GIT_BRANCH',
-				type: 'PT_BRANCH'
+				type: 'PT_BRANCH',
+				selectedValue: 'TOP',
+				sortMode: 'ASCENDING',
+				useRepository: "${helper.resolveRepoName()}"
 			choice name: 'PLATFORM',
 				choices: params.platform ?: 'ubuntu',
 				description: 'Run on specific platform'


### PR DESCRIPTION
## What is the current behavior?
The branch list which gets shown in the ``MANUAL_GIT_BRANCH`` selection is incorrect on the product repo.

## What's the issue?
 By default, the gitParameter will show the branches from the first repo, which is always the Jenkins shared library(symbol).

## How have you changed the behavior?
The branch list which gets shown in the ``MANUAL_GIT_BRANCH`` selection is correct on the product repo.

## How was this change tested?
Try to run a manual build on the product repo.
