### PR TITLE
[sdk/python]: rename buffer_ to buffer

### DIFF
--- a/sdk/javascript/generator/StructTypeFormatter.py
+++ b/sdk/javascript/generator/StructTypeFormatter.py
@@ -287,29 +287,29 @@ class StructFormatter(AbstractTypeFormatter):
 
 		serialize_line = None
 		if DisplayType.TYPED_ARRAY == field.display_type:
-			serialize_field = field.extensions.printer.store(field_value, 'buffer_')
+			serialize_field = field.extensions.printer.store(field_value, 'buffer')
 			serialize_line = f'{serialize_field};{field_comment}\n'
 		else:
 			serialize_field = field.extensions.printer.store(field_value)
-			serialize_line = f'buffer_.write({serialize_field});{field_comment}\n'
+			serialize_line = f'buffer.write({serialize_field});{field_comment}\n'
 
 		return indent_if_conditional(condition, serialize_line)
 
 	def get_serialize_descriptor(self):
-		body = 'const buffer_ = new Writer(this.size);\n'
+		body = 'const buffer = new Writer(this.size);\n'
 
 		# if first field is size replace serializer with custom one (to access builder .size() instead)
 		fields_iter = self.non_const_fields()
 		first_field = next(fields_iter)
 		if self.struct.size == first_field.extensions.printer.name:
-			body += f'buffer_.write(converter.intToBytes(this.size, {first_field.size}, false));\n'
+			body += f'buffer.write(converter.intToBytes(this.size, {first_field.size}, false));\n'
 		else:
 			body += self.generate_serialize_field(first_field)
 
 		for field in fields_iter:
 			body += self.generate_serialize_field(field)
 
-		body += 'return buffer_.storage;'
+		body += 'return buffer.storage;'
 		return MethodDescriptor(body=body)
 
 	def generate_size_field(self, field):

--- a/sdk/javascript/src/nem/models.js
+++ b/sdk/javascript/src/nem/models.js
@@ -396,19 +396,19 @@ class Transaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._type.serialize());
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._signatureSize, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._type.serialize());
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._signatureSize, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -555,17 +555,17 @@ class NonVerifiableTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._type.serialize());
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._type.serialize());
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -794,21 +794,21 @@ class Block {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._type.serialize());
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._signatureSize, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._previousBlockHash.serialize());
-		buffer_.write(this._height.serialize());
-		buffer_.write(converter.intToBytes(this._transactions.length, 4, false)); // bound: transactions_count
-		arrayHelpers.writeArray(buffer_, this._transactions);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._type.serialize());
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._signatureSize, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._previousBlockHash.serialize());
+		buffer.write(this._height.serialize());
+		buffer.write(converter.intToBytes(this._transactions.length, 4, false)); // bound: transactions_count
+		arrayHelpers.writeArray(buffer, this._transactions);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -1060,22 +1060,22 @@ class AccountKeyLinkTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._type.serialize());
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._signatureSize, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._linkAction.serialize());
-		buffer_.write(converter.intToBytes(this._remotePublicKeySize, 4, false));
-		buffer_.write(this._remotePublicKey.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._type.serialize());
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._signatureSize, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._linkAction.serialize());
+		buffer.write(converter.intToBytes(this._remotePublicKeySize, 4, false));
+		buffer.write(this._remotePublicKey.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -1262,20 +1262,20 @@ class NonVerifiableAccountKeyLinkTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._type.serialize());
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._linkAction.serialize());
-		buffer_.write(converter.intToBytes(this._remotePublicKeySize, 4, false));
-		buffer_.write(this._remotePublicKey.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._type.serialize());
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._linkAction.serialize());
+		buffer.write(converter.intToBytes(this._remotePublicKeySize, 4, false));
+		buffer.write(this._remotePublicKey.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -1331,10 +1331,10 @@ class NamespaceId {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._name.length, 4, false)); // bound: name_size
-		buffer_.write(this._name);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._name.length, 4, false)); // bound: name_size
+		buffer.write(this._name);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -1396,11 +1396,11 @@ class MosaicId {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._namespaceId.serialize());
-		buffer_.write(converter.intToBytes(this._name.length, 4, false)); // bound: name_size
-		buffer_.write(this._name);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._namespaceId.serialize());
+		buffer.write(converter.intToBytes(this._name.length, 4, false)); // bound: name_size
+		buffer.write(this._name);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -1464,11 +1464,11 @@ class Mosaic {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.mosaicId.size, 4, false)); // bound: mosaic_id_size
-		buffer_.write(this._mosaicId.serialize());
-		buffer_.write(this._amount.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.mosaicId.size, 4, false)); // bound: mosaic_id_size
+		buffer.write(this._mosaicId.serialize());
+		buffer.write(this._amount.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -1518,10 +1518,10 @@ class SizePrefixedMosaic {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.mosaic.size, 4, false)); // bound: mosaic_size
-		buffer_.write(this._mosaic.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.mosaic.size, 4, false)); // bound: mosaic_size
+		buffer.write(this._mosaic.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -1664,14 +1664,14 @@ class MosaicLevy {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._transferFeeType.serialize());
-		buffer_.write(converter.intToBytes(this._recipientAddressSize, 4, false));
-		buffer_.write(this._recipientAddress.serialize());
-		buffer_.write(converter.intToBytes(this.mosaicId.size, 4, false)); // bound: mosaic_id_size
-		buffer_.write(this._mosaicId.serialize());
-		buffer_.write(this._fee.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._transferFeeType.serialize());
+		buffer.write(converter.intToBytes(this._recipientAddressSize, 4, false));
+		buffer.write(this._recipientAddress.serialize());
+		buffer.write(converter.intToBytes(this.mosaicId.size, 4, false)); // bound: mosaic_id_size
+		buffer.write(this._mosaicId.serialize());
+		buffer.write(this._fee.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -1739,12 +1739,12 @@ class MosaicProperty {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._name.length, 4, false)); // bound: name_size
-		buffer_.write(this._name);
-		buffer_.write(converter.intToBytes(this._value.length, 4, false)); // bound: value_size
-		buffer_.write(this._value);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._name.length, 4, false)); // bound: name_size
+		buffer.write(this._name);
+		buffer.write(converter.intToBytes(this._value.length, 4, false)); // bound: value_size
+		buffer.write(this._value);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -1794,10 +1794,10 @@ class SizePrefixedMosaicProperty {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.property.size, 4, false)); // bound: property_size
-		buffer_.write(this._property.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.property.size, 4, false)); // bound: property_size
+		buffer.write(this._property.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -1932,20 +1932,20 @@ class MosaicDefinition {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._ownerPublicKeySize, 4, false));
-		buffer_.write(this._ownerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this.id.size, 4, false)); // bound: id_size
-		buffer_.write(this._id.serialize());
-		buffer_.write(converter.intToBytes(this._description.length, 4, false)); // bound: description_size
-		buffer_.write(this._description);
-		buffer_.write(converter.intToBytes(this._properties.length, 4, false)); // bound: properties_count
-		arrayHelpers.writeArray(buffer_, this._properties);
-		buffer_.write(converter.intToBytes(this._levySize, 4, false));
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._ownerPublicKeySize, 4, false));
+		buffer.write(this._ownerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this.id.size, 4, false)); // bound: id_size
+		buffer.write(this._id.serialize());
+		buffer.write(converter.intToBytes(this._description.length, 4, false)); // bound: description_size
+		buffer.write(this._description);
+		buffer.write(converter.intToBytes(this._properties.length, 4, false)); // bound: properties_count
+		arrayHelpers.writeArray(buffer, this._properties);
+		buffer.write(converter.intToBytes(this._levySize, 4, false));
 		if (0 !== this.levySize)
-			buffer_.write(this._levy.serialize());
+			buffer.write(this._levy.serialize());
 
-		return buffer_.storage;
+		return buffer.storage;
 	}
 
 	toString() {
@@ -2039,13 +2039,13 @@ class MosaicDefinitionTransactionBody {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.mosaicDefinition.size, 4, false)); // bound: mosaic_definition_size
-		buffer_.write(this._mosaicDefinition.serialize());
-		buffer_.write(converter.intToBytes(this._rentalFeeSinkSize, 4, false));
-		buffer_.write(this._rentalFeeSink.serialize());
-		buffer_.write(this._rentalFee.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.mosaicDefinition.size, 4, false)); // bound: mosaic_definition_size
+		buffer.write(this._mosaicDefinition.serialize());
+		buffer.write(converter.intToBytes(this._rentalFeeSinkSize, 4, false));
+		buffer.write(this._rentalFeeSink.serialize());
+		buffer.write(this._rentalFee.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -2263,24 +2263,24 @@ class MosaicDefinitionTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._type.serialize());
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._signatureSize, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(converter.intToBytes(this.mosaicDefinition.size, 4, false)); // bound: mosaic_definition_size
-		buffer_.write(this._mosaicDefinition.serialize());
-		buffer_.write(converter.intToBytes(this._rentalFeeSinkSize, 4, false));
-		buffer_.write(this._rentalFeeSink.serialize());
-		buffer_.write(this._rentalFee.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._type.serialize());
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._signatureSize, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(converter.intToBytes(this.mosaicDefinition.size, 4, false)); // bound: mosaic_definition_size
+		buffer.write(this._mosaicDefinition.serialize());
+		buffer.write(converter.intToBytes(this._rentalFeeSinkSize, 4, false));
+		buffer.write(this._rentalFeeSink.serialize());
+		buffer.write(this._rentalFee.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -2486,22 +2486,22 @@ class NonVerifiableMosaicDefinitionTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._type.serialize());
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(converter.intToBytes(this.mosaicDefinition.size, 4, false)); // bound: mosaic_definition_size
-		buffer_.write(this._mosaicDefinition.serialize());
-		buffer_.write(converter.intToBytes(this._rentalFeeSinkSize, 4, false));
-		buffer_.write(this._rentalFeeSink.serialize());
-		buffer_.write(this._rentalFee.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._type.serialize());
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(converter.intToBytes(this.mosaicDefinition.size, 4, false)); // bound: mosaic_definition_size
+		buffer.write(this._mosaicDefinition.serialize());
+		buffer.write(converter.intToBytes(this._rentalFeeSinkSize, 4, false));
+		buffer.write(this._rentalFeeSink.serialize());
+		buffer.write(this._rentalFee.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -2637,12 +2637,12 @@ class MosaicSupplyChangeTransactionBody {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.mosaicId.size, 4, false)); // bound: mosaic_id_size
-		buffer_.write(this._mosaicId.serialize());
-		buffer_.write(this._action.serialize());
-		buffer_.write(this._delta.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.mosaicId.size, 4, false)); // bound: mosaic_id_size
+		buffer.write(this._mosaicId.serialize());
+		buffer.write(this._action.serialize());
+		buffer.write(this._delta.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -2854,23 +2854,23 @@ class MosaicSupplyChangeTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._type.serialize());
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._signatureSize, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(converter.intToBytes(this.mosaicId.size, 4, false)); // bound: mosaic_id_size
-		buffer_.write(this._mosaicId.serialize());
-		buffer_.write(this._action.serialize());
-		buffer_.write(this._delta.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._type.serialize());
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._signatureSize, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(converter.intToBytes(this.mosaicId.size, 4, false)); // bound: mosaic_id_size
+		buffer.write(this._mosaicId.serialize());
+		buffer.write(this._action.serialize());
+		buffer.write(this._delta.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -3070,21 +3070,21 @@ class NonVerifiableMosaicSupplyChangeTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._type.serialize());
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(converter.intToBytes(this.mosaicId.size, 4, false)); // bound: mosaic_id_size
-		buffer_.write(this._mosaicId.serialize());
-		buffer_.write(this._action.serialize());
-		buffer_.write(this._delta.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._type.serialize());
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(converter.intToBytes(this.mosaicId.size, 4, false)); // bound: mosaic_id_size
+		buffer.write(this._mosaicId.serialize());
+		buffer.write(this._action.serialize());
+		buffer.write(this._delta.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -3204,11 +3204,11 @@ class MultisigAccountModification {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._modificationType.serialize());
-		buffer_.write(converter.intToBytes(this._cosignatoryPublicKeySize, 4, false));
-		buffer_.write(this._cosignatoryPublicKey.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._modificationType.serialize());
+		buffer.write(converter.intToBytes(this._cosignatoryPublicKeySize, 4, false));
+		buffer.write(this._cosignatoryPublicKey.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -3258,10 +3258,10 @@ class SizePrefixedMultisigAccountModification {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.modification.size, 4, false)); // bound: modification_size
-		buffer_.write(this._modification.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.modification.size, 4, false)); // bound: modification_size
+		buffer.write(this._modification.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -3442,21 +3442,21 @@ class MultisigAccountModificationTransactionV1 {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._type.serialize());
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._signatureSize, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(converter.intToBytes(this._modifications.length, 4, false)); // bound: modifications_count
-		arrayHelpers.writeArray(buffer_, this._modifications);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._type.serialize());
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._signatureSize, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(converter.intToBytes(this._modifications.length, 4, false)); // bound: modifications_count
+		arrayHelpers.writeArray(buffer, this._modifications);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -3625,19 +3625,19 @@ class NonVerifiableMultisigAccountModificationTransactionV1 {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._type.serialize());
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(converter.intToBytes(this._modifications.length, 4, false)); // bound: modifications_count
-		arrayHelpers.writeArray(buffer_, this._modifications);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._type.serialize());
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(converter.intToBytes(this._modifications.length, 4, false)); // bound: modifications_count
+		arrayHelpers.writeArray(buffer, this._modifications);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -3844,23 +3844,23 @@ class MultisigAccountModificationTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._type.serialize());
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._signatureSize, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(converter.intToBytes(this._modifications.length, 4, false)); // bound: modifications_count
-		arrayHelpers.writeArray(buffer_, this._modifications);
-		buffer_.write(converter.intToBytes(this._minApprovalDeltaSize, 4, false));
-		buffer_.write(converter.intToBytes(this._minApprovalDelta, 4, true));
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._type.serialize());
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._signatureSize, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(converter.intToBytes(this._modifications.length, 4, false)); // bound: modifications_count
+		arrayHelpers.writeArray(buffer, this._modifications);
+		buffer.write(converter.intToBytes(this._minApprovalDeltaSize, 4, false));
+		buffer.write(converter.intToBytes(this._minApprovalDelta, 4, true));
+		return buffer.storage;
 	}
 
 	toString() {
@@ -4049,21 +4049,21 @@ class NonVerifiableMultisigAccountModificationTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._type.serialize());
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(converter.intToBytes(this._modifications.length, 4, false)); // bound: modifications_count
-		arrayHelpers.writeArray(buffer_, this._modifications);
-		buffer_.write(converter.intToBytes(this._minApprovalDeltaSize, 4, false));
-		buffer_.write(converter.intToBytes(this._minApprovalDelta, 4, true));
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._type.serialize());
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(converter.intToBytes(this._modifications.length, 4, false)); // bound: modifications_count
+		arrayHelpers.writeArray(buffer, this._modifications);
+		buffer.write(converter.intToBytes(this._minApprovalDeltaSize, 4, false));
+		buffer.write(converter.intToBytes(this._minApprovalDelta, 4, true));
+		return buffer.storage;
 	}
 
 	toString() {
@@ -4281,24 +4281,24 @@ class Cosignature {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._type.serialize());
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._signatureSize, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(converter.intToBytes(this._multisigTransactionHashOuterSize, 4, false));
-		buffer_.write(converter.intToBytes(this._multisigTransactionHashSize, 4, false));
-		buffer_.write(this._multisigTransactionHash.serialize());
-		buffer_.write(converter.intToBytes(this._multisigAccountAddressSize, 4, false));
-		buffer_.write(this._multisigAccountAddress.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._type.serialize());
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._signatureSize, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(converter.intToBytes(this._multisigTransactionHashOuterSize, 4, false));
+		buffer.write(converter.intToBytes(this._multisigTransactionHashSize, 4, false));
+		buffer.write(this._multisigTransactionHash.serialize());
+		buffer.write(converter.intToBytes(this._multisigAccountAddressSize, 4, false));
+		buffer.write(this._multisigAccountAddress.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -4356,10 +4356,10 @@ class SizePrefixedCosignature {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.cosignature.size, 4, false)); // bound: cosignature_size
-		buffer_.write(this._cosignature.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.cosignature.size, 4, false)); // bound: cosignature_size
+		buffer.write(this._cosignature.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -4558,23 +4558,23 @@ class MultisigTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._type.serialize());
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._signatureSize, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(converter.intToBytes(this.innerTransaction.size, 4, false)); // bound: inner_transaction_size
-		buffer_.write(this._innerTransaction.serialize());
-		buffer_.write(converter.intToBytes(this._cosignatures.length, 4, false)); // bound: cosignatures_count
-		arrayHelpers.writeArray(buffer_, this._cosignatures);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._type.serialize());
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._signatureSize, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(converter.intToBytes(this.innerTransaction.size, 4, false)); // bound: inner_transaction_size
+		buffer.write(this._innerTransaction.serialize());
+		buffer.write(converter.intToBytes(this._cosignatures.length, 4, false)); // bound: cosignatures_count
+		arrayHelpers.writeArray(buffer, this._cosignatures);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -4691,17 +4691,17 @@ class NamespaceRegistrationTransactionBody {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._rentalFeeSinkSize, 4, false));
-		buffer_.write(this._rentalFeeSink.serialize());
-		buffer_.write(this._rentalFee.serialize());
-		buffer_.write(converter.intToBytes(this._name.length, 4, false)); // bound: name_size
-		buffer_.write(this._name);
-		buffer_.write(converter.intToBytes((this._parentName ? this._parentName.length : 4294967295), 4, false)); // bound: parent_name_size
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._rentalFeeSinkSize, 4, false));
+		buffer.write(this._rentalFeeSink.serialize());
+		buffer.write(this._rentalFee.serialize());
+		buffer.write(converter.intToBytes(this._name.length, 4, false)); // bound: name_size
+		buffer.write(this._name);
+		buffer.write(converter.intToBytes((this._parentName ? this._parentName.length : 4294967295), 4, false)); // bound: parent_name_size
 		if (this.parentName)
-			buffer_.write(this._parentName);
+			buffer.write(this._parentName);
 
-		return buffer_.storage;
+		return buffer.storage;
 	}
 
 	toString() {
@@ -4943,28 +4943,28 @@ class NamespaceRegistrationTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._type.serialize());
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._signatureSize, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(converter.intToBytes(this._rentalFeeSinkSize, 4, false));
-		buffer_.write(this._rentalFeeSink.serialize());
-		buffer_.write(this._rentalFee.serialize());
-		buffer_.write(converter.intToBytes(this._name.length, 4, false)); // bound: name_size
-		buffer_.write(this._name);
-		buffer_.write(converter.intToBytes((this._parentName ? this._parentName.length : 4294967295), 4, false)); // bound: parent_name_size
+		const buffer = new Writer(this.size);
+		buffer.write(this._type.serialize());
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._signatureSize, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(converter.intToBytes(this._rentalFeeSinkSize, 4, false));
+		buffer.write(this._rentalFeeSink.serialize());
+		buffer.write(this._rentalFee.serialize());
+		buffer.write(converter.intToBytes(this._name.length, 4, false)); // bound: name_size
+		buffer.write(this._name);
+		buffer.write(converter.intToBytes((this._parentName ? this._parentName.length : 4294967295), 4, false)); // bound: parent_name_size
 		if (this.parentName)
-			buffer_.write(this._parentName);
+			buffer.write(this._parentName);
 
-		return buffer_.storage;
+		return buffer.storage;
 	}
 
 	toString() {
@@ -5194,26 +5194,26 @@ class NonVerifiableNamespaceRegistrationTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._type.serialize());
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(converter.intToBytes(this._rentalFeeSinkSize, 4, false));
-		buffer_.write(this._rentalFeeSink.serialize());
-		buffer_.write(this._rentalFee.serialize());
-		buffer_.write(converter.intToBytes(this._name.length, 4, false)); // bound: name_size
-		buffer_.write(this._name);
-		buffer_.write(converter.intToBytes((this._parentName ? this._parentName.length : 4294967295), 4, false)); // bound: parent_name_size
+		const buffer = new Writer(this.size);
+		buffer.write(this._type.serialize());
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(converter.intToBytes(this._rentalFeeSinkSize, 4, false));
+		buffer.write(this._rentalFeeSink.serialize());
+		buffer.write(this._rentalFee.serialize());
+		buffer.write(converter.intToBytes(this._name.length, 4, false)); // bound: name_size
+		buffer.write(this._name);
+		buffer.write(converter.intToBytes((this._parentName ? this._parentName.length : 4294967295), 4, false)); // bound: parent_name_size
 		if (this.parentName)
-			buffer_.write(this._parentName);
+			buffer.write(this._parentName);
 
-		return buffer_.storage;
+		return buffer.storage;
 	}
 
 	toString() {
@@ -5333,11 +5333,11 @@ class Message {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._messageType.serialize());
-		buffer_.write(converter.intToBytes(this._message.length, 4, false)); // bound: message_size
-		buffer_.write(this._message);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._messageType.serialize());
+		buffer.write(converter.intToBytes(this._message.length, 4, false)); // bound: message_size
+		buffer.write(this._message);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -5568,26 +5568,26 @@ class TransferTransactionV1 {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._type.serialize());
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._signatureSize, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(converter.intToBytes(this._recipientAddressSize, 4, false));
-		buffer_.write(this._recipientAddress.serialize());
-		buffer_.write(this._amount.serialize());
-		buffer_.write(converter.intToBytes(this._messageEnvelopeSize, 4, false));
+		const buffer = new Writer(this.size);
+		buffer.write(this._type.serialize());
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._signatureSize, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(converter.intToBytes(this._recipientAddressSize, 4, false));
+		buffer.write(this._recipientAddress.serialize());
+		buffer.write(this._amount.serialize());
+		buffer.write(converter.intToBytes(this._messageEnvelopeSize, 4, false));
 		if (0 !== this.messageEnvelopeSize)
-			buffer_.write(this._message.serialize());
+			buffer.write(this._message.serialize());
 
-		return buffer_.storage;
+		return buffer.storage;
 	}
 
 	toString() {
@@ -5810,24 +5810,24 @@ class NonVerifiableTransferTransactionV1 {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._type.serialize());
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(converter.intToBytes(this._recipientAddressSize, 4, false));
-		buffer_.write(this._recipientAddress.serialize());
-		buffer_.write(this._amount.serialize());
-		buffer_.write(converter.intToBytes(this._messageEnvelopeSize, 4, false));
+		const buffer = new Writer(this.size);
+		buffer.write(this._type.serialize());
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(converter.intToBytes(this._recipientAddressSize, 4, false));
+		buffer.write(this._recipientAddress.serialize());
+		buffer.write(this._amount.serialize());
+		buffer.write(converter.intToBytes(this._messageEnvelopeSize, 4, false));
 		if (0 !== this.messageEnvelopeSize)
-			buffer_.write(this._message.serialize());
+			buffer.write(this._message.serialize());
 
-		return buffer_.storage;
+		return buffer.storage;
 	}
 
 	toString() {
@@ -6086,28 +6086,28 @@ class TransferTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._type.serialize());
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._signatureSize, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(converter.intToBytes(this._recipientAddressSize, 4, false));
-		buffer_.write(this._recipientAddress.serialize());
-		buffer_.write(this._amount.serialize());
-		buffer_.write(converter.intToBytes(this._messageEnvelopeSize, 4, false));
+		const buffer = new Writer(this.size);
+		buffer.write(this._type.serialize());
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._signatureSize, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(converter.intToBytes(this._recipientAddressSize, 4, false));
+		buffer.write(this._recipientAddress.serialize());
+		buffer.write(this._amount.serialize());
+		buffer.write(converter.intToBytes(this._messageEnvelopeSize, 4, false));
 		if (0 !== this.messageEnvelopeSize)
-			buffer_.write(this._message.serialize());
+			buffer.write(this._message.serialize());
 
-		buffer_.write(converter.intToBytes(this._mosaics.length, 4, false)); // bound: mosaics_count
-		arrayHelpers.writeArray(buffer_, this._mosaics);
-		return buffer_.storage;
+		buffer.write(converter.intToBytes(this._mosaics.length, 4, false)); // bound: mosaics_count
+		arrayHelpers.writeArray(buffer, this._mosaics);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -6348,26 +6348,26 @@ class NonVerifiableTransferTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._type.serialize());
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(converter.intToBytes(this._recipientAddressSize, 4, false));
-		buffer_.write(this._recipientAddress.serialize());
-		buffer_.write(this._amount.serialize());
-		buffer_.write(converter.intToBytes(this._messageEnvelopeSize, 4, false));
+		const buffer = new Writer(this.size);
+		buffer.write(this._type.serialize());
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 2, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(converter.intToBytes(this._signerPublicKeySize, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(converter.intToBytes(this._recipientAddressSize, 4, false));
+		buffer.write(this._recipientAddress.serialize());
+		buffer.write(this._amount.serialize());
+		buffer.write(converter.intToBytes(this._messageEnvelopeSize, 4, false));
 		if (0 !== this.messageEnvelopeSize)
-			buffer_.write(this._message.serialize());
+			buffer.write(this._message.serialize());
 
-		buffer_.write(converter.intToBytes(this._mosaics.length, 4, false)); // bound: mosaics_count
-		arrayHelpers.writeArray(buffer_, this._mosaics);
-		return buffer_.storage;
+		buffer.write(converter.intToBytes(this._mosaics.length, 4, false)); // bound: mosaics_count
+		arrayHelpers.writeArray(buffer, this._mosaics);
+		return buffer.storage;
 	}
 
 	toString() {

--- a/sdk/javascript/src/symbol/models.js
+++ b/sdk/javascript/src/symbol/models.js
@@ -406,10 +406,10 @@ class Mosaic {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._mosaicId.serialize());
-		buffer_.write(this._amount.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._mosaicId.serialize());
+		buffer.write(this._amount.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -469,10 +469,10 @@ class UnresolvedMosaic {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._mosaicId.serialize());
-		buffer_.write(this._amount.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._mosaicId.serialize());
+		buffer.write(this._amount.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -806,18 +806,18 @@ class Transaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -925,15 +925,15 @@ class EmbeddedTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -1120,11 +1120,11 @@ class VrfProof {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._gamma.serialize());
-		buffer_.write(this._verificationHash.serialize());
-		buffer_.write(this._scalar.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._gamma.serialize());
+		buffer.write(this._verificationHash.serialize());
+		buffer.write(this._scalar.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -1382,26 +1382,26 @@ class Block {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._height.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(this._difficulty.serialize());
-		buffer_.write(this._generationHashProof.serialize());
-		buffer_.write(this._previousBlockHash.serialize());
-		buffer_.write(this._transactionsHash.serialize());
-		buffer_.write(this._receiptsHash.serialize());
-		buffer_.write(this._stateHash.serialize());
-		buffer_.write(this._beneficiaryAddress.serialize());
-		buffer_.write(this._feeMultiplier.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._height.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(this._difficulty.serialize());
+		buffer.write(this._generationHashProof.serialize());
+		buffer.write(this._previousBlockHash.serialize());
+		buffer.write(this._transactionsHash.serialize());
+		buffer.write(this._receiptsHash.serialize());
+		buffer.write(this._stateHash.serialize());
+		buffer.write(this._beneficiaryAddress.serialize());
+		buffer.write(this._feeMultiplier.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -1743,31 +1743,31 @@ class NemesisBlock {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._height.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(this._difficulty.serialize());
-		buffer_.write(this._generationHashProof.serialize());
-		buffer_.write(this._previousBlockHash.serialize());
-		buffer_.write(this._transactionsHash.serialize());
-		buffer_.write(this._receiptsHash.serialize());
-		buffer_.write(this._stateHash.serialize());
-		buffer_.write(this._beneficiaryAddress.serialize());
-		buffer_.write(this._feeMultiplier.serialize());
-		buffer_.write(converter.intToBytes(this._votingEligibleAccountsCount, 4, false));
-		buffer_.write(converter.intToBytes(this._harvestingEligibleAccountsCount, 8, false));
-		buffer_.write(this._totalVotingBalance.serialize());
-		buffer_.write(this._previousImportanceBlockHash.serialize());
-		arrayHelpers.writeArray(buffer_, this._transactions);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._height.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(this._difficulty.serialize());
+		buffer.write(this._generationHashProof.serialize());
+		buffer.write(this._previousBlockHash.serialize());
+		buffer.write(this._transactionsHash.serialize());
+		buffer.write(this._receiptsHash.serialize());
+		buffer.write(this._stateHash.serialize());
+		buffer.write(this._beneficiaryAddress.serialize());
+		buffer.write(this._feeMultiplier.serialize());
+		buffer.write(converter.intToBytes(this._votingEligibleAccountsCount, 4, false));
+		buffer.write(converter.intToBytes(this._harvestingEligibleAccountsCount, 8, false));
+		buffer.write(this._totalVotingBalance.serialize());
+		buffer.write(this._previousImportanceBlockHash.serialize());
+		arrayHelpers.writeArray(buffer, this._transactions);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -2066,28 +2066,28 @@ class NormalBlock {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._height.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(this._difficulty.serialize());
-		buffer_.write(this._generationHashProof.serialize());
-		buffer_.write(this._previousBlockHash.serialize());
-		buffer_.write(this._transactionsHash.serialize());
-		buffer_.write(this._receiptsHash.serialize());
-		buffer_.write(this._stateHash.serialize());
-		buffer_.write(this._beneficiaryAddress.serialize());
-		buffer_.write(this._feeMultiplier.serialize());
-		buffer_.write(converter.intToBytes(this._blockHeaderReserved_1, 4, false));
-		arrayHelpers.writeArray(buffer_, this._transactions);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._height.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(this._difficulty.serialize());
+		buffer.write(this._generationHashProof.serialize());
+		buffer.write(this._previousBlockHash.serialize());
+		buffer.write(this._transactionsHash.serialize());
+		buffer.write(this._receiptsHash.serialize());
+		buffer.write(this._stateHash.serialize());
+		buffer.write(this._beneficiaryAddress.serialize());
+		buffer.write(this._feeMultiplier.serialize());
+		buffer.write(converter.intToBytes(this._blockHeaderReserved_1, 4, false));
+		arrayHelpers.writeArray(buffer, this._transactions);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -2430,31 +2430,31 @@ class ImportanceBlock {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._height.serialize());
-		buffer_.write(this._timestamp.serialize());
-		buffer_.write(this._difficulty.serialize());
-		buffer_.write(this._generationHashProof.serialize());
-		buffer_.write(this._previousBlockHash.serialize());
-		buffer_.write(this._transactionsHash.serialize());
-		buffer_.write(this._receiptsHash.serialize());
-		buffer_.write(this._stateHash.serialize());
-		buffer_.write(this._beneficiaryAddress.serialize());
-		buffer_.write(this._feeMultiplier.serialize());
-		buffer_.write(converter.intToBytes(this._votingEligibleAccountsCount, 4, false));
-		buffer_.write(converter.intToBytes(this._harvestingEligibleAccountsCount, 8, false));
-		buffer_.write(this._totalVotingBalance.serialize());
-		buffer_.write(this._previousImportanceBlockHash.serialize());
-		arrayHelpers.writeArray(buffer_, this._transactions);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._height.serialize());
+		buffer.write(this._timestamp.serialize());
+		buffer.write(this._difficulty.serialize());
+		buffer.write(this._generationHashProof.serialize());
+		buffer.write(this._previousBlockHash.serialize());
+		buffer.write(this._transactionsHash.serialize());
+		buffer.write(this._receiptsHash.serialize());
+		buffer.write(this._stateHash.serialize());
+		buffer.write(this._beneficiaryAddress.serialize());
+		buffer.write(this._feeMultiplier.serialize());
+		buffer.write(converter.intToBytes(this._votingEligibleAccountsCount, 4, false));
+		buffer.write(converter.intToBytes(this._harvestingEligibleAccountsCount, 8, false));
+		buffer.write(this._totalVotingBalance.serialize());
+		buffer.write(this._previousImportanceBlockHash.serialize());
+		arrayHelpers.writeArray(buffer, this._transactions);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -2532,10 +2532,10 @@ class FinalizationRound {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._epoch.serialize());
-		buffer_.write(this._point.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._epoch.serialize());
+		buffer.write(this._point.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -2609,11 +2609,11 @@ class FinalizedBlockHeader {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._round.serialize());
-		buffer_.write(this._height.serialize());
-		buffer_.write(this._hash.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._round.serialize());
+		buffer.write(this._height.serialize());
+		buffer.write(this._hash.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -2753,11 +2753,11 @@ class Receipt {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 2, false));
-		buffer_.write(this._type.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._version, 2, false));
+		buffer.write(this._type.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -2850,13 +2850,13 @@ class HarvestFeeReceipt {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 2, false));
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._mosaic.serialize());
-		buffer_.write(this._targetAddress.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._version, 2, false));
+		buffer.write(this._type.serialize());
+		buffer.write(this._mosaic.serialize());
+		buffer.write(this._targetAddress.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -2937,12 +2937,12 @@ class InflationReceipt {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 2, false));
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._mosaic.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._version, 2, false));
+		buffer.write(this._type.serialize());
+		buffer.write(this._mosaic.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -3036,13 +3036,13 @@ class LockHashCreatedFeeReceipt {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 2, false));
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._mosaic.serialize());
-		buffer_.write(this._targetAddress.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._version, 2, false));
+		buffer.write(this._type.serialize());
+		buffer.write(this._mosaic.serialize());
+		buffer.write(this._targetAddress.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -3137,13 +3137,13 @@ class LockHashCompletedFeeReceipt {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 2, false));
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._mosaic.serialize());
-		buffer_.write(this._targetAddress.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._version, 2, false));
+		buffer.write(this._type.serialize());
+		buffer.write(this._mosaic.serialize());
+		buffer.write(this._targetAddress.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -3238,13 +3238,13 @@ class LockHashExpiredFeeReceipt {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 2, false));
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._mosaic.serialize());
-		buffer_.write(this._targetAddress.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._version, 2, false));
+		buffer.write(this._type.serialize());
+		buffer.write(this._mosaic.serialize());
+		buffer.write(this._targetAddress.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -3339,13 +3339,13 @@ class LockSecretCreatedFeeReceipt {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 2, false));
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._mosaic.serialize());
-		buffer_.write(this._targetAddress.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._version, 2, false));
+		buffer.write(this._type.serialize());
+		buffer.write(this._mosaic.serialize());
+		buffer.write(this._targetAddress.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -3440,13 +3440,13 @@ class LockSecretCompletedFeeReceipt {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 2, false));
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._mosaic.serialize());
-		buffer_.write(this._targetAddress.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._version, 2, false));
+		buffer.write(this._type.serialize());
+		buffer.write(this._mosaic.serialize());
+		buffer.write(this._targetAddress.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -3541,13 +3541,13 @@ class LockSecretExpiredFeeReceipt {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 2, false));
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._mosaic.serialize());
-		buffer_.write(this._targetAddress.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._version, 2, false));
+		buffer.write(this._type.serialize());
+		buffer.write(this._mosaic.serialize());
+		buffer.write(this._targetAddress.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -3628,12 +3628,12 @@ class MosaicExpiredReceipt {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 2, false));
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._artifactId.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._version, 2, false));
+		buffer.write(this._type.serialize());
+		buffer.write(this._artifactId.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -3741,14 +3741,14 @@ class MosaicRentalFeeReceipt {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 2, false));
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._mosaic.serialize());
-		buffer_.write(this._senderAddress.serialize());
-		buffer_.write(this._recipientAddress.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._version, 2, false));
+		buffer.write(this._type.serialize());
+		buffer.write(this._mosaic.serialize());
+		buffer.write(this._senderAddress.serialize());
+		buffer.write(this._recipientAddress.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -3939,12 +3939,12 @@ class NamespaceExpiredReceipt {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 2, false));
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._artifactId.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._version, 2, false));
+		buffer.write(this._type.serialize());
+		buffer.write(this._artifactId.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -4024,12 +4024,12 @@ class NamespaceDeletedReceipt {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 2, false));
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._artifactId.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._version, 2, false));
+		buffer.write(this._type.serialize());
+		buffer.write(this._artifactId.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -4137,14 +4137,14 @@ class NamespaceRentalFeeReceipt {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 2, false));
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._mosaic.serialize());
-		buffer_.write(this._senderAddress.serialize());
-		buffer_.write(this._recipientAddress.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._version, 2, false));
+		buffer.write(this._type.serialize());
+		buffer.write(this._mosaic.serialize());
+		buffer.write(this._senderAddress.serialize());
+		buffer.write(this._recipientAddress.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -4205,10 +4205,10 @@ class ReceiptSource {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._primaryId, 4, false));
-		buffer_.write(converter.intToBytes(this._secondaryId, 4, false));
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._primaryId, 4, false));
+		buffer.write(converter.intToBytes(this._secondaryId, 4, false));
+		return buffer.storage;
 	}
 
 	toString() {
@@ -4268,10 +4268,10 @@ class AddressResolutionEntry {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._source.serialize());
-		buffer_.write(this._resolvedValue.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._source.serialize());
+		buffer.write(this._resolvedValue.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -4334,11 +4334,11 @@ class AddressResolutionStatement {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._unresolved.serialize());
-		buffer_.write(converter.intToBytes(this._resolutionEntries.length, 4, false)); // bound: resolution_entries_count
-		arrayHelpers.writeArray(buffer_, this._resolutionEntries);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._unresolved.serialize());
+		buffer.write(converter.intToBytes(this._resolutionEntries.length, 4, false)); // bound: resolution_entries_count
+		arrayHelpers.writeArray(buffer, this._resolutionEntries);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -4398,10 +4398,10 @@ class MosaicResolutionEntry {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._source.serialize());
-		buffer_.write(this._resolvedValue.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._source.serialize());
+		buffer.write(this._resolvedValue.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -4464,11 +4464,11 @@ class MosaicResolutionStatement {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._unresolved.serialize());
-		buffer_.write(converter.intToBytes(this._resolutionEntries.length, 4, false)); // bound: resolution_entries_count
-		arrayHelpers.writeArray(buffer_, this._resolutionEntries);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._unresolved.serialize());
+		buffer.write(converter.intToBytes(this._resolutionEntries.length, 4, false)); // bound: resolution_entries_count
+		arrayHelpers.writeArray(buffer, this._resolutionEntries);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -4543,12 +4543,12 @@ class TransactionStatement {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._primaryId, 4, false));
-		buffer_.write(converter.intToBytes(this._secondaryId, 4, false));
-		buffer_.write(converter.intToBytes(this._receipts.length, 4, false)); // bound: receipt_count
-		arrayHelpers.writeArray(buffer_, this._receipts);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._primaryId, 4, false));
+		buffer.write(converter.intToBytes(this._secondaryId, 4, false));
+		buffer.write(converter.intToBytes(this._receipts.length, 4, false)); // bound: receipt_count
+		arrayHelpers.writeArray(buffer, this._receipts);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -4632,14 +4632,14 @@ class BlockStatement {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._transactionStatements.length, 4, false)); // bound: transaction_statement_count
-		arrayHelpers.writeArray(buffer_, this._transactionStatements);
-		buffer_.write(converter.intToBytes(this._addressResolutionStatements.length, 4, false)); // bound: address_resolution_statement_count
-		arrayHelpers.writeArray(buffer_, this._addressResolutionStatements);
-		buffer_.write(converter.intToBytes(this._mosaicResolutionStatements.length, 4, false)); // bound: mosaic_resolution_statement_count
-		arrayHelpers.writeArray(buffer_, this._mosaicResolutionStatements);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._transactionStatements.length, 4, false)); // bound: transaction_statement_count
+		arrayHelpers.writeArray(buffer, this._transactionStatements);
+		buffer.write(converter.intToBytes(this._addressResolutionStatements.length, 4, false)); // bound: address_resolution_statement_count
+		arrayHelpers.writeArray(buffer, this._addressResolutionStatements);
+		buffer.write(converter.intToBytes(this._mosaicResolutionStatements.length, 4, false)); // bound: mosaic_resolution_statement_count
+		arrayHelpers.writeArray(buffer, this._mosaicResolutionStatements);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -4858,11 +4858,11 @@ class PinnedVotingKey {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._votingKey.serialize());
-		buffer_.write(this._startEpoch.serialize());
-		buffer_.write(this._endEpoch.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._votingKey.serialize());
+		buffer.write(this._startEpoch.serialize());
+		buffer.write(this._endEpoch.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -4923,10 +4923,10 @@ class ImportanceSnapshot {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._importance.serialize());
-		buffer_.write(this._height.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._importance.serialize());
+		buffer.write(this._height.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -5012,12 +5012,12 @@ class HeightActivityBucket {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._startHeight.serialize());
-		buffer_.write(this._totalFeesPaid.serialize());
-		buffer_.write(converter.intToBytes(this._beneficiaryCount, 4, false));
-		buffer_.write(converter.intToBytes(this._rawScore, 8, false));
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._startHeight.serialize());
+		buffer.write(this._totalFeesPaid.serialize());
+		buffer.write(converter.intToBytes(this._beneficiaryCount, 4, false));
+		buffer.write(converter.intToBytes(this._rawScore, 8, false));
+		return buffer.storage;
 	}
 
 	toString() {
@@ -5065,9 +5065,9 @@ class HeightActivityBuckets {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		arrayHelpers.writeArrayCount(buffer_, this._buckets, 5);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		arrayHelpers.writeArrayCount(buffer, this._buckets, 5);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -5338,35 +5338,35 @@ class AccountState {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._version, 2, false));
-		buffer_.write(this._address.serialize());
-		buffer_.write(this._addressHeight.serialize());
-		buffer_.write(this._publicKey.serialize());
-		buffer_.write(this._publicKeyHeight.serialize());
-		buffer_.write(this._accountType.serialize());
-		buffer_.write(this._format.serialize());
-		buffer_.write(this._supplementalPublicKeysMask.serialize());
-		buffer_.write(converter.intToBytes(this._votingPublicKeys.length, 1, false)); // bound: voting_public_keys_count
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._version, 2, false));
+		buffer.write(this._address.serialize());
+		buffer.write(this._addressHeight.serialize());
+		buffer.write(this._publicKey.serialize());
+		buffer.write(this._publicKeyHeight.serialize());
+		buffer.write(this._accountType.serialize());
+		buffer.write(this._format.serialize());
+		buffer.write(this._supplementalPublicKeysMask.serialize());
+		buffer.write(converter.intToBytes(this._votingPublicKeys.length, 1, false)); // bound: voting_public_keys_count
 		if (this.supplementalPublicKeysMask.has(AccountKeyTypeFlags.LINKED))
-			buffer_.write(this._linkedPublicKey.serialize());
+			buffer.write(this._linkedPublicKey.serialize());
 
 		if (this.supplementalPublicKeysMask.has(AccountKeyTypeFlags.NODE))
-			buffer_.write(this._nodePublicKey.serialize());
+			buffer.write(this._nodePublicKey.serialize());
 
 		if (this.supplementalPublicKeysMask.has(AccountKeyTypeFlags.VRF))
-			buffer_.write(this._vrfPublicKey.serialize());
+			buffer.write(this._vrfPublicKey.serialize());
 
-		arrayHelpers.writeArray(buffer_, this._votingPublicKeys);
+		arrayHelpers.writeArray(buffer, this._votingPublicKeys);
 		if (AccountStateFormat.HIGH_VALUE === this.format)
-			buffer_.write(this._importanceSnapshots.serialize());
+			buffer.write(this._importanceSnapshots.serialize());
 
 		if (AccountStateFormat.HIGH_VALUE === this.format)
-			buffer_.write(this._activityBuckets.serialize());
+			buffer.write(this._activityBuckets.serialize());
 
-		buffer_.write(converter.intToBytes(this._balances.length, 2, false)); // bound: balances_count
-		arrayHelpers.writeArray(buffer_, this._balances);
-		return buffer_.storage;
+		buffer.write(converter.intToBytes(this._balances.length, 2, false)); // bound: balances_count
+		arrayHelpers.writeArray(buffer, this._balances);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -5550,14 +5550,14 @@ class HashLockInfo {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._version, 2, false));
-		buffer_.write(this._ownerAddress.serialize());
-		buffer_.write(this._mosaic.serialize());
-		buffer_.write(this._endHeight.serialize());
-		buffer_.write(this._status.serialize());
-		buffer_.write(this._hash.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._version, 2, false));
+		buffer.write(this._ownerAddress.serialize());
+		buffer.write(this._mosaic.serialize());
+		buffer.write(this._endHeight.serialize());
+		buffer.write(this._status.serialize());
+		buffer.write(this._hash.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -5675,10 +5675,10 @@ class MetadataValue {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._data.length, 2, false)); // bound: size
-		buffer_.write(this._data);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._data.length, 2, false)); // bound: size
+		buffer.write(this._data);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -5805,15 +5805,15 @@ class MetadataEntry {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._version, 2, false));
-		buffer_.write(this._sourceAddress.serialize());
-		buffer_.write(this._targetAddress.serialize());
-		buffer_.write(this._scopedMetadataKey.serialize());
-		buffer_.write(converter.intToBytes(this._targetId, 8, false));
-		buffer_.write(this._metadataType.serialize());
-		buffer_.write(this._value.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._version, 2, false));
+		buffer.write(this._sourceAddress.serialize());
+		buffer.write(this._targetAddress.serialize());
+		buffer.write(this._scopedMetadataKey.serialize());
+		buffer.write(converter.intToBytes(this._targetId, 8, false));
+		buffer.write(this._metadataType.serialize());
+		buffer.write(this._value.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -6004,11 +6004,11 @@ class MosaicProperties {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._flags.serialize());
-		buffer_.write(converter.intToBytes(this._divisibility, 1, false));
-		buffer_.write(this._duration.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._flags.serialize());
+		buffer.write(converter.intToBytes(this._divisibility, 1, false));
+		buffer.write(this._duration.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -6096,12 +6096,12 @@ class MosaicDefinition {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._startHeight.serialize());
-		buffer_.write(this._ownerAddress.serialize());
-		buffer_.write(converter.intToBytes(this._revision, 4, false));
-		buffer_.write(this._properties.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._startHeight.serialize());
+		buffer.write(this._ownerAddress.serialize());
+		buffer.write(converter.intToBytes(this._revision, 4, false));
+		buffer.write(this._properties.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -6190,12 +6190,12 @@ class MosaicEntry {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._version, 2, false));
-		buffer_.write(this._mosaicId.serialize());
-		buffer_.write(this._supply.serialize());
-		buffer_.write(this._definition.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._version, 2, false));
+		buffer.write(this._mosaicId.serialize());
+		buffer.write(this._supply.serialize());
+		buffer.write(this._definition.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -6316,16 +6316,16 @@ class MultisigEntry {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._version, 2, false));
-		buffer_.write(converter.intToBytes(this._minApproval, 4, false));
-		buffer_.write(converter.intToBytes(this._minRemoval, 4, false));
-		buffer_.write(this._accountAddress.serialize());
-		buffer_.write(converter.intToBytes(this._cosignatoryAddresses.length, 8, false)); // bound: cosignatory_addresses_count
-		arrayHelpers.writeArray(buffer_, this._cosignatoryAddresses);
-		buffer_.write(converter.intToBytes(this._multisigAddresses.length, 8, false)); // bound: multisig_addresses_count
-		arrayHelpers.writeArray(buffer_, this._multisigAddresses);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._version, 2, false));
+		buffer.write(converter.intToBytes(this._minApproval, 4, false));
+		buffer.write(converter.intToBytes(this._minRemoval, 4, false));
+		buffer.write(this._accountAddress.serialize());
+		buffer.write(converter.intToBytes(this._cosignatoryAddresses.length, 8, false)); // bound: cosignatory_addresses_count
+		arrayHelpers.writeArray(buffer, this._cosignatoryAddresses);
+		buffer.write(converter.intToBytes(this._multisigAddresses.length, 8, false)); // bound: multisig_addresses_count
+		arrayHelpers.writeArray(buffer, this._multisigAddresses);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -6389,10 +6389,10 @@ class NamespaceLifetime {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._lifetimeStart.serialize());
-		buffer_.write(this._lifetimeEnd.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._lifetimeStart.serialize());
+		buffer.write(this._lifetimeEnd.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -6524,15 +6524,15 @@ class NamespaceAlias {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._namespaceAliasType.serialize());
+		const buffer = new Writer(this.size);
+		buffer.write(this._namespaceAliasType.serialize());
 		if (NamespaceAliasType.MOSAIC_ID === this.namespaceAliasType)
-			buffer_.write(this._mosaicAlias.serialize());
+			buffer.write(this._mosaicAlias.serialize());
 
 		if (NamespaceAliasType.ADDRESS === this.namespaceAliasType)
-			buffer_.write(this._addressAlias.serialize());
+			buffer.write(this._addressAlias.serialize());
 
-		return buffer_.storage;
+		return buffer.storage;
 	}
 
 	toString() {
@@ -6600,11 +6600,11 @@ class NamespacePath {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._path.length, 1, false)); // bound: path_size
-		arrayHelpers.writeArray(buffer_, this._path);
-		buffer_.write(this._alias.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._path.length, 1, false)); // bound: path_size
+		arrayHelpers.writeArray(buffer, this._path);
+		buffer.write(this._alias.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -6722,15 +6722,15 @@ class RootNamespaceHistory {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._version, 2, false));
-		buffer_.write(this._id.serialize());
-		buffer_.write(this._ownerAddress.serialize());
-		buffer_.write(this._lifetime.serialize());
-		buffer_.write(this._rootAlias.serialize());
-		buffer_.write(converter.intToBytes(this._paths.length, 8, false)); // bound: children_count
-		arrayHelpers.writeArray(buffer_, this._paths, e => e.path.value);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._version, 2, false));
+		buffer.write(this._id.serialize());
+		buffer.write(this._ownerAddress.serialize());
+		buffer.write(this._lifetime.serialize());
+		buffer.write(this._rootAlias.serialize());
+		buffer.write(converter.intToBytes(this._paths.length, 8, false)); // bound: children_count
+		arrayHelpers.writeArray(buffer, this._paths, e => e.path.value);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -6833,10 +6833,10 @@ class AccountRestrictionAddressValue {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._restrictionValues.length, 8, false)); // bound: restriction_values_count
-		arrayHelpers.writeArray(buffer_, this._restrictionValues);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._restrictionValues.length, 8, false)); // bound: restriction_values_count
+		arrayHelpers.writeArray(buffer, this._restrictionValues);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -6884,10 +6884,10 @@ class AccountRestrictionMosaicValue {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._restrictionValues.length, 8, false)); // bound: restriction_values_count
-		arrayHelpers.writeArray(buffer_, this._restrictionValues);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._restrictionValues.length, 8, false)); // bound: restriction_values_count
+		arrayHelpers.writeArray(buffer, this._restrictionValues);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -6935,10 +6935,10 @@ class AccountRestrictionTransactionTypeValue {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._restrictionValues.length, 8, false)); // bound: restriction_values_count
-		arrayHelpers.writeArray(buffer_, this._restrictionValues);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._restrictionValues.length, 8, false)); // bound: restriction_values_count
+		arrayHelpers.writeArray(buffer, this._restrictionValues);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -7040,18 +7040,18 @@ class AccountRestrictionsInfo {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._restrictionFlags.serialize());
+		const buffer = new Writer(this.size);
+		buffer.write(this._restrictionFlags.serialize());
 		if (this.restrictionFlags.has(AccountRestrictionFlags.ADDRESS))
-			buffer_.write(this._addressRestrictions.serialize());
+			buffer.write(this._addressRestrictions.serialize());
 
 		if (this.restrictionFlags.has(AccountRestrictionFlags.MOSAIC_ID))
-			buffer_.write(this._mosaicIdRestrictions.serialize());
+			buffer.write(this._mosaicIdRestrictions.serialize());
 
 		if (this.restrictionFlags.has(AccountRestrictionFlags.TRANSACTION_TYPE))
-			buffer_.write(this._transactionTypeRestrictions.serialize());
+			buffer.write(this._transactionTypeRestrictions.serialize());
 
-		return buffer_.storage;
+		return buffer.storage;
 	}
 
 	toString() {
@@ -7135,12 +7135,12 @@ class AccountRestrictions {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._version, 2, false));
-		buffer_.write(this._address.serialize());
-		buffer_.write(converter.intToBytes(this._restrictions.length, 8, false)); // bound: restrictions_count
-		arrayHelpers.writeArray(buffer_, this._restrictions);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._version, 2, false));
+		buffer.write(this._address.serialize());
+		buffer.write(converter.intToBytes(this._restrictions.length, 8, false)); // bound: restrictions_count
+		arrayHelpers.writeArray(buffer, this._restrictions);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -7319,10 +7319,10 @@ class AddressKeyValue {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._key.serialize());
-		buffer_.write(converter.intToBytes(this._value, 8, false));
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._key.serialize());
+		buffer.write(converter.intToBytes(this._value, 8, false));
+		return buffer.storage;
 	}
 
 	toString() {
@@ -7371,10 +7371,10 @@ class AddressKeyValueSet {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._keys.length, 1, false)); // bound: key_value_count
-		arrayHelpers.writeArray(buffer_, this._keys, e => e.key.value);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._keys.length, 1, false)); // bound: key_value_count
+		arrayHelpers.writeArray(buffer, this._keys, e => e.key.value);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -7446,11 +7446,11 @@ class RestrictionRule {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._referenceMosaicId.serialize());
-		buffer_.write(converter.intToBytes(this._restrictionValue, 8, false));
-		buffer_.write(this._restrictionType.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._referenceMosaicId.serialize());
+		buffer.write(converter.intToBytes(this._restrictionValue, 8, false));
+		buffer.write(this._restrictionType.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -7511,10 +7511,10 @@ class GlobalKeyValue {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._key.serialize());
-		buffer_.write(this._restrictionRule.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._key.serialize());
+		buffer.write(this._restrictionRule.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -7563,10 +7563,10 @@ class GlobalKeyValueSet {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._keys.length, 1, false)); // bound: key_value_count
-		arrayHelpers.writeArray(buffer_, this._keys, e => e.key.value);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._keys.length, 1, false)); // bound: key_value_count
+		arrayHelpers.writeArray(buffer, this._keys, e => e.key.value);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -7639,11 +7639,11 @@ class MosaicAddressRestrictionEntry {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._mosaicId.serialize());
-		buffer_.write(this._address.serialize());
-		buffer_.write(this._keyPairs.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._mosaicId.serialize());
+		buffer.write(this._address.serialize());
+		buffer.write(this._keyPairs.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -7704,10 +7704,10 @@ class MosaicGlobalRestrictionEntry {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(this._mosaicId.serialize());
-		buffer_.write(this._keyPairs.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(this._mosaicId.serialize());
+		buffer.write(this._keyPairs.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -7804,16 +7804,16 @@ class MosaicRestrictionEntry {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._version, 2, false));
-		buffer_.write(this._entryType.serialize());
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._version, 2, false));
+		buffer.write(this._entryType.serialize());
 		if (MosaicRestrictionEntryType.ADDRESS === this.entryType)
-			buffer_.write(this._addressEntry.serialize());
+			buffer.write(this._addressEntry.serialize());
 
 		if (MosaicRestrictionEntryType.GLOBAL === this.entryType)
-			buffer_.write(this._globalEntry.serialize());
+			buffer.write(this._globalEntry.serialize());
 
-		return buffer_.storage;
+		return buffer.storage;
 	}
 
 	toString() {
@@ -8010,16 +8010,16 @@ class SecretLockInfo {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._version, 2, false));
-		buffer_.write(this._ownerAddress.serialize());
-		buffer_.write(this._mosaic.serialize());
-		buffer_.write(this._endHeight.serialize());
-		buffer_.write(this._status.serialize());
-		buffer_.write(this._hashAlgorithm.serialize());
-		buffer_.write(this._secret.serialize());
-		buffer_.write(this._recipient.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._version, 2, false));
+		buffer.write(this._ownerAddress.serialize());
+		buffer.write(this._mosaic.serialize());
+		buffer.write(this._endHeight.serialize());
+		buffer.write(this._status.serialize());
+		buffer.write(this._hashAlgorithm.serialize());
+		buffer.write(this._secret.serialize());
+		buffer.write(this._recipient.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -8202,20 +8202,20 @@ class AccountKeyLinkTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._linkedPublicKey.serialize());
-		buffer_.write(this._linkAction.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._linkedPublicKey.serialize());
+		buffer.write(this._linkAction.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -8357,17 +8357,17 @@ class EmbeddedAccountKeyLinkTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._linkedPublicKey.serialize());
-		buffer_.write(this._linkAction.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._linkedPublicKey.serialize());
+		buffer.write(this._linkAction.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -8548,20 +8548,20 @@ class NodeKeyLinkTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._linkedPublicKey.serialize());
-		buffer_.write(this._linkAction.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._linkedPublicKey.serialize());
+		buffer.write(this._linkAction.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -8703,17 +8703,17 @@ class EmbeddedNodeKeyLinkTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._linkedPublicKey.serialize());
-		buffer_.write(this._linkAction.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._linkedPublicKey.serialize());
+		buffer.write(this._linkAction.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -8790,11 +8790,11 @@ class Cosignature {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._version, 8, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(this._signature.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._version, 8, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(this._signature.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -8882,12 +8882,12 @@ class DetachedCosignature {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this._version, 8, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._parentHash.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this._version, 8, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(this._signature.serialize());
+		buffer.write(this._parentHash.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -9089,23 +9089,23 @@ class AggregateCompleteTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._transactionsHash.serialize());
-		buffer_.write(converter.intToBytes(this.transactions.map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0), 4, false)); // bound: payload_size
-		buffer_.write(converter.intToBytes(this._aggregateTransactionHeaderReserved_1, 4, false));
-		arrayHelpers.writeVariableSizeElements(buffer_, this._transactions, 8);
-		arrayHelpers.writeArray(buffer_, this._cosignatures);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._transactionsHash.serialize());
+		buffer.write(converter.intToBytes(this.transactions.map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0), 4, false)); // bound: payload_size
+		buffer.write(converter.intToBytes(this._aggregateTransactionHeaderReserved_1, 4, false));
+		arrayHelpers.writeVariableSizeElements(buffer, this._transactions, 8);
+		arrayHelpers.writeArray(buffer, this._cosignatures);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -9313,23 +9313,23 @@ class AggregateBondedTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._transactionsHash.serialize());
-		buffer_.write(converter.intToBytes(this.transactions.map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0), 4, false)); // bound: payload_size
-		buffer_.write(converter.intToBytes(this._aggregateTransactionHeaderReserved_1, 4, false));
-		arrayHelpers.writeVariableSizeElements(buffer_, this._transactions, 8);
-		arrayHelpers.writeArray(buffer_, this._cosignatures);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._transactionsHash.serialize());
+		buffer.write(converter.intToBytes(this.transactions.map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0), 4, false)); // bound: payload_size
+		buffer.write(converter.intToBytes(this._aggregateTransactionHeaderReserved_1, 4, false));
+		arrayHelpers.writeVariableSizeElements(buffer, this._transactions, 8);
+		arrayHelpers.writeArray(buffer, this._cosignatures);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -9542,22 +9542,22 @@ class VotingKeyLinkTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._linkedPublicKey.serialize());
-		buffer_.write(this._startEpoch.serialize());
-		buffer_.write(this._endEpoch.serialize());
-		buffer_.write(this._linkAction.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._linkedPublicKey.serialize());
+		buffer.write(this._startEpoch.serialize());
+		buffer.write(this._endEpoch.serialize());
+		buffer.write(this._linkAction.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -9729,19 +9729,19 @@ class EmbeddedVotingKeyLinkTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._linkedPublicKey.serialize());
-		buffer_.write(this._startEpoch.serialize());
-		buffer_.write(this._endEpoch.serialize());
-		buffer_.write(this._linkAction.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._linkedPublicKey.serialize());
+		buffer.write(this._startEpoch.serialize());
+		buffer.write(this._endEpoch.serialize());
+		buffer.write(this._linkAction.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -9924,20 +9924,20 @@ class VrfKeyLinkTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._linkedPublicKey.serialize());
-		buffer_.write(this._linkAction.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._linkedPublicKey.serialize());
+		buffer.write(this._linkAction.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -10079,17 +10079,17 @@ class EmbeddedVrfKeyLinkTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._linkedPublicKey.serialize());
-		buffer_.write(this._linkAction.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._linkedPublicKey.serialize());
+		buffer.write(this._linkAction.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -10284,21 +10284,21 @@ class HashLockTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._mosaic.serialize());
-		buffer_.write(this._duration.serialize());
-		buffer_.write(this._hash.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._mosaic.serialize());
+		buffer.write(this._duration.serialize());
+		buffer.write(this._hash.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -10455,18 +10455,18 @@ class EmbeddedHashLockTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._mosaic.serialize());
-		buffer_.write(this._duration.serialize());
-		buffer_.write(this._hash.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._mosaic.serialize());
+		buffer.write(this._duration.serialize());
+		buffer.write(this._hash.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -10690,23 +10690,23 @@ class SecretLockTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._recipientAddress.serialize());
-		buffer_.write(this._secret.serialize());
-		buffer_.write(this._mosaic.serialize());
-		buffer_.write(this._duration.serialize());
-		buffer_.write(this._hashAlgorithm.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._recipientAddress.serialize());
+		buffer.write(this._secret.serialize());
+		buffer.write(this._mosaic.serialize());
+		buffer.write(this._duration.serialize());
+		buffer.write(this._hashAlgorithm.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -10893,20 +10893,20 @@ class EmbeddedSecretLockTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._recipientAddress.serialize());
-		buffer_.write(this._secret.serialize());
-		buffer_.write(this._mosaic.serialize());
-		buffer_.write(this._duration.serialize());
-		buffer_.write(this._hashAlgorithm.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._recipientAddress.serialize());
+		buffer.write(this._secret.serialize());
+		buffer.write(this._mosaic.serialize());
+		buffer.write(this._duration.serialize());
+		buffer.write(this._hashAlgorithm.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -11121,23 +11121,23 @@ class SecretProofTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._recipientAddress.serialize());
-		buffer_.write(this._secret.serialize());
-		buffer_.write(converter.intToBytes(this._proof.length, 2, false)); // bound: proof_size
-		buffer_.write(this._hashAlgorithm.serialize());
-		buffer_.write(this._proof);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._recipientAddress.serialize());
+		buffer.write(this._secret.serialize());
+		buffer.write(converter.intToBytes(this._proof.length, 2, false)); // bound: proof_size
+		buffer.write(this._hashAlgorithm.serialize());
+		buffer.write(this._proof);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -11312,20 +11312,20 @@ class EmbeddedSecretProofTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._recipientAddress.serialize());
-		buffer_.write(this._secret.serialize());
-		buffer_.write(converter.intToBytes(this._proof.length, 2, false)); // bound: proof_size
-		buffer_.write(this._hashAlgorithm.serialize());
-		buffer_.write(this._proof);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._recipientAddress.serialize());
+		buffer.write(this._secret.serialize());
+		buffer.write(converter.intToBytes(this._proof.length, 2, false)); // bound: proof_size
+		buffer.write(this._hashAlgorithm.serialize());
+		buffer.write(this._proof);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -11537,23 +11537,23 @@ class AccountMetadataTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._targetAddress.serialize());
-		buffer_.write(converter.intToBytes(this._scopedMetadataKey, 8, false));
-		buffer_.write(converter.intToBytes(this._valueSizeDelta, 2, true));
-		buffer_.write(converter.intToBytes(this._value.length, 2, false)); // bound: value_size
-		buffer_.write(this._value);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._targetAddress.serialize());
+		buffer.write(converter.intToBytes(this._scopedMetadataKey, 8, false));
+		buffer.write(converter.intToBytes(this._valueSizeDelta, 2, true));
+		buffer.write(converter.intToBytes(this._value.length, 2, false)); // bound: value_size
+		buffer.write(this._value);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -11726,20 +11726,20 @@ class EmbeddedAccountMetadataTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._targetAddress.serialize());
-		buffer_.write(converter.intToBytes(this._scopedMetadataKey, 8, false));
-		buffer_.write(converter.intToBytes(this._valueSizeDelta, 2, true));
-		buffer_.write(converter.intToBytes(this._value.length, 2, false)); // bound: value_size
-		buffer_.write(this._value);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._targetAddress.serialize());
+		buffer.write(converter.intToBytes(this._scopedMetadataKey, 8, false));
+		buffer.write(converter.intToBytes(this._valueSizeDelta, 2, true));
+		buffer.write(converter.intToBytes(this._value.length, 2, false)); // bound: value_size
+		buffer.write(this._value);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -11965,24 +11965,24 @@ class MosaicMetadataTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._targetAddress.serialize());
-		buffer_.write(converter.intToBytes(this._scopedMetadataKey, 8, false));
-		buffer_.write(this._targetMosaicId.serialize());
-		buffer_.write(converter.intToBytes(this._valueSizeDelta, 2, true));
-		buffer_.write(converter.intToBytes(this._value.length, 2, false)); // bound: value_size
-		buffer_.write(this._value);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._targetAddress.serialize());
+		buffer.write(converter.intToBytes(this._scopedMetadataKey, 8, false));
+		buffer.write(this._targetMosaicId.serialize());
+		buffer.write(converter.intToBytes(this._valueSizeDelta, 2, true));
+		buffer.write(converter.intToBytes(this._value.length, 2, false)); // bound: value_size
+		buffer.write(this._value);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -12170,21 +12170,21 @@ class EmbeddedMosaicMetadataTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._targetAddress.serialize());
-		buffer_.write(converter.intToBytes(this._scopedMetadataKey, 8, false));
-		buffer_.write(this._targetMosaicId.serialize());
-		buffer_.write(converter.intToBytes(this._valueSizeDelta, 2, true));
-		buffer_.write(converter.intToBytes(this._value.length, 2, false)); // bound: value_size
-		buffer_.write(this._value);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._targetAddress.serialize());
+		buffer.write(converter.intToBytes(this._scopedMetadataKey, 8, false));
+		buffer.write(this._targetMosaicId.serialize());
+		buffer.write(converter.intToBytes(this._valueSizeDelta, 2, true));
+		buffer.write(converter.intToBytes(this._value.length, 2, false)); // bound: value_size
+		buffer.write(this._value);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -12411,24 +12411,24 @@ class NamespaceMetadataTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._targetAddress.serialize());
-		buffer_.write(converter.intToBytes(this._scopedMetadataKey, 8, false));
-		buffer_.write(this._targetNamespaceId.serialize());
-		buffer_.write(converter.intToBytes(this._valueSizeDelta, 2, true));
-		buffer_.write(converter.intToBytes(this._value.length, 2, false)); // bound: value_size
-		buffer_.write(this._value);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._targetAddress.serialize());
+		buffer.write(converter.intToBytes(this._scopedMetadataKey, 8, false));
+		buffer.write(this._targetNamespaceId.serialize());
+		buffer.write(converter.intToBytes(this._valueSizeDelta, 2, true));
+		buffer.write(converter.intToBytes(this._value.length, 2, false)); // bound: value_size
+		buffer.write(this._value);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -12616,21 +12616,21 @@ class EmbeddedNamespaceMetadataTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._targetAddress.serialize());
-		buffer_.write(converter.intToBytes(this._scopedMetadataKey, 8, false));
-		buffer_.write(this._targetNamespaceId.serialize());
-		buffer_.write(converter.intToBytes(this._valueSizeDelta, 2, true));
-		buffer_.write(converter.intToBytes(this._value.length, 2, false)); // bound: value_size
-		buffer_.write(this._value);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._targetAddress.serialize());
+		buffer.write(converter.intToBytes(this._scopedMetadataKey, 8, false));
+		buffer.write(this._targetNamespaceId.serialize());
+		buffer.write(converter.intToBytes(this._valueSizeDelta, 2, true));
+		buffer.write(converter.intToBytes(this._value.length, 2, false)); // bound: value_size
+		buffer.write(this._value);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -12855,23 +12855,23 @@ class MosaicDefinitionTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._id.serialize());
-		buffer_.write(this._duration.serialize());
-		buffer_.write(this._nonce.serialize());
-		buffer_.write(this._flags.serialize());
-		buffer_.write(converter.intToBytes(this._divisibility, 1, false));
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._id.serialize());
+		buffer.write(this._duration.serialize());
+		buffer.write(this._nonce.serialize());
+		buffer.write(this._flags.serialize());
+		buffer.write(converter.intToBytes(this._divisibility, 1, false));
+		return buffer.storage;
 	}
 
 	toString() {
@@ -13057,20 +13057,20 @@ class EmbeddedMosaicDefinitionTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._id.serialize());
-		buffer_.write(this._duration.serialize());
-		buffer_.write(this._nonce.serialize());
-		buffer_.write(this._flags.serialize());
-		buffer_.write(converter.intToBytes(this._divisibility, 1, false));
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._id.serialize());
+		buffer.write(this._duration.serialize());
+		buffer.write(this._nonce.serialize());
+		buffer.write(this._flags.serialize());
+		buffer.write(converter.intToBytes(this._divisibility, 1, false));
+		return buffer.storage;
 	}
 
 	toString() {
@@ -13268,21 +13268,21 @@ class MosaicSupplyChangeTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._mosaicId.serialize());
-		buffer_.write(this._delta.serialize());
-		buffer_.write(this._action.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._mosaicId.serialize());
+		buffer.write(this._delta.serialize());
+		buffer.write(this._action.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -13439,18 +13439,18 @@ class EmbeddedMosaicSupplyChangeTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._mosaicId.serialize());
-		buffer_.write(this._delta.serialize());
-		buffer_.write(this._action.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._mosaicId.serialize());
+		buffer.write(this._delta.serialize());
+		buffer.write(this._action.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -13632,20 +13632,20 @@ class MosaicSupplyRevocationTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._sourceAddress.serialize());
-		buffer_.write(this._mosaic.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._sourceAddress.serialize());
+		buffer.write(this._mosaic.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -13787,17 +13787,17 @@ class EmbeddedMosaicSupplyRevocationTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._sourceAddress.serialize());
-		buffer_.write(this._mosaic.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._sourceAddress.serialize());
+		buffer.write(this._mosaic.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -14016,25 +14016,25 @@ class MultisigAccountModificationTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(converter.intToBytes(this._minRemovalDelta, 1, true));
-		buffer_.write(converter.intToBytes(this._minApprovalDelta, 1, true));
-		buffer_.write(converter.intToBytes(this._addressAdditions.length, 1, false)); // bound: address_additions_count
-		buffer_.write(converter.intToBytes(this._addressDeletions.length, 1, false)); // bound: address_deletions_count
-		buffer_.write(converter.intToBytes(this._multisigAccountModificationTransactionBodyReserved_1, 4, false));
-		arrayHelpers.writeArray(buffer_, this._addressAdditions);
-		arrayHelpers.writeArray(buffer_, this._addressDeletions);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(converter.intToBytes(this._minRemovalDelta, 1, true));
+		buffer.write(converter.intToBytes(this._minApprovalDelta, 1, true));
+		buffer.write(converter.intToBytes(this._addressAdditions.length, 1, false)); // bound: address_additions_count
+		buffer.write(converter.intToBytes(this._addressDeletions.length, 1, false)); // bound: address_deletions_count
+		buffer.write(converter.intToBytes(this._multisigAccountModificationTransactionBodyReserved_1, 4, false));
+		arrayHelpers.writeArray(buffer, this._addressAdditions);
+		arrayHelpers.writeArray(buffer, this._addressDeletions);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -14216,22 +14216,22 @@ class EmbeddedMultisigAccountModificationTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(converter.intToBytes(this._minRemovalDelta, 1, true));
-		buffer_.write(converter.intToBytes(this._minApprovalDelta, 1, true));
-		buffer_.write(converter.intToBytes(this._addressAdditions.length, 1, false)); // bound: address_additions_count
-		buffer_.write(converter.intToBytes(this._addressDeletions.length, 1, false)); // bound: address_deletions_count
-		buffer_.write(converter.intToBytes(this._multisigAccountModificationTransactionBodyReserved_1, 4, false));
-		arrayHelpers.writeArray(buffer_, this._addressAdditions);
-		arrayHelpers.writeArray(buffer_, this._addressDeletions);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(converter.intToBytes(this._minRemovalDelta, 1, true));
+		buffer.write(converter.intToBytes(this._minApprovalDelta, 1, true));
+		buffer.write(converter.intToBytes(this._addressAdditions.length, 1, false)); // bound: address_additions_count
+		buffer.write(converter.intToBytes(this._addressDeletions.length, 1, false)); // bound: address_deletions_count
+		buffer.write(converter.intToBytes(this._multisigAccountModificationTransactionBodyReserved_1, 4, false));
+		arrayHelpers.writeArray(buffer, this._addressAdditions);
+		arrayHelpers.writeArray(buffer, this._addressDeletions);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -14428,21 +14428,21 @@ class AddressAliasTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._namespaceId.serialize());
-		buffer_.write(this._address.serialize());
-		buffer_.write(this._aliasAction.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._namespaceId.serialize());
+		buffer.write(this._address.serialize());
+		buffer.write(this._aliasAction.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -14599,18 +14599,18 @@ class EmbeddedAddressAliasTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._namespaceId.serialize());
-		buffer_.write(this._address.serialize());
-		buffer_.write(this._aliasAction.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._namespaceId.serialize());
+		buffer.write(this._address.serialize());
+		buffer.write(this._aliasAction.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -14806,21 +14806,21 @@ class MosaicAliasTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._namespaceId.serialize());
-		buffer_.write(this._mosaicId.serialize());
-		buffer_.write(this._aliasAction.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._namespaceId.serialize());
+		buffer.write(this._mosaicId.serialize());
+		buffer.write(this._aliasAction.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -14977,18 +14977,18 @@ class EmbeddedMosaicAliasTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._namespaceId.serialize());
-		buffer_.write(this._mosaicId.serialize());
-		buffer_.write(this._aliasAction.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._namespaceId.serialize());
+		buffer.write(this._mosaicId.serialize());
+		buffer.write(this._aliasAction.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -15228,28 +15228,28 @@ class NamespaceRegistrationTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
 		if (NamespaceRegistrationType.ROOT === this.registrationType)
-			buffer_.write(this._duration.serialize());
+			buffer.write(this._duration.serialize());
 
 		if (NamespaceRegistrationType.CHILD === this.registrationType)
-			buffer_.write(this._parentId.serialize());
+			buffer.write(this._parentId.serialize());
 
-		buffer_.write(this._id.serialize());
-		buffer_.write(this._registrationType.serialize());
-		buffer_.write(converter.intToBytes(this._name.length, 1, false)); // bound: name_size
-		buffer_.write(this._name);
-		return buffer_.storage;
+		buffer.write(this._id.serialize());
+		buffer.write(this._registrationType.serialize());
+		buffer.write(converter.intToBytes(this._name.length, 1, false)); // bound: name_size
+		buffer.write(this._name);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -15456,25 +15456,25 @@ class EmbeddedNamespaceRegistrationTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
 		if (NamespaceRegistrationType.ROOT === this.registrationType)
-			buffer_.write(this._duration.serialize());
+			buffer.write(this._duration.serialize());
 
 		if (NamespaceRegistrationType.CHILD === this.registrationType)
-			buffer_.write(this._parentId.serialize());
+			buffer.write(this._parentId.serialize());
 
-		buffer_.write(this._id.serialize());
-		buffer_.write(this._registrationType.serialize());
-		buffer_.write(converter.intToBytes(this._name.length, 1, false)); // bound: name_size
-		buffer_.write(this._name);
-		return buffer_.storage;
+		buffer.write(this._id.serialize());
+		buffer.write(this._registrationType.serialize());
+		buffer.write(converter.intToBytes(this._name.length, 1, false)); // bound: name_size
+		buffer.write(this._name);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -15688,24 +15688,24 @@ class AccountAddressRestrictionTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._restrictionFlags.serialize());
-		buffer_.write(converter.intToBytes(this._restrictionAdditions.length, 1, false)); // bound: restriction_additions_count
-		buffer_.write(converter.intToBytes(this._restrictionDeletions.length, 1, false)); // bound: restriction_deletions_count
-		buffer_.write(converter.intToBytes(this._accountRestrictionTransactionBodyReserved_1, 4, false));
-		arrayHelpers.writeArray(buffer_, this._restrictionAdditions);
-		arrayHelpers.writeArray(buffer_, this._restrictionDeletions);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._restrictionFlags.serialize());
+		buffer.write(converter.intToBytes(this._restrictionAdditions.length, 1, false)); // bound: restriction_additions_count
+		buffer.write(converter.intToBytes(this._restrictionDeletions.length, 1, false)); // bound: restriction_deletions_count
+		buffer.write(converter.intToBytes(this._accountRestrictionTransactionBodyReserved_1, 4, false));
+		arrayHelpers.writeArray(buffer, this._restrictionAdditions);
+		arrayHelpers.writeArray(buffer, this._restrictionDeletions);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -15874,21 +15874,21 @@ class EmbeddedAccountAddressRestrictionTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._restrictionFlags.serialize());
-		buffer_.write(converter.intToBytes(this._restrictionAdditions.length, 1, false)); // bound: restriction_additions_count
-		buffer_.write(converter.intToBytes(this._restrictionDeletions.length, 1, false)); // bound: restriction_deletions_count
-		buffer_.write(converter.intToBytes(this._accountRestrictionTransactionBodyReserved_1, 4, false));
-		arrayHelpers.writeArray(buffer_, this._restrictionAdditions);
-		arrayHelpers.writeArray(buffer_, this._restrictionDeletions);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._restrictionFlags.serialize());
+		buffer.write(converter.intToBytes(this._restrictionAdditions.length, 1, false)); // bound: restriction_additions_count
+		buffer.write(converter.intToBytes(this._restrictionDeletions.length, 1, false)); // bound: restriction_deletions_count
+		buffer.write(converter.intToBytes(this._accountRestrictionTransactionBodyReserved_1, 4, false));
+		arrayHelpers.writeArray(buffer, this._restrictionAdditions);
+		arrayHelpers.writeArray(buffer, this._restrictionDeletions);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -16096,24 +16096,24 @@ class AccountMosaicRestrictionTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._restrictionFlags.serialize());
-		buffer_.write(converter.intToBytes(this._restrictionAdditions.length, 1, false)); // bound: restriction_additions_count
-		buffer_.write(converter.intToBytes(this._restrictionDeletions.length, 1, false)); // bound: restriction_deletions_count
-		buffer_.write(converter.intToBytes(this._accountRestrictionTransactionBodyReserved_1, 4, false));
-		arrayHelpers.writeArray(buffer_, this._restrictionAdditions);
-		arrayHelpers.writeArray(buffer_, this._restrictionDeletions);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._restrictionFlags.serialize());
+		buffer.write(converter.intToBytes(this._restrictionAdditions.length, 1, false)); // bound: restriction_additions_count
+		buffer.write(converter.intToBytes(this._restrictionDeletions.length, 1, false)); // bound: restriction_deletions_count
+		buffer.write(converter.intToBytes(this._accountRestrictionTransactionBodyReserved_1, 4, false));
+		arrayHelpers.writeArray(buffer, this._restrictionAdditions);
+		arrayHelpers.writeArray(buffer, this._restrictionDeletions);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -16282,21 +16282,21 @@ class EmbeddedAccountMosaicRestrictionTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._restrictionFlags.serialize());
-		buffer_.write(converter.intToBytes(this._restrictionAdditions.length, 1, false)); // bound: restriction_additions_count
-		buffer_.write(converter.intToBytes(this._restrictionDeletions.length, 1, false)); // bound: restriction_deletions_count
-		buffer_.write(converter.intToBytes(this._accountRestrictionTransactionBodyReserved_1, 4, false));
-		arrayHelpers.writeArray(buffer_, this._restrictionAdditions);
-		arrayHelpers.writeArray(buffer_, this._restrictionDeletions);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._restrictionFlags.serialize());
+		buffer.write(converter.intToBytes(this._restrictionAdditions.length, 1, false)); // bound: restriction_additions_count
+		buffer.write(converter.intToBytes(this._restrictionDeletions.length, 1, false)); // bound: restriction_deletions_count
+		buffer.write(converter.intToBytes(this._accountRestrictionTransactionBodyReserved_1, 4, false));
+		arrayHelpers.writeArray(buffer, this._restrictionAdditions);
+		arrayHelpers.writeArray(buffer, this._restrictionDeletions);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -16504,24 +16504,24 @@ class AccountOperationRestrictionTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._restrictionFlags.serialize());
-		buffer_.write(converter.intToBytes(this._restrictionAdditions.length, 1, false)); // bound: restriction_additions_count
-		buffer_.write(converter.intToBytes(this._restrictionDeletions.length, 1, false)); // bound: restriction_deletions_count
-		buffer_.write(converter.intToBytes(this._accountRestrictionTransactionBodyReserved_1, 4, false));
-		arrayHelpers.writeArray(buffer_, this._restrictionAdditions);
-		arrayHelpers.writeArray(buffer_, this._restrictionDeletions);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._restrictionFlags.serialize());
+		buffer.write(converter.intToBytes(this._restrictionAdditions.length, 1, false)); // bound: restriction_additions_count
+		buffer.write(converter.intToBytes(this._restrictionDeletions.length, 1, false)); // bound: restriction_deletions_count
+		buffer.write(converter.intToBytes(this._accountRestrictionTransactionBodyReserved_1, 4, false));
+		arrayHelpers.writeArray(buffer, this._restrictionAdditions);
+		arrayHelpers.writeArray(buffer, this._restrictionDeletions);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -16690,21 +16690,21 @@ class EmbeddedAccountOperationRestrictionTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._restrictionFlags.serialize());
-		buffer_.write(converter.intToBytes(this._restrictionAdditions.length, 1, false)); // bound: restriction_additions_count
-		buffer_.write(converter.intToBytes(this._restrictionDeletions.length, 1, false)); // bound: restriction_deletions_count
-		buffer_.write(converter.intToBytes(this._accountRestrictionTransactionBodyReserved_1, 4, false));
-		arrayHelpers.writeArray(buffer_, this._restrictionAdditions);
-		arrayHelpers.writeArray(buffer_, this._restrictionDeletions);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._restrictionFlags.serialize());
+		buffer.write(converter.intToBytes(this._restrictionAdditions.length, 1, false)); // bound: restriction_additions_count
+		buffer.write(converter.intToBytes(this._restrictionDeletions.length, 1, false)); // bound: restriction_deletions_count
+		buffer.write(converter.intToBytes(this._accountRestrictionTransactionBodyReserved_1, 4, false));
+		arrayHelpers.writeArray(buffer, this._restrictionAdditions);
+		arrayHelpers.writeArray(buffer, this._restrictionDeletions);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -16925,23 +16925,23 @@ class MosaicAddressRestrictionTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._mosaicId.serialize());
-		buffer_.write(converter.intToBytes(this._restrictionKey, 8, false));
-		buffer_.write(converter.intToBytes(this._previousRestrictionValue, 8, false));
-		buffer_.write(converter.intToBytes(this._newRestrictionValue, 8, false));
-		buffer_.write(this._targetAddress.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._mosaicId.serialize());
+		buffer.write(converter.intToBytes(this._restrictionKey, 8, false));
+		buffer.write(converter.intToBytes(this._previousRestrictionValue, 8, false));
+		buffer.write(converter.intToBytes(this._newRestrictionValue, 8, false));
+		buffer.write(this._targetAddress.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -17125,20 +17125,20 @@ class EmbeddedMosaicAddressRestrictionTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._mosaicId.serialize());
-		buffer_.write(converter.intToBytes(this._restrictionKey, 8, false));
-		buffer_.write(converter.intToBytes(this._previousRestrictionValue, 8, false));
-		buffer_.write(converter.intToBytes(this._newRestrictionValue, 8, false));
-		buffer_.write(this._targetAddress.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._mosaicId.serialize());
+		buffer.write(converter.intToBytes(this._restrictionKey, 8, false));
+		buffer.write(converter.intToBytes(this._previousRestrictionValue, 8, false));
+		buffer.write(converter.intToBytes(this._newRestrictionValue, 8, false));
+		buffer.write(this._targetAddress.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -17389,25 +17389,25 @@ class MosaicGlobalRestrictionTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._mosaicId.serialize());
-		buffer_.write(this._referenceMosaicId.serialize());
-		buffer_.write(converter.intToBytes(this._restrictionKey, 8, false));
-		buffer_.write(converter.intToBytes(this._previousRestrictionValue, 8, false));
-		buffer_.write(converter.intToBytes(this._newRestrictionValue, 8, false));
-		buffer_.write(this._previousRestrictionType.serialize());
-		buffer_.write(this._newRestrictionType.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._mosaicId.serialize());
+		buffer.write(this._referenceMosaicId.serialize());
+		buffer.write(converter.intToBytes(this._restrictionKey, 8, false));
+		buffer.write(converter.intToBytes(this._previousRestrictionValue, 8, false));
+		buffer.write(converter.intToBytes(this._newRestrictionValue, 8, false));
+		buffer.write(this._previousRestrictionType.serialize());
+		buffer.write(this._newRestrictionType.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -17621,22 +17621,22 @@ class EmbeddedMosaicGlobalRestrictionTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._mosaicId.serialize());
-		buffer_.write(this._referenceMosaicId.serialize());
-		buffer_.write(converter.intToBytes(this._restrictionKey, 8, false));
-		buffer_.write(converter.intToBytes(this._previousRestrictionValue, 8, false));
-		buffer_.write(converter.intToBytes(this._newRestrictionValue, 8, false));
-		buffer_.write(this._previousRestrictionType.serialize());
-		buffer_.write(this._newRestrictionType.serialize());
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._mosaicId.serialize());
+		buffer.write(this._referenceMosaicId.serialize());
+		buffer.write(converter.intToBytes(this._restrictionKey, 8, false));
+		buffer.write(converter.intToBytes(this._previousRestrictionValue, 8, false));
+		buffer.write(converter.intToBytes(this._newRestrictionValue, 8, false));
+		buffer.write(this._previousRestrictionType.serialize());
+		buffer.write(this._newRestrictionType.serialize());
+		return buffer.storage;
 	}
 
 	toString() {
@@ -17854,25 +17854,25 @@ class TransferTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
-		buffer_.write(this._signature.serialize());
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._fee.serialize());
-		buffer_.write(this._deadline.serialize());
-		buffer_.write(this._recipientAddress.serialize());
-		buffer_.write(converter.intToBytes(this._message.length, 2, false)); // bound: message_size
-		buffer_.write(converter.intToBytes(this._mosaics.length, 1, false)); // bound: mosaics_count
-		buffer_.write(converter.intToBytes(this._transferTransactionBodyReserved_1, 1, false));
-		buffer_.write(converter.intToBytes(this._transferTransactionBodyReserved_2, 4, false));
-		arrayHelpers.writeArray(buffer_, this._mosaics, e => e.mosaicId.value);
-		buffer_.write(this._message);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._verifiableEntityHeaderReserved_1, 4, false));
+		buffer.write(this._signature.serialize());
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._fee.serialize());
+		buffer.write(this._deadline.serialize());
+		buffer.write(this._recipientAddress.serialize());
+		buffer.write(converter.intToBytes(this._message.length, 2, false)); // bound: message_size
+		buffer.write(converter.intToBytes(this._mosaics.length, 1, false)); // bound: mosaics_count
+		buffer.write(converter.intToBytes(this._transferTransactionBodyReserved_1, 1, false));
+		buffer.write(converter.intToBytes(this._transferTransactionBodyReserved_2, 4, false));
+		arrayHelpers.writeArray(buffer, this._mosaics, e => e.mosaicId.value);
+		buffer.write(this._message);
+		return buffer.storage;
 	}
 
 	toString() {
@@ -18047,22 +18047,22 @@ class EmbeddedTransferTransaction {
 	}
 
 	serialize() {
-		const buffer_ = new Writer(this.size);
-		buffer_.write(converter.intToBytes(this.size, 4, false));
-		buffer_.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
-		buffer_.write(this._signerPublicKey.serialize());
-		buffer_.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
-		buffer_.write(converter.intToBytes(this._version, 1, false));
-		buffer_.write(this._network.serialize());
-		buffer_.write(this._type.serialize());
-		buffer_.write(this._recipientAddress.serialize());
-		buffer_.write(converter.intToBytes(this._message.length, 2, false)); // bound: message_size
-		buffer_.write(converter.intToBytes(this._mosaics.length, 1, false)); // bound: mosaics_count
-		buffer_.write(converter.intToBytes(this._transferTransactionBodyReserved_1, 1, false));
-		buffer_.write(converter.intToBytes(this._transferTransactionBodyReserved_2, 4, false));
-		arrayHelpers.writeArray(buffer_, this._mosaics, e => e.mosaicId.value);
-		buffer_.write(this._message);
-		return buffer_.storage;
+		const buffer = new Writer(this.size);
+		buffer.write(converter.intToBytes(this.size, 4, false));
+		buffer.write(converter.intToBytes(this._embeddedTransactionHeaderReserved_1, 4, false));
+		buffer.write(this._signerPublicKey.serialize());
+		buffer.write(converter.intToBytes(this._entityBodyReserved_1, 4, false));
+		buffer.write(converter.intToBytes(this._version, 1, false));
+		buffer.write(this._network.serialize());
+		buffer.write(this._type.serialize());
+		buffer.write(this._recipientAddress.serialize());
+		buffer.write(converter.intToBytes(this._message.length, 2, false)); // bound: message_size
+		buffer.write(converter.intToBytes(this._mosaics.length, 1, false)); // bound: mosaics_count
+		buffer.write(converter.intToBytes(this._transferTransactionBodyReserved_1, 1, false));
+		buffer.write(converter.intToBytes(this._transferTransactionBodyReserved_2, 4, false));
+		arrayHelpers.writeArray(buffer, this._mosaics, e => e.mosaicId.value);
+		buffer.write(this._message);
+		return buffer.storage;
 	}
 
 	toString() {

--- a/sdk/python/generator/EnumTypeFormatter.py
+++ b/sdk/python/generator/EnumTypeFormatter.py
@@ -31,14 +31,14 @@ class EnumTypeFormatter(AbstractTypeFormatter):
 		return None
 
 	def get_deserialize_descriptor(self):
-		body = 'buffer_ = memoryview(payload)\n'
+		body = 'buffer = memoryview(payload)\n'
 		body += f'return {self.typename}({self.int_printer.load()})'
 		return MethodDescriptor(body=body)
 
 	def get_serialize_descriptor(self):
-		body = 'buffer_ = bytes()\n'
-		body += f'buffer_ += {self.int_printer.store("self.value")}\n'
-		body += 'return buffer_'
+		body = 'buffer = bytes()\n'
+		body += f'buffer += {self.int_printer.store("self.value")}\n'
+		body += 'return buffer'
 		return MethodDescriptor(body=body)
 
 	def get_size_descriptor(self):

--- a/sdk/python/generator/FactoryFormatter.py
+++ b/sdk/python/generator/FactoryFormatter.py
@@ -59,7 +59,7 @@ class FactoryFormatter(AbstractTypeFormatter):
 		return f'({values}): {name}'
 
 	def get_deserialize_descriptor(self):
-		body = 'buffer_ = bytes(payload)\n'
+		body = 'buffer = bytes(payload)\n'
 		body += f'{self.printer.name} = {self.printer.load()}\n'
 
 		body += 'mapping = {\n'
@@ -76,7 +76,7 @@ class FactoryFormatter(AbstractTypeFormatter):
 		values = ', '.join(map(lambda discriminator: f'{self.printer.name}.{fix_name(discriminator)}', discriminators))
 		body += f'discriminator = ({values})\n'
 		body += 'factory_class = mapping[discriminator]\n'
-		body += 'return factory_class.deserialize(buffer_)'
+		body += 'return factory_class.deserialize(buffer)'
 
 		return MethodDescriptor(body=body, result=self.abstract.name)
 

--- a/sdk/python/generator/PodTypeFormatter.py
+++ b/sdk/python/generator/PodTypeFormatter.py
@@ -39,7 +39,7 @@ class PodTypeFormatter(AbstractTypeFormatter):
 		return MethodDescriptor(body=body, arguments=arguments)
 
 	def get_deserialize_descriptor(self):
-		body = 'buffer_ = memoryview(payload)\n'
+		body = 'buffer = memoryview(payload)\n'
 		body += f'return {self.typename}({self.printer.load()})'
 		return MethodDescriptor(body=body)
 

--- a/sdk/python/generator/printers.py
+++ b/sdk/python/generator/printers.py
@@ -28,7 +28,7 @@ class IntPrinter(Printer):
 
 	def load(self):
 		data_size = self.get_size()
-		return f'int.from_bytes(buffer_[:{data_size}], byteorder=\'little\', signed={not self.descriptor.is_unsigned})'
+		return f'int.from_bytes(buffer[:{data_size}], byteorder=\'little\', signed={not self.descriptor.is_unsigned})'
 
 	def advancement_size(self):
 		return self.get_size()
@@ -74,13 +74,13 @@ class TypedArrayPrinter(Printer):
 
 			data_size = self.descriptor.size
 			alignment = self.descriptor.field_type.alignment
-			return f'ArrayHelpers.read_variable_size_elements(buffer_[:{data_size}], {factory_name}, {alignment})'
+			return f'ArrayHelpers.read_variable_size_elements(buffer[:{data_size}], {factory_name}, {alignment})'
 
 		if self.descriptor.field_type.is_expandable:
-			return f'ArrayHelpers.read_array(buffer_, {self.descriptor.field_type.element_type})'
+			return f'ArrayHelpers.read_array(buffer, {self.descriptor.field_type.element_type})'
 
 		args = [
-			'buffer_',
+			'buffer',
 			self.descriptor.field_type.element_type,
 			str(self.descriptor.size),
 		]
@@ -149,7 +149,7 @@ class ArrayPrinter(Printer):
 		return size
 
 	def load(self):
-		return f'ArrayHelpers.get_bytes(buffer_, {self.advancement_size()})'
+		return f'ArrayHelpers.get_bytes(buffer, {self.advancement_size()})'
 
 	def advancement_size(self):
 		# like get_size() but without self prefix, as this refers to local method field
@@ -190,7 +190,7 @@ class BuiltinPrinter(Printer):
 	def get_size(self):
 		return f'self.{self.name}.size'
 
-	def load(self, buffer_name='buffer_'):
+	def load(self, buffer_name='buffer'):
 		if DisplayType.STRUCT == self.descriptor.display_type and self.descriptor.is_abstract:
 			# HACK: factories use this printers as well, ignore them
 			if 'parent' != self.name:

--- a/sdk/python/symbolchain/nc/__init__.py
+++ b/sdk/python/symbolchain/nc/__init__.py
@@ -28,8 +28,8 @@ class Amount(BaseValue):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Amount:
-		buffer_ = memoryview(payload)
-		return Amount(int.from_bytes(buffer_[:8], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return Amount(int.from_bytes(buffer[:8], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
 		return self.value.to_bytes(8, byteorder='little', signed=False)
@@ -43,8 +43,8 @@ class Height(BaseValue):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Height:
-		buffer_ = memoryview(payload)
-		return Height(int.from_bytes(buffer_[:8], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return Height(int.from_bytes(buffer[:8], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
 		return self.value.to_bytes(8, byteorder='little', signed=False)
@@ -58,8 +58,8 @@ class Timestamp(BaseValue):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Timestamp:
-		buffer_ = memoryview(payload)
-		return Timestamp(int.from_bytes(buffer_[:4], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return Timestamp(int.from_bytes(buffer[:4], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
 		return self.value.to_bytes(4, byteorder='little', signed=False)
@@ -77,8 +77,8 @@ class Address(ByteArray):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Address:
-		buffer_ = memoryview(payload)
-		return Address(ArrayHelpers.get_bytes(buffer_, 40))
+		buffer = memoryview(payload)
+		return Address(ArrayHelpers.get_bytes(buffer, 40))
 
 	def serialize(self) -> bytes:
 		return self.bytes
@@ -96,8 +96,8 @@ class Hash256(ByteArray):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Hash256:
-		buffer_ = memoryview(payload)
-		return Hash256(ArrayHelpers.get_bytes(buffer_, 32))
+		buffer = memoryview(payload)
+		return Hash256(ArrayHelpers.get_bytes(buffer, 32))
 
 	def serialize(self) -> bytes:
 		return self.bytes
@@ -115,8 +115,8 @@ class PublicKey(ByteArray):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> PublicKey:
-		buffer_ = memoryview(payload)
-		return PublicKey(ArrayHelpers.get_bytes(buffer_, 32))
+		buffer = memoryview(payload)
+		return PublicKey(ArrayHelpers.get_bytes(buffer, 32))
 
 	def serialize(self) -> bytes:
 		return self.bytes
@@ -134,8 +134,8 @@ class Signature(ByteArray):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Signature:
-		buffer_ = memoryview(payload)
-		return Signature(ArrayHelpers.get_bytes(buffer_, 64))
+		buffer = memoryview(payload)
+		return Signature(ArrayHelpers.get_bytes(buffer, 64))
 
 	def serialize(self) -> bytes:
 		return self.bytes
@@ -151,13 +151,13 @@ class NetworkType(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NetworkType:
-		buffer_ = memoryview(payload)
-		return NetworkType(int.from_bytes(buffer_[:1], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return NetworkType(int.from_bytes(buffer[:1], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(1, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(1, byteorder='little', signed=False)
+		return buffer
 
 
 class TransactionType(Enum):
@@ -176,13 +176,13 @@ class TransactionType(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> TransactionType:
-		buffer_ = memoryview(payload)
-		return TransactionType(int.from_bytes(buffer_[:4], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return TransactionType(int.from_bytes(buffer[:4], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(4, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(4, byteorder='little', signed=False)
+		return buffer
 
 
 class Transaction:
@@ -291,32 +291,32 @@ class Transaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Transaction:
-		buffer_ = memoryview(payload)
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
+		buffer = memoryview(payload)
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		signer_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		signer_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signer_public_key_size == 32, f'Invalid value of reserved field ({signer_public_key_size})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		signature_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		signature_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signature_size == 64, f'Invalid value of reserved field ({signature_size})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
 
 		instance = Transaction()
 		instance._type_ = type_
@@ -330,19 +330,19 @@ class Transaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._signature_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._type_.serialize()
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._signature_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -451,27 +451,27 @@ class NonVerifiableTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NonVerifiableTransaction:
-		buffer_ = memoryview(payload)
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
+		buffer = memoryview(payload)
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		signer_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		signer_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signer_public_key_size == 32, f'Invalid value of reserved field ({signer_public_key_size})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
 
 		instance = NonVerifiableTransaction()
 		instance._type_ = type_
@@ -484,17 +484,17 @@ class NonVerifiableTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._type_.serialize()
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -519,13 +519,13 @@ class BlockType(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> BlockType:
-		buffer_ = memoryview(payload)
-		return BlockType(int.from_bytes(buffer_[:4], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return BlockType(int.from_bytes(buffer[:4], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(4, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(4, byteorder='little', signed=False)
+		return buffer
 
 
 class Block:
@@ -646,36 +646,36 @@ class Block:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Block:
-		buffer_ = memoryview(payload)
-		type_ = BlockType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
+		buffer = memoryview(payload)
+		type_ = BlockType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		signer_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		signer_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signer_public_key_size == 32, f'Invalid value of reserved field ({signer_public_key_size})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		signature_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		signature_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signature_size == 64, f'Invalid value of reserved field ({signature_size})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		previous_block_hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[previous_block_hash.size:]
-		height = Height.deserialize(buffer_)
-		buffer_ = buffer_[height.size:]
-		transactions_count = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		transactions = ArrayHelpers.read_array_count(buffer_, Transaction, transactions_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, transactions)):]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		previous_block_hash = Hash256.deserialize(buffer)
+		buffer = buffer[previous_block_hash.size:]
+		height = Height.deserialize(buffer)
+		buffer = buffer[height.size:]
+		transactions_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		transactions = ArrayHelpers.read_array_count(buffer, Transaction, transactions_count)
+		buffer = buffer[sum(map(lambda e: e.size, transactions)):]
 
 		instance = Block()
 		instance._type_ = type_
@@ -690,21 +690,21 @@ class Block:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._signature_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._previous_block_hash.serialize()
-		buffer_ += self._height.serialize()
-		buffer_ += len(self._transactions).to_bytes(4, byteorder='little', signed=False)  # transactions_count
-		buffer_ += ArrayHelpers.write_array(self._transactions)
-		return buffer_
+		buffer = bytes()
+		buffer += self._type_.serialize()
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._signature_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._previous_block_hash.serialize()
+		buffer += self._height.serialize()
+		buffer += len(self._transactions).to_bytes(4, byteorder='little', signed=False)  # transactions_count
+		buffer += ArrayHelpers.write_array(self._transactions)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -731,13 +731,13 @@ class LinkAction(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> LinkAction:
-		buffer_ = memoryview(payload)
-		return LinkAction(int.from_bytes(buffer_[:4], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return LinkAction(int.from_bytes(buffer[:4], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(4, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(4, byteorder='little', signed=False)
+		return buffer
 
 
 class AccountKeyLinkTransaction:
@@ -872,39 +872,39 @@ class AccountKeyLinkTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AccountKeyLinkTransaction:
-		buffer_ = memoryview(payload)
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
+		buffer = memoryview(payload)
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		signer_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		signer_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signer_public_key_size == 32, f'Invalid value of reserved field ({signer_public_key_size})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		signature_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		signature_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signature_size == 64, f'Invalid value of reserved field ({signature_size})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		link_action = LinkAction.deserialize(buffer_)
-		buffer_ = buffer_[link_action.size:]
-		remote_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		link_action = LinkAction.deserialize(buffer)
+		buffer = buffer[link_action.size:]
+		remote_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert remote_public_key_size == 32, f'Invalid value of reserved field ({remote_public_key_size})'
-		remote_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[remote_public_key.size:]
+		remote_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[remote_public_key.size:]
 
 		instance = AccountKeyLinkTransaction()
 		instance._type_ = type_
@@ -920,22 +920,22 @@ class AccountKeyLinkTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._signature_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._link_action.serialize()
-		buffer_ += self._remote_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._remote_public_key.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._type_.serialize()
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._signature_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._link_action.serialize()
+		buffer += self._remote_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._remote_public_key.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -1072,34 +1072,34 @@ class NonVerifiableAccountKeyLinkTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NonVerifiableAccountKeyLinkTransaction:
-		buffer_ = memoryview(payload)
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
+		buffer = memoryview(payload)
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		signer_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		signer_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signer_public_key_size == 32, f'Invalid value of reserved field ({signer_public_key_size})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		link_action = LinkAction.deserialize(buffer_)
-		buffer_ = buffer_[link_action.size:]
-		remote_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		link_action = LinkAction.deserialize(buffer)
+		buffer = buffer[link_action.size:]
+		remote_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert remote_public_key_size == 32, f'Invalid value of reserved field ({remote_public_key_size})'
-		remote_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[remote_public_key.size:]
+		remote_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[remote_public_key.size:]
 
 		instance = NonVerifiableAccountKeyLinkTransaction()
 		instance._type_ = type_
@@ -1114,20 +1114,20 @@ class NonVerifiableAccountKeyLinkTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._link_action.serialize()
-		buffer_ += self._remote_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._remote_public_key.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._type_.serialize()
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._link_action.serialize()
+		buffer += self._remote_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._remote_public_key.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -1169,21 +1169,21 @@ class NamespaceId:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NamespaceId:
-		buffer_ = memoryview(payload)
-		name_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		name = ArrayHelpers.get_bytes(buffer_, name_size)
-		buffer_ = buffer_[name_size:]
+		buffer = memoryview(payload)
+		name_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		name = ArrayHelpers.get_bytes(buffer, name_size)
+		buffer = buffer[name_size:]
 
 		instance = NamespaceId()
 		instance._name = name
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += len(self._name).to_bytes(4, byteorder='little', signed=False)  # name_size
-		buffer_ += self._name
-		return buffer_
+		buffer = bytes()
+		buffer += len(self._name).to_bytes(4, byteorder='little', signed=False)  # name_size
+		buffer += self._name
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -1228,13 +1228,13 @@ class MosaicId:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicId:
-		buffer_ = memoryview(payload)
-		namespace_id = NamespaceId.deserialize(buffer_)
-		buffer_ = buffer_[namespace_id.size:]
-		name_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		name = ArrayHelpers.get_bytes(buffer_, name_size)
-		buffer_ = buffer_[name_size:]
+		buffer = memoryview(payload)
+		namespace_id = NamespaceId.deserialize(buffer)
+		buffer = buffer[namespace_id.size:]
+		name_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		name = ArrayHelpers.get_bytes(buffer, name_size)
+		buffer = buffer[name_size:]
 
 		instance = MosaicId()
 		instance._namespace_id = namespace_id
@@ -1242,11 +1242,11 @@ class MosaicId:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._namespace_id.serialize()
-		buffer_ += len(self._name).to_bytes(4, byteorder='little', signed=False)  # name_size
-		buffer_ += self._name
-		return buffer_
+		buffer = bytes()
+		buffer += self._namespace_id.serialize()
+		buffer += len(self._name).to_bytes(4, byteorder='little', signed=False)  # name_size
+		buffer += self._name
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -1292,14 +1292,14 @@ class Mosaic:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Mosaic:
-		buffer_ = memoryview(payload)
-		mosaic_id_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		buffer = memoryview(payload)
+		mosaic_id_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		# marking sizeof field
-		mosaic_id = MosaicId.deserialize(buffer_[:mosaic_id_size])
-		buffer_ = buffer_[mosaic_id.size:]
-		amount = Amount.deserialize(buffer_)
-		buffer_ = buffer_[amount.size:]
+		mosaic_id = MosaicId.deserialize(buffer[:mosaic_id_size])
+		buffer = buffer[mosaic_id.size:]
+		amount = Amount.deserialize(buffer)
+		buffer = buffer[amount.size:]
 
 		instance = Mosaic()
 		instance._mosaic_id = mosaic_id
@@ -1307,11 +1307,11 @@ class Mosaic:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.mosaic_id.size.to_bytes(4, byteorder='little', signed=False)  # mosaic_id_size
-		buffer_ += self._mosaic_id.serialize()
-		buffer_ += self._amount.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.mosaic_id.size.to_bytes(4, byteorder='little', signed=False)  # mosaic_id_size
+		buffer += self._mosaic_id.serialize()
+		buffer += self._amount.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -1346,22 +1346,22 @@ class SizePrefixedMosaic:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> SizePrefixedMosaic:
-		buffer_ = memoryview(payload)
-		mosaic_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		buffer = memoryview(payload)
+		mosaic_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		# marking sizeof field
-		mosaic = Mosaic.deserialize(buffer_[:mosaic_size])
-		buffer_ = buffer_[mosaic.size:]
+		mosaic = Mosaic.deserialize(buffer[:mosaic_size])
+		buffer = buffer[mosaic.size:]
 
 		instance = SizePrefixedMosaic()
 		instance._mosaic = mosaic
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.mosaic.size.to_bytes(4, byteorder='little', signed=False)  # mosaic_size
-		buffer_ += self._mosaic.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.mosaic.size.to_bytes(4, byteorder='little', signed=False)  # mosaic_size
+		buffer += self._mosaic.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -1380,13 +1380,13 @@ class MosaicTransferFeeType(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicTransferFeeType:
-		buffer_ = memoryview(payload)
-		return MosaicTransferFeeType(int.from_bytes(buffer_[:4], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return MosaicTransferFeeType(int.from_bytes(buffer[:4], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(4, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(4, byteorder='little', signed=False)
+		return buffer
 
 
 class MosaicLevy:
@@ -1449,21 +1449,21 @@ class MosaicLevy:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicLevy:
-		buffer_ = memoryview(payload)
-		transfer_fee_type = MosaicTransferFeeType.deserialize(buffer_)
-		buffer_ = buffer_[transfer_fee_type.size:]
-		recipient_address_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		buffer = memoryview(payload)
+		transfer_fee_type = MosaicTransferFeeType.deserialize(buffer)
+		buffer = buffer[transfer_fee_type.size:]
+		recipient_address_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert recipient_address_size == 40, f'Invalid value of reserved field ({recipient_address_size})'
-		recipient_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[recipient_address.size:]
-		mosaic_id_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		recipient_address = Address.deserialize(buffer)
+		buffer = buffer[recipient_address.size:]
+		mosaic_id_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		# marking sizeof field
-		mosaic_id = MosaicId.deserialize(buffer_[:mosaic_id_size])
-		buffer_ = buffer_[mosaic_id.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
+		mosaic_id = MosaicId.deserialize(buffer[:mosaic_id_size])
+		buffer = buffer[mosaic_id.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
 
 		instance = MosaicLevy()
 		instance._transfer_fee_type = transfer_fee_type
@@ -1473,14 +1473,14 @@ class MosaicLevy:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._transfer_fee_type.serialize()
-		buffer_ += self._recipient_address_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._recipient_address.serialize()
-		buffer_ += self.mosaic_id.size.to_bytes(4, byteorder='little', signed=False)  # mosaic_id_size
-		buffer_ += self._mosaic_id.serialize()
-		buffer_ += self._fee.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._transfer_fee_type.serialize()
+		buffer += self._recipient_address_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._recipient_address.serialize()
+		buffer += self.mosaic_id.size.to_bytes(4, byteorder='little', signed=False)  # mosaic_id_size
+		buffer += self._mosaic_id.serialize()
+		buffer += self._fee.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -1529,15 +1529,15 @@ class MosaicProperty:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicProperty:
-		buffer_ = memoryview(payload)
-		name_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		name = ArrayHelpers.get_bytes(buffer_, name_size)
-		buffer_ = buffer_[name_size:]
-		value_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		value = ArrayHelpers.get_bytes(buffer_, value_size)
-		buffer_ = buffer_[value_size:]
+		buffer = memoryview(payload)
+		name_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		name = ArrayHelpers.get_bytes(buffer, name_size)
+		buffer = buffer[name_size:]
+		value_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		value = ArrayHelpers.get_bytes(buffer, value_size)
+		buffer = buffer[value_size:]
 
 		instance = MosaicProperty()
 		instance._name = name
@@ -1545,12 +1545,12 @@ class MosaicProperty:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += len(self._name).to_bytes(4, byteorder='little', signed=False)  # name_size
-		buffer_ += self._name
-		buffer_ += len(self._value).to_bytes(4, byteorder='little', signed=False)  # value_size
-		buffer_ += self._value
-		return buffer_
+		buffer = bytes()
+		buffer += len(self._name).to_bytes(4, byteorder='little', signed=False)  # name_size
+		buffer += self._name
+		buffer += len(self._value).to_bytes(4, byteorder='little', signed=False)  # value_size
+		buffer += self._value
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -1585,22 +1585,22 @@ class SizePrefixedMosaicProperty:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> SizePrefixedMosaicProperty:
-		buffer_ = memoryview(payload)
-		property_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		buffer = memoryview(payload)
+		property_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		# marking sizeof field
-		property_ = MosaicProperty.deserialize(buffer_[:property_size])
-		buffer_ = buffer_[property_.size:]
+		property_ = MosaicProperty.deserialize(buffer[:property_size])
+		buffer = buffer[property_.size:]
 
 		instance = SizePrefixedMosaicProperty()
 		instance._property_ = property_
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.property_.size.to_bytes(4, byteorder='little', signed=False)  # property_size
-		buffer_ += self._property_.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.property_.size.to_bytes(4, byteorder='little', signed=False)  # property_size
+		buffer += self._property_.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -1693,31 +1693,31 @@ class MosaicDefinition:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicDefinition:
-		buffer_ = memoryview(payload)
-		owner_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		buffer = memoryview(payload)
+		owner_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert owner_public_key_size == 32, f'Invalid value of reserved field ({owner_public_key_size})'
-		owner_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[owner_public_key.size:]
-		id_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		owner_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[owner_public_key.size:]
+		id_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		# marking sizeof field
-		id = MosaicId.deserialize(buffer_[:id_size])
-		buffer_ = buffer_[id.size:]
-		description_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		description = ArrayHelpers.get_bytes(buffer_, description_size)
-		buffer_ = buffer_[description_size:]
-		properties_count = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		properties = ArrayHelpers.read_array_count(buffer_, SizePrefixedMosaicProperty, properties_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, properties)):]
-		levy_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		id = MosaicId.deserialize(buffer[:id_size])
+		buffer = buffer[id.size:]
+		description_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		description = ArrayHelpers.get_bytes(buffer, description_size)
+		buffer = buffer[description_size:]
+		properties_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		properties = ArrayHelpers.read_array_count(buffer, SizePrefixedMosaicProperty, properties_count)
+		buffer = buffer[sum(map(lambda e: e.size, properties)):]
+		levy_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		levy = None
 		if 0 != levy_size:
-			levy = MosaicLevy.deserialize(buffer_)
-			buffer_ = buffer_[levy.size:]
+			levy = MosaicLevy.deserialize(buffer)
+			buffer = buffer[levy.size:]
 
 		instance = MosaicDefinition()
 		instance._owner_public_key = owner_public_key
@@ -1729,19 +1729,19 @@ class MosaicDefinition:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._owner_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._owner_public_key.serialize()
-		buffer_ += self.id.size.to_bytes(4, byteorder='little', signed=False)  # id_size
-		buffer_ += self._id.serialize()
-		buffer_ += len(self._description).to_bytes(4, byteorder='little', signed=False)  # description_size
-		buffer_ += self._description
-		buffer_ += len(self._properties).to_bytes(4, byteorder='little', signed=False)  # properties_count
-		buffer_ += ArrayHelpers.write_array(self._properties)
-		buffer_ += self._levy_size.to_bytes(4, byteorder='little', signed=False)
+		buffer = bytes()
+		buffer += self._owner_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._owner_public_key.serialize()
+		buffer += self.id.size.to_bytes(4, byteorder='little', signed=False)  # id_size
+		buffer += self._id.serialize()
+		buffer += len(self._description).to_bytes(4, byteorder='little', signed=False)  # description_size
+		buffer += self._description
+		buffer += len(self._properties).to_bytes(4, byteorder='little', signed=False)  # properties_count
+		buffer += ArrayHelpers.write_array(self._properties)
+		buffer += self._levy_size.to_bytes(4, byteorder='little', signed=False)
 		if 0 != self.levy_size:
-			buffer_ += self._levy.serialize()
-		return buffer_
+			buffer += self._levy.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -1807,19 +1807,19 @@ class MosaicDefinitionTransactionBody:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicDefinitionTransactionBody:
-		buffer_ = memoryview(payload)
-		mosaic_definition_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		buffer = memoryview(payload)
+		mosaic_definition_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		# marking sizeof field
-		mosaic_definition = MosaicDefinition.deserialize(buffer_[:mosaic_definition_size])
-		buffer_ = buffer_[mosaic_definition.size:]
-		rental_fee_sink_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		mosaic_definition = MosaicDefinition.deserialize(buffer[:mosaic_definition_size])
+		buffer = buffer[mosaic_definition.size:]
+		rental_fee_sink_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert rental_fee_sink_size == 40, f'Invalid value of reserved field ({rental_fee_sink_size})'
-		rental_fee_sink = Address.deserialize(buffer_)
-		buffer_ = buffer_[rental_fee_sink.size:]
-		rental_fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[rental_fee.size:]
+		rental_fee_sink = Address.deserialize(buffer)
+		buffer = buffer[rental_fee_sink.size:]
+		rental_fee = Amount.deserialize(buffer)
+		buffer = buffer[rental_fee.size:]
 
 		instance = MosaicDefinitionTransactionBody()
 		instance._mosaic_definition = mosaic_definition
@@ -1828,13 +1828,13 @@ class MosaicDefinitionTransactionBody:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.mosaic_definition.size.to_bytes(4, byteorder='little', signed=False)  # mosaic_definition_size
-		buffer_ += self._mosaic_definition.serialize()
-		buffer_ += self._rental_fee_sink_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._rental_fee_sink.serialize()
-		buffer_ += self._rental_fee.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.mosaic_definition.size.to_bytes(4, byteorder='little', signed=False)  # mosaic_definition_size
+		buffer += self._mosaic_definition.serialize()
+		buffer += self._rental_fee_sink_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._rental_fee_sink.serialize()
+		buffer += self._rental_fee.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -1989,44 +1989,44 @@ class MosaicDefinitionTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicDefinitionTransaction:
-		buffer_ = memoryview(payload)
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
+		buffer = memoryview(payload)
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		signer_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		signer_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signer_public_key_size == 32, f'Invalid value of reserved field ({signer_public_key_size})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		signature_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		signature_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signature_size == 64, f'Invalid value of reserved field ({signature_size})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		mosaic_definition_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		mosaic_definition_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		# marking sizeof field
-		mosaic_definition = MosaicDefinition.deserialize(buffer_[:mosaic_definition_size])
-		buffer_ = buffer_[mosaic_definition.size:]
-		rental_fee_sink_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		mosaic_definition = MosaicDefinition.deserialize(buffer[:mosaic_definition_size])
+		buffer = buffer[mosaic_definition.size:]
+		rental_fee_sink_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert rental_fee_sink_size == 40, f'Invalid value of reserved field ({rental_fee_sink_size})'
-		rental_fee_sink = Address.deserialize(buffer_)
-		buffer_ = buffer_[rental_fee_sink.size:]
-		rental_fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[rental_fee.size:]
+		rental_fee_sink = Address.deserialize(buffer)
+		buffer = buffer[rental_fee_sink.size:]
+		rental_fee = Amount.deserialize(buffer)
+		buffer = buffer[rental_fee.size:]
 
 		instance = MosaicDefinitionTransaction()
 		instance._type_ = type_
@@ -2043,24 +2043,24 @@ class MosaicDefinitionTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._signature_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self.mosaic_definition.size.to_bytes(4, byteorder='little', signed=False)  # mosaic_definition_size
-		buffer_ += self._mosaic_definition.serialize()
-		buffer_ += self._rental_fee_sink_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._rental_fee_sink.serialize()
-		buffer_ += self._rental_fee.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._type_.serialize()
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._signature_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self.mosaic_definition.size.to_bytes(4, byteorder='little', signed=False)  # mosaic_definition_size
+		buffer += self._mosaic_definition.serialize()
+		buffer += self._rental_fee_sink_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._rental_fee_sink.serialize()
+		buffer += self._rental_fee.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -2210,39 +2210,39 @@ class NonVerifiableMosaicDefinitionTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NonVerifiableMosaicDefinitionTransaction:
-		buffer_ = memoryview(payload)
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
+		buffer = memoryview(payload)
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		signer_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		signer_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signer_public_key_size == 32, f'Invalid value of reserved field ({signer_public_key_size})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		mosaic_definition_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		mosaic_definition_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		# marking sizeof field
-		mosaic_definition = MosaicDefinition.deserialize(buffer_[:mosaic_definition_size])
-		buffer_ = buffer_[mosaic_definition.size:]
-		rental_fee_sink_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		mosaic_definition = MosaicDefinition.deserialize(buffer[:mosaic_definition_size])
+		buffer = buffer[mosaic_definition.size:]
+		rental_fee_sink_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert rental_fee_sink_size == 40, f'Invalid value of reserved field ({rental_fee_sink_size})'
-		rental_fee_sink = Address.deserialize(buffer_)
-		buffer_ = buffer_[rental_fee_sink.size:]
-		rental_fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[rental_fee.size:]
+		rental_fee_sink = Address.deserialize(buffer)
+		buffer = buffer[rental_fee_sink.size:]
+		rental_fee = Amount.deserialize(buffer)
+		buffer = buffer[rental_fee.size:]
 
 		instance = NonVerifiableMosaicDefinitionTransaction()
 		instance._type_ = type_
@@ -2258,22 +2258,22 @@ class NonVerifiableMosaicDefinitionTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self.mosaic_definition.size.to_bytes(4, byteorder='little', signed=False)  # mosaic_definition_size
-		buffer_ += self._mosaic_definition.serialize()
-		buffer_ += self._rental_fee_sink_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._rental_fee_sink.serialize()
-		buffer_ += self._rental_fee.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._type_.serialize()
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self.mosaic_definition.size.to_bytes(4, byteorder='little', signed=False)  # mosaic_definition_size
+		buffer += self._mosaic_definition.serialize()
+		buffer += self._rental_fee_sink_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._rental_fee_sink.serialize()
+		buffer += self._rental_fee.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -2301,13 +2301,13 @@ class MosaicSupplyChangeAction(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicSupplyChangeAction:
-		buffer_ = memoryview(payload)
-		return MosaicSupplyChangeAction(int.from_bytes(buffer_[:4], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return MosaicSupplyChangeAction(int.from_bytes(buffer[:4], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(4, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(4, byteorder='little', signed=False)
+		return buffer
 
 
 class MosaicSupplyChangeTransactionBody:
@@ -2359,16 +2359,16 @@ class MosaicSupplyChangeTransactionBody:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicSupplyChangeTransactionBody:
-		buffer_ = memoryview(payload)
-		mosaic_id_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		buffer = memoryview(payload)
+		mosaic_id_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		# marking sizeof field
-		mosaic_id = MosaicId.deserialize(buffer_[:mosaic_id_size])
-		buffer_ = buffer_[mosaic_id.size:]
-		action = MosaicSupplyChangeAction.deserialize(buffer_)
-		buffer_ = buffer_[action.size:]
-		delta = Amount.deserialize(buffer_)
-		buffer_ = buffer_[delta.size:]
+		mosaic_id = MosaicId.deserialize(buffer[:mosaic_id_size])
+		buffer = buffer[mosaic_id.size:]
+		action = MosaicSupplyChangeAction.deserialize(buffer)
+		buffer = buffer[action.size:]
+		delta = Amount.deserialize(buffer)
+		buffer = buffer[delta.size:]
 
 		instance = MosaicSupplyChangeTransactionBody()
 		instance._mosaic_id = mosaic_id
@@ -2377,12 +2377,12 @@ class MosaicSupplyChangeTransactionBody:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.mosaic_id.size.to_bytes(4, byteorder='little', signed=False)  # mosaic_id_size
-		buffer_ += self._mosaic_id.serialize()
-		buffer_ += self._action.serialize()
-		buffer_ += self._delta.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.mosaic_id.size.to_bytes(4, byteorder='little', signed=False)  # mosaic_id_size
+		buffer += self._mosaic_id.serialize()
+		buffer += self._action.serialize()
+		buffer += self._delta.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -2535,41 +2535,41 @@ class MosaicSupplyChangeTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicSupplyChangeTransaction:
-		buffer_ = memoryview(payload)
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
+		buffer = memoryview(payload)
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		signer_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		signer_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signer_public_key_size == 32, f'Invalid value of reserved field ({signer_public_key_size})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		signature_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		signature_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signature_size == 64, f'Invalid value of reserved field ({signature_size})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		mosaic_id_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		mosaic_id_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		# marking sizeof field
-		mosaic_id = MosaicId.deserialize(buffer_[:mosaic_id_size])
-		buffer_ = buffer_[mosaic_id.size:]
-		action = MosaicSupplyChangeAction.deserialize(buffer_)
-		buffer_ = buffer_[action.size:]
-		delta = Amount.deserialize(buffer_)
-		buffer_ = buffer_[delta.size:]
+		mosaic_id = MosaicId.deserialize(buffer[:mosaic_id_size])
+		buffer = buffer[mosaic_id.size:]
+		action = MosaicSupplyChangeAction.deserialize(buffer)
+		buffer = buffer[action.size:]
+		delta = Amount.deserialize(buffer)
+		buffer = buffer[delta.size:]
 
 		instance = MosaicSupplyChangeTransaction()
 		instance._type_ = type_
@@ -2586,23 +2586,23 @@ class MosaicSupplyChangeTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._signature_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self.mosaic_id.size.to_bytes(4, byteorder='little', signed=False)  # mosaic_id_size
-		buffer_ += self._mosaic_id.serialize()
-		buffer_ += self._action.serialize()
-		buffer_ += self._delta.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._type_.serialize()
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._signature_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self.mosaic_id.size.to_bytes(4, byteorder='little', signed=False)  # mosaic_id_size
+		buffer += self._mosaic_id.serialize()
+		buffer += self._action.serialize()
+		buffer += self._delta.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -2750,36 +2750,36 @@ class NonVerifiableMosaicSupplyChangeTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NonVerifiableMosaicSupplyChangeTransaction:
-		buffer_ = memoryview(payload)
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
+		buffer = memoryview(payload)
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		signer_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		signer_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signer_public_key_size == 32, f'Invalid value of reserved field ({signer_public_key_size})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		mosaic_id_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		mosaic_id_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		# marking sizeof field
-		mosaic_id = MosaicId.deserialize(buffer_[:mosaic_id_size])
-		buffer_ = buffer_[mosaic_id.size:]
-		action = MosaicSupplyChangeAction.deserialize(buffer_)
-		buffer_ = buffer_[action.size:]
-		delta = Amount.deserialize(buffer_)
-		buffer_ = buffer_[delta.size:]
+		mosaic_id = MosaicId.deserialize(buffer[:mosaic_id_size])
+		buffer = buffer[mosaic_id.size:]
+		action = MosaicSupplyChangeAction.deserialize(buffer)
+		buffer = buffer[action.size:]
+		delta = Amount.deserialize(buffer)
+		buffer = buffer[delta.size:]
 
 		instance = NonVerifiableMosaicSupplyChangeTransaction()
 		instance._type_ = type_
@@ -2795,21 +2795,21 @@ class NonVerifiableMosaicSupplyChangeTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self.mosaic_id.size.to_bytes(4, byteorder='little', signed=False)  # mosaic_id_size
-		buffer_ += self._mosaic_id.serialize()
-		buffer_ += self._action.serialize()
-		buffer_ += self._delta.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._type_.serialize()
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self.mosaic_id.size.to_bytes(4, byteorder='little', signed=False)  # mosaic_id_size
+		buffer += self._mosaic_id.serialize()
+		buffer += self._action.serialize()
+		buffer += self._delta.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -2837,13 +2837,13 @@ class MultisigAccountModificationType(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MultisigAccountModificationType:
-		buffer_ = memoryview(payload)
-		return MultisigAccountModificationType(int.from_bytes(buffer_[:4], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return MultisigAccountModificationType(int.from_bytes(buffer[:4], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(4, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(4, byteorder='little', signed=False)
+		return buffer
 
 
 class MultisigAccountModification:
@@ -2883,14 +2883,14 @@ class MultisigAccountModification:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MultisigAccountModification:
-		buffer_ = memoryview(payload)
-		modification_type = MultisigAccountModificationType.deserialize(buffer_)
-		buffer_ = buffer_[modification_type.size:]
-		cosignatory_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		buffer = memoryview(payload)
+		modification_type = MultisigAccountModificationType.deserialize(buffer)
+		buffer = buffer[modification_type.size:]
+		cosignatory_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert cosignatory_public_key_size == 32, f'Invalid value of reserved field ({cosignatory_public_key_size})'
-		cosignatory_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[cosignatory_public_key.size:]
+		cosignatory_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[cosignatory_public_key.size:]
 
 		instance = MultisigAccountModification()
 		instance._modification_type = modification_type
@@ -2898,11 +2898,11 @@ class MultisigAccountModification:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._modification_type.serialize()
-		buffer_ += self._cosignatory_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._cosignatory_public_key.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._modification_type.serialize()
+		buffer += self._cosignatory_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._cosignatory_public_key.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -2937,22 +2937,22 @@ class SizePrefixedMultisigAccountModification:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> SizePrefixedMultisigAccountModification:
-		buffer_ = memoryview(payload)
-		modification_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		buffer = memoryview(payload)
+		modification_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		# marking sizeof field
-		modification = MultisigAccountModification.deserialize(buffer_[:modification_size])
-		buffer_ = buffer_[modification.size:]
+		modification = MultisigAccountModification.deserialize(buffer[:modification_size])
+		buffer = buffer[modification.size:]
 
 		instance = SizePrefixedMultisigAccountModification()
 		instance._modification = modification
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.modification.size.to_bytes(4, byteorder='little', signed=False)  # modification_size
-		buffer_ += self._modification.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.modification.size.to_bytes(4, byteorder='little', signed=False)  # modification_size
+		buffer += self._modification.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -3081,36 +3081,36 @@ class MultisigAccountModificationTransactionV1:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MultisigAccountModificationTransactionV1:
-		buffer_ = memoryview(payload)
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
+		buffer = memoryview(payload)
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		signer_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		signer_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signer_public_key_size == 32, f'Invalid value of reserved field ({signer_public_key_size})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		signature_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		signature_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signature_size == 64, f'Invalid value of reserved field ({signature_size})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		modifications_count = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		modifications = ArrayHelpers.read_array_count(buffer_, SizePrefixedMultisigAccountModification, modifications_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, modifications)):]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		modifications_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		modifications = ArrayHelpers.read_array_count(buffer, SizePrefixedMultisigAccountModification, modifications_count)
+		buffer = buffer[sum(map(lambda e: e.size, modifications)):]
 
 		instance = MultisigAccountModificationTransactionV1()
 		instance._type_ = type_
@@ -3125,21 +3125,21 @@ class MultisigAccountModificationTransactionV1:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._signature_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += len(self._modifications).to_bytes(4, byteorder='little', signed=False)  # modifications_count
-		buffer_ += ArrayHelpers.write_array(self._modifications)
-		return buffer_
+		buffer = bytes()
+		buffer += self._type_.serialize()
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._signature_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += len(self._modifications).to_bytes(4, byteorder='little', signed=False)  # modifications_count
+		buffer += ArrayHelpers.write_array(self._modifications)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -3263,31 +3263,31 @@ class NonVerifiableMultisigAccountModificationTransactionV1:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NonVerifiableMultisigAccountModificationTransactionV1:
-		buffer_ = memoryview(payload)
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
+		buffer = memoryview(payload)
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		signer_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		signer_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signer_public_key_size == 32, f'Invalid value of reserved field ({signer_public_key_size})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		modifications_count = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		modifications = ArrayHelpers.read_array_count(buffer_, SizePrefixedMultisigAccountModification, modifications_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, modifications)):]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		modifications_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		modifications = ArrayHelpers.read_array_count(buffer, SizePrefixedMultisigAccountModification, modifications_count)
+		buffer = buffer[sum(map(lambda e: e.size, modifications)):]
 
 		instance = NonVerifiableMultisigAccountModificationTransactionV1()
 		instance._type_ = type_
@@ -3301,19 +3301,19 @@ class NonVerifiableMultisigAccountModificationTransactionV1:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += len(self._modifications).to_bytes(4, byteorder='little', signed=False)  # modifications_count
-		buffer_ += ArrayHelpers.write_array(self._modifications)
-		return buffer_
+		buffer = bytes()
+		buffer += self._type_.serialize()
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += len(self._modifications).to_bytes(4, byteorder='little', signed=False)  # modifications_count
+		buffer += ArrayHelpers.write_array(self._modifications)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -3461,41 +3461,41 @@ class MultisigAccountModificationTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MultisigAccountModificationTransaction:
-		buffer_ = memoryview(payload)
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
+		buffer = memoryview(payload)
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		signer_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		signer_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signer_public_key_size == 32, f'Invalid value of reserved field ({signer_public_key_size})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		signature_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		signature_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signature_size == 64, f'Invalid value of reserved field ({signature_size})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		modifications_count = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		modifications = ArrayHelpers.read_array_count(buffer_, SizePrefixedMultisigAccountModification, modifications_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, modifications)):]
-		min_approval_delta_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		modifications_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		modifications = ArrayHelpers.read_array_count(buffer, SizePrefixedMultisigAccountModification, modifications_count)
+		buffer = buffer[sum(map(lambda e: e.size, modifications)):]
+		min_approval_delta_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert min_approval_delta_size == 4, f'Invalid value of reserved field ({min_approval_delta_size})'
-		min_approval_delta = int.from_bytes(buffer_[:4], byteorder='little', signed=True)
-		buffer_ = buffer_[4:]
+		min_approval_delta = int.from_bytes(buffer[:4], byteorder='little', signed=True)
+		buffer = buffer[4:]
 
 		instance = MultisigAccountModificationTransaction()
 		instance._type_ = type_
@@ -3511,23 +3511,23 @@ class MultisigAccountModificationTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._signature_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += len(self._modifications).to_bytes(4, byteorder='little', signed=False)  # modifications_count
-		buffer_ += ArrayHelpers.write_array(self._modifications)
-		buffer_ += self._min_approval_delta_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._min_approval_delta.to_bytes(4, byteorder='little', signed=True)
-		return buffer_
+		buffer = bytes()
+		buffer += self._type_.serialize()
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._signature_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += len(self._modifications).to_bytes(4, byteorder='little', signed=False)  # modifications_count
+		buffer += ArrayHelpers.write_array(self._modifications)
+		buffer += self._min_approval_delta_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._min_approval_delta.to_bytes(4, byteorder='little', signed=True)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -3664,36 +3664,36 @@ class NonVerifiableMultisigAccountModificationTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NonVerifiableMultisigAccountModificationTransaction:
-		buffer_ = memoryview(payload)
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
+		buffer = memoryview(payload)
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		signer_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		signer_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signer_public_key_size == 32, f'Invalid value of reserved field ({signer_public_key_size})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		modifications_count = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		modifications = ArrayHelpers.read_array_count(buffer_, SizePrefixedMultisigAccountModification, modifications_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, modifications)):]
-		min_approval_delta_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		modifications_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		modifications = ArrayHelpers.read_array_count(buffer, SizePrefixedMultisigAccountModification, modifications_count)
+		buffer = buffer[sum(map(lambda e: e.size, modifications)):]
+		min_approval_delta_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert min_approval_delta_size == 4, f'Invalid value of reserved field ({min_approval_delta_size})'
-		min_approval_delta = int.from_bytes(buffer_[:4], byteorder='little', signed=True)
-		buffer_ = buffer_[4:]
+		min_approval_delta = int.from_bytes(buffer[:4], byteorder='little', signed=True)
+		buffer = buffer[4:]
 
 		instance = NonVerifiableMultisigAccountModificationTransaction()
 		instance._type_ = type_
@@ -3708,21 +3708,21 @@ class NonVerifiableMultisigAccountModificationTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += len(self._modifications).to_bytes(4, byteorder='little', signed=False)  # modifications_count
-		buffer_ += ArrayHelpers.write_array(self._modifications)
-		buffer_ += self._min_approval_delta_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._min_approval_delta.to_bytes(4, byteorder='little', signed=True)
-		return buffer_
+		buffer = bytes()
+		buffer += self._type_.serialize()
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += len(self._modifications).to_bytes(4, byteorder='little', signed=False)  # modifications_count
+		buffer += ArrayHelpers.write_array(self._modifications)
+		buffer += self._min_approval_delta_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._min_approval_delta.to_bytes(4, byteorder='little', signed=True)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -3875,45 +3875,45 @@ class Cosignature:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Cosignature:
-		buffer_ = memoryview(payload)
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
+		buffer = memoryview(payload)
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		signer_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		signer_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signer_public_key_size == 32, f'Invalid value of reserved field ({signer_public_key_size})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		signature_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		signature_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signature_size == 64, f'Invalid value of reserved field ({signature_size})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		multisig_transaction_hash_outer_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		multisig_transaction_hash_outer_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert multisig_transaction_hash_outer_size == 36, f'Invalid value of reserved field ({multisig_transaction_hash_outer_size})'
-		multisig_transaction_hash_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		multisig_transaction_hash_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert multisig_transaction_hash_size == 32, f'Invalid value of reserved field ({multisig_transaction_hash_size})'
-		multisig_transaction_hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[multisig_transaction_hash.size:]
-		multisig_account_address_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		multisig_transaction_hash = Hash256.deserialize(buffer)
+		buffer = buffer[multisig_transaction_hash.size:]
+		multisig_account_address_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert multisig_account_address_size == 40, f'Invalid value of reserved field ({multisig_account_address_size})'
-		multisig_account_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[multisig_account_address.size:]
+		multisig_account_address = Address.deserialize(buffer)
+		buffer = buffer[multisig_account_address.size:]
 
 		instance = Cosignature()
 		instance._type_ = type_
@@ -3929,24 +3929,24 @@ class Cosignature:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._signature_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._multisig_transaction_hash_outer_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._multisig_transaction_hash_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._multisig_transaction_hash.serialize()
-		buffer_ += self._multisig_account_address_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._multisig_account_address.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._type_.serialize()
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._signature_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._multisig_transaction_hash_outer_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._multisig_transaction_hash_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._multisig_transaction_hash.serialize()
+		buffer += self._multisig_account_address_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._multisig_account_address.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -3989,22 +3989,22 @@ class SizePrefixedCosignature:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> SizePrefixedCosignature:
-		buffer_ = memoryview(payload)
-		cosignature_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		buffer = memoryview(payload)
+		cosignature_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		# marking sizeof field
-		cosignature = Cosignature.deserialize(buffer_[:cosignature_size])
-		buffer_ = buffer_[cosignature.size:]
+		cosignature = Cosignature.deserialize(buffer[:cosignature_size])
+		buffer = buffer[cosignature.size:]
 
 		instance = SizePrefixedCosignature()
 		instance._cosignature = cosignature
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.cosignature.size.to_bytes(4, byteorder='little', signed=False)  # cosignature_size
-		buffer_ += self._cosignature.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.cosignature.size.to_bytes(4, byteorder='little', signed=False)  # cosignature_size
+		buffer += self._cosignature.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -4145,41 +4145,41 @@ class MultisigTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MultisigTransaction:
-		buffer_ = memoryview(payload)
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
+		buffer = memoryview(payload)
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		signer_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		signer_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signer_public_key_size == 32, f'Invalid value of reserved field ({signer_public_key_size})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		signature_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		signature_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signature_size == 64, f'Invalid value of reserved field ({signature_size})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		inner_transaction_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		inner_transaction_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		# marking sizeof field
-		inner_transaction = NonVerifiableTransactionFactory.deserialize(buffer_[:inner_transaction_size])
-		buffer_ = buffer_[inner_transaction.size:]
-		cosignatures_count = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		cosignatures = ArrayHelpers.read_array_count(buffer_, SizePrefixedCosignature, cosignatures_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, cosignatures)):]
+		inner_transaction = NonVerifiableTransactionFactory.deserialize(buffer[:inner_transaction_size])
+		buffer = buffer[inner_transaction.size:]
+		cosignatures_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		cosignatures = ArrayHelpers.read_array_count(buffer, SizePrefixedCosignature, cosignatures_count)
+		buffer = buffer[sum(map(lambda e: e.size, cosignatures)):]
 
 		instance = MultisigTransaction()
 		instance._type_ = type_
@@ -4195,23 +4195,23 @@ class MultisigTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._signature_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self.inner_transaction.size.to_bytes(4, byteorder='little', signed=False)  # inner_transaction_size
-		buffer_ += self._inner_transaction.serialize()
-		buffer_ += len(self._cosignatures).to_bytes(4, byteorder='little', signed=False)  # cosignatures_count
-		buffer_ += ArrayHelpers.write_array(self._cosignatures)
-		return buffer_
+		buffer = bytes()
+		buffer += self._type_.serialize()
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._signature_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self.inner_transaction.size.to_bytes(4, byteorder='little', signed=False)  # inner_transaction_size
+		buffer += self._inner_transaction.serialize()
+		buffer += len(self._cosignatures).to_bytes(4, byteorder='little', signed=False)  # cosignatures_count
+		buffer += ArrayHelpers.write_array(self._cosignatures)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -4293,24 +4293,24 @@ class NamespaceRegistrationTransactionBody:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NamespaceRegistrationTransactionBody:
-		buffer_ = memoryview(payload)
-		rental_fee_sink_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		buffer = memoryview(payload)
+		rental_fee_sink_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert rental_fee_sink_size == 40, f'Invalid value of reserved field ({rental_fee_sink_size})'
-		rental_fee_sink = Address.deserialize(buffer_)
-		buffer_ = buffer_[rental_fee_sink.size:]
-		rental_fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[rental_fee.size:]
-		name_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		name = ArrayHelpers.get_bytes(buffer_, name_size)
-		buffer_ = buffer_[name_size:]
-		parent_name_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		rental_fee_sink = Address.deserialize(buffer)
+		buffer = buffer[rental_fee_sink.size:]
+		rental_fee = Amount.deserialize(buffer)
+		buffer = buffer[rental_fee.size:]
+		name_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		name = ArrayHelpers.get_bytes(buffer, name_size)
+		buffer = buffer[name_size:]
+		parent_name_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		parent_name = None
 		if 4294967295 != parent_name_size:
-			parent_name = ArrayHelpers.get_bytes(buffer_, parent_name_size)
-			buffer_ = buffer_[parent_name_size:]
+			parent_name = ArrayHelpers.get_bytes(buffer, parent_name_size)
+			buffer = buffer[parent_name_size:]
 
 		instance = NamespaceRegistrationTransactionBody()
 		instance._rental_fee_sink = rental_fee_sink
@@ -4320,16 +4320,16 @@ class NamespaceRegistrationTransactionBody:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._rental_fee_sink_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._rental_fee_sink.serialize()
-		buffer_ += self._rental_fee.serialize()
-		buffer_ += len(self._name).to_bytes(4, byteorder='little', signed=False)  # name_size
-		buffer_ += self._name
-		buffer_ += (len(self._parent_name) if self._parent_name is not None else 4294967295).to_bytes(4, byteorder='little', signed=False)  # parent_name_size
+		buffer = bytes()
+		buffer += self._rental_fee_sink_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._rental_fee_sink.serialize()
+		buffer += self._rental_fee.serialize()
+		buffer += len(self._name).to_bytes(4, byteorder='little', signed=False)  # name_size
+		buffer += self._name
+		buffer += (len(self._parent_name) if self._parent_name is not None else 4294967295).to_bytes(4, byteorder='little', signed=False)  # parent_name_size
 		if self.parent_name:
-			buffer_ += self._parent_name
-		return buffer_
+			buffer += self._parent_name
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -4499,49 +4499,49 @@ class NamespaceRegistrationTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NamespaceRegistrationTransaction:
-		buffer_ = memoryview(payload)
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
+		buffer = memoryview(payload)
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		signer_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		signer_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signer_public_key_size == 32, f'Invalid value of reserved field ({signer_public_key_size})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		signature_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		signature_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signature_size == 64, f'Invalid value of reserved field ({signature_size})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		rental_fee_sink_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		rental_fee_sink_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert rental_fee_sink_size == 40, f'Invalid value of reserved field ({rental_fee_sink_size})'
-		rental_fee_sink = Address.deserialize(buffer_)
-		buffer_ = buffer_[rental_fee_sink.size:]
-		rental_fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[rental_fee.size:]
-		name_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		name = ArrayHelpers.get_bytes(buffer_, name_size)
-		buffer_ = buffer_[name_size:]
-		parent_name_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		rental_fee_sink = Address.deserialize(buffer)
+		buffer = buffer[rental_fee_sink.size:]
+		rental_fee = Amount.deserialize(buffer)
+		buffer = buffer[rental_fee.size:]
+		name_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		name = ArrayHelpers.get_bytes(buffer, name_size)
+		buffer = buffer[name_size:]
+		parent_name_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		parent_name = None
 		if 4294967295 != parent_name_size:
-			parent_name = ArrayHelpers.get_bytes(buffer_, parent_name_size)
-			buffer_ = buffer_[parent_name_size:]
+			parent_name = ArrayHelpers.get_bytes(buffer, parent_name_size)
+			buffer = buffer[parent_name_size:]
 
 		instance = NamespaceRegistrationTransaction()
 		instance._type_ = type_
@@ -4559,27 +4559,27 @@ class NamespaceRegistrationTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._signature_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._rental_fee_sink_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._rental_fee_sink.serialize()
-		buffer_ += self._rental_fee.serialize()
-		buffer_ += len(self._name).to_bytes(4, byteorder='little', signed=False)  # name_size
-		buffer_ += self._name
-		buffer_ += (len(self._parent_name) if self._parent_name is not None else 4294967295).to_bytes(4, byteorder='little', signed=False)  # parent_name_size
+		buffer = bytes()
+		buffer += self._type_.serialize()
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._signature_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._rental_fee_sink_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._rental_fee_sink.serialize()
+		buffer += self._rental_fee.serialize()
+		buffer += len(self._name).to_bytes(4, byteorder='little', signed=False)  # name_size
+		buffer += self._name
+		buffer += (len(self._parent_name) if self._parent_name is not None else 4294967295).to_bytes(4, byteorder='little', signed=False)  # parent_name_size
 		if self.parent_name:
-			buffer_ += self._parent_name
-		return buffer_
+			buffer += self._parent_name
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -4744,44 +4744,44 @@ class NonVerifiableNamespaceRegistrationTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NonVerifiableNamespaceRegistrationTransaction:
-		buffer_ = memoryview(payload)
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
+		buffer = memoryview(payload)
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		signer_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		signer_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signer_public_key_size == 32, f'Invalid value of reserved field ({signer_public_key_size})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		rental_fee_sink_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		rental_fee_sink_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert rental_fee_sink_size == 40, f'Invalid value of reserved field ({rental_fee_sink_size})'
-		rental_fee_sink = Address.deserialize(buffer_)
-		buffer_ = buffer_[rental_fee_sink.size:]
-		rental_fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[rental_fee.size:]
-		name_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		name = ArrayHelpers.get_bytes(buffer_, name_size)
-		buffer_ = buffer_[name_size:]
-		parent_name_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		rental_fee_sink = Address.deserialize(buffer)
+		buffer = buffer[rental_fee_sink.size:]
+		rental_fee = Amount.deserialize(buffer)
+		buffer = buffer[rental_fee.size:]
+		name_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		name = ArrayHelpers.get_bytes(buffer, name_size)
+		buffer = buffer[name_size:]
+		parent_name_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		parent_name = None
 		if 4294967295 != parent_name_size:
-			parent_name = ArrayHelpers.get_bytes(buffer_, parent_name_size)
-			buffer_ = buffer_[parent_name_size:]
+			parent_name = ArrayHelpers.get_bytes(buffer, parent_name_size)
+			buffer = buffer[parent_name_size:]
 
 		instance = NonVerifiableNamespaceRegistrationTransaction()
 		instance._type_ = type_
@@ -4798,25 +4798,25 @@ class NonVerifiableNamespaceRegistrationTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._rental_fee_sink_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._rental_fee_sink.serialize()
-		buffer_ += self._rental_fee.serialize()
-		buffer_ += len(self._name).to_bytes(4, byteorder='little', signed=False)  # name_size
-		buffer_ += self._name
-		buffer_ += (len(self._parent_name) if self._parent_name is not None else 4294967295).to_bytes(4, byteorder='little', signed=False)  # parent_name_size
+		buffer = bytes()
+		buffer += self._type_.serialize()
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._rental_fee_sink_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._rental_fee_sink.serialize()
+		buffer += self._rental_fee.serialize()
+		buffer += len(self._name).to_bytes(4, byteorder='little', signed=False)  # name_size
+		buffer += self._name
+		buffer += (len(self._parent_name) if self._parent_name is not None else 4294967295).to_bytes(4, byteorder='little', signed=False)  # parent_name_size
 		if self.parent_name:
-			buffer_ += self._parent_name
-		return buffer_
+			buffer += self._parent_name
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -4846,13 +4846,13 @@ class MessageType(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MessageType:
-		buffer_ = memoryview(payload)
-		return MessageType(int.from_bytes(buffer_[:4], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return MessageType(int.from_bytes(buffer[:4], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(4, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(4, byteorder='little', signed=False)
+		return buffer
 
 
 class Message:
@@ -4891,13 +4891,13 @@ class Message:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Message:
-		buffer_ = memoryview(payload)
-		message_type = MessageType.deserialize(buffer_)
-		buffer_ = buffer_[message_type.size:]
-		message_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		message = ArrayHelpers.get_bytes(buffer_, message_size)
-		buffer_ = buffer_[message_size:]
+		buffer = memoryview(payload)
+		message_type = MessageType.deserialize(buffer)
+		buffer = buffer[message_type.size:]
+		message_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		message = ArrayHelpers.get_bytes(buffer, message_size)
+		buffer = buffer[message_size:]
 
 		instance = Message()
 		instance._message_type = message_type
@@ -4905,11 +4905,11 @@ class Message:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._message_type.serialize()
-		buffer_ += len(self._message).to_bytes(4, byteorder='little', signed=False)  # message_size
-		buffer_ += self._message
-		return buffer_
+		buffer = bytes()
+		buffer += self._message_type.serialize()
+		buffer += len(self._message).to_bytes(4, byteorder='little', signed=False)  # message_size
+		buffer += self._message
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -5073,45 +5073,45 @@ class TransferTransactionV1:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> TransferTransactionV1:
-		buffer_ = memoryview(payload)
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
+		buffer = memoryview(payload)
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		signer_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		signer_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signer_public_key_size == 32, f'Invalid value of reserved field ({signer_public_key_size})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		signature_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		signature_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signature_size == 64, f'Invalid value of reserved field ({signature_size})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		recipient_address_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		recipient_address_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert recipient_address_size == 40, f'Invalid value of reserved field ({recipient_address_size})'
-		recipient_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[recipient_address.size:]
-		amount = Amount.deserialize(buffer_)
-		buffer_ = buffer_[amount.size:]
-		message_envelope_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		recipient_address = Address.deserialize(buffer)
+		buffer = buffer[recipient_address.size:]
+		amount = Amount.deserialize(buffer)
+		buffer = buffer[amount.size:]
+		message_envelope_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		message = None
 		if 0 != message_envelope_size:
-			message = Message.deserialize(buffer_)
-			buffer_ = buffer_[message.size:]
+			message = Message.deserialize(buffer)
+			buffer = buffer[message.size:]
 
 		instance = TransferTransactionV1()
 		instance._type_ = type_
@@ -5129,25 +5129,25 @@ class TransferTransactionV1:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._signature_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._recipient_address_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._recipient_address.serialize()
-		buffer_ += self._amount.serialize()
-		buffer_ += self._message_envelope_size.to_bytes(4, byteorder='little', signed=False)
+		buffer = bytes()
+		buffer += self._type_.serialize()
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._signature_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._recipient_address_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._recipient_address.serialize()
+		buffer += self._amount.serialize()
+		buffer += self._message_envelope_size.to_bytes(4, byteorder='little', signed=False)
 		if 0 != self.message_envelope_size:
-			buffer_ += self._message.serialize()
-		return buffer_
+			buffer += self._message.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -5309,40 +5309,40 @@ class NonVerifiableTransferTransactionV1:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NonVerifiableTransferTransactionV1:
-		buffer_ = memoryview(payload)
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
+		buffer = memoryview(payload)
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		signer_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		signer_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signer_public_key_size == 32, f'Invalid value of reserved field ({signer_public_key_size})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		recipient_address_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		recipient_address_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert recipient_address_size == 40, f'Invalid value of reserved field ({recipient_address_size})'
-		recipient_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[recipient_address.size:]
-		amount = Amount.deserialize(buffer_)
-		buffer_ = buffer_[amount.size:]
-		message_envelope_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		recipient_address = Address.deserialize(buffer)
+		buffer = buffer[recipient_address.size:]
+		amount = Amount.deserialize(buffer)
+		buffer = buffer[amount.size:]
+		message_envelope_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		message = None
 		if 0 != message_envelope_size:
-			message = Message.deserialize(buffer_)
-			buffer_ = buffer_[message.size:]
+			message = Message.deserialize(buffer)
+			buffer = buffer[message.size:]
 
 		instance = NonVerifiableTransferTransactionV1()
 		instance._type_ = type_
@@ -5359,23 +5359,23 @@ class NonVerifiableTransferTransactionV1:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._recipient_address_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._recipient_address.serialize()
-		buffer_ += self._amount.serialize()
-		buffer_ += self._message_envelope_size.to_bytes(4, byteorder='little', signed=False)
+		buffer = bytes()
+		buffer += self._type_.serialize()
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._recipient_address_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._recipient_address.serialize()
+		buffer += self._amount.serialize()
+		buffer += self._message_envelope_size.to_bytes(4, byteorder='little', signed=False)
 		if 0 != self.message_envelope_size:
-			buffer_ += self._message.serialize()
-		return buffer_
+			buffer += self._message.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -5561,49 +5561,49 @@ class TransferTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> TransferTransaction:
-		buffer_ = memoryview(payload)
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
+		buffer = memoryview(payload)
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		signer_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		signer_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signer_public_key_size == 32, f'Invalid value of reserved field ({signer_public_key_size})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		signature_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		signature_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signature_size == 64, f'Invalid value of reserved field ({signature_size})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		recipient_address_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		recipient_address_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert recipient_address_size == 40, f'Invalid value of reserved field ({recipient_address_size})'
-		recipient_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[recipient_address.size:]
-		amount = Amount.deserialize(buffer_)
-		buffer_ = buffer_[amount.size:]
-		message_envelope_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		recipient_address = Address.deserialize(buffer)
+		buffer = buffer[recipient_address.size:]
+		amount = Amount.deserialize(buffer)
+		buffer = buffer[amount.size:]
+		message_envelope_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		message = None
 		if 0 != message_envelope_size:
-			message = Message.deserialize(buffer_)
-			buffer_ = buffer_[message.size:]
-		mosaics_count = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		mosaics = ArrayHelpers.read_array_count(buffer_, SizePrefixedMosaic, mosaics_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, mosaics)):]
+			message = Message.deserialize(buffer)
+			buffer = buffer[message.size:]
+		mosaics_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		mosaics = ArrayHelpers.read_array_count(buffer, SizePrefixedMosaic, mosaics_count)
+		buffer = buffer[sum(map(lambda e: e.size, mosaics)):]
 
 		instance = TransferTransaction()
 		instance._type_ = type_
@@ -5622,27 +5622,27 @@ class TransferTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._signature_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._recipient_address_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._recipient_address.serialize()
-		buffer_ += self._amount.serialize()
-		buffer_ += self._message_envelope_size.to_bytes(4, byteorder='little', signed=False)
+		buffer = bytes()
+		buffer += self._type_.serialize()
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._signature_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._recipient_address_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._recipient_address.serialize()
+		buffer += self._amount.serialize()
+		buffer += self._message_envelope_size.to_bytes(4, byteorder='little', signed=False)
 		if 0 != self.message_envelope_size:
-			buffer_ += self._message.serialize()
-		buffer_ += len(self._mosaics).to_bytes(4, byteorder='little', signed=False)  # mosaics_count
-		buffer_ += ArrayHelpers.write_array(self._mosaics)
-		return buffer_
+			buffer += self._message.serialize()
+		buffer += len(self._mosaics).to_bytes(4, byteorder='little', signed=False)  # mosaics_count
+		buffer += ArrayHelpers.write_array(self._mosaics)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -5817,44 +5817,44 @@ class NonVerifiableTransferTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NonVerifiableTransferTransaction:
-		buffer_ = memoryview(payload)
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
+		buffer = memoryview(payload)
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		signer_public_key_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		signer_public_key_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert signer_public_key_size == 32, f'Invalid value of reserved field ({signer_public_key_size})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		recipient_address_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		recipient_address_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert recipient_address_size == 40, f'Invalid value of reserved field ({recipient_address_size})'
-		recipient_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[recipient_address.size:]
-		amount = Amount.deserialize(buffer_)
-		buffer_ = buffer_[amount.size:]
-		message_envelope_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		recipient_address = Address.deserialize(buffer)
+		buffer = buffer[recipient_address.size:]
+		amount = Amount.deserialize(buffer)
+		buffer = buffer[amount.size:]
+		message_envelope_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		message = None
 		if 0 != message_envelope_size:
-			message = Message.deserialize(buffer_)
-			buffer_ = buffer_[message.size:]
-		mosaics_count = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		mosaics = ArrayHelpers.read_array_count(buffer_, SizePrefixedMosaic, mosaics_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, mosaics)):]
+			message = Message.deserialize(buffer)
+			buffer = buffer[message.size:]
+		mosaics_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		mosaics = ArrayHelpers.read_array_count(buffer, SizePrefixedMosaic, mosaics_count)
+		buffer = buffer[sum(map(lambda e: e.size, mosaics)):]
 
 		instance = NonVerifiableTransferTransaction()
 		instance._type_ = type_
@@ -5872,25 +5872,25 @@ class NonVerifiableTransferTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._recipient_address_size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._recipient_address.serialize()
-		buffer_ += self._amount.serialize()
-		buffer_ += self._message_envelope_size.to_bytes(4, byteorder='little', signed=False)
+		buffer = bytes()
+		buffer += self._type_.serialize()
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._entity_body_reserved_1.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._signer_public_key_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._recipient_address_size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._recipient_address.serialize()
+		buffer += self._amount.serialize()
+		buffer += self._message_envelope_size.to_bytes(4, byteorder='little', signed=False)
 		if 0 != self.message_envelope_size:
-			buffer_ += self._message.serialize()
-		buffer_ += len(self._mosaics).to_bytes(4, byteorder='little', signed=False)  # mosaics_count
-		buffer_ += ArrayHelpers.write_array(self._mosaics)
-		return buffer_
+			buffer += self._message.serialize()
+		buffer += len(self._mosaics).to_bytes(4, byteorder='little', signed=False)  # mosaics_count
+		buffer += ArrayHelpers.write_array(self._mosaics)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -5914,8 +5914,8 @@ class NonVerifiableTransferTransaction:
 class TransactionFactory:
 	@classmethod
 	def deserialize(cls, payload: bytes) -> Transaction:
-		buffer_ = bytes(payload)
-		parent = Transaction.deserialize(buffer_)
+		buffer = bytes(payload)
+		parent = Transaction.deserialize(buffer)
 		mapping = {
 			(AccountKeyLinkTransaction.TRANSACTION_TYPE, AccountKeyLinkTransaction.TRANSACTION_VERSION): AccountKeyLinkTransaction,
 			(MosaicDefinitionTransaction.TRANSACTION_TYPE, MosaicDefinitionTransaction.TRANSACTION_VERSION): MosaicDefinitionTransaction,
@@ -5930,7 +5930,7 @@ class TransactionFactory:
 		}
 		discriminator = (parent.type_, parent.version)
 		factory_class = mapping[discriminator]
-		return factory_class.deserialize(buffer_)
+		return factory_class.deserialize(buffer)
 
 	@classmethod
 	def create_by_name(cls, entity_name: str) -> Transaction:
@@ -5956,8 +5956,8 @@ class TransactionFactory:
 class NonVerifiableTransactionFactory:
 	@classmethod
 	def deserialize(cls, payload: bytes) -> NonVerifiableTransaction:
-		buffer_ = bytes(payload)
-		parent = NonVerifiableTransaction.deserialize(buffer_)
+		buffer = bytes(payload)
+		parent = NonVerifiableTransaction.deserialize(buffer)
 		mapping = {
 			(NonVerifiableAccountKeyLinkTransaction.TRANSACTION_TYPE, NonVerifiableAccountKeyLinkTransaction.TRANSACTION_VERSION): NonVerifiableAccountKeyLinkTransaction,
 			(NonVerifiableMosaicDefinitionTransaction.TRANSACTION_TYPE, NonVerifiableMosaicDefinitionTransaction.TRANSACTION_VERSION): NonVerifiableMosaicDefinitionTransaction,
@@ -5970,7 +5970,7 @@ class NonVerifiableTransactionFactory:
 		}
 		discriminator = (parent.type_, parent.version)
 		factory_class = mapping[discriminator]
-		return factory_class.deserialize(buffer_)
+		return factory_class.deserialize(buffer)
 
 	@classmethod
 	def create_by_name(cls, entity_name: str) -> NonVerifiableTransaction:

--- a/sdk/python/symbolchain/sc/__init__.py
+++ b/sdk/python/symbolchain/sc/__init__.py
@@ -28,8 +28,8 @@ class Amount(BaseValue):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Amount:
-		buffer_ = memoryview(payload)
-		return Amount(int.from_bytes(buffer_[:8], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return Amount(int.from_bytes(buffer[:8], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
 		return self.value.to_bytes(8, byteorder='little', signed=False)
@@ -43,8 +43,8 @@ class BlockDuration(BaseValue):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> BlockDuration:
-		buffer_ = memoryview(payload)
-		return BlockDuration(int.from_bytes(buffer_[:8], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return BlockDuration(int.from_bytes(buffer[:8], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
 		return self.value.to_bytes(8, byteorder='little', signed=False)
@@ -58,8 +58,8 @@ class BlockFeeMultiplier(BaseValue):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> BlockFeeMultiplier:
-		buffer_ = memoryview(payload)
-		return BlockFeeMultiplier(int.from_bytes(buffer_[:4], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return BlockFeeMultiplier(int.from_bytes(buffer[:4], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
 		return self.value.to_bytes(4, byteorder='little', signed=False)
@@ -73,8 +73,8 @@ class Difficulty(BaseValue):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Difficulty:
-		buffer_ = memoryview(payload)
-		return Difficulty(int.from_bytes(buffer_[:8], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return Difficulty(int.from_bytes(buffer[:8], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
 		return self.value.to_bytes(8, byteorder='little', signed=False)
@@ -88,8 +88,8 @@ class FinalizationEpoch(BaseValue):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> FinalizationEpoch:
-		buffer_ = memoryview(payload)
-		return FinalizationEpoch(int.from_bytes(buffer_[:4], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return FinalizationEpoch(int.from_bytes(buffer[:4], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
 		return self.value.to_bytes(4, byteorder='little', signed=False)
@@ -103,8 +103,8 @@ class FinalizationPoint(BaseValue):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> FinalizationPoint:
-		buffer_ = memoryview(payload)
-		return FinalizationPoint(int.from_bytes(buffer_[:4], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return FinalizationPoint(int.from_bytes(buffer[:4], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
 		return self.value.to_bytes(4, byteorder='little', signed=False)
@@ -118,8 +118,8 @@ class Height(BaseValue):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Height:
-		buffer_ = memoryview(payload)
-		return Height(int.from_bytes(buffer_[:8], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return Height(int.from_bytes(buffer[:8], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
 		return self.value.to_bytes(8, byteorder='little', signed=False)
@@ -133,8 +133,8 @@ class Importance(BaseValue):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Importance:
-		buffer_ = memoryview(payload)
-		return Importance(int.from_bytes(buffer_[:8], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return Importance(int.from_bytes(buffer[:8], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
 		return self.value.to_bytes(8, byteorder='little', signed=False)
@@ -148,8 +148,8 @@ class ImportanceHeight(BaseValue):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> ImportanceHeight:
-		buffer_ = memoryview(payload)
-		return ImportanceHeight(int.from_bytes(buffer_[:8], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return ImportanceHeight(int.from_bytes(buffer[:8], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
 		return self.value.to_bytes(8, byteorder='little', signed=False)
@@ -163,8 +163,8 @@ class UnresolvedMosaicId(BaseValue):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> UnresolvedMosaicId:
-		buffer_ = memoryview(payload)
-		return UnresolvedMosaicId(int.from_bytes(buffer_[:8], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return UnresolvedMosaicId(int.from_bytes(buffer[:8], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
 		return self.value.to_bytes(8, byteorder='little', signed=False)
@@ -178,8 +178,8 @@ class MosaicId(BaseValue):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicId:
-		buffer_ = memoryview(payload)
-		return MosaicId(int.from_bytes(buffer_[:8], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return MosaicId(int.from_bytes(buffer[:8], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
 		return self.value.to_bytes(8, byteorder='little', signed=False)
@@ -193,8 +193,8 @@ class Timestamp(BaseValue):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Timestamp:
-		buffer_ = memoryview(payload)
-		return Timestamp(int.from_bytes(buffer_[:8], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return Timestamp(int.from_bytes(buffer[:8], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
 		return self.value.to_bytes(8, byteorder='little', signed=False)
@@ -212,8 +212,8 @@ class UnresolvedAddress(ByteArray):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> UnresolvedAddress:
-		buffer_ = memoryview(payload)
-		return UnresolvedAddress(ArrayHelpers.get_bytes(buffer_, 24))
+		buffer = memoryview(payload)
+		return UnresolvedAddress(ArrayHelpers.get_bytes(buffer, 24))
 
 	def serialize(self) -> bytes:
 		return self.bytes
@@ -231,8 +231,8 @@ class Address(ByteArray):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Address:
-		buffer_ = memoryview(payload)
-		return Address(ArrayHelpers.get_bytes(buffer_, 24))
+		buffer = memoryview(payload)
+		return Address(ArrayHelpers.get_bytes(buffer, 24))
 
 	def serialize(self) -> bytes:
 		return self.bytes
@@ -250,8 +250,8 @@ class Hash256(ByteArray):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Hash256:
-		buffer_ = memoryview(payload)
-		return Hash256(ArrayHelpers.get_bytes(buffer_, 32))
+		buffer = memoryview(payload)
+		return Hash256(ArrayHelpers.get_bytes(buffer, 32))
 
 	def serialize(self) -> bytes:
 		return self.bytes
@@ -269,8 +269,8 @@ class Hash512(ByteArray):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Hash512:
-		buffer_ = memoryview(payload)
-		return Hash512(ArrayHelpers.get_bytes(buffer_, 64))
+		buffer = memoryview(payload)
+		return Hash512(ArrayHelpers.get_bytes(buffer, 64))
 
 	def serialize(self) -> bytes:
 		return self.bytes
@@ -288,8 +288,8 @@ class PublicKey(ByteArray):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> PublicKey:
-		buffer_ = memoryview(payload)
-		return PublicKey(ArrayHelpers.get_bytes(buffer_, 32))
+		buffer = memoryview(payload)
+		return PublicKey(ArrayHelpers.get_bytes(buffer, 32))
 
 	def serialize(self) -> bytes:
 		return self.bytes
@@ -307,8 +307,8 @@ class VotingPublicKey(ByteArray):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> VotingPublicKey:
-		buffer_ = memoryview(payload)
-		return VotingPublicKey(ArrayHelpers.get_bytes(buffer_, 32))
+		buffer = memoryview(payload)
+		return VotingPublicKey(ArrayHelpers.get_bytes(buffer, 32))
 
 	def serialize(self) -> bytes:
 		return self.bytes
@@ -326,8 +326,8 @@ class Signature(ByteArray):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Signature:
-		buffer_ = memoryview(payload)
-		return Signature(ArrayHelpers.get_bytes(buffer_, 64))
+		buffer = memoryview(payload)
+		return Signature(ArrayHelpers.get_bytes(buffer, 64))
 
 	def serialize(self) -> bytes:
 		return self.bytes
@@ -368,11 +368,11 @@ class Mosaic:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Mosaic:
-		buffer_ = memoryview(payload)
-		mosaic_id = MosaicId.deserialize(buffer_)
-		buffer_ = buffer_[mosaic_id.size:]
-		amount = Amount.deserialize(buffer_)
-		buffer_ = buffer_[amount.size:]
+		buffer = memoryview(payload)
+		mosaic_id = MosaicId.deserialize(buffer)
+		buffer = buffer[mosaic_id.size:]
+		amount = Amount.deserialize(buffer)
+		buffer = buffer[amount.size:]
 
 		instance = Mosaic()
 		instance._mosaic_id = mosaic_id
@@ -380,10 +380,10 @@ class Mosaic:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._mosaic_id.serialize()
-		buffer_ += self._amount.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._mosaic_id.serialize()
+		buffer += self._amount.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -428,11 +428,11 @@ class UnresolvedMosaic:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> UnresolvedMosaic:
-		buffer_ = memoryview(payload)
-		mosaic_id = UnresolvedMosaicId.deserialize(buffer_)
-		buffer_ = buffer_[mosaic_id.size:]
-		amount = Amount.deserialize(buffer_)
-		buffer_ = buffer_[amount.size:]
+		buffer = memoryview(payload)
+		mosaic_id = UnresolvedMosaicId.deserialize(buffer)
+		buffer = buffer[mosaic_id.size:]
+		amount = Amount.deserialize(buffer)
+		buffer = buffer[amount.size:]
 
 		instance = UnresolvedMosaic()
 		instance._mosaic_id = mosaic_id
@@ -440,10 +440,10 @@ class UnresolvedMosaic:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._mosaic_id.serialize()
-		buffer_ += self._amount.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._mosaic_id.serialize()
+		buffer += self._amount.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -463,13 +463,13 @@ class LinkAction(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> LinkAction:
-		buffer_ = memoryview(payload)
-		return LinkAction(int.from_bytes(buffer_[:1], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return LinkAction(int.from_bytes(buffer[:1], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(1, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(1, byteorder='little', signed=False)
+		return buffer
 
 
 class NetworkType(Enum):
@@ -482,13 +482,13 @@ class NetworkType(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NetworkType:
-		buffer_ = memoryview(payload)
-		return NetworkType(int.from_bytes(buffer_[:1], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return NetworkType(int.from_bytes(buffer[:1], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(1, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(1, byteorder='little', signed=False)
+		return buffer
 
 
 class TransactionType(Enum):
@@ -524,13 +524,13 @@ class TransactionType(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> TransactionType:
-		buffer_ = memoryview(payload)
-		return TransactionType(int.from_bytes(buffer_[:2], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return TransactionType(int.from_bytes(buffer[:2], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(2, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(2, byteorder='little', signed=False)
+		return buffer
 
 
 class Transaction:
@@ -627,31 +627,31 @@ class Transaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Transaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
 
 		instance = Transaction()
 		instance._signature = signature
@@ -664,18 +664,18 @@ class Transaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -751,25 +751,25 @@ class EmbeddedTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
 
 		instance = EmbeddedTransaction()
 		instance._signer_public_key = signer_public_key
@@ -779,15 +779,15 @@ class EmbeddedTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -811,8 +811,8 @@ class ProofGamma(ByteArray):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> ProofGamma:
-		buffer_ = memoryview(payload)
-		return ProofGamma(ArrayHelpers.get_bytes(buffer_, 32))
+		buffer = memoryview(payload)
+		return ProofGamma(ArrayHelpers.get_bytes(buffer, 32))
 
 	def serialize(self) -> bytes:
 		return self.bytes
@@ -830,8 +830,8 @@ class ProofVerificationHash(ByteArray):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> ProofVerificationHash:
-		buffer_ = memoryview(payload)
-		return ProofVerificationHash(ArrayHelpers.get_bytes(buffer_, 16))
+		buffer = memoryview(payload)
+		return ProofVerificationHash(ArrayHelpers.get_bytes(buffer, 16))
 
 	def serialize(self) -> bytes:
 		return self.bytes
@@ -849,8 +849,8 @@ class ProofScalar(ByteArray):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> ProofScalar:
-		buffer_ = memoryview(payload)
-		return ProofScalar(ArrayHelpers.get_bytes(buffer_, 32))
+		buffer = memoryview(payload)
+		return ProofScalar(ArrayHelpers.get_bytes(buffer, 32))
 
 	def serialize(self) -> bytes:
 		return self.bytes
@@ -867,13 +867,13 @@ class BlockType(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> BlockType:
-		buffer_ = memoryview(payload)
-		return BlockType(int.from_bytes(buffer_[:2], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return BlockType(int.from_bytes(buffer[:2], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(2, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(2, byteorder='little', signed=False)
+		return buffer
 
 
 class VrfProof:
@@ -922,13 +922,13 @@ class VrfProof:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> VrfProof:
-		buffer_ = memoryview(payload)
-		gamma = ProofGamma.deserialize(buffer_)
-		buffer_ = buffer_[gamma.size:]
-		verification_hash = ProofVerificationHash.deserialize(buffer_)
-		buffer_ = buffer_[verification_hash.size:]
-		scalar = ProofScalar.deserialize(buffer_)
-		buffer_ = buffer_[scalar.size:]
+		buffer = memoryview(payload)
+		gamma = ProofGamma.deserialize(buffer)
+		buffer = buffer[gamma.size:]
+		verification_hash = ProofVerificationHash.deserialize(buffer)
+		buffer = buffer[verification_hash.size:]
+		scalar = ProofScalar.deserialize(buffer)
+		buffer = buffer[scalar.size:]
 
 		instance = VrfProof()
 		instance._gamma = gamma
@@ -937,11 +937,11 @@ class VrfProof:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._gamma.serialize()
-		buffer_ += self._verification_hash.serialize()
-		buffer_ += self._scalar.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._gamma.serialize()
+		buffer += self._verification_hash.serialize()
+		buffer += self._scalar.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -1134,47 +1134,47 @@ class Block:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Block:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = BlockType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		height = Height.deserialize(buffer_)
-		buffer_ = buffer_[height.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		difficulty = Difficulty.deserialize(buffer_)
-		buffer_ = buffer_[difficulty.size:]
-		generation_hash_proof = VrfProof.deserialize(buffer_)
-		buffer_ = buffer_[generation_hash_proof.size:]
-		previous_block_hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[previous_block_hash.size:]
-		transactions_hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[transactions_hash.size:]
-		receipts_hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[receipts_hash.size:]
-		state_hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[state_hash.size:]
-		beneficiary_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[beneficiary_address.size:]
-		fee_multiplier = BlockFeeMultiplier.deserialize(buffer_)
-		buffer_ = buffer_[fee_multiplier.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = BlockType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		height = Height.deserialize(buffer)
+		buffer = buffer[height.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		difficulty = Difficulty.deserialize(buffer)
+		buffer = buffer[difficulty.size:]
+		generation_hash_proof = VrfProof.deserialize(buffer)
+		buffer = buffer[generation_hash_proof.size:]
+		previous_block_hash = Hash256.deserialize(buffer)
+		buffer = buffer[previous_block_hash.size:]
+		transactions_hash = Hash256.deserialize(buffer)
+		buffer = buffer[transactions_hash.size:]
+		receipts_hash = Hash256.deserialize(buffer)
+		buffer = buffer[receipts_hash.size:]
+		state_hash = Hash256.deserialize(buffer)
+		buffer = buffer[state_hash.size:]
+		beneficiary_address = Address.deserialize(buffer)
+		buffer = buffer[beneficiary_address.size:]
+		fee_multiplier = BlockFeeMultiplier.deserialize(buffer)
+		buffer = buffer[fee_multiplier.size:]
 
 		instance = Block()
 		instance._signature = signature
@@ -1195,26 +1195,26 @@ class Block:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._height.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._difficulty.serialize()
-		buffer_ += self._generation_hash_proof.serialize()
-		buffer_ += self._previous_block_hash.serialize()
-		buffer_ += self._transactions_hash.serialize()
-		buffer_ += self._receipts_hash.serialize()
-		buffer_ += self._state_hash.serialize()
-		buffer_ += self._beneficiary_address.serialize()
-		buffer_ += self._fee_multiplier.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._height.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._difficulty.serialize()
+		buffer += self._generation_hash_proof.serialize()
+		buffer += self._previous_block_hash.serialize()
+		buffer += self._transactions_hash.serialize()
+		buffer += self._receipts_hash.serialize()
+		buffer += self._state_hash.serialize()
+		buffer += self._beneficiary_address.serialize()
+		buffer += self._fee_multiplier.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -1474,57 +1474,57 @@ class NemesisBlock:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NemesisBlock:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = BlockType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		height = Height.deserialize(buffer_)
-		buffer_ = buffer_[height.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		difficulty = Difficulty.deserialize(buffer_)
-		buffer_ = buffer_[difficulty.size:]
-		generation_hash_proof = VrfProof.deserialize(buffer_)
-		buffer_ = buffer_[generation_hash_proof.size:]
-		previous_block_hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[previous_block_hash.size:]
-		transactions_hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[transactions_hash.size:]
-		receipts_hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[receipts_hash.size:]
-		state_hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[state_hash.size:]
-		beneficiary_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[beneficiary_address.size:]
-		fee_multiplier = BlockFeeMultiplier.deserialize(buffer_)
-		buffer_ = buffer_[fee_multiplier.size:]
-		voting_eligible_accounts_count = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		harvesting_eligible_accounts_count = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		total_voting_balance = Amount.deserialize(buffer_)
-		buffer_ = buffer_[total_voting_balance.size:]
-		previous_importance_block_hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[previous_importance_block_hash.size:]
-		transactions = ArrayHelpers.read_array(buffer_, Transaction)
-		buffer_ = buffer_[sum(map(lambda e: e.size, transactions)):]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = BlockType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		height = Height.deserialize(buffer)
+		buffer = buffer[height.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		difficulty = Difficulty.deserialize(buffer)
+		buffer = buffer[difficulty.size:]
+		generation_hash_proof = VrfProof.deserialize(buffer)
+		buffer = buffer[generation_hash_proof.size:]
+		previous_block_hash = Hash256.deserialize(buffer)
+		buffer = buffer[previous_block_hash.size:]
+		transactions_hash = Hash256.deserialize(buffer)
+		buffer = buffer[transactions_hash.size:]
+		receipts_hash = Hash256.deserialize(buffer)
+		buffer = buffer[receipts_hash.size:]
+		state_hash = Hash256.deserialize(buffer)
+		buffer = buffer[state_hash.size:]
+		beneficiary_address = Address.deserialize(buffer)
+		buffer = buffer[beneficiary_address.size:]
+		fee_multiplier = BlockFeeMultiplier.deserialize(buffer)
+		buffer = buffer[fee_multiplier.size:]
+		voting_eligible_accounts_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		harvesting_eligible_accounts_count = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		total_voting_balance = Amount.deserialize(buffer)
+		buffer = buffer[total_voting_balance.size:]
+		previous_importance_block_hash = Hash256.deserialize(buffer)
+		buffer = buffer[previous_importance_block_hash.size:]
+		transactions = ArrayHelpers.read_array(buffer, Transaction)
+		buffer = buffer[sum(map(lambda e: e.size, transactions)):]
 
 		instance = NemesisBlock()
 		instance._signature = signature
@@ -1550,31 +1550,31 @@ class NemesisBlock:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._height.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._difficulty.serialize()
-		buffer_ += self._generation_hash_proof.serialize()
-		buffer_ += self._previous_block_hash.serialize()
-		buffer_ += self._transactions_hash.serialize()
-		buffer_ += self._receipts_hash.serialize()
-		buffer_ += self._state_hash.serialize()
-		buffer_ += self._beneficiary_address.serialize()
-		buffer_ += self._fee_multiplier.serialize()
-		buffer_ += self._voting_eligible_accounts_count.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._harvesting_eligible_accounts_count.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._total_voting_balance.serialize()
-		buffer_ += self._previous_importance_block_hash.serialize()
-		buffer_ += ArrayHelpers.write_array(self._transactions)
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._height.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._difficulty.serialize()
+		buffer += self._generation_hash_proof.serialize()
+		buffer += self._previous_block_hash.serialize()
+		buffer += self._transactions_hash.serialize()
+		buffer += self._receipts_hash.serialize()
+		buffer += self._state_hash.serialize()
+		buffer += self._beneficiary_address.serialize()
+		buffer += self._fee_multiplier.serialize()
+		buffer += self._voting_eligible_accounts_count.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._harvesting_eligible_accounts_count.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._total_voting_balance.serialize()
+		buffer += self._previous_importance_block_hash.serialize()
+		buffer += ArrayHelpers.write_array(self._transactions)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -1799,52 +1799,52 @@ class NormalBlock:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NormalBlock:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = BlockType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		height = Height.deserialize(buffer_)
-		buffer_ = buffer_[height.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		difficulty = Difficulty.deserialize(buffer_)
-		buffer_ = buffer_[difficulty.size:]
-		generation_hash_proof = VrfProof.deserialize(buffer_)
-		buffer_ = buffer_[generation_hash_proof.size:]
-		previous_block_hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[previous_block_hash.size:]
-		transactions_hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[transactions_hash.size:]
-		receipts_hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[receipts_hash.size:]
-		state_hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[state_hash.size:]
-		beneficiary_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[beneficiary_address.size:]
-		fee_multiplier = BlockFeeMultiplier.deserialize(buffer_)
-		buffer_ = buffer_[fee_multiplier.size:]
-		block_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = BlockType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		height = Height.deserialize(buffer)
+		buffer = buffer[height.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		difficulty = Difficulty.deserialize(buffer)
+		buffer = buffer[difficulty.size:]
+		generation_hash_proof = VrfProof.deserialize(buffer)
+		buffer = buffer[generation_hash_proof.size:]
+		previous_block_hash = Hash256.deserialize(buffer)
+		buffer = buffer[previous_block_hash.size:]
+		transactions_hash = Hash256.deserialize(buffer)
+		buffer = buffer[transactions_hash.size:]
+		receipts_hash = Hash256.deserialize(buffer)
+		buffer = buffer[receipts_hash.size:]
+		state_hash = Hash256.deserialize(buffer)
+		buffer = buffer[state_hash.size:]
+		beneficiary_address = Address.deserialize(buffer)
+		buffer = buffer[beneficiary_address.size:]
+		fee_multiplier = BlockFeeMultiplier.deserialize(buffer)
+		buffer = buffer[fee_multiplier.size:]
+		block_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert block_header_reserved_1 == 0, f'Invalid value of reserved field ({block_header_reserved_1})'
-		transactions = ArrayHelpers.read_array(buffer_, Transaction)
-		buffer_ = buffer_[sum(map(lambda e: e.size, transactions)):]
+		transactions = ArrayHelpers.read_array(buffer, Transaction)
+		buffer = buffer[sum(map(lambda e: e.size, transactions)):]
 
 		instance = NormalBlock()
 		instance._signature = signature
@@ -1866,28 +1866,28 @@ class NormalBlock:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._height.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._difficulty.serialize()
-		buffer_ += self._generation_hash_proof.serialize()
-		buffer_ += self._previous_block_hash.serialize()
-		buffer_ += self._transactions_hash.serialize()
-		buffer_ += self._receipts_hash.serialize()
-		buffer_ += self._state_hash.serialize()
-		buffer_ += self._beneficiary_address.serialize()
-		buffer_ += self._fee_multiplier.serialize()
-		buffer_ += self._block_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += ArrayHelpers.write_array(self._transactions)
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._height.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._difficulty.serialize()
+		buffer += self._generation_hash_proof.serialize()
+		buffer += self._previous_block_hash.serialize()
+		buffer += self._transactions_hash.serialize()
+		buffer += self._receipts_hash.serialize()
+		buffer += self._state_hash.serialize()
+		buffer += self._beneficiary_address.serialize()
+		buffer += self._fee_multiplier.serialize()
+		buffer += self._block_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += ArrayHelpers.write_array(self._transactions)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -2148,57 +2148,57 @@ class ImportanceBlock:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> ImportanceBlock:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = BlockType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		height = Height.deserialize(buffer_)
-		buffer_ = buffer_[height.size:]
-		timestamp = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[timestamp.size:]
-		difficulty = Difficulty.deserialize(buffer_)
-		buffer_ = buffer_[difficulty.size:]
-		generation_hash_proof = VrfProof.deserialize(buffer_)
-		buffer_ = buffer_[generation_hash_proof.size:]
-		previous_block_hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[previous_block_hash.size:]
-		transactions_hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[transactions_hash.size:]
-		receipts_hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[receipts_hash.size:]
-		state_hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[state_hash.size:]
-		beneficiary_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[beneficiary_address.size:]
-		fee_multiplier = BlockFeeMultiplier.deserialize(buffer_)
-		buffer_ = buffer_[fee_multiplier.size:]
-		voting_eligible_accounts_count = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		harvesting_eligible_accounts_count = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		total_voting_balance = Amount.deserialize(buffer_)
-		buffer_ = buffer_[total_voting_balance.size:]
-		previous_importance_block_hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[previous_importance_block_hash.size:]
-		transactions = ArrayHelpers.read_array(buffer_, Transaction)
-		buffer_ = buffer_[sum(map(lambda e: e.size, transactions)):]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = BlockType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		height = Height.deserialize(buffer)
+		buffer = buffer[height.size:]
+		timestamp = Timestamp.deserialize(buffer)
+		buffer = buffer[timestamp.size:]
+		difficulty = Difficulty.deserialize(buffer)
+		buffer = buffer[difficulty.size:]
+		generation_hash_proof = VrfProof.deserialize(buffer)
+		buffer = buffer[generation_hash_proof.size:]
+		previous_block_hash = Hash256.deserialize(buffer)
+		buffer = buffer[previous_block_hash.size:]
+		transactions_hash = Hash256.deserialize(buffer)
+		buffer = buffer[transactions_hash.size:]
+		receipts_hash = Hash256.deserialize(buffer)
+		buffer = buffer[receipts_hash.size:]
+		state_hash = Hash256.deserialize(buffer)
+		buffer = buffer[state_hash.size:]
+		beneficiary_address = Address.deserialize(buffer)
+		buffer = buffer[beneficiary_address.size:]
+		fee_multiplier = BlockFeeMultiplier.deserialize(buffer)
+		buffer = buffer[fee_multiplier.size:]
+		voting_eligible_accounts_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		harvesting_eligible_accounts_count = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		total_voting_balance = Amount.deserialize(buffer)
+		buffer = buffer[total_voting_balance.size:]
+		previous_importance_block_hash = Hash256.deserialize(buffer)
+		buffer = buffer[previous_importance_block_hash.size:]
+		transactions = ArrayHelpers.read_array(buffer, Transaction)
+		buffer = buffer[sum(map(lambda e: e.size, transactions)):]
 
 		instance = ImportanceBlock()
 		instance._signature = signature
@@ -2224,31 +2224,31 @@ class ImportanceBlock:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._height.serialize()
-		buffer_ += self._timestamp.serialize()
-		buffer_ += self._difficulty.serialize()
-		buffer_ += self._generation_hash_proof.serialize()
-		buffer_ += self._previous_block_hash.serialize()
-		buffer_ += self._transactions_hash.serialize()
-		buffer_ += self._receipts_hash.serialize()
-		buffer_ += self._state_hash.serialize()
-		buffer_ += self._beneficiary_address.serialize()
-		buffer_ += self._fee_multiplier.serialize()
-		buffer_ += self._voting_eligible_accounts_count.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._harvesting_eligible_accounts_count.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._total_voting_balance.serialize()
-		buffer_ += self._previous_importance_block_hash.serialize()
-		buffer_ += ArrayHelpers.write_array(self._transactions)
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._height.serialize()
+		buffer += self._timestamp.serialize()
+		buffer += self._difficulty.serialize()
+		buffer += self._generation_hash_proof.serialize()
+		buffer += self._previous_block_hash.serialize()
+		buffer += self._transactions_hash.serialize()
+		buffer += self._receipts_hash.serialize()
+		buffer += self._state_hash.serialize()
+		buffer += self._beneficiary_address.serialize()
+		buffer += self._fee_multiplier.serialize()
+		buffer += self._voting_eligible_accounts_count.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._harvesting_eligible_accounts_count.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._total_voting_balance.serialize()
+		buffer += self._previous_importance_block_hash.serialize()
+		buffer += ArrayHelpers.write_array(self._transactions)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -2311,11 +2311,11 @@ class FinalizationRound:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> FinalizationRound:
-		buffer_ = memoryview(payload)
-		epoch = FinalizationEpoch.deserialize(buffer_)
-		buffer_ = buffer_[epoch.size:]
-		point = FinalizationPoint.deserialize(buffer_)
-		buffer_ = buffer_[point.size:]
+		buffer = memoryview(payload)
+		epoch = FinalizationEpoch.deserialize(buffer)
+		buffer = buffer[epoch.size:]
+		point = FinalizationPoint.deserialize(buffer)
+		buffer = buffer[point.size:]
 
 		instance = FinalizationRound()
 		instance._epoch = epoch
@@ -2323,10 +2323,10 @@ class FinalizationRound:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._epoch.serialize()
-		buffer_ += self._point.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._epoch.serialize()
+		buffer += self._point.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -2382,13 +2382,13 @@ class FinalizedBlockHeader:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> FinalizedBlockHeader:
-		buffer_ = memoryview(payload)
-		round = FinalizationRound.deserialize(buffer_)
-		buffer_ = buffer_[round.size:]
-		height = Height.deserialize(buffer_)
-		buffer_ = buffer_[height.size:]
-		hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[hash.size:]
+		buffer = memoryview(payload)
+		round = FinalizationRound.deserialize(buffer)
+		buffer = buffer[round.size:]
+		height = Height.deserialize(buffer)
+		buffer = buffer[height.size:]
+		hash = Hash256.deserialize(buffer)
+		buffer = buffer[hash.size:]
 
 		instance = FinalizedBlockHeader()
 		instance._round = round
@@ -2397,11 +2397,11 @@ class FinalizedBlockHeader:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._round.serialize()
-		buffer_ += self._height.serialize()
-		buffer_ += self._hash.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._round.serialize()
+		buffer += self._height.serialize()
+		buffer += self._hash.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -2436,13 +2436,13 @@ class ReceiptType(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> ReceiptType:
-		buffer_ = memoryview(payload)
-		return ReceiptType(int.from_bytes(buffer_[:2], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return ReceiptType(int.from_bytes(buffer[:2], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(2, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(2, byteorder='little', signed=False)
+		return buffer
 
 
 class Receipt:
@@ -2480,15 +2480,15 @@ class Receipt:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Receipt:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		version = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		type_ = ReceiptType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
+		version = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		type_ = ReceiptType.deserialize(buffer)
+		buffer = buffer[type_.size:]
 
 		instance = Receipt()
 		instance._version = version
@@ -2496,11 +2496,11 @@ class Receipt:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._type_.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._type_.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -2568,19 +2568,19 @@ class HarvestFeeReceipt:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> HarvestFeeReceipt:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		version = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		type_ = ReceiptType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		mosaic = Mosaic.deserialize(buffer_)
-		buffer_ = buffer_[mosaic.size:]
-		target_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[target_address.size:]
+		version = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		type_ = ReceiptType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		mosaic = Mosaic.deserialize(buffer)
+		buffer = buffer[mosaic.size:]
+		target_address = Address.deserialize(buffer)
+		buffer = buffer[target_address.size:]
 
 		instance = HarvestFeeReceipt()
 		instance._version = version
@@ -2590,13 +2590,13 @@ class HarvestFeeReceipt:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._type_.serialize()
-		buffer_ += self._mosaic.serialize()
-		buffer_ += self._target_address.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._type_.serialize()
+		buffer += self._mosaic.serialize()
+		buffer += self._target_address.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -2655,17 +2655,17 @@ class InflationReceipt:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> InflationReceipt:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		version = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		type_ = ReceiptType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		mosaic = Mosaic.deserialize(buffer_)
-		buffer_ = buffer_[mosaic.size:]
+		version = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		type_ = ReceiptType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		mosaic = Mosaic.deserialize(buffer)
+		buffer = buffer[mosaic.size:]
 
 		instance = InflationReceipt()
 		instance._version = version
@@ -2674,12 +2674,12 @@ class InflationReceipt:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._type_.serialize()
-		buffer_ += self._mosaic.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._type_.serialize()
+		buffer += self._mosaic.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -2748,19 +2748,19 @@ class LockHashCreatedFeeReceipt:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> LockHashCreatedFeeReceipt:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		version = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		type_ = ReceiptType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		mosaic = Mosaic.deserialize(buffer_)
-		buffer_ = buffer_[mosaic.size:]
-		target_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[target_address.size:]
+		version = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		type_ = ReceiptType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		mosaic = Mosaic.deserialize(buffer)
+		buffer = buffer[mosaic.size:]
+		target_address = Address.deserialize(buffer)
+		buffer = buffer[target_address.size:]
 
 		instance = LockHashCreatedFeeReceipt()
 		instance._version = version
@@ -2770,13 +2770,13 @@ class LockHashCreatedFeeReceipt:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._type_.serialize()
-		buffer_ += self._mosaic.serialize()
-		buffer_ += self._target_address.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._type_.serialize()
+		buffer += self._mosaic.serialize()
+		buffer += self._target_address.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -2846,19 +2846,19 @@ class LockHashCompletedFeeReceipt:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> LockHashCompletedFeeReceipt:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		version = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		type_ = ReceiptType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		mosaic = Mosaic.deserialize(buffer_)
-		buffer_ = buffer_[mosaic.size:]
-		target_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[target_address.size:]
+		version = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		type_ = ReceiptType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		mosaic = Mosaic.deserialize(buffer)
+		buffer = buffer[mosaic.size:]
+		target_address = Address.deserialize(buffer)
+		buffer = buffer[target_address.size:]
 
 		instance = LockHashCompletedFeeReceipt()
 		instance._version = version
@@ -2868,13 +2868,13 @@ class LockHashCompletedFeeReceipt:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._type_.serialize()
-		buffer_ += self._mosaic.serialize()
-		buffer_ += self._target_address.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._type_.serialize()
+		buffer += self._mosaic.serialize()
+		buffer += self._target_address.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -2944,19 +2944,19 @@ class LockHashExpiredFeeReceipt:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> LockHashExpiredFeeReceipt:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		version = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		type_ = ReceiptType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		mosaic = Mosaic.deserialize(buffer_)
-		buffer_ = buffer_[mosaic.size:]
-		target_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[target_address.size:]
+		version = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		type_ = ReceiptType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		mosaic = Mosaic.deserialize(buffer)
+		buffer = buffer[mosaic.size:]
+		target_address = Address.deserialize(buffer)
+		buffer = buffer[target_address.size:]
 
 		instance = LockHashExpiredFeeReceipt()
 		instance._version = version
@@ -2966,13 +2966,13 @@ class LockHashExpiredFeeReceipt:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._type_.serialize()
-		buffer_ += self._mosaic.serialize()
-		buffer_ += self._target_address.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._type_.serialize()
+		buffer += self._mosaic.serialize()
+		buffer += self._target_address.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -3042,19 +3042,19 @@ class LockSecretCreatedFeeReceipt:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> LockSecretCreatedFeeReceipt:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		version = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		type_ = ReceiptType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		mosaic = Mosaic.deserialize(buffer_)
-		buffer_ = buffer_[mosaic.size:]
-		target_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[target_address.size:]
+		version = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		type_ = ReceiptType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		mosaic = Mosaic.deserialize(buffer)
+		buffer = buffer[mosaic.size:]
+		target_address = Address.deserialize(buffer)
+		buffer = buffer[target_address.size:]
 
 		instance = LockSecretCreatedFeeReceipt()
 		instance._version = version
@@ -3064,13 +3064,13 @@ class LockSecretCreatedFeeReceipt:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._type_.serialize()
-		buffer_ += self._mosaic.serialize()
-		buffer_ += self._target_address.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._type_.serialize()
+		buffer += self._mosaic.serialize()
+		buffer += self._target_address.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -3140,19 +3140,19 @@ class LockSecretCompletedFeeReceipt:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> LockSecretCompletedFeeReceipt:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		version = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		type_ = ReceiptType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		mosaic = Mosaic.deserialize(buffer_)
-		buffer_ = buffer_[mosaic.size:]
-		target_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[target_address.size:]
+		version = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		type_ = ReceiptType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		mosaic = Mosaic.deserialize(buffer)
+		buffer = buffer[mosaic.size:]
+		target_address = Address.deserialize(buffer)
+		buffer = buffer[target_address.size:]
 
 		instance = LockSecretCompletedFeeReceipt()
 		instance._version = version
@@ -3162,13 +3162,13 @@ class LockSecretCompletedFeeReceipt:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._type_.serialize()
-		buffer_ += self._mosaic.serialize()
-		buffer_ += self._target_address.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._type_.serialize()
+		buffer += self._mosaic.serialize()
+		buffer += self._target_address.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -3238,19 +3238,19 @@ class LockSecretExpiredFeeReceipt:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> LockSecretExpiredFeeReceipt:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		version = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		type_ = ReceiptType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		mosaic = Mosaic.deserialize(buffer_)
-		buffer_ = buffer_[mosaic.size:]
-		target_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[target_address.size:]
+		version = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		type_ = ReceiptType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		mosaic = Mosaic.deserialize(buffer)
+		buffer = buffer[mosaic.size:]
+		target_address = Address.deserialize(buffer)
+		buffer = buffer[target_address.size:]
 
 		instance = LockSecretExpiredFeeReceipt()
 		instance._version = version
@@ -3260,13 +3260,13 @@ class LockSecretExpiredFeeReceipt:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._type_.serialize()
-		buffer_ += self._mosaic.serialize()
-		buffer_ += self._target_address.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._type_.serialize()
+		buffer += self._mosaic.serialize()
+		buffer += self._target_address.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -3325,17 +3325,17 @@ class MosaicExpiredReceipt:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicExpiredReceipt:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		version = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		type_ = ReceiptType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		artifact_id = MosaicId.deserialize(buffer_)
-		buffer_ = buffer_[artifact_id.size:]
+		version = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		type_ = ReceiptType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		artifact_id = MosaicId.deserialize(buffer)
+		buffer = buffer[artifact_id.size:]
 
 		instance = MosaicExpiredReceipt()
 		instance._version = version
@@ -3344,12 +3344,12 @@ class MosaicExpiredReceipt:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._type_.serialize()
-		buffer_ += self._artifact_id.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._type_.serialize()
+		buffer += self._artifact_id.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -3429,21 +3429,21 @@ class MosaicRentalFeeReceipt:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicRentalFeeReceipt:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		version = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		type_ = ReceiptType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		mosaic = Mosaic.deserialize(buffer_)
-		buffer_ = buffer_[mosaic.size:]
-		sender_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[sender_address.size:]
-		recipient_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[recipient_address.size:]
+		version = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		type_ = ReceiptType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		mosaic = Mosaic.deserialize(buffer)
+		buffer = buffer[mosaic.size:]
+		sender_address = Address.deserialize(buffer)
+		buffer = buffer[sender_address.size:]
+		recipient_address = Address.deserialize(buffer)
+		buffer = buffer[recipient_address.size:]
 
 		instance = MosaicRentalFeeReceipt()
 		instance._version = version
@@ -3454,14 +3454,14 @@ class MosaicRentalFeeReceipt:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._type_.serialize()
-		buffer_ += self._mosaic.serialize()
-		buffer_ += self._sender_address.serialize()
-		buffer_ += self._recipient_address.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._type_.serialize()
+		buffer += self._mosaic.serialize()
+		buffer += self._sender_address.serialize()
+		buffer += self._recipient_address.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -3482,8 +3482,8 @@ class NamespaceId(BaseValue):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NamespaceId:
-		buffer_ = memoryview(payload)
-		return NamespaceId(int.from_bytes(buffer_[:8], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return NamespaceId(int.from_bytes(buffer[:8], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
 		return self.value.to_bytes(8, byteorder='little', signed=False)
@@ -3499,13 +3499,13 @@ class NamespaceRegistrationType(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NamespaceRegistrationType:
-		buffer_ = memoryview(payload)
-		return NamespaceRegistrationType(int.from_bytes(buffer_[:1], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return NamespaceRegistrationType(int.from_bytes(buffer[:1], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(1, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(1, byteorder='little', signed=False)
+		return buffer
 
 
 class AliasAction(Enum):
@@ -3518,13 +3518,13 @@ class AliasAction(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AliasAction:
-		buffer_ = memoryview(payload)
-		return AliasAction(int.from_bytes(buffer_[:1], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return AliasAction(int.from_bytes(buffer[:1], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(1, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(1, byteorder='little', signed=False)
+		return buffer
 
 
 class NamespaceExpiredReceipt:
@@ -3574,17 +3574,17 @@ class NamespaceExpiredReceipt:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NamespaceExpiredReceipt:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		version = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		type_ = ReceiptType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		artifact_id = NamespaceId.deserialize(buffer_)
-		buffer_ = buffer_[artifact_id.size:]
+		version = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		type_ = ReceiptType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		artifact_id = NamespaceId.deserialize(buffer)
+		buffer = buffer[artifact_id.size:]
 
 		instance = NamespaceExpiredReceipt()
 		instance._version = version
@@ -3593,12 +3593,12 @@ class NamespaceExpiredReceipt:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._type_.serialize()
-		buffer_ += self._artifact_id.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._type_.serialize()
+		buffer += self._artifact_id.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -3656,17 +3656,17 @@ class NamespaceDeletedReceipt:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NamespaceDeletedReceipt:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		version = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		type_ = ReceiptType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		artifact_id = NamespaceId.deserialize(buffer_)
-		buffer_ = buffer_[artifact_id.size:]
+		version = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		type_ = ReceiptType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		artifact_id = NamespaceId.deserialize(buffer)
+		buffer = buffer[artifact_id.size:]
 
 		instance = NamespaceDeletedReceipt()
 		instance._version = version
@@ -3675,12 +3675,12 @@ class NamespaceDeletedReceipt:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._type_.serialize()
-		buffer_ += self._artifact_id.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._type_.serialize()
+		buffer += self._artifact_id.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -3760,21 +3760,21 @@ class NamespaceRentalFeeReceipt:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NamespaceRentalFeeReceipt:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		version = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		type_ = ReceiptType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		mosaic = Mosaic.deserialize(buffer_)
-		buffer_ = buffer_[mosaic.size:]
-		sender_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[sender_address.size:]
-		recipient_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[recipient_address.size:]
+		version = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		type_ = ReceiptType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		mosaic = Mosaic.deserialize(buffer)
+		buffer = buffer[mosaic.size:]
+		sender_address = Address.deserialize(buffer)
+		buffer = buffer[sender_address.size:]
+		recipient_address = Address.deserialize(buffer)
+		buffer = buffer[recipient_address.size:]
 
 		instance = NamespaceRentalFeeReceipt()
 		instance._version = version
@@ -3785,14 +3785,14 @@ class NamespaceRentalFeeReceipt:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._type_.serialize()
-		buffer_ += self._mosaic.serialize()
-		buffer_ += self._sender_address.serialize()
-		buffer_ += self._recipient_address.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._type_.serialize()
+		buffer += self._mosaic.serialize()
+		buffer += self._sender_address.serialize()
+		buffer += self._recipient_address.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -3838,11 +3838,11 @@ class ReceiptSource:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> ReceiptSource:
-		buffer_ = memoryview(payload)
-		primary_id = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		secondary_id = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		buffer = memoryview(payload)
+		primary_id = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		secondary_id = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 
 		instance = ReceiptSource()
 		instance._primary_id = primary_id
@@ -3850,10 +3850,10 @@ class ReceiptSource:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._primary_id.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._secondary_id.to_bytes(4, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self._primary_id.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._secondary_id.to_bytes(4, byteorder='little', signed=False)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -3898,11 +3898,11 @@ class AddressResolutionEntry:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AddressResolutionEntry:
-		buffer_ = memoryview(payload)
-		source = ReceiptSource.deserialize(buffer_)
-		buffer_ = buffer_[source.size:]
-		resolved_value = Address.deserialize(buffer_)
-		buffer_ = buffer_[resolved_value.size:]
+		buffer = memoryview(payload)
+		source = ReceiptSource.deserialize(buffer)
+		buffer = buffer[source.size:]
+		resolved_value = Address.deserialize(buffer)
+		buffer = buffer[resolved_value.size:]
 
 		instance = AddressResolutionEntry()
 		instance._source = source
@@ -3910,10 +3910,10 @@ class AddressResolutionEntry:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._source.serialize()
-		buffer_ += self._resolved_value.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._source.serialize()
+		buffer += self._resolved_value.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -3959,13 +3959,13 @@ class AddressResolutionStatement:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AddressResolutionStatement:
-		buffer_ = memoryview(payload)
-		unresolved = UnresolvedAddress.deserialize(buffer_)
-		buffer_ = buffer_[unresolved.size:]
-		resolution_entries_count = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		resolution_entries = ArrayHelpers.read_array_count(buffer_, AddressResolutionEntry, resolution_entries_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, resolution_entries)):]
+		buffer = memoryview(payload)
+		unresolved = UnresolvedAddress.deserialize(buffer)
+		buffer = buffer[unresolved.size:]
+		resolution_entries_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		resolution_entries = ArrayHelpers.read_array_count(buffer, AddressResolutionEntry, resolution_entries_count)
+		buffer = buffer[sum(map(lambda e: e.size, resolution_entries)):]
 
 		instance = AddressResolutionStatement()
 		instance._unresolved = unresolved
@@ -3973,11 +3973,11 @@ class AddressResolutionStatement:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._unresolved.serialize()
-		buffer_ += len(self._resolution_entries).to_bytes(4, byteorder='little', signed=False)  # resolution_entries_count
-		buffer_ += ArrayHelpers.write_array(self._resolution_entries)
-		return buffer_
+		buffer = bytes()
+		buffer += self._unresolved.serialize()
+		buffer += len(self._resolution_entries).to_bytes(4, byteorder='little', signed=False)  # resolution_entries_count
+		buffer += ArrayHelpers.write_array(self._resolution_entries)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -4022,11 +4022,11 @@ class MosaicResolutionEntry:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicResolutionEntry:
-		buffer_ = memoryview(payload)
-		source = ReceiptSource.deserialize(buffer_)
-		buffer_ = buffer_[source.size:]
-		resolved_value = MosaicId.deserialize(buffer_)
-		buffer_ = buffer_[resolved_value.size:]
+		buffer = memoryview(payload)
+		source = ReceiptSource.deserialize(buffer)
+		buffer = buffer[source.size:]
+		resolved_value = MosaicId.deserialize(buffer)
+		buffer = buffer[resolved_value.size:]
 
 		instance = MosaicResolutionEntry()
 		instance._source = source
@@ -4034,10 +4034,10 @@ class MosaicResolutionEntry:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._source.serialize()
-		buffer_ += self._resolved_value.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._source.serialize()
+		buffer += self._resolved_value.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -4083,13 +4083,13 @@ class MosaicResolutionStatement:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicResolutionStatement:
-		buffer_ = memoryview(payload)
-		unresolved = UnresolvedMosaicId.deserialize(buffer_)
-		buffer_ = buffer_[unresolved.size:]
-		resolution_entries_count = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		resolution_entries = ArrayHelpers.read_array_count(buffer_, MosaicResolutionEntry, resolution_entries_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, resolution_entries)):]
+		buffer = memoryview(payload)
+		unresolved = UnresolvedMosaicId.deserialize(buffer)
+		buffer = buffer[unresolved.size:]
+		resolution_entries_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		resolution_entries = ArrayHelpers.read_array_count(buffer, MosaicResolutionEntry, resolution_entries_count)
+		buffer = buffer[sum(map(lambda e: e.size, resolution_entries)):]
 
 		instance = MosaicResolutionStatement()
 		instance._unresolved = unresolved
@@ -4097,11 +4097,11 @@ class MosaicResolutionStatement:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._unresolved.serialize()
-		buffer_ += len(self._resolution_entries).to_bytes(4, byteorder='little', signed=False)  # resolution_entries_count
-		buffer_ += ArrayHelpers.write_array(self._resolution_entries)
-		return buffer_
+		buffer = bytes()
+		buffer += self._unresolved.serialize()
+		buffer += len(self._resolution_entries).to_bytes(4, byteorder='little', signed=False)  # resolution_entries_count
+		buffer += ArrayHelpers.write_array(self._resolution_entries)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -4156,15 +4156,15 @@ class TransactionStatement:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> TransactionStatement:
-		buffer_ = memoryview(payload)
-		primary_id = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		secondary_id = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		receipt_count = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		receipts = ArrayHelpers.read_array_count(buffer_, Receipt, receipt_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, receipts)):]
+		buffer = memoryview(payload)
+		primary_id = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		secondary_id = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		receipt_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		receipts = ArrayHelpers.read_array_count(buffer, Receipt, receipt_count)
+		buffer = buffer[sum(map(lambda e: e.size, receipts)):]
 
 		instance = TransactionStatement()
 		instance._primary_id = primary_id
@@ -4173,12 +4173,12 @@ class TransactionStatement:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._primary_id.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._secondary_id.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += len(self._receipts).to_bytes(4, byteorder='little', signed=False)  # receipt_count
-		buffer_ += ArrayHelpers.write_array(self._receipts)
-		return buffer_
+		buffer = bytes()
+		buffer += self._primary_id.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._secondary_id.to_bytes(4, byteorder='little', signed=False)
+		buffer += len(self._receipts).to_bytes(4, byteorder='little', signed=False)  # receipt_count
+		buffer += ArrayHelpers.write_array(self._receipts)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -4238,19 +4238,19 @@ class BlockStatement:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> BlockStatement:
-		buffer_ = memoryview(payload)
-		transaction_statement_count = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		transaction_statements = ArrayHelpers.read_array_count(buffer_, TransactionStatement, transaction_statement_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, transaction_statements)):]
-		address_resolution_statement_count = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		address_resolution_statements = ArrayHelpers.read_array_count(buffer_, AddressResolutionStatement, address_resolution_statement_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, address_resolution_statements)):]
-		mosaic_resolution_statement_count = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		mosaic_resolution_statements = ArrayHelpers.read_array_count(buffer_, MosaicResolutionStatement, mosaic_resolution_statement_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, mosaic_resolution_statements)):]
+		buffer = memoryview(payload)
+		transaction_statement_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		transaction_statements = ArrayHelpers.read_array_count(buffer, TransactionStatement, transaction_statement_count)
+		buffer = buffer[sum(map(lambda e: e.size, transaction_statements)):]
+		address_resolution_statement_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		address_resolution_statements = ArrayHelpers.read_array_count(buffer, AddressResolutionStatement, address_resolution_statement_count)
+		buffer = buffer[sum(map(lambda e: e.size, address_resolution_statements)):]
+		mosaic_resolution_statement_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		mosaic_resolution_statements = ArrayHelpers.read_array_count(buffer, MosaicResolutionStatement, mosaic_resolution_statement_count)
+		buffer = buffer[sum(map(lambda e: e.size, mosaic_resolution_statements)):]
 
 		instance = BlockStatement()
 		instance._transaction_statements = transaction_statements
@@ -4259,14 +4259,14 @@ class BlockStatement:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += len(self._transaction_statements).to_bytes(4, byteorder='little', signed=False)  # transaction_statement_count
-		buffer_ += ArrayHelpers.write_array(self._transaction_statements)
-		buffer_ += len(self._address_resolution_statements).to_bytes(4, byteorder='little', signed=False)  # address_resolution_statement_count
-		buffer_ += ArrayHelpers.write_array(self._address_resolution_statements)
-		buffer_ += len(self._mosaic_resolution_statements).to_bytes(4, byteorder='little', signed=False)  # mosaic_resolution_statement_count
-		buffer_ += ArrayHelpers.write_array(self._mosaic_resolution_statements)
-		return buffer_
+		buffer = bytes()
+		buffer += len(self._transaction_statements).to_bytes(4, byteorder='little', signed=False)  # transaction_statement_count
+		buffer += ArrayHelpers.write_array(self._transaction_statements)
+		buffer += len(self._address_resolution_statements).to_bytes(4, byteorder='little', signed=False)  # address_resolution_statement_count
+		buffer += ArrayHelpers.write_array(self._address_resolution_statements)
+		buffer += len(self._mosaic_resolution_statements).to_bytes(4, byteorder='little', signed=False)  # mosaic_resolution_statement_count
+		buffer += ArrayHelpers.write_array(self._mosaic_resolution_statements)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -4289,13 +4289,13 @@ class AccountType(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AccountType:
-		buffer_ = memoryview(payload)
-		return AccountType(int.from_bytes(buffer_[:1], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return AccountType(int.from_bytes(buffer[:1], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(1, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(1, byteorder='little', signed=False)
+		return buffer
 
 
 class AccountKeyTypeFlags(Flag):
@@ -4310,13 +4310,13 @@ class AccountKeyTypeFlags(Flag):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AccountKeyTypeFlags:
-		buffer_ = memoryview(payload)
-		return AccountKeyTypeFlags(int.from_bytes(buffer_[:1], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return AccountKeyTypeFlags(int.from_bytes(buffer[:1], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(1, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(1, byteorder='little', signed=False)
+		return buffer
 
 
 class AccountStateFormat(Enum):
@@ -4329,13 +4329,13 @@ class AccountStateFormat(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AccountStateFormat:
-		buffer_ = memoryview(payload)
-		return AccountStateFormat(int.from_bytes(buffer_[:1], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return AccountStateFormat(int.from_bytes(buffer[:1], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(1, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(1, byteorder='little', signed=False)
+		return buffer
 
 
 class PinnedVotingKey:
@@ -4384,13 +4384,13 @@ class PinnedVotingKey:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> PinnedVotingKey:
-		buffer_ = memoryview(payload)
-		voting_key = VotingPublicKey.deserialize(buffer_)
-		buffer_ = buffer_[voting_key.size:]
-		start_epoch = FinalizationEpoch.deserialize(buffer_)
-		buffer_ = buffer_[start_epoch.size:]
-		end_epoch = FinalizationEpoch.deserialize(buffer_)
-		buffer_ = buffer_[end_epoch.size:]
+		buffer = memoryview(payload)
+		voting_key = VotingPublicKey.deserialize(buffer)
+		buffer = buffer[voting_key.size:]
+		start_epoch = FinalizationEpoch.deserialize(buffer)
+		buffer = buffer[start_epoch.size:]
+		end_epoch = FinalizationEpoch.deserialize(buffer)
+		buffer = buffer[end_epoch.size:]
 
 		instance = PinnedVotingKey()
 		instance._voting_key = voting_key
@@ -4399,11 +4399,11 @@ class PinnedVotingKey:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._voting_key.serialize()
-		buffer_ += self._start_epoch.serialize()
-		buffer_ += self._end_epoch.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._voting_key.serialize()
+		buffer += self._start_epoch.serialize()
+		buffer += self._end_epoch.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -4449,11 +4449,11 @@ class ImportanceSnapshot:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> ImportanceSnapshot:
-		buffer_ = memoryview(payload)
-		importance = Importance.deserialize(buffer_)
-		buffer_ = buffer_[importance.size:]
-		height = ImportanceHeight.deserialize(buffer_)
-		buffer_ = buffer_[height.size:]
+		buffer = memoryview(payload)
+		importance = Importance.deserialize(buffer)
+		buffer = buffer[importance.size:]
+		height = ImportanceHeight.deserialize(buffer)
+		buffer = buffer[height.size:]
 
 		instance = ImportanceSnapshot()
 		instance._importance = importance
@@ -4461,10 +4461,10 @@ class ImportanceSnapshot:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._importance.serialize()
-		buffer_ += self._height.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._importance.serialize()
+		buffer += self._height.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -4529,15 +4529,15 @@ class HeightActivityBucket:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> HeightActivityBucket:
-		buffer_ = memoryview(payload)
-		start_height = ImportanceHeight.deserialize(buffer_)
-		buffer_ = buffer_[start_height.size:]
-		total_fees_paid = Amount.deserialize(buffer_)
-		buffer_ = buffer_[total_fees_paid.size:]
-		beneficiary_count = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		raw_score = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
+		buffer = memoryview(payload)
+		start_height = ImportanceHeight.deserialize(buffer)
+		buffer = buffer[start_height.size:]
+		total_fees_paid = Amount.deserialize(buffer)
+		buffer = buffer[total_fees_paid.size:]
+		beneficiary_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		raw_score = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
 
 		instance = HeightActivityBucket()
 		instance._start_height = start_height
@@ -4547,12 +4547,12 @@ class HeightActivityBucket:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._start_height.serialize()
-		buffer_ += self._total_fees_paid.serialize()
-		buffer_ += self._beneficiary_count.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._raw_score.to_bytes(8, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self._start_height.serialize()
+		buffer += self._total_fees_paid.serialize()
+		buffer += self._beneficiary_count.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._raw_score.to_bytes(8, byteorder='little', signed=False)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -4588,18 +4588,18 @@ class HeightActivityBuckets:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> HeightActivityBuckets:
-		buffer_ = memoryview(payload)
-		buckets = ArrayHelpers.read_array_count(buffer_, HeightActivityBucket, 5)
-		buffer_ = buffer_[sum(map(lambda e: e.size, buckets)):]
+		buffer = memoryview(payload)
+		buckets = ArrayHelpers.read_array_count(buffer, HeightActivityBucket, 5)
+		buffer = buffer[sum(map(lambda e: e.size, buckets)):]
 
 		instance = HeightActivityBuckets()
 		instance._buckets = buckets
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += ArrayHelpers.write_array_count(self._buckets, 5)
-		return buffer_
+		buffer = bytes()
+		buffer += ArrayHelpers.write_array_count(self._buckets, 5)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -4792,51 +4792,51 @@ class AccountState:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AccountState:
-		buffer_ = memoryview(payload)
-		version = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		address = Address.deserialize(buffer_)
-		buffer_ = buffer_[address.size:]
-		address_height = Height.deserialize(buffer_)
-		buffer_ = buffer_[address_height.size:]
-		public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[public_key.size:]
-		public_key_height = Height.deserialize(buffer_)
-		buffer_ = buffer_[public_key_height.size:]
-		account_type = AccountType.deserialize(buffer_)
-		buffer_ = buffer_[account_type.size:]
-		format = AccountStateFormat.deserialize(buffer_)
-		buffer_ = buffer_[format.size:]
-		supplemental_public_keys_mask = AccountKeyTypeFlags.deserialize(buffer_)
-		buffer_ = buffer_[supplemental_public_keys_mask.size:]
-		voting_public_keys_count = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
+		buffer = memoryview(payload)
+		version = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		address = Address.deserialize(buffer)
+		buffer = buffer[address.size:]
+		address_height = Height.deserialize(buffer)
+		buffer = buffer[address_height.size:]
+		public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[public_key.size:]
+		public_key_height = Height.deserialize(buffer)
+		buffer = buffer[public_key_height.size:]
+		account_type = AccountType.deserialize(buffer)
+		buffer = buffer[account_type.size:]
+		format = AccountStateFormat.deserialize(buffer)
+		buffer = buffer[format.size:]
+		supplemental_public_keys_mask = AccountKeyTypeFlags.deserialize(buffer)
+		buffer = buffer[supplemental_public_keys_mask.size:]
+		voting_public_keys_count = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
 		linked_public_key = None
 		if AccountKeyTypeFlags.LINKED in supplemental_public_keys_mask:
-			linked_public_key = PublicKey.deserialize(buffer_)
-			buffer_ = buffer_[linked_public_key.size:]
+			linked_public_key = PublicKey.deserialize(buffer)
+			buffer = buffer[linked_public_key.size:]
 		node_public_key = None
 		if AccountKeyTypeFlags.NODE in supplemental_public_keys_mask:
-			node_public_key = PublicKey.deserialize(buffer_)
-			buffer_ = buffer_[node_public_key.size:]
+			node_public_key = PublicKey.deserialize(buffer)
+			buffer = buffer[node_public_key.size:]
 		vrf_public_key = None
 		if AccountKeyTypeFlags.VRF in supplemental_public_keys_mask:
-			vrf_public_key = PublicKey.deserialize(buffer_)
-			buffer_ = buffer_[vrf_public_key.size:]
-		voting_public_keys = ArrayHelpers.read_array_count(buffer_, PinnedVotingKey, voting_public_keys_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, voting_public_keys)):]
+			vrf_public_key = PublicKey.deserialize(buffer)
+			buffer = buffer[vrf_public_key.size:]
+		voting_public_keys = ArrayHelpers.read_array_count(buffer, PinnedVotingKey, voting_public_keys_count)
+		buffer = buffer[sum(map(lambda e: e.size, voting_public_keys)):]
 		importance_snapshots = None
 		if AccountStateFormat.HIGH_VALUE == format:
-			importance_snapshots = ImportanceSnapshot.deserialize(buffer_)
-			buffer_ = buffer_[importance_snapshots.size:]
+			importance_snapshots = ImportanceSnapshot.deserialize(buffer)
+			buffer = buffer[importance_snapshots.size:]
 		activity_buckets = None
 		if AccountStateFormat.HIGH_VALUE == format:
-			activity_buckets = HeightActivityBuckets.deserialize(buffer_)
-			buffer_ = buffer_[activity_buckets.size:]
-		balances_count = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		balances = ArrayHelpers.read_array_count(buffer_, Mosaic, balances_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, balances)):]
+			activity_buckets = HeightActivityBuckets.deserialize(buffer)
+			buffer = buffer[activity_buckets.size:]
+		balances_count = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		balances = ArrayHelpers.read_array_count(buffer, Mosaic, balances_count)
+		buffer = buffer[sum(map(lambda e: e.size, balances)):]
 
 		instance = AccountState()
 		instance._version = version
@@ -4857,30 +4857,30 @@ class AccountState:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._version.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._address.serialize()
-		buffer_ += self._address_height.serialize()
-		buffer_ += self._public_key.serialize()
-		buffer_ += self._public_key_height.serialize()
-		buffer_ += self._account_type.serialize()
-		buffer_ += self._format.serialize()
-		buffer_ += self._supplemental_public_keys_mask.serialize()
-		buffer_ += len(self._voting_public_keys).to_bytes(1, byteorder='little', signed=False)  # voting_public_keys_count
+		buffer = bytes()
+		buffer += self._version.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._address.serialize()
+		buffer += self._address_height.serialize()
+		buffer += self._public_key.serialize()
+		buffer += self._public_key_height.serialize()
+		buffer += self._account_type.serialize()
+		buffer += self._format.serialize()
+		buffer += self._supplemental_public_keys_mask.serialize()
+		buffer += len(self._voting_public_keys).to_bytes(1, byteorder='little', signed=False)  # voting_public_keys_count
 		if AccountKeyTypeFlags.LINKED in self.supplemental_public_keys_mask:
-			buffer_ += self._linked_public_key.serialize()
+			buffer += self._linked_public_key.serialize()
 		if AccountKeyTypeFlags.NODE in self.supplemental_public_keys_mask:
-			buffer_ += self._node_public_key.serialize()
+			buffer += self._node_public_key.serialize()
 		if AccountKeyTypeFlags.VRF in self.supplemental_public_keys_mask:
-			buffer_ += self._vrf_public_key.serialize()
-		buffer_ += ArrayHelpers.write_array(self._voting_public_keys)
+			buffer += self._vrf_public_key.serialize()
+		buffer += ArrayHelpers.write_array(self._voting_public_keys)
 		if AccountStateFormat.HIGH_VALUE == self.format:
-			buffer_ += self._importance_snapshots.serialize()
+			buffer += self._importance_snapshots.serialize()
 		if AccountStateFormat.HIGH_VALUE == self.format:
-			buffer_ += self._activity_buckets.serialize()
-		buffer_ += len(self._balances).to_bytes(2, byteorder='little', signed=False)  # balances_count
-		buffer_ += ArrayHelpers.write_array(self._balances)
-		return buffer_
+			buffer += self._activity_buckets.serialize()
+		buffer += len(self._balances).to_bytes(2, byteorder='little', signed=False)  # balances_count
+		buffer += ArrayHelpers.write_array(self._balances)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -4918,13 +4918,13 @@ class LockStatus(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> LockStatus:
-		buffer_ = memoryview(payload)
-		return LockStatus(int.from_bytes(buffer_[:1], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return LockStatus(int.from_bytes(buffer[:1], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(1, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(1, byteorder='little', signed=False)
+		return buffer
 
 
 class HashLockInfo:
@@ -5005,19 +5005,19 @@ class HashLockInfo:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> HashLockInfo:
-		buffer_ = memoryview(payload)
-		version = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		owner_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[owner_address.size:]
-		mosaic = Mosaic.deserialize(buffer_)
-		buffer_ = buffer_[mosaic.size:]
-		end_height = Height.deserialize(buffer_)
-		buffer_ = buffer_[end_height.size:]
-		status = LockStatus.deserialize(buffer_)
-		buffer_ = buffer_[status.size:]
-		hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[hash.size:]
+		buffer = memoryview(payload)
+		version = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		owner_address = Address.deserialize(buffer)
+		buffer = buffer[owner_address.size:]
+		mosaic = Mosaic.deserialize(buffer)
+		buffer = buffer[mosaic.size:]
+		end_height = Height.deserialize(buffer)
+		buffer = buffer[end_height.size:]
+		status = LockStatus.deserialize(buffer)
+		buffer = buffer[status.size:]
+		hash = Hash256.deserialize(buffer)
+		buffer = buffer[hash.size:]
 
 		instance = HashLockInfo()
 		instance._version = version
@@ -5029,14 +5029,14 @@ class HashLockInfo:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._version.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._owner_address.serialize()
-		buffer_ += self._mosaic.serialize()
-		buffer_ += self._end_height.serialize()
-		buffer_ += self._status.serialize()
-		buffer_ += self._hash.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._version.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._owner_address.serialize()
+		buffer += self._mosaic.serialize()
+		buffer += self._end_height.serialize()
+		buffer += self._status.serialize()
+		buffer += self._hash.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -5058,8 +5058,8 @@ class ScopedMetadataKey(BaseValue):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> ScopedMetadataKey:
-		buffer_ = memoryview(payload)
-		return ScopedMetadataKey(int.from_bytes(buffer_[:8], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return ScopedMetadataKey(int.from_bytes(buffer[:8], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
 		return self.value.to_bytes(8, byteorder='little', signed=False)
@@ -5076,13 +5076,13 @@ class MetadataType(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MetadataType:
-		buffer_ = memoryview(payload)
-		return MetadataType(int.from_bytes(buffer_[:1], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return MetadataType(int.from_bytes(buffer[:1], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(1, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(1, byteorder='little', signed=False)
+		return buffer
 
 
 class MetadataValue:
@@ -5110,21 +5110,21 @@ class MetadataValue:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MetadataValue:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		data = ArrayHelpers.get_bytes(buffer_, size_)
-		buffer_ = buffer_[size_:]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		data = ArrayHelpers.get_bytes(buffer, size_)
+		buffer = buffer[size_:]
 
 		instance = MetadataValue()
 		instance._data = data
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += len(self._data).to_bytes(2, byteorder='little', signed=False)  # size
-		buffer_ += self._data
-		return buffer_
+		buffer = bytes()
+		buffer += len(self._data).to_bytes(2, byteorder='little', signed=False)  # size
+		buffer += self._data
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -5221,21 +5221,21 @@ class MetadataEntry:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MetadataEntry:
-		buffer_ = memoryview(payload)
-		version = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		source_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[source_address.size:]
-		target_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[target_address.size:]
-		scoped_metadata_key = ScopedMetadataKey.deserialize(buffer_)
-		buffer_ = buffer_[scoped_metadata_key.size:]
-		target_id = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		metadata_type = MetadataType.deserialize(buffer_)
-		buffer_ = buffer_[metadata_type.size:]
-		value = MetadataValue.deserialize(buffer_)
-		buffer_ = buffer_[value.size:]
+		buffer = memoryview(payload)
+		version = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		source_address = Address.deserialize(buffer)
+		buffer = buffer[source_address.size:]
+		target_address = Address.deserialize(buffer)
+		buffer = buffer[target_address.size:]
+		scoped_metadata_key = ScopedMetadataKey.deserialize(buffer)
+		buffer = buffer[scoped_metadata_key.size:]
+		target_id = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		metadata_type = MetadataType.deserialize(buffer)
+		buffer = buffer[metadata_type.size:]
+		value = MetadataValue.deserialize(buffer)
+		buffer = buffer[value.size:]
 
 		instance = MetadataEntry()
 		instance._version = version
@@ -5248,15 +5248,15 @@ class MetadataEntry:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._version.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._source_address.serialize()
-		buffer_ += self._target_address.serialize()
-		buffer_ += self._scoped_metadata_key.serialize()
-		buffer_ += self._target_id.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._metadata_type.serialize()
-		buffer_ += self._value.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._version.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._source_address.serialize()
+		buffer += self._target_address.serialize()
+		buffer += self._scoped_metadata_key.serialize()
+		buffer += self._target_id.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._metadata_type.serialize()
+		buffer += self._value.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -5279,8 +5279,8 @@ class MosaicNonce(BaseValue):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicNonce:
-		buffer_ = memoryview(payload)
-		return MosaicNonce(int.from_bytes(buffer_[:4], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return MosaicNonce(int.from_bytes(buffer[:4], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
 		return self.value.to_bytes(4, byteorder='little', signed=False)
@@ -5299,13 +5299,13 @@ class MosaicFlags(Flag):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicFlags:
-		buffer_ = memoryview(payload)
-		return MosaicFlags(int.from_bytes(buffer_[:1], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return MosaicFlags(int.from_bytes(buffer[:1], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(1, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(1, byteorder='little', signed=False)
+		return buffer
 
 
 class MosaicSupplyChangeAction(Enum):
@@ -5318,13 +5318,13 @@ class MosaicSupplyChangeAction(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicSupplyChangeAction:
-		buffer_ = memoryview(payload)
-		return MosaicSupplyChangeAction(int.from_bytes(buffer_[:1], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return MosaicSupplyChangeAction(int.from_bytes(buffer[:1], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(1, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(1, byteorder='little', signed=False)
+		return buffer
 
 
 class MosaicProperties:
@@ -5372,13 +5372,13 @@ class MosaicProperties:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicProperties:
-		buffer_ = memoryview(payload)
-		flags = MosaicFlags.deserialize(buffer_)
-		buffer_ = buffer_[flags.size:]
-		divisibility = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		duration = BlockDuration.deserialize(buffer_)
-		buffer_ = buffer_[duration.size:]
+		buffer = memoryview(payload)
+		flags = MosaicFlags.deserialize(buffer)
+		buffer = buffer[flags.size:]
+		divisibility = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		duration = BlockDuration.deserialize(buffer)
+		buffer = buffer[duration.size:]
 
 		instance = MosaicProperties()
 		instance._flags = flags
@@ -5387,11 +5387,11 @@ class MosaicProperties:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._flags.serialize()
-		buffer_ += self._divisibility.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._duration.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._flags.serialize()
+		buffer += self._divisibility.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._duration.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -5458,15 +5458,15 @@ class MosaicDefinition:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicDefinition:
-		buffer_ = memoryview(payload)
-		start_height = Height.deserialize(buffer_)
-		buffer_ = buffer_[start_height.size:]
-		owner_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[owner_address.size:]
-		revision = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		properties = MosaicProperties.deserialize(buffer_)
-		buffer_ = buffer_[properties.size:]
+		buffer = memoryview(payload)
+		start_height = Height.deserialize(buffer)
+		buffer = buffer[start_height.size:]
+		owner_address = Address.deserialize(buffer)
+		buffer = buffer[owner_address.size:]
+		revision = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		properties = MosaicProperties.deserialize(buffer)
+		buffer = buffer[properties.size:]
 
 		instance = MosaicDefinition()
 		instance._start_height = start_height
@@ -5476,12 +5476,12 @@ class MosaicDefinition:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._start_height.serialize()
-		buffer_ += self._owner_address.serialize()
-		buffer_ += self._revision.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._properties.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._start_height.serialize()
+		buffer += self._owner_address.serialize()
+		buffer += self._revision.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._properties.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -5549,15 +5549,15 @@ class MosaicEntry:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicEntry:
-		buffer_ = memoryview(payload)
-		version = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		mosaic_id = MosaicId.deserialize(buffer_)
-		buffer_ = buffer_[mosaic_id.size:]
-		supply = Amount.deserialize(buffer_)
-		buffer_ = buffer_[supply.size:]
-		definition = MosaicDefinition.deserialize(buffer_)
-		buffer_ = buffer_[definition.size:]
+		buffer = memoryview(payload)
+		version = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		mosaic_id = MosaicId.deserialize(buffer)
+		buffer = buffer[mosaic_id.size:]
+		supply = Amount.deserialize(buffer)
+		buffer = buffer[supply.size:]
+		definition = MosaicDefinition.deserialize(buffer)
+		buffer = buffer[definition.size:]
 
 		instance = MosaicEntry()
 		instance._version = version
@@ -5567,12 +5567,12 @@ class MosaicEntry:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._version.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._mosaic_id.serialize()
-		buffer_ += self._supply.serialize()
-		buffer_ += self._definition.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._version.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._mosaic_id.serialize()
+		buffer += self._supply.serialize()
+		buffer += self._definition.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -5662,23 +5662,23 @@ class MultisigEntry:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MultisigEntry:
-		buffer_ = memoryview(payload)
-		version = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		min_approval = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		min_removal = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		account_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[account_address.size:]
-		cosignatory_addresses_count = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		cosignatory_addresses = ArrayHelpers.read_array_count(buffer_, Address, cosignatory_addresses_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, cosignatory_addresses)):]
-		multisig_addresses_count = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		multisig_addresses = ArrayHelpers.read_array_count(buffer_, Address, multisig_addresses_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, multisig_addresses)):]
+		buffer = memoryview(payload)
+		version = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		min_approval = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		min_removal = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		account_address = Address.deserialize(buffer)
+		buffer = buffer[account_address.size:]
+		cosignatory_addresses_count = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		cosignatory_addresses = ArrayHelpers.read_array_count(buffer, Address, cosignatory_addresses_count)
+		buffer = buffer[sum(map(lambda e: e.size, cosignatory_addresses)):]
+		multisig_addresses_count = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		multisig_addresses = ArrayHelpers.read_array_count(buffer, Address, multisig_addresses_count)
+		buffer = buffer[sum(map(lambda e: e.size, multisig_addresses)):]
 
 		instance = MultisigEntry()
 		instance._version = version
@@ -5690,16 +5690,16 @@ class MultisigEntry:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._version.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._min_approval.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._min_removal.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._account_address.serialize()
-		buffer_ += len(self._cosignatory_addresses).to_bytes(8, byteorder='little', signed=False)  # cosignatory_addresses_count
-		buffer_ += ArrayHelpers.write_array(self._cosignatory_addresses)
-		buffer_ += len(self._multisig_addresses).to_bytes(8, byteorder='little', signed=False)  # multisig_addresses_count
-		buffer_ += ArrayHelpers.write_array(self._multisig_addresses)
-		return buffer_
+		buffer = bytes()
+		buffer += self._version.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._min_approval.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._min_removal.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._account_address.serialize()
+		buffer += len(self._cosignatory_addresses).to_bytes(8, byteorder='little', signed=False)  # cosignatory_addresses_count
+		buffer += ArrayHelpers.write_array(self._cosignatory_addresses)
+		buffer += len(self._multisig_addresses).to_bytes(8, byteorder='little', signed=False)  # multisig_addresses_count
+		buffer += ArrayHelpers.write_array(self._multisig_addresses)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -5748,11 +5748,11 @@ class NamespaceLifetime:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NamespaceLifetime:
-		buffer_ = memoryview(payload)
-		lifetime_start = Height.deserialize(buffer_)
-		buffer_ = buffer_[lifetime_start.size:]
-		lifetime_end = Height.deserialize(buffer_)
-		buffer_ = buffer_[lifetime_end.size:]
+		buffer = memoryview(payload)
+		lifetime_start = Height.deserialize(buffer)
+		buffer = buffer[lifetime_start.size:]
+		lifetime_end = Height.deserialize(buffer)
+		buffer = buffer[lifetime_end.size:]
 
 		instance = NamespaceLifetime()
 		instance._lifetime_start = lifetime_start
@@ -5760,10 +5760,10 @@ class NamespaceLifetime:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._lifetime_start.serialize()
-		buffer_ += self._lifetime_end.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._lifetime_start.serialize()
+		buffer += self._lifetime_end.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -5784,13 +5784,13 @@ class NamespaceAliasType(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NamespaceAliasType:
-		buffer_ = memoryview(payload)
-		return NamespaceAliasType(int.from_bytes(buffer_[:1], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return NamespaceAliasType(int.from_bytes(buffer[:1], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(1, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(1, byteorder='little', signed=False)
+		return buffer
 
 
 class NamespaceAlias:
@@ -5841,17 +5841,17 @@ class NamespaceAlias:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NamespaceAlias:
-		buffer_ = memoryview(payload)
-		namespace_alias_type = NamespaceAliasType.deserialize(buffer_)
-		buffer_ = buffer_[namespace_alias_type.size:]
+		buffer = memoryview(payload)
+		namespace_alias_type = NamespaceAliasType.deserialize(buffer)
+		buffer = buffer[namespace_alias_type.size:]
 		mosaic_alias = None
 		if NamespaceAliasType.MOSAIC_ID == namespace_alias_type:
-			mosaic_alias = MosaicId.deserialize(buffer_)
-			buffer_ = buffer_[mosaic_alias.size:]
+			mosaic_alias = MosaicId.deserialize(buffer)
+			buffer = buffer[mosaic_alias.size:]
 		address_alias = None
 		if NamespaceAliasType.ADDRESS == namespace_alias_type:
-			address_alias = Address.deserialize(buffer_)
-			buffer_ = buffer_[address_alias.size:]
+			address_alias = Address.deserialize(buffer)
+			buffer = buffer[address_alias.size:]
 
 		instance = NamespaceAlias()
 		instance._namespace_alias_type = namespace_alias_type
@@ -5860,13 +5860,13 @@ class NamespaceAlias:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._namespace_alias_type.serialize()
+		buffer = bytes()
+		buffer += self._namespace_alias_type.serialize()
 		if NamespaceAliasType.MOSAIC_ID == self.namespace_alias_type:
-			buffer_ += self._mosaic_alias.serialize()
+			buffer += self._mosaic_alias.serialize()
 		if NamespaceAliasType.ADDRESS == self.namespace_alias_type:
-			buffer_ += self._address_alias.serialize()
-		return buffer_
+			buffer += self._address_alias.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -5915,13 +5915,13 @@ class NamespacePath:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NamespacePath:
-		buffer_ = memoryview(payload)
-		path_size = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		path = ArrayHelpers.read_array_count(buffer_, NamespaceId, path_size)
-		buffer_ = buffer_[sum(map(lambda e: e.size, path)):]
-		alias = NamespaceAlias.deserialize(buffer_)
-		buffer_ = buffer_[alias.size:]
+		buffer = memoryview(payload)
+		path_size = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		path = ArrayHelpers.read_array_count(buffer, NamespaceId, path_size)
+		buffer = buffer[sum(map(lambda e: e.size, path)):]
+		alias = NamespaceAlias.deserialize(buffer)
+		buffer = buffer[alias.size:]
 
 		instance = NamespacePath()
 		instance._path = path
@@ -5929,11 +5929,11 @@ class NamespacePath:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += len(self._path).to_bytes(1, byteorder='little', signed=False)  # path_size
-		buffer_ += ArrayHelpers.write_array(self._path)
-		buffer_ += self._alias.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += len(self._path).to_bytes(1, byteorder='little', signed=False)  # path_size
+		buffer += ArrayHelpers.write_array(self._path)
+		buffer += self._alias.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -6022,21 +6022,21 @@ class RootNamespaceHistory:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> RootNamespaceHistory:
-		buffer_ = memoryview(payload)
-		version = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		id = NamespaceId.deserialize(buffer_)
-		buffer_ = buffer_[id.size:]
-		owner_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[owner_address.size:]
-		lifetime = NamespaceLifetime.deserialize(buffer_)
-		buffer_ = buffer_[lifetime.size:]
-		root_alias = NamespaceAlias.deserialize(buffer_)
-		buffer_ = buffer_[root_alias.size:]
-		children_count = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		paths = ArrayHelpers.read_array_count(buffer_, NamespacePath, children_count, lambda e: e.path)
-		buffer_ = buffer_[sum(map(lambda e: e.size, paths)):]
+		buffer = memoryview(payload)
+		version = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		id = NamespaceId.deserialize(buffer)
+		buffer = buffer[id.size:]
+		owner_address = Address.deserialize(buffer)
+		buffer = buffer[owner_address.size:]
+		lifetime = NamespaceLifetime.deserialize(buffer)
+		buffer = buffer[lifetime.size:]
+		root_alias = NamespaceAlias.deserialize(buffer)
+		buffer = buffer[root_alias.size:]
+		children_count = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		paths = ArrayHelpers.read_array_count(buffer, NamespacePath, children_count, lambda e: e.path)
+		buffer = buffer[sum(map(lambda e: e.size, paths)):]
 
 		instance = RootNamespaceHistory()
 		instance._version = version
@@ -6048,15 +6048,15 @@ class RootNamespaceHistory:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._version.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._id.serialize()
-		buffer_ += self._owner_address.serialize()
-		buffer_ += self._lifetime.serialize()
-		buffer_ += self._root_alias.serialize()
-		buffer_ += len(self._paths).to_bytes(8, byteorder='little', signed=False)  # children_count
-		buffer_ += ArrayHelpers.write_array(self._paths, lambda e: e.path)
-		return buffer_
+		buffer = bytes()
+		buffer += self._version.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._id.serialize()
+		buffer += self._owner_address.serialize()
+		buffer += self._lifetime.serialize()
+		buffer += self._root_alias.serialize()
+		buffer += len(self._paths).to_bytes(8, byteorder='little', signed=False)  # children_count
+		buffer += ArrayHelpers.write_array(self._paths, lambda e: e.path)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -6083,13 +6083,13 @@ class AccountRestrictionFlags(Flag):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AccountRestrictionFlags:
-		buffer_ = memoryview(payload)
-		return AccountRestrictionFlags(int.from_bytes(buffer_[:2], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return AccountRestrictionFlags(int.from_bytes(buffer[:2], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(2, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(2, byteorder='little', signed=False)
+		return buffer
 
 
 class AccountRestrictionAddressValue:
@@ -6117,21 +6117,21 @@ class AccountRestrictionAddressValue:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AccountRestrictionAddressValue:
-		buffer_ = memoryview(payload)
-		restriction_values_count = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		restriction_values = ArrayHelpers.read_array_count(buffer_, Address, restriction_values_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, restriction_values)):]
+		buffer = memoryview(payload)
+		restriction_values_count = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		restriction_values = ArrayHelpers.read_array_count(buffer, Address, restriction_values_count)
+		buffer = buffer[sum(map(lambda e: e.size, restriction_values)):]
 
 		instance = AccountRestrictionAddressValue()
 		instance._restriction_values = restriction_values
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += len(self._restriction_values).to_bytes(8, byteorder='little', signed=False)  # restriction_values_count
-		buffer_ += ArrayHelpers.write_array(self._restriction_values)
-		return buffer_
+		buffer = bytes()
+		buffer += len(self._restriction_values).to_bytes(8, byteorder='little', signed=False)  # restriction_values_count
+		buffer += ArrayHelpers.write_array(self._restriction_values)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -6165,21 +6165,21 @@ class AccountRestrictionMosaicValue:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AccountRestrictionMosaicValue:
-		buffer_ = memoryview(payload)
-		restriction_values_count = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		restriction_values = ArrayHelpers.read_array_count(buffer_, MosaicId, restriction_values_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, restriction_values)):]
+		buffer = memoryview(payload)
+		restriction_values_count = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		restriction_values = ArrayHelpers.read_array_count(buffer, MosaicId, restriction_values_count)
+		buffer = buffer[sum(map(lambda e: e.size, restriction_values)):]
 
 		instance = AccountRestrictionMosaicValue()
 		instance._restriction_values = restriction_values
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += len(self._restriction_values).to_bytes(8, byteorder='little', signed=False)  # restriction_values_count
-		buffer_ += ArrayHelpers.write_array(self._restriction_values)
-		return buffer_
+		buffer = bytes()
+		buffer += len(self._restriction_values).to_bytes(8, byteorder='little', signed=False)  # restriction_values_count
+		buffer += ArrayHelpers.write_array(self._restriction_values)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -6213,21 +6213,21 @@ class AccountRestrictionTransactionTypeValue:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AccountRestrictionTransactionTypeValue:
-		buffer_ = memoryview(payload)
-		restriction_values_count = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		restriction_values = ArrayHelpers.read_array_count(buffer_, TransactionType, restriction_values_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, restriction_values)):]
+		buffer = memoryview(payload)
+		restriction_values_count = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		restriction_values = ArrayHelpers.read_array_count(buffer, TransactionType, restriction_values_count)
+		buffer = buffer[sum(map(lambda e: e.size, restriction_values)):]
 
 		instance = AccountRestrictionTransactionTypeValue()
 		instance._restriction_values = restriction_values
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += len(self._restriction_values).to_bytes(8, byteorder='little', signed=False)  # restriction_values_count
-		buffer_ += ArrayHelpers.write_array(self._restriction_values)
-		return buffer_
+		buffer = bytes()
+		buffer += len(self._restriction_values).to_bytes(8, byteorder='little', signed=False)  # restriction_values_count
+		buffer += ArrayHelpers.write_array(self._restriction_values)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -6296,21 +6296,21 @@ class AccountRestrictionsInfo:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AccountRestrictionsInfo:
-		buffer_ = memoryview(payload)
-		restriction_flags = AccountRestrictionFlags.deserialize(buffer_)
-		buffer_ = buffer_[restriction_flags.size:]
+		buffer = memoryview(payload)
+		restriction_flags = AccountRestrictionFlags.deserialize(buffer)
+		buffer = buffer[restriction_flags.size:]
 		address_restrictions = None
 		if AccountRestrictionFlags.ADDRESS in restriction_flags:
-			address_restrictions = AccountRestrictionAddressValue.deserialize(buffer_)
-			buffer_ = buffer_[address_restrictions.size:]
+			address_restrictions = AccountRestrictionAddressValue.deserialize(buffer)
+			buffer = buffer[address_restrictions.size:]
 		mosaic_id_restrictions = None
 		if AccountRestrictionFlags.MOSAIC_ID in restriction_flags:
-			mosaic_id_restrictions = AccountRestrictionMosaicValue.deserialize(buffer_)
-			buffer_ = buffer_[mosaic_id_restrictions.size:]
+			mosaic_id_restrictions = AccountRestrictionMosaicValue.deserialize(buffer)
+			buffer = buffer[mosaic_id_restrictions.size:]
 		transaction_type_restrictions = None
 		if AccountRestrictionFlags.TRANSACTION_TYPE in restriction_flags:
-			transaction_type_restrictions = AccountRestrictionTransactionTypeValue.deserialize(buffer_)
-			buffer_ = buffer_[transaction_type_restrictions.size:]
+			transaction_type_restrictions = AccountRestrictionTransactionTypeValue.deserialize(buffer)
+			buffer = buffer[transaction_type_restrictions.size:]
 
 		instance = AccountRestrictionsInfo()
 		instance._restriction_flags = restriction_flags
@@ -6320,15 +6320,15 @@ class AccountRestrictionsInfo:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._restriction_flags.serialize()
+		buffer = bytes()
+		buffer += self._restriction_flags.serialize()
 		if AccountRestrictionFlags.ADDRESS in self.restriction_flags:
-			buffer_ += self._address_restrictions.serialize()
+			buffer += self._address_restrictions.serialize()
 		if AccountRestrictionFlags.MOSAIC_ID in self.restriction_flags:
-			buffer_ += self._mosaic_id_restrictions.serialize()
+			buffer += self._mosaic_id_restrictions.serialize()
 		if AccountRestrictionFlags.TRANSACTION_TYPE in self.restriction_flags:
-			buffer_ += self._transaction_type_restrictions.serialize()
-		return buffer_
+			buffer += self._transaction_type_restrictions.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -6389,15 +6389,15 @@ class AccountRestrictions:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AccountRestrictions:
-		buffer_ = memoryview(payload)
-		version = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		address = Address.deserialize(buffer_)
-		buffer_ = buffer_[address.size:]
-		restrictions_count = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		restrictions = ArrayHelpers.read_array_count(buffer_, AccountRestrictionsInfo, restrictions_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, restrictions)):]
+		buffer = memoryview(payload)
+		version = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		address = Address.deserialize(buffer)
+		buffer = buffer[address.size:]
+		restrictions_count = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		restrictions = ArrayHelpers.read_array_count(buffer, AccountRestrictionsInfo, restrictions_count)
+		buffer = buffer[sum(map(lambda e: e.size, restrictions)):]
 
 		instance = AccountRestrictions()
 		instance._version = version
@@ -6406,12 +6406,12 @@ class AccountRestrictions:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._version.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._address.serialize()
-		buffer_ += len(self._restrictions).to_bytes(8, byteorder='little', signed=False)  # restrictions_count
-		buffer_ += ArrayHelpers.write_array(self._restrictions)
-		return buffer_
+		buffer = bytes()
+		buffer += self._version.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._address.serialize()
+		buffer += len(self._restrictions).to_bytes(8, byteorder='little', signed=False)  # restrictions_count
+		buffer += ArrayHelpers.write_array(self._restrictions)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -6430,8 +6430,8 @@ class MosaicRestrictionKey(BaseValue):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicRestrictionKey:
-		buffer_ = memoryview(payload)
-		return MosaicRestrictionKey(int.from_bytes(buffer_[:8], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return MosaicRestrictionKey(int.from_bytes(buffer[:8], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
 		return self.value.to_bytes(8, byteorder='little', signed=False)
@@ -6452,13 +6452,13 @@ class MosaicRestrictionType(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicRestrictionType:
-		buffer_ = memoryview(payload)
-		return MosaicRestrictionType(int.from_bytes(buffer_[:1], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return MosaicRestrictionType(int.from_bytes(buffer[:1], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(1, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(1, byteorder='little', signed=False)
+		return buffer
 
 
 class MosaicRestrictionEntryType(Enum):
@@ -6471,13 +6471,13 @@ class MosaicRestrictionEntryType(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicRestrictionEntryType:
-		buffer_ = memoryview(payload)
-		return MosaicRestrictionEntryType(int.from_bytes(buffer_[:1], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return MosaicRestrictionEntryType(int.from_bytes(buffer[:1], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(1, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(1, byteorder='little', signed=False)
+		return buffer
 
 
 class AddressKeyValue:
@@ -6514,11 +6514,11 @@ class AddressKeyValue:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AddressKeyValue:
-		buffer_ = memoryview(payload)
-		key = MosaicRestrictionKey.deserialize(buffer_)
-		buffer_ = buffer_[key.size:]
-		value = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
+		buffer = memoryview(payload)
+		key = MosaicRestrictionKey.deserialize(buffer)
+		buffer = buffer[key.size:]
+		value = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
 
 		instance = AddressKeyValue()
 		instance._key = key
@@ -6526,10 +6526,10 @@ class AddressKeyValue:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._key.serialize()
-		buffer_ += self._value.to_bytes(8, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self._key.serialize()
+		buffer += self._value.to_bytes(8, byteorder='little', signed=False)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -6564,21 +6564,21 @@ class AddressKeyValueSet:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AddressKeyValueSet:
-		buffer_ = memoryview(payload)
-		key_value_count = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		keys = ArrayHelpers.read_array_count(buffer_, AddressKeyValue, key_value_count, lambda e: e.key)
-		buffer_ = buffer_[sum(map(lambda e: e.size, keys)):]
+		buffer = memoryview(payload)
+		key_value_count = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		keys = ArrayHelpers.read_array_count(buffer, AddressKeyValue, key_value_count, lambda e: e.key)
+		buffer = buffer[sum(map(lambda e: e.size, keys)):]
 
 		instance = AddressKeyValueSet()
 		instance._keys = keys
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += len(self._keys).to_bytes(1, byteorder='little', signed=False)  # key_value_count
-		buffer_ += ArrayHelpers.write_array(self._keys, lambda e: e.key)
-		return buffer_
+		buffer = bytes()
+		buffer += len(self._keys).to_bytes(1, byteorder='little', signed=False)  # key_value_count
+		buffer += ArrayHelpers.write_array(self._keys, lambda e: e.key)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -6632,13 +6632,13 @@ class RestrictionRule:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> RestrictionRule:
-		buffer_ = memoryview(payload)
-		reference_mosaic_id = MosaicId.deserialize(buffer_)
-		buffer_ = buffer_[reference_mosaic_id.size:]
-		restriction_value = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		restriction_type = MosaicRestrictionType.deserialize(buffer_)
-		buffer_ = buffer_[restriction_type.size:]
+		buffer = memoryview(payload)
+		reference_mosaic_id = MosaicId.deserialize(buffer)
+		buffer = buffer[reference_mosaic_id.size:]
+		restriction_value = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		restriction_type = MosaicRestrictionType.deserialize(buffer)
+		buffer = buffer[restriction_type.size:]
 
 		instance = RestrictionRule()
 		instance._reference_mosaic_id = reference_mosaic_id
@@ -6647,11 +6647,11 @@ class RestrictionRule:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._reference_mosaic_id.serialize()
-		buffer_ += self._restriction_value.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._restriction_type.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._reference_mosaic_id.serialize()
+		buffer += self._restriction_value.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._restriction_type.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -6697,11 +6697,11 @@ class GlobalKeyValue:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> GlobalKeyValue:
-		buffer_ = memoryview(payload)
-		key = MosaicRestrictionKey.deserialize(buffer_)
-		buffer_ = buffer_[key.size:]
-		restriction_rule = RestrictionRule.deserialize(buffer_)
-		buffer_ = buffer_[restriction_rule.size:]
+		buffer = memoryview(payload)
+		key = MosaicRestrictionKey.deserialize(buffer)
+		buffer = buffer[key.size:]
+		restriction_rule = RestrictionRule.deserialize(buffer)
+		buffer = buffer[restriction_rule.size:]
 
 		instance = GlobalKeyValue()
 		instance._key = key
@@ -6709,10 +6709,10 @@ class GlobalKeyValue:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._key.serialize()
-		buffer_ += self._restriction_rule.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._key.serialize()
+		buffer += self._restriction_rule.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -6747,21 +6747,21 @@ class GlobalKeyValueSet:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> GlobalKeyValueSet:
-		buffer_ = memoryview(payload)
-		key_value_count = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		keys = ArrayHelpers.read_array_count(buffer_, GlobalKeyValue, key_value_count, lambda e: e.key)
-		buffer_ = buffer_[sum(map(lambda e: e.size, keys)):]
+		buffer = memoryview(payload)
+		key_value_count = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		keys = ArrayHelpers.read_array_count(buffer, GlobalKeyValue, key_value_count, lambda e: e.key)
+		buffer = buffer[sum(map(lambda e: e.size, keys)):]
 
 		instance = GlobalKeyValueSet()
 		instance._keys = keys
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += len(self._keys).to_bytes(1, byteorder='little', signed=False)  # key_value_count
-		buffer_ += ArrayHelpers.write_array(self._keys, lambda e: e.key)
-		return buffer_
+		buffer = bytes()
+		buffer += len(self._keys).to_bytes(1, byteorder='little', signed=False)  # key_value_count
+		buffer += ArrayHelpers.write_array(self._keys, lambda e: e.key)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -6816,13 +6816,13 @@ class MosaicAddressRestrictionEntry:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicAddressRestrictionEntry:
-		buffer_ = memoryview(payload)
-		mosaic_id = MosaicId.deserialize(buffer_)
-		buffer_ = buffer_[mosaic_id.size:]
-		address = Address.deserialize(buffer_)
-		buffer_ = buffer_[address.size:]
-		key_pairs = AddressKeyValueSet.deserialize(buffer_)
-		buffer_ = buffer_[key_pairs.size:]
+		buffer = memoryview(payload)
+		mosaic_id = MosaicId.deserialize(buffer)
+		buffer = buffer[mosaic_id.size:]
+		address = Address.deserialize(buffer)
+		buffer = buffer[address.size:]
+		key_pairs = AddressKeyValueSet.deserialize(buffer)
+		buffer = buffer[key_pairs.size:]
 
 		instance = MosaicAddressRestrictionEntry()
 		instance._mosaic_id = mosaic_id
@@ -6831,11 +6831,11 @@ class MosaicAddressRestrictionEntry:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._mosaic_id.serialize()
-		buffer_ += self._address.serialize()
-		buffer_ += self._key_pairs.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._mosaic_id.serialize()
+		buffer += self._address.serialize()
+		buffer += self._key_pairs.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -6881,11 +6881,11 @@ class MosaicGlobalRestrictionEntry:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicGlobalRestrictionEntry:
-		buffer_ = memoryview(payload)
-		mosaic_id = MosaicId.deserialize(buffer_)
-		buffer_ = buffer_[mosaic_id.size:]
-		key_pairs = GlobalKeyValueSet.deserialize(buffer_)
-		buffer_ = buffer_[key_pairs.size:]
+		buffer = memoryview(payload)
+		mosaic_id = MosaicId.deserialize(buffer)
+		buffer = buffer[mosaic_id.size:]
+		key_pairs = GlobalKeyValueSet.deserialize(buffer)
+		buffer = buffer[key_pairs.size:]
 
 		instance = MosaicGlobalRestrictionEntry()
 		instance._mosaic_id = mosaic_id
@@ -6893,10 +6893,10 @@ class MosaicGlobalRestrictionEntry:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._mosaic_id.serialize()
-		buffer_ += self._key_pairs.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._mosaic_id.serialize()
+		buffer += self._key_pairs.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -6964,19 +6964,19 @@ class MosaicRestrictionEntry:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicRestrictionEntry:
-		buffer_ = memoryview(payload)
-		version = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		entry_type = MosaicRestrictionEntryType.deserialize(buffer_)
-		buffer_ = buffer_[entry_type.size:]
+		buffer = memoryview(payload)
+		version = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		entry_type = MosaicRestrictionEntryType.deserialize(buffer)
+		buffer = buffer[entry_type.size:]
 		address_entry = None
 		if MosaicRestrictionEntryType.ADDRESS == entry_type:
-			address_entry = MosaicAddressRestrictionEntry.deserialize(buffer_)
-			buffer_ = buffer_[address_entry.size:]
+			address_entry = MosaicAddressRestrictionEntry.deserialize(buffer)
+			buffer = buffer[address_entry.size:]
 		global_entry = None
 		if MosaicRestrictionEntryType.GLOBAL == entry_type:
-			global_entry = MosaicGlobalRestrictionEntry.deserialize(buffer_)
-			buffer_ = buffer_[global_entry.size:]
+			global_entry = MosaicGlobalRestrictionEntry.deserialize(buffer)
+			buffer = buffer[global_entry.size:]
 
 		instance = MosaicRestrictionEntry()
 		instance._version = version
@@ -6986,14 +6986,14 @@ class MosaicRestrictionEntry:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._version.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._entry_type.serialize()
+		buffer = bytes()
+		buffer += self._version.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._entry_type.serialize()
 		if MosaicRestrictionEntryType.ADDRESS == self.entry_type:
-			buffer_ += self._address_entry.serialize()
+			buffer += self._address_entry.serialize()
 		if MosaicRestrictionEntryType.GLOBAL == self.entry_type:
-			buffer_ += self._global_entry.serialize()
-		return buffer_
+			buffer += self._global_entry.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -7018,13 +7018,13 @@ class LockHashAlgorithm(Enum):
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> LockHashAlgorithm:
-		buffer_ = memoryview(payload)
-		return LockHashAlgorithm(int.from_bytes(buffer_[:1], byteorder='little', signed=False))
+		buffer = memoryview(payload)
+		return LockHashAlgorithm(int.from_bytes(buffer[:1], byteorder='little', signed=False))
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.value.to_bytes(1, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.value.to_bytes(1, byteorder='little', signed=False)
+		return buffer
 
 
 class SecretLockInfo:
@@ -7127,23 +7127,23 @@ class SecretLockInfo:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> SecretLockInfo:
-		buffer_ = memoryview(payload)
-		version = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		owner_address = Address.deserialize(buffer_)
-		buffer_ = buffer_[owner_address.size:]
-		mosaic = Mosaic.deserialize(buffer_)
-		buffer_ = buffer_[mosaic.size:]
-		end_height = Height.deserialize(buffer_)
-		buffer_ = buffer_[end_height.size:]
-		status = LockStatus.deserialize(buffer_)
-		buffer_ = buffer_[status.size:]
-		hash_algorithm = LockHashAlgorithm.deserialize(buffer_)
-		buffer_ = buffer_[hash_algorithm.size:]
-		secret = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[secret.size:]
-		recipient = Address.deserialize(buffer_)
-		buffer_ = buffer_[recipient.size:]
+		buffer = memoryview(payload)
+		version = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		owner_address = Address.deserialize(buffer)
+		buffer = buffer[owner_address.size:]
+		mosaic = Mosaic.deserialize(buffer)
+		buffer = buffer[mosaic.size:]
+		end_height = Height.deserialize(buffer)
+		buffer = buffer[end_height.size:]
+		status = LockStatus.deserialize(buffer)
+		buffer = buffer[status.size:]
+		hash_algorithm = LockHashAlgorithm.deserialize(buffer)
+		buffer = buffer[hash_algorithm.size:]
+		secret = Hash256.deserialize(buffer)
+		buffer = buffer[secret.size:]
+		recipient = Address.deserialize(buffer)
+		buffer = buffer[recipient.size:]
 
 		instance = SecretLockInfo()
 		instance._version = version
@@ -7157,16 +7157,16 @@ class SecretLockInfo:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._version.to_bytes(2, byteorder='little', signed=False)
-		buffer_ += self._owner_address.serialize()
-		buffer_ += self._mosaic.serialize()
-		buffer_ += self._end_height.serialize()
-		buffer_ += self._status.serialize()
-		buffer_ += self._hash_algorithm.serialize()
-		buffer_ += self._secret.serialize()
-		buffer_ += self._recipient.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._version.to_bytes(2, byteorder='little', signed=False)
+		buffer += self._owner_address.serialize()
+		buffer += self._mosaic.serialize()
+		buffer += self._end_height.serialize()
+		buffer += self._status.serialize()
+		buffer += self._hash_algorithm.serialize()
+		buffer += self._secret.serialize()
+		buffer += self._recipient.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -7300,35 +7300,35 @@ class AccountKeyLinkTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AccountKeyLinkTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		linked_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[linked_public_key.size:]
-		link_action = LinkAction.deserialize(buffer_)
-		buffer_ = buffer_[link_action.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		linked_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[linked_public_key.size:]
+		link_action = LinkAction.deserialize(buffer)
+		buffer = buffer[link_action.size:]
 
 		instance = AccountKeyLinkTransaction()
 		instance._signature = signature
@@ -7343,20 +7343,20 @@ class AccountKeyLinkTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._linked_public_key.serialize()
-		buffer_ += self._link_action.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._linked_public_key.serialize()
+		buffer += self._link_action.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -7458,29 +7458,29 @@ class EmbeddedAccountKeyLinkTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedAccountKeyLinkTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		linked_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[linked_public_key.size:]
-		link_action = LinkAction.deserialize(buffer_)
-		buffer_ = buffer_[link_action.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		linked_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[linked_public_key.size:]
+		link_action = LinkAction.deserialize(buffer)
+		buffer = buffer[link_action.size:]
 
 		instance = EmbeddedAccountKeyLinkTransaction()
 		instance._signer_public_key = signer_public_key
@@ -7492,17 +7492,17 @@ class EmbeddedAccountKeyLinkTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._linked_public_key.serialize()
-		buffer_ += self._link_action.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._linked_public_key.serialize()
+		buffer += self._link_action.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -7634,35 +7634,35 @@ class NodeKeyLinkTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NodeKeyLinkTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		linked_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[linked_public_key.size:]
-		link_action = LinkAction.deserialize(buffer_)
-		buffer_ = buffer_[link_action.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		linked_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[linked_public_key.size:]
+		link_action = LinkAction.deserialize(buffer)
+		buffer = buffer[link_action.size:]
 
 		instance = NodeKeyLinkTransaction()
 		instance._signature = signature
@@ -7677,20 +7677,20 @@ class NodeKeyLinkTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._linked_public_key.serialize()
-		buffer_ += self._link_action.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._linked_public_key.serialize()
+		buffer += self._link_action.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -7792,29 +7792,29 @@ class EmbeddedNodeKeyLinkTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedNodeKeyLinkTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		linked_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[linked_public_key.size:]
-		link_action = LinkAction.deserialize(buffer_)
-		buffer_ = buffer_[link_action.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		linked_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[linked_public_key.size:]
+		link_action = LinkAction.deserialize(buffer)
+		buffer = buffer[link_action.size:]
 
 		instance = EmbeddedNodeKeyLinkTransaction()
 		instance._signer_public_key = signer_public_key
@@ -7826,17 +7826,17 @@ class EmbeddedNodeKeyLinkTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._linked_public_key.serialize()
-		buffer_ += self._link_action.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._linked_public_key.serialize()
+		buffer += self._link_action.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -7895,13 +7895,13 @@ class Cosignature:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> Cosignature:
-		buffer_ = memoryview(payload)
-		version = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
+		buffer = memoryview(payload)
+		version = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
 
 		instance = Cosignature()
 		instance._version = version
@@ -7910,11 +7910,11 @@ class Cosignature:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._version.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._signature.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._version.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._signature.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -7981,15 +7981,15 @@ class DetachedCosignature:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> DetachedCosignature:
-		buffer_ = memoryview(payload)
-		version = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		parent_hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[parent_hash.size:]
+		buffer = memoryview(payload)
+		version = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		parent_hash = Hash256.deserialize(buffer)
+		buffer = buffer[parent_hash.size:]
 
 		instance = DetachedCosignature()
 		instance._version = version
@@ -7999,12 +7999,12 @@ class DetachedCosignature:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self._version.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._signature.serialize()
-		buffer_ += self._parent_hash.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self._version.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._signature.serialize()
+		buffer += self._parent_hash.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -8148,42 +8148,42 @@ class AggregateCompleteTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AggregateCompleteTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		transactions_hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[transactions_hash.size:]
-		payload_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		aggregate_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		transactions_hash = Hash256.deserialize(buffer)
+		buffer = buffer[transactions_hash.size:]
+		payload_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		aggregate_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert aggregate_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({aggregate_transaction_header_reserved_1})'
-		transactions = ArrayHelpers.read_variable_size_elements(buffer_[:payload_size], EmbeddedTransactionFactory, 8)
-		buffer_ = buffer_[payload_size:]
-		cosignatures = ArrayHelpers.read_array(buffer_, Cosignature)
-		buffer_ = buffer_[sum(map(lambda e: e.size, cosignatures)):]
+		transactions = ArrayHelpers.read_variable_size_elements(buffer[:payload_size], EmbeddedTransactionFactory, 8)
+		buffer = buffer[payload_size:]
+		cosignatures = ArrayHelpers.read_array(buffer, Cosignature)
+		buffer = buffer[sum(map(lambda e: e.size, cosignatures)):]
 
 		instance = AggregateCompleteTransaction()
 		instance._signature = signature
@@ -8199,23 +8199,23 @@ class AggregateCompleteTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._transactions_hash.serialize()
-		buffer_ += sum(map(lambda e: ArrayHelpers.align_up(e.size, 8), self.transactions)).to_bytes(4, byteorder='little', signed=False)  # payload_size
-		buffer_ += self._aggregate_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += ArrayHelpers.write_variable_size_elements(self._transactions, 8)
-		buffer_ += ArrayHelpers.write_array(self._cosignatures)
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._transactions_hash.serialize()
+		buffer += sum(map(lambda e: ArrayHelpers.align_up(e.size, 8), self.transactions)).to_bytes(4, byteorder='little', signed=False)  # payload_size
+		buffer += self._aggregate_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += ArrayHelpers.write_variable_size_elements(self._transactions, 8)
+		buffer += ArrayHelpers.write_array(self._cosignatures)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -8365,42 +8365,42 @@ class AggregateBondedTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AggregateBondedTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		transactions_hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[transactions_hash.size:]
-		payload_size = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		aggregate_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		transactions_hash = Hash256.deserialize(buffer)
+		buffer = buffer[transactions_hash.size:]
+		payload_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		aggregate_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert aggregate_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({aggregate_transaction_header_reserved_1})'
-		transactions = ArrayHelpers.read_variable_size_elements(buffer_[:payload_size], EmbeddedTransactionFactory, 8)
-		buffer_ = buffer_[payload_size:]
-		cosignatures = ArrayHelpers.read_array(buffer_, Cosignature)
-		buffer_ = buffer_[sum(map(lambda e: e.size, cosignatures)):]
+		transactions = ArrayHelpers.read_variable_size_elements(buffer[:payload_size], EmbeddedTransactionFactory, 8)
+		buffer = buffer[payload_size:]
+		cosignatures = ArrayHelpers.read_array(buffer, Cosignature)
+		buffer = buffer[sum(map(lambda e: e.size, cosignatures)):]
 
 		instance = AggregateBondedTransaction()
 		instance._signature = signature
@@ -8416,23 +8416,23 @@ class AggregateBondedTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._transactions_hash.serialize()
-		buffer_ += sum(map(lambda e: ArrayHelpers.align_up(e.size, 8), self.transactions)).to_bytes(4, byteorder='little', signed=False)  # payload_size
-		buffer_ += self._aggregate_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += ArrayHelpers.write_variable_size_elements(self._transactions, 8)
-		buffer_ += ArrayHelpers.write_array(self._cosignatures)
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._transactions_hash.serialize()
+		buffer += sum(map(lambda e: ArrayHelpers.align_up(e.size, 8), self.transactions)).to_bytes(4, byteorder='little', signed=False)  # payload_size
+		buffer += self._aggregate_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += ArrayHelpers.write_variable_size_elements(self._transactions, 8)
+		buffer += ArrayHelpers.write_array(self._cosignatures)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -8590,39 +8590,39 @@ class VotingKeyLinkTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> VotingKeyLinkTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		linked_public_key = VotingPublicKey.deserialize(buffer_)
-		buffer_ = buffer_[linked_public_key.size:]
-		start_epoch = FinalizationEpoch.deserialize(buffer_)
-		buffer_ = buffer_[start_epoch.size:]
-		end_epoch = FinalizationEpoch.deserialize(buffer_)
-		buffer_ = buffer_[end_epoch.size:]
-		link_action = LinkAction.deserialize(buffer_)
-		buffer_ = buffer_[link_action.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		linked_public_key = VotingPublicKey.deserialize(buffer)
+		buffer = buffer[linked_public_key.size:]
+		start_epoch = FinalizationEpoch.deserialize(buffer)
+		buffer = buffer[start_epoch.size:]
+		end_epoch = FinalizationEpoch.deserialize(buffer)
+		buffer = buffer[end_epoch.size:]
+		link_action = LinkAction.deserialize(buffer)
+		buffer = buffer[link_action.size:]
 
 		instance = VotingKeyLinkTransaction()
 		instance._signature = signature
@@ -8639,22 +8639,22 @@ class VotingKeyLinkTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._linked_public_key.serialize()
-		buffer_ += self._start_epoch.serialize()
-		buffer_ += self._end_epoch.serialize()
-		buffer_ += self._link_action.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._linked_public_key.serialize()
+		buffer += self._start_epoch.serialize()
+		buffer += self._end_epoch.serialize()
+		buffer += self._link_action.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -8780,33 +8780,33 @@ class EmbeddedVotingKeyLinkTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedVotingKeyLinkTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		linked_public_key = VotingPublicKey.deserialize(buffer_)
-		buffer_ = buffer_[linked_public_key.size:]
-		start_epoch = FinalizationEpoch.deserialize(buffer_)
-		buffer_ = buffer_[start_epoch.size:]
-		end_epoch = FinalizationEpoch.deserialize(buffer_)
-		buffer_ = buffer_[end_epoch.size:]
-		link_action = LinkAction.deserialize(buffer_)
-		buffer_ = buffer_[link_action.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		linked_public_key = VotingPublicKey.deserialize(buffer)
+		buffer = buffer[linked_public_key.size:]
+		start_epoch = FinalizationEpoch.deserialize(buffer)
+		buffer = buffer[start_epoch.size:]
+		end_epoch = FinalizationEpoch.deserialize(buffer)
+		buffer = buffer[end_epoch.size:]
+		link_action = LinkAction.deserialize(buffer)
+		buffer = buffer[link_action.size:]
 
 		instance = EmbeddedVotingKeyLinkTransaction()
 		instance._signer_public_key = signer_public_key
@@ -8820,19 +8820,19 @@ class EmbeddedVotingKeyLinkTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._linked_public_key.serialize()
-		buffer_ += self._start_epoch.serialize()
-		buffer_ += self._end_epoch.serialize()
-		buffer_ += self._link_action.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._linked_public_key.serialize()
+		buffer += self._start_epoch.serialize()
+		buffer += self._end_epoch.serialize()
+		buffer += self._link_action.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -8966,35 +8966,35 @@ class VrfKeyLinkTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> VrfKeyLinkTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		linked_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[linked_public_key.size:]
-		link_action = LinkAction.deserialize(buffer_)
-		buffer_ = buffer_[link_action.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		linked_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[linked_public_key.size:]
+		link_action = LinkAction.deserialize(buffer)
+		buffer = buffer[link_action.size:]
 
 		instance = VrfKeyLinkTransaction()
 		instance._signature = signature
@@ -9009,20 +9009,20 @@ class VrfKeyLinkTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._linked_public_key.serialize()
-		buffer_ += self._link_action.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._linked_public_key.serialize()
+		buffer += self._link_action.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -9124,29 +9124,29 @@ class EmbeddedVrfKeyLinkTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedVrfKeyLinkTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		linked_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[linked_public_key.size:]
-		link_action = LinkAction.deserialize(buffer_)
-		buffer_ = buffer_[link_action.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		linked_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[linked_public_key.size:]
+		link_action = LinkAction.deserialize(buffer)
+		buffer = buffer[link_action.size:]
 
 		instance = EmbeddedVrfKeyLinkTransaction()
 		instance._signer_public_key = signer_public_key
@@ -9158,17 +9158,17 @@ class EmbeddedVrfKeyLinkTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._linked_public_key.serialize()
-		buffer_ += self._link_action.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._linked_public_key.serialize()
+		buffer += self._link_action.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -9311,37 +9311,37 @@ class HashLockTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> HashLockTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		mosaic = UnresolvedMosaic.deserialize(buffer_)
-		buffer_ = buffer_[mosaic.size:]
-		duration = BlockDuration.deserialize(buffer_)
-		buffer_ = buffer_[duration.size:]
-		hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[hash.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		mosaic = UnresolvedMosaic.deserialize(buffer)
+		buffer = buffer[mosaic.size:]
+		duration = BlockDuration.deserialize(buffer)
+		buffer = buffer[duration.size:]
+		hash = Hash256.deserialize(buffer)
+		buffer = buffer[hash.size:]
 
 		instance = HashLockTransaction()
 		instance._signature = signature
@@ -9357,21 +9357,21 @@ class HashLockTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._mosaic.serialize()
-		buffer_ += self._duration.serialize()
-		buffer_ += self._hash.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._mosaic.serialize()
+		buffer += self._duration.serialize()
+		buffer += self._hash.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -9485,31 +9485,31 @@ class EmbeddedHashLockTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedHashLockTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		mosaic = UnresolvedMosaic.deserialize(buffer_)
-		buffer_ = buffer_[mosaic.size:]
-		duration = BlockDuration.deserialize(buffer_)
-		buffer_ = buffer_[duration.size:]
-		hash = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[hash.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		mosaic = UnresolvedMosaic.deserialize(buffer)
+		buffer = buffer[mosaic.size:]
+		duration = BlockDuration.deserialize(buffer)
+		buffer = buffer[duration.size:]
+		hash = Hash256.deserialize(buffer)
+		buffer = buffer[hash.size:]
 
 		instance = EmbeddedHashLockTransaction()
 		instance._signer_public_key = signer_public_key
@@ -9522,18 +9522,18 @@ class EmbeddedHashLockTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._mosaic.serialize()
-		buffer_ += self._duration.serialize()
-		buffer_ += self._hash.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._mosaic.serialize()
+		buffer += self._duration.serialize()
+		buffer += self._hash.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -9699,41 +9699,41 @@ class SecretLockTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> SecretLockTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		recipient_address = UnresolvedAddress.deserialize(buffer_)
-		buffer_ = buffer_[recipient_address.size:]
-		secret = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[secret.size:]
-		mosaic = UnresolvedMosaic.deserialize(buffer_)
-		buffer_ = buffer_[mosaic.size:]
-		duration = BlockDuration.deserialize(buffer_)
-		buffer_ = buffer_[duration.size:]
-		hash_algorithm = LockHashAlgorithm.deserialize(buffer_)
-		buffer_ = buffer_[hash_algorithm.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		recipient_address = UnresolvedAddress.deserialize(buffer)
+		buffer = buffer[recipient_address.size:]
+		secret = Hash256.deserialize(buffer)
+		buffer = buffer[secret.size:]
+		mosaic = UnresolvedMosaic.deserialize(buffer)
+		buffer = buffer[mosaic.size:]
+		duration = BlockDuration.deserialize(buffer)
+		buffer = buffer[duration.size:]
+		hash_algorithm = LockHashAlgorithm.deserialize(buffer)
+		buffer = buffer[hash_algorithm.size:]
 
 		instance = SecretLockTransaction()
 		instance._signature = signature
@@ -9751,23 +9751,23 @@ class SecretLockTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._recipient_address.serialize()
-		buffer_ += self._secret.serialize()
-		buffer_ += self._mosaic.serialize()
-		buffer_ += self._duration.serialize()
-		buffer_ += self._hash_algorithm.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._recipient_address.serialize()
+		buffer += self._secret.serialize()
+		buffer += self._mosaic.serialize()
+		buffer += self._duration.serialize()
+		buffer += self._hash_algorithm.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -9905,35 +9905,35 @@ class EmbeddedSecretLockTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedSecretLockTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		recipient_address = UnresolvedAddress.deserialize(buffer_)
-		buffer_ = buffer_[recipient_address.size:]
-		secret = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[secret.size:]
-		mosaic = UnresolvedMosaic.deserialize(buffer_)
-		buffer_ = buffer_[mosaic.size:]
-		duration = BlockDuration.deserialize(buffer_)
-		buffer_ = buffer_[duration.size:]
-		hash_algorithm = LockHashAlgorithm.deserialize(buffer_)
-		buffer_ = buffer_[hash_algorithm.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		recipient_address = UnresolvedAddress.deserialize(buffer)
+		buffer = buffer[recipient_address.size:]
+		secret = Hash256.deserialize(buffer)
+		buffer = buffer[secret.size:]
+		mosaic = UnresolvedMosaic.deserialize(buffer)
+		buffer = buffer[mosaic.size:]
+		duration = BlockDuration.deserialize(buffer)
+		buffer = buffer[duration.size:]
+		hash_algorithm = LockHashAlgorithm.deserialize(buffer)
+		buffer = buffer[hash_algorithm.size:]
 
 		instance = EmbeddedSecretLockTransaction()
 		instance._signer_public_key = signer_public_key
@@ -9948,20 +9948,20 @@ class EmbeddedSecretLockTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._recipient_address.serialize()
-		buffer_ += self._secret.serialize()
-		buffer_ += self._mosaic.serialize()
-		buffer_ += self._duration.serialize()
-		buffer_ += self._hash_algorithm.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._recipient_address.serialize()
+		buffer += self._secret.serialize()
+		buffer += self._mosaic.serialize()
+		buffer += self._duration.serialize()
+		buffer += self._hash_algorithm.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -10119,41 +10119,41 @@ class SecretProofTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> SecretProofTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		recipient_address = UnresolvedAddress.deserialize(buffer_)
-		buffer_ = buffer_[recipient_address.size:]
-		secret = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[secret.size:]
-		proof_size = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		hash_algorithm = LockHashAlgorithm.deserialize(buffer_)
-		buffer_ = buffer_[hash_algorithm.size:]
-		proof = ArrayHelpers.get_bytes(buffer_, proof_size)
-		buffer_ = buffer_[proof_size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		recipient_address = UnresolvedAddress.deserialize(buffer)
+		buffer = buffer[recipient_address.size:]
+		secret = Hash256.deserialize(buffer)
+		buffer = buffer[secret.size:]
+		proof_size = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		hash_algorithm = LockHashAlgorithm.deserialize(buffer)
+		buffer = buffer[hash_algorithm.size:]
+		proof = ArrayHelpers.get_bytes(buffer, proof_size)
+		buffer = buffer[proof_size:]
 
 		instance = SecretProofTransaction()
 		instance._signature = signature
@@ -10170,23 +10170,23 @@ class SecretProofTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._recipient_address.serialize()
-		buffer_ += self._secret.serialize()
-		buffer_ += len(self._proof).to_bytes(2, byteorder='little', signed=False)  # proof_size
-		buffer_ += self._hash_algorithm.serialize()
-		buffer_ += self._proof
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._recipient_address.serialize()
+		buffer += self._secret.serialize()
+		buffer += len(self._proof).to_bytes(2, byteorder='little', signed=False)  # proof_size
+		buffer += self._hash_algorithm.serialize()
+		buffer += self._proof
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -10313,35 +10313,35 @@ class EmbeddedSecretProofTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedSecretProofTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		recipient_address = UnresolvedAddress.deserialize(buffer_)
-		buffer_ = buffer_[recipient_address.size:]
-		secret = Hash256.deserialize(buffer_)
-		buffer_ = buffer_[secret.size:]
-		proof_size = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		hash_algorithm = LockHashAlgorithm.deserialize(buffer_)
-		buffer_ = buffer_[hash_algorithm.size:]
-		proof = ArrayHelpers.get_bytes(buffer_, proof_size)
-		buffer_ = buffer_[proof_size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		recipient_address = UnresolvedAddress.deserialize(buffer)
+		buffer = buffer[recipient_address.size:]
+		secret = Hash256.deserialize(buffer)
+		buffer = buffer[secret.size:]
+		proof_size = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		hash_algorithm = LockHashAlgorithm.deserialize(buffer)
+		buffer = buffer[hash_algorithm.size:]
+		proof = ArrayHelpers.get_bytes(buffer, proof_size)
+		buffer = buffer[proof_size:]
 
 		instance = EmbeddedSecretProofTransaction()
 		instance._signer_public_key = signer_public_key
@@ -10355,20 +10355,20 @@ class EmbeddedSecretProofTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._recipient_address.serialize()
-		buffer_ += self._secret.serialize()
-		buffer_ += len(self._proof).to_bytes(2, byteorder='little', signed=False)  # proof_size
-		buffer_ += self._hash_algorithm.serialize()
-		buffer_ += self._proof
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._recipient_address.serialize()
+		buffer += self._secret.serialize()
+		buffer += len(self._proof).to_bytes(2, byteorder='little', signed=False)  # proof_size
+		buffer += self._hash_algorithm.serialize()
+		buffer += self._proof
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -10523,41 +10523,41 @@ class AccountMetadataTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AccountMetadataTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		target_address = UnresolvedAddress.deserialize(buffer_)
-		buffer_ = buffer_[target_address.size:]
-		scoped_metadata_key = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		value_size_delta = int.from_bytes(buffer_[:2], byteorder='little', signed=True)
-		buffer_ = buffer_[2:]
-		value_size = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		value = ArrayHelpers.get_bytes(buffer_, value_size)
-		buffer_ = buffer_[value_size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		target_address = UnresolvedAddress.deserialize(buffer)
+		buffer = buffer[target_address.size:]
+		scoped_metadata_key = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		value_size_delta = int.from_bytes(buffer[:2], byteorder='little', signed=True)
+		buffer = buffer[2:]
+		value_size = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		value = ArrayHelpers.get_bytes(buffer, value_size)
+		buffer = buffer[value_size:]
 
 		instance = AccountMetadataTransaction()
 		instance._signature = signature
@@ -10574,23 +10574,23 @@ class AccountMetadataTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._target_address.serialize()
-		buffer_ += self._scoped_metadata_key.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._value_size_delta.to_bytes(2, byteorder='little', signed=True)
-		buffer_ += len(self._value).to_bytes(2, byteorder='little', signed=False)  # value_size
-		buffer_ += self._value
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._target_address.serialize()
+		buffer += self._scoped_metadata_key.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._value_size_delta.to_bytes(2, byteorder='little', signed=True)
+		buffer += len(self._value).to_bytes(2, byteorder='little', signed=False)  # value_size
+		buffer += self._value
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -10715,35 +10715,35 @@ class EmbeddedAccountMetadataTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedAccountMetadataTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		target_address = UnresolvedAddress.deserialize(buffer_)
-		buffer_ = buffer_[target_address.size:]
-		scoped_metadata_key = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		value_size_delta = int.from_bytes(buffer_[:2], byteorder='little', signed=True)
-		buffer_ = buffer_[2:]
-		value_size = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		value = ArrayHelpers.get_bytes(buffer_, value_size)
-		buffer_ = buffer_[value_size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		target_address = UnresolvedAddress.deserialize(buffer)
+		buffer = buffer[target_address.size:]
+		scoped_metadata_key = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		value_size_delta = int.from_bytes(buffer[:2], byteorder='little', signed=True)
+		buffer = buffer[2:]
+		value_size = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		value = ArrayHelpers.get_bytes(buffer, value_size)
+		buffer = buffer[value_size:]
 
 		instance = EmbeddedAccountMetadataTransaction()
 		instance._signer_public_key = signer_public_key
@@ -10757,20 +10757,20 @@ class EmbeddedAccountMetadataTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._target_address.serialize()
-		buffer_ += self._scoped_metadata_key.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._value_size_delta.to_bytes(2, byteorder='little', signed=True)
-		buffer_ += len(self._value).to_bytes(2, byteorder='little', signed=False)  # value_size
-		buffer_ += self._value
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._target_address.serialize()
+		buffer += self._scoped_metadata_key.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._value_size_delta.to_bytes(2, byteorder='little', signed=True)
+		buffer += len(self._value).to_bytes(2, byteorder='little', signed=False)  # value_size
+		buffer += self._value
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -10936,43 +10936,43 @@ class MosaicMetadataTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicMetadataTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		target_address = UnresolvedAddress.deserialize(buffer_)
-		buffer_ = buffer_[target_address.size:]
-		scoped_metadata_key = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		target_mosaic_id = UnresolvedMosaicId.deserialize(buffer_)
-		buffer_ = buffer_[target_mosaic_id.size:]
-		value_size_delta = int.from_bytes(buffer_[:2], byteorder='little', signed=True)
-		buffer_ = buffer_[2:]
-		value_size = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		value = ArrayHelpers.get_bytes(buffer_, value_size)
-		buffer_ = buffer_[value_size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		target_address = UnresolvedAddress.deserialize(buffer)
+		buffer = buffer[target_address.size:]
+		scoped_metadata_key = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		target_mosaic_id = UnresolvedMosaicId.deserialize(buffer)
+		buffer = buffer[target_mosaic_id.size:]
+		value_size_delta = int.from_bytes(buffer[:2], byteorder='little', signed=True)
+		buffer = buffer[2:]
+		value_size = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		value = ArrayHelpers.get_bytes(buffer, value_size)
+		buffer = buffer[value_size:]
 
 		instance = MosaicMetadataTransaction()
 		instance._signature = signature
@@ -10990,24 +10990,24 @@ class MosaicMetadataTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._target_address.serialize()
-		buffer_ += self._scoped_metadata_key.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._target_mosaic_id.serialize()
-		buffer_ += self._value_size_delta.to_bytes(2, byteorder='little', signed=True)
-		buffer_ += len(self._value).to_bytes(2, byteorder='little', signed=False)  # value_size
-		buffer_ += self._value
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._target_address.serialize()
+		buffer += self._scoped_metadata_key.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._target_mosaic_id.serialize()
+		buffer += self._value_size_delta.to_bytes(2, byteorder='little', signed=True)
+		buffer += len(self._value).to_bytes(2, byteorder='little', signed=False)  # value_size
+		buffer += self._value
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -11144,37 +11144,37 @@ class EmbeddedMosaicMetadataTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedMosaicMetadataTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		target_address = UnresolvedAddress.deserialize(buffer_)
-		buffer_ = buffer_[target_address.size:]
-		scoped_metadata_key = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		target_mosaic_id = UnresolvedMosaicId.deserialize(buffer_)
-		buffer_ = buffer_[target_mosaic_id.size:]
-		value_size_delta = int.from_bytes(buffer_[:2], byteorder='little', signed=True)
-		buffer_ = buffer_[2:]
-		value_size = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		value = ArrayHelpers.get_bytes(buffer_, value_size)
-		buffer_ = buffer_[value_size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		target_address = UnresolvedAddress.deserialize(buffer)
+		buffer = buffer[target_address.size:]
+		scoped_metadata_key = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		target_mosaic_id = UnresolvedMosaicId.deserialize(buffer)
+		buffer = buffer[target_mosaic_id.size:]
+		value_size_delta = int.from_bytes(buffer[:2], byteorder='little', signed=True)
+		buffer = buffer[2:]
+		value_size = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		value = ArrayHelpers.get_bytes(buffer, value_size)
+		buffer = buffer[value_size:]
 
 		instance = EmbeddedMosaicMetadataTransaction()
 		instance._signer_public_key = signer_public_key
@@ -11189,21 +11189,21 @@ class EmbeddedMosaicMetadataTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._target_address.serialize()
-		buffer_ += self._scoped_metadata_key.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._target_mosaic_id.serialize()
-		buffer_ += self._value_size_delta.to_bytes(2, byteorder='little', signed=True)
-		buffer_ += len(self._value).to_bytes(2, byteorder='little', signed=False)  # value_size
-		buffer_ += self._value
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._target_address.serialize()
+		buffer += self._scoped_metadata_key.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._target_mosaic_id.serialize()
+		buffer += self._value_size_delta.to_bytes(2, byteorder='little', signed=True)
+		buffer += len(self._value).to_bytes(2, byteorder='little', signed=False)  # value_size
+		buffer += self._value
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -11370,43 +11370,43 @@ class NamespaceMetadataTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NamespaceMetadataTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		target_address = UnresolvedAddress.deserialize(buffer_)
-		buffer_ = buffer_[target_address.size:]
-		scoped_metadata_key = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		target_namespace_id = NamespaceId.deserialize(buffer_)
-		buffer_ = buffer_[target_namespace_id.size:]
-		value_size_delta = int.from_bytes(buffer_[:2], byteorder='little', signed=True)
-		buffer_ = buffer_[2:]
-		value_size = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		value = ArrayHelpers.get_bytes(buffer_, value_size)
-		buffer_ = buffer_[value_size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		target_address = UnresolvedAddress.deserialize(buffer)
+		buffer = buffer[target_address.size:]
+		scoped_metadata_key = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		target_namespace_id = NamespaceId.deserialize(buffer)
+		buffer = buffer[target_namespace_id.size:]
+		value_size_delta = int.from_bytes(buffer[:2], byteorder='little', signed=True)
+		buffer = buffer[2:]
+		value_size = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		value = ArrayHelpers.get_bytes(buffer, value_size)
+		buffer = buffer[value_size:]
 
 		instance = NamespaceMetadataTransaction()
 		instance._signature = signature
@@ -11424,24 +11424,24 @@ class NamespaceMetadataTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._target_address.serialize()
-		buffer_ += self._scoped_metadata_key.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._target_namespace_id.serialize()
-		buffer_ += self._value_size_delta.to_bytes(2, byteorder='little', signed=True)
-		buffer_ += len(self._value).to_bytes(2, byteorder='little', signed=False)  # value_size
-		buffer_ += self._value
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._target_address.serialize()
+		buffer += self._scoped_metadata_key.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._target_namespace_id.serialize()
+		buffer += self._value_size_delta.to_bytes(2, byteorder='little', signed=True)
+		buffer += len(self._value).to_bytes(2, byteorder='little', signed=False)  # value_size
+		buffer += self._value
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -11578,37 +11578,37 @@ class EmbeddedNamespaceMetadataTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedNamespaceMetadataTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		target_address = UnresolvedAddress.deserialize(buffer_)
-		buffer_ = buffer_[target_address.size:]
-		scoped_metadata_key = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		target_namespace_id = NamespaceId.deserialize(buffer_)
-		buffer_ = buffer_[target_namespace_id.size:]
-		value_size_delta = int.from_bytes(buffer_[:2], byteorder='little', signed=True)
-		buffer_ = buffer_[2:]
-		value_size = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		value = ArrayHelpers.get_bytes(buffer_, value_size)
-		buffer_ = buffer_[value_size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		target_address = UnresolvedAddress.deserialize(buffer)
+		buffer = buffer[target_address.size:]
+		scoped_metadata_key = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		target_namespace_id = NamespaceId.deserialize(buffer)
+		buffer = buffer[target_namespace_id.size:]
+		value_size_delta = int.from_bytes(buffer[:2], byteorder='little', signed=True)
+		buffer = buffer[2:]
+		value_size = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		value = ArrayHelpers.get_bytes(buffer, value_size)
+		buffer = buffer[value_size:]
 
 		instance = EmbeddedNamespaceMetadataTransaction()
 		instance._signer_public_key = signer_public_key
@@ -11623,21 +11623,21 @@ class EmbeddedNamespaceMetadataTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._target_address.serialize()
-		buffer_ += self._scoped_metadata_key.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._target_namespace_id.serialize()
-		buffer_ += self._value_size_delta.to_bytes(2, byteorder='little', signed=True)
-		buffer_ += len(self._value).to_bytes(2, byteorder='little', signed=False)  # value_size
-		buffer_ += self._value
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._target_address.serialize()
+		buffer += self._scoped_metadata_key.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._target_namespace_id.serialize()
+		buffer += self._value_size_delta.to_bytes(2, byteorder='little', signed=True)
+		buffer += len(self._value).to_bytes(2, byteorder='little', signed=False)  # value_size
+		buffer += self._value
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -11804,41 +11804,41 @@ class MosaicDefinitionTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicDefinitionTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		id = MosaicId.deserialize(buffer_)
-		buffer_ = buffer_[id.size:]
-		duration = BlockDuration.deserialize(buffer_)
-		buffer_ = buffer_[duration.size:]
-		nonce = MosaicNonce.deserialize(buffer_)
-		buffer_ = buffer_[nonce.size:]
-		flags = MosaicFlags.deserialize(buffer_)
-		buffer_ = buffer_[flags.size:]
-		divisibility = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		id = MosaicId.deserialize(buffer)
+		buffer = buffer[id.size:]
+		duration = BlockDuration.deserialize(buffer)
+		buffer = buffer[duration.size:]
+		nonce = MosaicNonce.deserialize(buffer)
+		buffer = buffer[nonce.size:]
+		flags = MosaicFlags.deserialize(buffer)
+		buffer = buffer[flags.size:]
+		divisibility = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
 
 		instance = MosaicDefinitionTransaction()
 		instance._signature = signature
@@ -11856,23 +11856,23 @@ class MosaicDefinitionTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._id.serialize()
-		buffer_ += self._duration.serialize()
-		buffer_ += self._nonce.serialize()
-		buffer_ += self._flags.serialize()
-		buffer_ += self._divisibility.to_bytes(1, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._id.serialize()
+		buffer += self._duration.serialize()
+		buffer += self._nonce.serialize()
+		buffer += self._flags.serialize()
+		buffer += self._divisibility.to_bytes(1, byteorder='little', signed=False)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -12009,35 +12009,35 @@ class EmbeddedMosaicDefinitionTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedMosaicDefinitionTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		id = MosaicId.deserialize(buffer_)
-		buffer_ = buffer_[id.size:]
-		duration = BlockDuration.deserialize(buffer_)
-		buffer_ = buffer_[duration.size:]
-		nonce = MosaicNonce.deserialize(buffer_)
-		buffer_ = buffer_[nonce.size:]
-		flags = MosaicFlags.deserialize(buffer_)
-		buffer_ = buffer_[flags.size:]
-		divisibility = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		id = MosaicId.deserialize(buffer)
+		buffer = buffer[id.size:]
+		duration = BlockDuration.deserialize(buffer)
+		buffer = buffer[duration.size:]
+		nonce = MosaicNonce.deserialize(buffer)
+		buffer = buffer[nonce.size:]
+		flags = MosaicFlags.deserialize(buffer)
+		buffer = buffer[flags.size:]
+		divisibility = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
 
 		instance = EmbeddedMosaicDefinitionTransaction()
 		instance._signer_public_key = signer_public_key
@@ -12052,20 +12052,20 @@ class EmbeddedMosaicDefinitionTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._id.serialize()
-		buffer_ += self._duration.serialize()
-		buffer_ += self._nonce.serialize()
-		buffer_ += self._flags.serialize()
-		buffer_ += self._divisibility.to_bytes(1, byteorder='little', signed=False)
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._id.serialize()
+		buffer += self._duration.serialize()
+		buffer += self._nonce.serialize()
+		buffer += self._flags.serialize()
+		buffer += self._divisibility.to_bytes(1, byteorder='little', signed=False)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -12211,37 +12211,37 @@ class MosaicSupplyChangeTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicSupplyChangeTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		mosaic_id = UnresolvedMosaicId.deserialize(buffer_)
-		buffer_ = buffer_[mosaic_id.size:]
-		delta = Amount.deserialize(buffer_)
-		buffer_ = buffer_[delta.size:]
-		action = MosaicSupplyChangeAction.deserialize(buffer_)
-		buffer_ = buffer_[action.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		mosaic_id = UnresolvedMosaicId.deserialize(buffer)
+		buffer = buffer[mosaic_id.size:]
+		delta = Amount.deserialize(buffer)
+		buffer = buffer[delta.size:]
+		action = MosaicSupplyChangeAction.deserialize(buffer)
+		buffer = buffer[action.size:]
 
 		instance = MosaicSupplyChangeTransaction()
 		instance._signature = signature
@@ -12257,21 +12257,21 @@ class MosaicSupplyChangeTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._mosaic_id.serialize()
-		buffer_ += self._delta.serialize()
-		buffer_ += self._action.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._mosaic_id.serialize()
+		buffer += self._delta.serialize()
+		buffer += self._action.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -12385,31 +12385,31 @@ class EmbeddedMosaicSupplyChangeTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedMosaicSupplyChangeTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		mosaic_id = UnresolvedMosaicId.deserialize(buffer_)
-		buffer_ = buffer_[mosaic_id.size:]
-		delta = Amount.deserialize(buffer_)
-		buffer_ = buffer_[delta.size:]
-		action = MosaicSupplyChangeAction.deserialize(buffer_)
-		buffer_ = buffer_[action.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		mosaic_id = UnresolvedMosaicId.deserialize(buffer)
+		buffer = buffer[mosaic_id.size:]
+		delta = Amount.deserialize(buffer)
+		buffer = buffer[delta.size:]
+		action = MosaicSupplyChangeAction.deserialize(buffer)
+		buffer = buffer[action.size:]
 
 		instance = EmbeddedMosaicSupplyChangeTransaction()
 		instance._signer_public_key = signer_public_key
@@ -12422,18 +12422,18 @@ class EmbeddedMosaicSupplyChangeTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._mosaic_id.serialize()
-		buffer_ += self._delta.serialize()
-		buffer_ += self._action.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._mosaic_id.serialize()
+		buffer += self._delta.serialize()
+		buffer += self._action.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -12566,35 +12566,35 @@ class MosaicSupplyRevocationTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicSupplyRevocationTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		source_address = UnresolvedAddress.deserialize(buffer_)
-		buffer_ = buffer_[source_address.size:]
-		mosaic = UnresolvedMosaic.deserialize(buffer_)
-		buffer_ = buffer_[mosaic.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		source_address = UnresolvedAddress.deserialize(buffer)
+		buffer = buffer[source_address.size:]
+		mosaic = UnresolvedMosaic.deserialize(buffer)
+		buffer = buffer[mosaic.size:]
 
 		instance = MosaicSupplyRevocationTransaction()
 		instance._signature = signature
@@ -12609,20 +12609,20 @@ class MosaicSupplyRevocationTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._source_address.serialize()
-		buffer_ += self._mosaic.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._source_address.serialize()
+		buffer += self._mosaic.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -12724,29 +12724,29 @@ class EmbeddedMosaicSupplyRevocationTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedMosaicSupplyRevocationTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		source_address = UnresolvedAddress.deserialize(buffer_)
-		buffer_ = buffer_[source_address.size:]
-		mosaic = UnresolvedMosaic.deserialize(buffer_)
-		buffer_ = buffer_[mosaic.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		source_address = UnresolvedAddress.deserialize(buffer)
+		buffer = buffer[source_address.size:]
+		mosaic = UnresolvedMosaic.deserialize(buffer)
+		buffer = buffer[mosaic.size:]
 
 		instance = EmbeddedMosaicSupplyRevocationTransaction()
 		instance._signer_public_key = signer_public_key
@@ -12758,17 +12758,17 @@ class EmbeddedMosaicSupplyRevocationTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._source_address.serialize()
-		buffer_ += self._mosaic.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._source_address.serialize()
+		buffer += self._mosaic.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -12924,46 +12924,46 @@ class MultisigAccountModificationTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MultisigAccountModificationTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		min_removal_delta = int.from_bytes(buffer_[:1], byteorder='little', signed=True)
-		buffer_ = buffer_[1:]
-		min_approval_delta = int.from_bytes(buffer_[:1], byteorder='little', signed=True)
-		buffer_ = buffer_[1:]
-		address_additions_count = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		address_deletions_count = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		multisig_account_modification_transaction_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		min_removal_delta = int.from_bytes(buffer[:1], byteorder='little', signed=True)
+		buffer = buffer[1:]
+		min_approval_delta = int.from_bytes(buffer[:1], byteorder='little', signed=True)
+		buffer = buffer[1:]
+		address_additions_count = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		address_deletions_count = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		multisig_account_modification_transaction_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert multisig_account_modification_transaction_body_reserved_1 == 0, f'Invalid value of reserved field ({multisig_account_modification_transaction_body_reserved_1})'
-		address_additions = ArrayHelpers.read_array_count(buffer_, UnresolvedAddress, address_additions_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, address_additions)):]
-		address_deletions = ArrayHelpers.read_array_count(buffer_, UnresolvedAddress, address_deletions_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, address_deletions)):]
+		address_additions = ArrayHelpers.read_array_count(buffer, UnresolvedAddress, address_additions_count)
+		buffer = buffer[sum(map(lambda e: e.size, address_additions)):]
+		address_deletions = ArrayHelpers.read_array_count(buffer, UnresolvedAddress, address_deletions_count)
+		buffer = buffer[sum(map(lambda e: e.size, address_deletions)):]
 
 		instance = MultisigAccountModificationTransaction()
 		instance._signature = signature
@@ -12980,25 +12980,25 @@ class MultisigAccountModificationTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._min_removal_delta.to_bytes(1, byteorder='little', signed=True)
-		buffer_ += self._min_approval_delta.to_bytes(1, byteorder='little', signed=True)
-		buffer_ += len(self._address_additions).to_bytes(1, byteorder='little', signed=False)  # address_additions_count
-		buffer_ += len(self._address_deletions).to_bytes(1, byteorder='little', signed=False)  # address_deletions_count
-		buffer_ += self._multisig_account_modification_transaction_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += ArrayHelpers.write_array(self._address_additions)
-		buffer_ += ArrayHelpers.write_array(self._address_deletions)
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._min_removal_delta.to_bytes(1, byteorder='little', signed=True)
+		buffer += self._min_approval_delta.to_bytes(1, byteorder='little', signed=True)
+		buffer += len(self._address_additions).to_bytes(1, byteorder='little', signed=False)  # address_additions_count
+		buffer += len(self._address_deletions).to_bytes(1, byteorder='little', signed=False)  # address_deletions_count
+		buffer += self._multisig_account_modification_transaction_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += ArrayHelpers.write_array(self._address_additions)
+		buffer += ArrayHelpers.write_array(self._address_deletions)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -13126,40 +13126,40 @@ class EmbeddedMultisigAccountModificationTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedMultisigAccountModificationTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		min_removal_delta = int.from_bytes(buffer_[:1], byteorder='little', signed=True)
-		buffer_ = buffer_[1:]
-		min_approval_delta = int.from_bytes(buffer_[:1], byteorder='little', signed=True)
-		buffer_ = buffer_[1:]
-		address_additions_count = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		address_deletions_count = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		multisig_account_modification_transaction_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		min_removal_delta = int.from_bytes(buffer[:1], byteorder='little', signed=True)
+		buffer = buffer[1:]
+		min_approval_delta = int.from_bytes(buffer[:1], byteorder='little', signed=True)
+		buffer = buffer[1:]
+		address_additions_count = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		address_deletions_count = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		multisig_account_modification_transaction_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert multisig_account_modification_transaction_body_reserved_1 == 0, f'Invalid value of reserved field ({multisig_account_modification_transaction_body_reserved_1})'
-		address_additions = ArrayHelpers.read_array_count(buffer_, UnresolvedAddress, address_additions_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, address_additions)):]
-		address_deletions = ArrayHelpers.read_array_count(buffer_, UnresolvedAddress, address_deletions_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, address_deletions)):]
+		address_additions = ArrayHelpers.read_array_count(buffer, UnresolvedAddress, address_additions_count)
+		buffer = buffer[sum(map(lambda e: e.size, address_additions)):]
+		address_deletions = ArrayHelpers.read_array_count(buffer, UnresolvedAddress, address_deletions_count)
+		buffer = buffer[sum(map(lambda e: e.size, address_deletions)):]
 
 		instance = EmbeddedMultisigAccountModificationTransaction()
 		instance._signer_public_key = signer_public_key
@@ -13173,22 +13173,22 @@ class EmbeddedMultisigAccountModificationTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._min_removal_delta.to_bytes(1, byteorder='little', signed=True)
-		buffer_ += self._min_approval_delta.to_bytes(1, byteorder='little', signed=True)
-		buffer_ += len(self._address_additions).to_bytes(1, byteorder='little', signed=False)  # address_additions_count
-		buffer_ += len(self._address_deletions).to_bytes(1, byteorder='little', signed=False)  # address_deletions_count
-		buffer_ += self._multisig_account_modification_transaction_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += ArrayHelpers.write_array(self._address_additions)
-		buffer_ += ArrayHelpers.write_array(self._address_deletions)
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._min_removal_delta.to_bytes(1, byteorder='little', signed=True)
+		buffer += self._min_approval_delta.to_bytes(1, byteorder='little', signed=True)
+		buffer += len(self._address_additions).to_bytes(1, byteorder='little', signed=False)  # address_additions_count
+		buffer += len(self._address_deletions).to_bytes(1, byteorder='little', signed=False)  # address_deletions_count
+		buffer += self._multisig_account_modification_transaction_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += ArrayHelpers.write_array(self._address_additions)
+		buffer += ArrayHelpers.write_array(self._address_deletions)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -13333,37 +13333,37 @@ class AddressAliasTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AddressAliasTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		namespace_id = NamespaceId.deserialize(buffer_)
-		buffer_ = buffer_[namespace_id.size:]
-		address = Address.deserialize(buffer_)
-		buffer_ = buffer_[address.size:]
-		alias_action = AliasAction.deserialize(buffer_)
-		buffer_ = buffer_[alias_action.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		namespace_id = NamespaceId.deserialize(buffer)
+		buffer = buffer[namespace_id.size:]
+		address = Address.deserialize(buffer)
+		buffer = buffer[address.size:]
+		alias_action = AliasAction.deserialize(buffer)
+		buffer = buffer[alias_action.size:]
 
 		instance = AddressAliasTransaction()
 		instance._signature = signature
@@ -13379,21 +13379,21 @@ class AddressAliasTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._namespace_id.serialize()
-		buffer_ += self._address.serialize()
-		buffer_ += self._alias_action.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._namespace_id.serialize()
+		buffer += self._address.serialize()
+		buffer += self._alias_action.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -13507,31 +13507,31 @@ class EmbeddedAddressAliasTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedAddressAliasTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		namespace_id = NamespaceId.deserialize(buffer_)
-		buffer_ = buffer_[namespace_id.size:]
-		address = Address.deserialize(buffer_)
-		buffer_ = buffer_[address.size:]
-		alias_action = AliasAction.deserialize(buffer_)
-		buffer_ = buffer_[alias_action.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		namespace_id = NamespaceId.deserialize(buffer)
+		buffer = buffer[namespace_id.size:]
+		address = Address.deserialize(buffer)
+		buffer = buffer[address.size:]
+		alias_action = AliasAction.deserialize(buffer)
+		buffer = buffer[alias_action.size:]
 
 		instance = EmbeddedAddressAliasTransaction()
 		instance._signer_public_key = signer_public_key
@@ -13544,18 +13544,18 @@ class EmbeddedAddressAliasTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._namespace_id.serialize()
-		buffer_ += self._address.serialize()
-		buffer_ += self._alias_action.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._namespace_id.serialize()
+		buffer += self._address.serialize()
+		buffer += self._alias_action.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -13699,37 +13699,37 @@ class MosaicAliasTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicAliasTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		namespace_id = NamespaceId.deserialize(buffer_)
-		buffer_ = buffer_[namespace_id.size:]
-		mosaic_id = MosaicId.deserialize(buffer_)
-		buffer_ = buffer_[mosaic_id.size:]
-		alias_action = AliasAction.deserialize(buffer_)
-		buffer_ = buffer_[alias_action.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		namespace_id = NamespaceId.deserialize(buffer)
+		buffer = buffer[namespace_id.size:]
+		mosaic_id = MosaicId.deserialize(buffer)
+		buffer = buffer[mosaic_id.size:]
+		alias_action = AliasAction.deserialize(buffer)
+		buffer = buffer[alias_action.size:]
 
 		instance = MosaicAliasTransaction()
 		instance._signature = signature
@@ -13745,21 +13745,21 @@ class MosaicAliasTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._namespace_id.serialize()
-		buffer_ += self._mosaic_id.serialize()
-		buffer_ += self._alias_action.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._namespace_id.serialize()
+		buffer += self._mosaic_id.serialize()
+		buffer += self._alias_action.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -13873,31 +13873,31 @@ class EmbeddedMosaicAliasTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedMosaicAliasTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		namespace_id = NamespaceId.deserialize(buffer_)
-		buffer_ = buffer_[namespace_id.size:]
-		mosaic_id = MosaicId.deserialize(buffer_)
-		buffer_ = buffer_[mosaic_id.size:]
-		alias_action = AliasAction.deserialize(buffer_)
-		buffer_ = buffer_[alias_action.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		namespace_id = NamespaceId.deserialize(buffer)
+		buffer = buffer[namespace_id.size:]
+		mosaic_id = MosaicId.deserialize(buffer)
+		buffer = buffer[mosaic_id.size:]
+		alias_action = AliasAction.deserialize(buffer)
+		buffer = buffer[alias_action.size:]
 
 		instance = EmbeddedMosaicAliasTransaction()
 		instance._signer_public_key = signer_public_key
@@ -13910,18 +13910,18 @@ class EmbeddedMosaicAliasTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._namespace_id.serialize()
-		buffer_ += self._mosaic_id.serialize()
-		buffer_ += self._alias_action.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._namespace_id.serialize()
+		buffer += self._mosaic_id.serialize()
+		buffer += self._alias_action.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -14090,40 +14090,40 @@ class NamespaceRegistrationTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> NamespaceRegistrationTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
 		# deserialize to temporary buffer for further processing
-		duration_temporary = BlockDuration.deserialize(buffer_)
-		registration_type_condition = buffer_[:duration_temporary.size]
-		buffer_ = buffer_[duration_temporary.size:]
+		duration_temporary = BlockDuration.deserialize(buffer)
+		registration_type_condition = buffer[:duration_temporary.size]
+		buffer = buffer[duration_temporary.size:]
 
-		id = NamespaceId.deserialize(buffer_)
-		buffer_ = buffer_[id.size:]
-		registration_type = NamespaceRegistrationType.deserialize(buffer_)
-		buffer_ = buffer_[registration_type.size:]
+		id = NamespaceId.deserialize(buffer)
+		buffer = buffer[id.size:]
+		registration_type = NamespaceRegistrationType.deserialize(buffer)
+		buffer = buffer[registration_type.size:]
 		duration = None
 		if NamespaceRegistrationType.ROOT == registration_type:
 			duration = BlockDuration.deserialize(registration_type_condition)
@@ -14132,10 +14132,10 @@ class NamespaceRegistrationTransaction:
 		if NamespaceRegistrationType.CHILD == registration_type:
 			parent_id = NamespaceId.deserialize(registration_type_condition)
 			registration_type_condition = registration_type_condition[parent_id.size:]
-		name_size = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		name = ArrayHelpers.get_bytes(buffer_, name_size)
-		buffer_ = buffer_[name_size:]
+		name_size = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		name = ArrayHelpers.get_bytes(buffer, name_size)
+		buffer = buffer[name_size:]
 
 		instance = NamespaceRegistrationTransaction()
 		instance._signature = signature
@@ -14153,26 +14153,26 @@ class NamespaceRegistrationTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
 		if NamespaceRegistrationType.ROOT == self.registration_type:
-			buffer_ += self._duration.serialize()
+			buffer += self._duration.serialize()
 		if NamespaceRegistrationType.CHILD == self.registration_type:
-			buffer_ += self._parent_id.serialize()
-		buffer_ += self._id.serialize()
-		buffer_ += self._registration_type.serialize()
-		buffer_ += len(self._name).to_bytes(1, byteorder='little', signed=False)  # name_size
-		buffer_ += self._name
-		return buffer_
+			buffer += self._parent_id.serialize()
+		buffer += self._id.serialize()
+		buffer += self._registration_type.serialize()
+		buffer += len(self._name).to_bytes(1, byteorder='little', signed=False)  # name_size
+		buffer += self._name
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -14315,34 +14315,34 @@ class EmbeddedNamespaceRegistrationTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedNamespaceRegistrationTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
 		# deserialize to temporary buffer for further processing
-		duration_temporary = BlockDuration.deserialize(buffer_)
-		registration_type_condition = buffer_[:duration_temporary.size]
-		buffer_ = buffer_[duration_temporary.size:]
+		duration_temporary = BlockDuration.deserialize(buffer)
+		registration_type_condition = buffer[:duration_temporary.size]
+		buffer = buffer[duration_temporary.size:]
 
-		id = NamespaceId.deserialize(buffer_)
-		buffer_ = buffer_[id.size:]
-		registration_type = NamespaceRegistrationType.deserialize(buffer_)
-		buffer_ = buffer_[registration_type.size:]
+		id = NamespaceId.deserialize(buffer)
+		buffer = buffer[id.size:]
+		registration_type = NamespaceRegistrationType.deserialize(buffer)
+		buffer = buffer[registration_type.size:]
 		duration = None
 		if NamespaceRegistrationType.ROOT == registration_type:
 			duration = BlockDuration.deserialize(registration_type_condition)
@@ -14351,10 +14351,10 @@ class EmbeddedNamespaceRegistrationTransaction:
 		if NamespaceRegistrationType.CHILD == registration_type:
 			parent_id = NamespaceId.deserialize(registration_type_condition)
 			registration_type_condition = registration_type_condition[parent_id.size:]
-		name_size = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		name = ArrayHelpers.get_bytes(buffer_, name_size)
-		buffer_ = buffer_[name_size:]
+		name_size = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		name = ArrayHelpers.get_bytes(buffer, name_size)
+		buffer = buffer[name_size:]
 
 		instance = EmbeddedNamespaceRegistrationTransaction()
 		instance._signer_public_key = signer_public_key
@@ -14369,23 +14369,23 @@ class EmbeddedNamespaceRegistrationTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
 		if NamespaceRegistrationType.ROOT == self.registration_type:
-			buffer_ += self._duration.serialize()
+			buffer += self._duration.serialize()
 		if NamespaceRegistrationType.CHILD == self.registration_type:
-			buffer_ += self._parent_id.serialize()
-		buffer_ += self._id.serialize()
-		buffer_ += self._registration_type.serialize()
-		buffer_ += len(self._name).to_bytes(1, byteorder='little', signed=False)  # name_size
-		buffer_ += self._name
-		return buffer_
+			buffer += self._parent_id.serialize()
+		buffer += self._id.serialize()
+		buffer += self._registration_type.serialize()
+		buffer += len(self._name).to_bytes(1, byteorder='little', signed=False)  # name_size
+		buffer += self._name
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -14537,44 +14537,44 @@ class AccountAddressRestrictionTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AccountAddressRestrictionTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		restriction_flags = AccountRestrictionFlags.deserialize(buffer_)
-		buffer_ = buffer_[restriction_flags.size:]
-		restriction_additions_count = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		restriction_deletions_count = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		account_restriction_transaction_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		restriction_flags = AccountRestrictionFlags.deserialize(buffer)
+		buffer = buffer[restriction_flags.size:]
+		restriction_additions_count = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		restriction_deletions_count = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		account_restriction_transaction_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert account_restriction_transaction_body_reserved_1 == 0, f'Invalid value of reserved field ({account_restriction_transaction_body_reserved_1})'
-		restriction_additions = ArrayHelpers.read_array_count(buffer_, UnresolvedAddress, restriction_additions_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, restriction_additions)):]
-		restriction_deletions = ArrayHelpers.read_array_count(buffer_, UnresolvedAddress, restriction_deletions_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, restriction_deletions)):]
+		restriction_additions = ArrayHelpers.read_array_count(buffer, UnresolvedAddress, restriction_additions_count)
+		buffer = buffer[sum(map(lambda e: e.size, restriction_additions)):]
+		restriction_deletions = ArrayHelpers.read_array_count(buffer, UnresolvedAddress, restriction_deletions_count)
+		buffer = buffer[sum(map(lambda e: e.size, restriction_deletions)):]
 
 		instance = AccountAddressRestrictionTransaction()
 		instance._signature = signature
@@ -14590,24 +14590,24 @@ class AccountAddressRestrictionTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._restriction_flags.serialize()
-		buffer_ += len(self._restriction_additions).to_bytes(1, byteorder='little', signed=False)  # restriction_additions_count
-		buffer_ += len(self._restriction_deletions).to_bytes(1, byteorder='little', signed=False)  # restriction_deletions_count
-		buffer_ += self._account_restriction_transaction_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += ArrayHelpers.write_array(self._restriction_additions)
-		buffer_ += ArrayHelpers.write_array(self._restriction_deletions)
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._restriction_flags.serialize()
+		buffer += len(self._restriction_additions).to_bytes(1, byteorder='little', signed=False)  # restriction_additions_count
+		buffer += len(self._restriction_deletions).to_bytes(1, byteorder='little', signed=False)  # restriction_deletions_count
+		buffer += self._account_restriction_transaction_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += ArrayHelpers.write_array(self._restriction_additions)
+		buffer += ArrayHelpers.write_array(self._restriction_deletions)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -14725,38 +14725,38 @@ class EmbeddedAccountAddressRestrictionTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedAccountAddressRestrictionTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		restriction_flags = AccountRestrictionFlags.deserialize(buffer_)
-		buffer_ = buffer_[restriction_flags.size:]
-		restriction_additions_count = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		restriction_deletions_count = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		account_restriction_transaction_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		restriction_flags = AccountRestrictionFlags.deserialize(buffer)
+		buffer = buffer[restriction_flags.size:]
+		restriction_additions_count = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		restriction_deletions_count = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		account_restriction_transaction_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert account_restriction_transaction_body_reserved_1 == 0, f'Invalid value of reserved field ({account_restriction_transaction_body_reserved_1})'
-		restriction_additions = ArrayHelpers.read_array_count(buffer_, UnresolvedAddress, restriction_additions_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, restriction_additions)):]
-		restriction_deletions = ArrayHelpers.read_array_count(buffer_, UnresolvedAddress, restriction_deletions_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, restriction_deletions)):]
+		restriction_additions = ArrayHelpers.read_array_count(buffer, UnresolvedAddress, restriction_additions_count)
+		buffer = buffer[sum(map(lambda e: e.size, restriction_additions)):]
+		restriction_deletions = ArrayHelpers.read_array_count(buffer, UnresolvedAddress, restriction_deletions_count)
+		buffer = buffer[sum(map(lambda e: e.size, restriction_deletions)):]
 
 		instance = EmbeddedAccountAddressRestrictionTransaction()
 		instance._signer_public_key = signer_public_key
@@ -14769,21 +14769,21 @@ class EmbeddedAccountAddressRestrictionTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._restriction_flags.serialize()
-		buffer_ += len(self._restriction_additions).to_bytes(1, byteorder='little', signed=False)  # restriction_additions_count
-		buffer_ += len(self._restriction_deletions).to_bytes(1, byteorder='little', signed=False)  # restriction_deletions_count
-		buffer_ += self._account_restriction_transaction_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += ArrayHelpers.write_array(self._restriction_additions)
-		buffer_ += ArrayHelpers.write_array(self._restriction_deletions)
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._restriction_flags.serialize()
+		buffer += len(self._restriction_additions).to_bytes(1, byteorder='little', signed=False)  # restriction_additions_count
+		buffer += len(self._restriction_deletions).to_bytes(1, byteorder='little', signed=False)  # restriction_deletions_count
+		buffer += self._account_restriction_transaction_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += ArrayHelpers.write_array(self._restriction_additions)
+		buffer += ArrayHelpers.write_array(self._restriction_deletions)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -14931,44 +14931,44 @@ class AccountMosaicRestrictionTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AccountMosaicRestrictionTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		restriction_flags = AccountRestrictionFlags.deserialize(buffer_)
-		buffer_ = buffer_[restriction_flags.size:]
-		restriction_additions_count = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		restriction_deletions_count = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		account_restriction_transaction_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		restriction_flags = AccountRestrictionFlags.deserialize(buffer)
+		buffer = buffer[restriction_flags.size:]
+		restriction_additions_count = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		restriction_deletions_count = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		account_restriction_transaction_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert account_restriction_transaction_body_reserved_1 == 0, f'Invalid value of reserved field ({account_restriction_transaction_body_reserved_1})'
-		restriction_additions = ArrayHelpers.read_array_count(buffer_, UnresolvedMosaicId, restriction_additions_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, restriction_additions)):]
-		restriction_deletions = ArrayHelpers.read_array_count(buffer_, UnresolvedMosaicId, restriction_deletions_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, restriction_deletions)):]
+		restriction_additions = ArrayHelpers.read_array_count(buffer, UnresolvedMosaicId, restriction_additions_count)
+		buffer = buffer[sum(map(lambda e: e.size, restriction_additions)):]
+		restriction_deletions = ArrayHelpers.read_array_count(buffer, UnresolvedMosaicId, restriction_deletions_count)
+		buffer = buffer[sum(map(lambda e: e.size, restriction_deletions)):]
 
 		instance = AccountMosaicRestrictionTransaction()
 		instance._signature = signature
@@ -14984,24 +14984,24 @@ class AccountMosaicRestrictionTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._restriction_flags.serialize()
-		buffer_ += len(self._restriction_additions).to_bytes(1, byteorder='little', signed=False)  # restriction_additions_count
-		buffer_ += len(self._restriction_deletions).to_bytes(1, byteorder='little', signed=False)  # restriction_deletions_count
-		buffer_ += self._account_restriction_transaction_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += ArrayHelpers.write_array(self._restriction_additions)
-		buffer_ += ArrayHelpers.write_array(self._restriction_deletions)
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._restriction_flags.serialize()
+		buffer += len(self._restriction_additions).to_bytes(1, byteorder='little', signed=False)  # restriction_additions_count
+		buffer += len(self._restriction_deletions).to_bytes(1, byteorder='little', signed=False)  # restriction_deletions_count
+		buffer += self._account_restriction_transaction_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += ArrayHelpers.write_array(self._restriction_additions)
+		buffer += ArrayHelpers.write_array(self._restriction_deletions)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -15119,38 +15119,38 @@ class EmbeddedAccountMosaicRestrictionTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedAccountMosaicRestrictionTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		restriction_flags = AccountRestrictionFlags.deserialize(buffer_)
-		buffer_ = buffer_[restriction_flags.size:]
-		restriction_additions_count = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		restriction_deletions_count = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		account_restriction_transaction_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		restriction_flags = AccountRestrictionFlags.deserialize(buffer)
+		buffer = buffer[restriction_flags.size:]
+		restriction_additions_count = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		restriction_deletions_count = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		account_restriction_transaction_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert account_restriction_transaction_body_reserved_1 == 0, f'Invalid value of reserved field ({account_restriction_transaction_body_reserved_1})'
-		restriction_additions = ArrayHelpers.read_array_count(buffer_, UnresolvedMosaicId, restriction_additions_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, restriction_additions)):]
-		restriction_deletions = ArrayHelpers.read_array_count(buffer_, UnresolvedMosaicId, restriction_deletions_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, restriction_deletions)):]
+		restriction_additions = ArrayHelpers.read_array_count(buffer, UnresolvedMosaicId, restriction_additions_count)
+		buffer = buffer[sum(map(lambda e: e.size, restriction_additions)):]
+		restriction_deletions = ArrayHelpers.read_array_count(buffer, UnresolvedMosaicId, restriction_deletions_count)
+		buffer = buffer[sum(map(lambda e: e.size, restriction_deletions)):]
 
 		instance = EmbeddedAccountMosaicRestrictionTransaction()
 		instance._signer_public_key = signer_public_key
@@ -15163,21 +15163,21 @@ class EmbeddedAccountMosaicRestrictionTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._restriction_flags.serialize()
-		buffer_ += len(self._restriction_additions).to_bytes(1, byteorder='little', signed=False)  # restriction_additions_count
-		buffer_ += len(self._restriction_deletions).to_bytes(1, byteorder='little', signed=False)  # restriction_deletions_count
-		buffer_ += self._account_restriction_transaction_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += ArrayHelpers.write_array(self._restriction_additions)
-		buffer_ += ArrayHelpers.write_array(self._restriction_deletions)
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._restriction_flags.serialize()
+		buffer += len(self._restriction_additions).to_bytes(1, byteorder='little', signed=False)  # restriction_additions_count
+		buffer += len(self._restriction_deletions).to_bytes(1, byteorder='little', signed=False)  # restriction_deletions_count
+		buffer += self._account_restriction_transaction_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += ArrayHelpers.write_array(self._restriction_additions)
+		buffer += ArrayHelpers.write_array(self._restriction_deletions)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -15325,44 +15325,44 @@ class AccountOperationRestrictionTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> AccountOperationRestrictionTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		restriction_flags = AccountRestrictionFlags.deserialize(buffer_)
-		buffer_ = buffer_[restriction_flags.size:]
-		restriction_additions_count = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		restriction_deletions_count = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		account_restriction_transaction_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		restriction_flags = AccountRestrictionFlags.deserialize(buffer)
+		buffer = buffer[restriction_flags.size:]
+		restriction_additions_count = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		restriction_deletions_count = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		account_restriction_transaction_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert account_restriction_transaction_body_reserved_1 == 0, f'Invalid value of reserved field ({account_restriction_transaction_body_reserved_1})'
-		restriction_additions = ArrayHelpers.read_array_count(buffer_, TransactionType, restriction_additions_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, restriction_additions)):]
-		restriction_deletions = ArrayHelpers.read_array_count(buffer_, TransactionType, restriction_deletions_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, restriction_deletions)):]
+		restriction_additions = ArrayHelpers.read_array_count(buffer, TransactionType, restriction_additions_count)
+		buffer = buffer[sum(map(lambda e: e.size, restriction_additions)):]
+		restriction_deletions = ArrayHelpers.read_array_count(buffer, TransactionType, restriction_deletions_count)
+		buffer = buffer[sum(map(lambda e: e.size, restriction_deletions)):]
 
 		instance = AccountOperationRestrictionTransaction()
 		instance._signature = signature
@@ -15378,24 +15378,24 @@ class AccountOperationRestrictionTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._restriction_flags.serialize()
-		buffer_ += len(self._restriction_additions).to_bytes(1, byteorder='little', signed=False)  # restriction_additions_count
-		buffer_ += len(self._restriction_deletions).to_bytes(1, byteorder='little', signed=False)  # restriction_deletions_count
-		buffer_ += self._account_restriction_transaction_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += ArrayHelpers.write_array(self._restriction_additions)
-		buffer_ += ArrayHelpers.write_array(self._restriction_deletions)
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._restriction_flags.serialize()
+		buffer += len(self._restriction_additions).to_bytes(1, byteorder='little', signed=False)  # restriction_additions_count
+		buffer += len(self._restriction_deletions).to_bytes(1, byteorder='little', signed=False)  # restriction_deletions_count
+		buffer += self._account_restriction_transaction_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += ArrayHelpers.write_array(self._restriction_additions)
+		buffer += ArrayHelpers.write_array(self._restriction_deletions)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -15513,38 +15513,38 @@ class EmbeddedAccountOperationRestrictionTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedAccountOperationRestrictionTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		restriction_flags = AccountRestrictionFlags.deserialize(buffer_)
-		buffer_ = buffer_[restriction_flags.size:]
-		restriction_additions_count = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		restriction_deletions_count = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		account_restriction_transaction_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		restriction_flags = AccountRestrictionFlags.deserialize(buffer)
+		buffer = buffer[restriction_flags.size:]
+		restriction_additions_count = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		restriction_deletions_count = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		account_restriction_transaction_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert account_restriction_transaction_body_reserved_1 == 0, f'Invalid value of reserved field ({account_restriction_transaction_body_reserved_1})'
-		restriction_additions = ArrayHelpers.read_array_count(buffer_, TransactionType, restriction_additions_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, restriction_additions)):]
-		restriction_deletions = ArrayHelpers.read_array_count(buffer_, TransactionType, restriction_deletions_count)
-		buffer_ = buffer_[sum(map(lambda e: e.size, restriction_deletions)):]
+		restriction_additions = ArrayHelpers.read_array_count(buffer, TransactionType, restriction_additions_count)
+		buffer = buffer[sum(map(lambda e: e.size, restriction_additions)):]
+		restriction_deletions = ArrayHelpers.read_array_count(buffer, TransactionType, restriction_deletions_count)
+		buffer = buffer[sum(map(lambda e: e.size, restriction_deletions)):]
 
 		instance = EmbeddedAccountOperationRestrictionTransaction()
 		instance._signer_public_key = signer_public_key
@@ -15557,21 +15557,21 @@ class EmbeddedAccountOperationRestrictionTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._restriction_flags.serialize()
-		buffer_ += len(self._restriction_additions).to_bytes(1, byteorder='little', signed=False)  # restriction_additions_count
-		buffer_ += len(self._restriction_deletions).to_bytes(1, byteorder='little', signed=False)  # restriction_deletions_count
-		buffer_ += self._account_restriction_transaction_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += ArrayHelpers.write_array(self._restriction_additions)
-		buffer_ += ArrayHelpers.write_array(self._restriction_deletions)
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._restriction_flags.serialize()
+		buffer += len(self._restriction_additions).to_bytes(1, byteorder='little', signed=False)  # restriction_additions_count
+		buffer += len(self._restriction_deletions).to_bytes(1, byteorder='little', signed=False)  # restriction_deletions_count
+		buffer += self._account_restriction_transaction_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += ArrayHelpers.write_array(self._restriction_additions)
+		buffer += ArrayHelpers.write_array(self._restriction_deletions)
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -15734,41 +15734,41 @@ class MosaicAddressRestrictionTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicAddressRestrictionTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		mosaic_id = UnresolvedMosaicId.deserialize(buffer_)
-		buffer_ = buffer_[mosaic_id.size:]
-		restriction_key = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		previous_restriction_value = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		new_restriction_value = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		target_address = UnresolvedAddress.deserialize(buffer_)
-		buffer_ = buffer_[target_address.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		mosaic_id = UnresolvedMosaicId.deserialize(buffer)
+		buffer = buffer[mosaic_id.size:]
+		restriction_key = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		previous_restriction_value = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		new_restriction_value = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		target_address = UnresolvedAddress.deserialize(buffer)
+		buffer = buffer[target_address.size:]
 
 		instance = MosaicAddressRestrictionTransaction()
 		instance._signature = signature
@@ -15786,23 +15786,23 @@ class MosaicAddressRestrictionTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._mosaic_id.serialize()
-		buffer_ += self._restriction_key.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._previous_restriction_value.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._new_restriction_value.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._target_address.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._mosaic_id.serialize()
+		buffer += self._restriction_key.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._previous_restriction_value.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._new_restriction_value.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._target_address.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -15937,35 +15937,35 @@ class EmbeddedMosaicAddressRestrictionTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedMosaicAddressRestrictionTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		mosaic_id = UnresolvedMosaicId.deserialize(buffer_)
-		buffer_ = buffer_[mosaic_id.size:]
-		restriction_key = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		previous_restriction_value = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		new_restriction_value = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		target_address = UnresolvedAddress.deserialize(buffer_)
-		buffer_ = buffer_[target_address.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		mosaic_id = UnresolvedMosaicId.deserialize(buffer)
+		buffer = buffer[mosaic_id.size:]
+		restriction_key = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		previous_restriction_value = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		new_restriction_value = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		target_address = UnresolvedAddress.deserialize(buffer)
+		buffer = buffer[target_address.size:]
 
 		instance = EmbeddedMosaicAddressRestrictionTransaction()
 		instance._signer_public_key = signer_public_key
@@ -15980,20 +15980,20 @@ class EmbeddedMosaicAddressRestrictionTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._mosaic_id.serialize()
-		buffer_ += self._restriction_key.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._previous_restriction_value.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._new_restriction_value.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._target_address.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._mosaic_id.serialize()
+		buffer += self._restriction_key.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._previous_restriction_value.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._new_restriction_value.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._target_address.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -16180,45 +16180,45 @@ class MosaicGlobalRestrictionTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> MosaicGlobalRestrictionTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		mosaic_id = UnresolvedMosaicId.deserialize(buffer_)
-		buffer_ = buffer_[mosaic_id.size:]
-		reference_mosaic_id = UnresolvedMosaicId.deserialize(buffer_)
-		buffer_ = buffer_[reference_mosaic_id.size:]
-		restriction_key = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		previous_restriction_value = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		new_restriction_value = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		previous_restriction_type = MosaicRestrictionType.deserialize(buffer_)
-		buffer_ = buffer_[previous_restriction_type.size:]
-		new_restriction_type = MosaicRestrictionType.deserialize(buffer_)
-		buffer_ = buffer_[new_restriction_type.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		mosaic_id = UnresolvedMosaicId.deserialize(buffer)
+		buffer = buffer[mosaic_id.size:]
+		reference_mosaic_id = UnresolvedMosaicId.deserialize(buffer)
+		buffer = buffer[reference_mosaic_id.size:]
+		restriction_key = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		previous_restriction_value = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		new_restriction_value = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		previous_restriction_type = MosaicRestrictionType.deserialize(buffer)
+		buffer = buffer[previous_restriction_type.size:]
+		new_restriction_type = MosaicRestrictionType.deserialize(buffer)
+		buffer = buffer[new_restriction_type.size:]
 
 		instance = MosaicGlobalRestrictionTransaction()
 		instance._signature = signature
@@ -16238,25 +16238,25 @@ class MosaicGlobalRestrictionTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._mosaic_id.serialize()
-		buffer_ += self._reference_mosaic_id.serialize()
-		buffer_ += self._restriction_key.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._previous_restriction_value.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._new_restriction_value.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._previous_restriction_type.serialize()
-		buffer_ += self._new_restriction_type.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._mosaic_id.serialize()
+		buffer += self._reference_mosaic_id.serialize()
+		buffer += self._restriction_key.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._previous_restriction_value.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._new_restriction_value.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._previous_restriction_type.serialize()
+		buffer += self._new_restriction_type.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -16415,39 +16415,39 @@ class EmbeddedMosaicGlobalRestrictionTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedMosaicGlobalRestrictionTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		mosaic_id = UnresolvedMosaicId.deserialize(buffer_)
-		buffer_ = buffer_[mosaic_id.size:]
-		reference_mosaic_id = UnresolvedMosaicId.deserialize(buffer_)
-		buffer_ = buffer_[reference_mosaic_id.size:]
-		restriction_key = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		previous_restriction_value = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		new_restriction_value = int.from_bytes(buffer_[:8], byteorder='little', signed=False)
-		buffer_ = buffer_[8:]
-		previous_restriction_type = MosaicRestrictionType.deserialize(buffer_)
-		buffer_ = buffer_[previous_restriction_type.size:]
-		new_restriction_type = MosaicRestrictionType.deserialize(buffer_)
-		buffer_ = buffer_[new_restriction_type.size:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		mosaic_id = UnresolvedMosaicId.deserialize(buffer)
+		buffer = buffer[mosaic_id.size:]
+		reference_mosaic_id = UnresolvedMosaicId.deserialize(buffer)
+		buffer = buffer[reference_mosaic_id.size:]
+		restriction_key = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		previous_restriction_value = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		new_restriction_value = int.from_bytes(buffer[:8], byteorder='little', signed=False)
+		buffer = buffer[8:]
+		previous_restriction_type = MosaicRestrictionType.deserialize(buffer)
+		buffer = buffer[previous_restriction_type.size:]
+		new_restriction_type = MosaicRestrictionType.deserialize(buffer)
+		buffer = buffer[new_restriction_type.size:]
 
 		instance = EmbeddedMosaicGlobalRestrictionTransaction()
 		instance._signer_public_key = signer_public_key
@@ -16464,22 +16464,22 @@ class EmbeddedMosaicGlobalRestrictionTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._mosaic_id.serialize()
-		buffer_ += self._reference_mosaic_id.serialize()
-		buffer_ += self._restriction_key.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._previous_restriction_value.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._new_restriction_value.to_bytes(8, byteorder='little', signed=False)
-		buffer_ += self._previous_restriction_type.serialize()
-		buffer_ += self._new_restriction_type.serialize()
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._mosaic_id.serialize()
+		buffer += self._reference_mosaic_id.serialize()
+		buffer += self._restriction_key.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._previous_restriction_value.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._new_restriction_value.to_bytes(8, byteorder='little', signed=False)
+		buffer += self._previous_restriction_type.serialize()
+		buffer += self._new_restriction_type.serialize()
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -16633,47 +16633,47 @@ class TransferTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> TransferTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		verifiable_entity_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		verifiable_entity_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert verifiable_entity_header_reserved_1 == 0, f'Invalid value of reserved field ({verifiable_entity_header_reserved_1})'
-		signature = Signature.deserialize(buffer_)
-		buffer_ = buffer_[signature.size:]
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signature = Signature.deserialize(buffer)
+		buffer = buffer[signature.size:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		fee = Amount.deserialize(buffer_)
-		buffer_ = buffer_[fee.size:]
-		deadline = Timestamp.deserialize(buffer_)
-		buffer_ = buffer_[deadline.size:]
-		recipient_address = UnresolvedAddress.deserialize(buffer_)
-		buffer_ = buffer_[recipient_address.size:]
-		message_size = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		mosaics_count = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		transfer_transaction_body_reserved_1 = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		fee = Amount.deserialize(buffer)
+		buffer = buffer[fee.size:]
+		deadline = Timestamp.deserialize(buffer)
+		buffer = buffer[deadline.size:]
+		recipient_address = UnresolvedAddress.deserialize(buffer)
+		buffer = buffer[recipient_address.size:]
+		message_size = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		mosaics_count = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		transfer_transaction_body_reserved_1 = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
 		assert transfer_transaction_body_reserved_1 == 0, f'Invalid value of reserved field ({transfer_transaction_body_reserved_1})'
-		transfer_transaction_body_reserved_2 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		transfer_transaction_body_reserved_2 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert transfer_transaction_body_reserved_2 == 0, f'Invalid value of reserved field ({transfer_transaction_body_reserved_2})'
-		mosaics = ArrayHelpers.read_array_count(buffer_, UnresolvedMosaic, mosaics_count, lambda e: e.mosaic_id)
-		buffer_ = buffer_[sum(map(lambda e: e.size, mosaics)):]
-		message = ArrayHelpers.get_bytes(buffer_, message_size)
-		buffer_ = buffer_[message_size:]
+		mosaics = ArrayHelpers.read_array_count(buffer, UnresolvedMosaic, mosaics_count, lambda e: e.mosaic_id)
+		buffer = buffer[sum(map(lambda e: e.size, mosaics)):]
+		message = ArrayHelpers.get_bytes(buffer, message_size)
+		buffer = buffer[message_size:]
 
 		instance = TransferTransaction()
 		instance._signature = signature
@@ -16689,25 +16689,25 @@ class TransferTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signature.serialize()
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._fee.serialize()
-		buffer_ += self._deadline.serialize()
-		buffer_ += self._recipient_address.serialize()
-		buffer_ += len(self._message).to_bytes(2, byteorder='little', signed=False)  # message_size
-		buffer_ += len(self._mosaics).to_bytes(1, byteorder='little', signed=False)  # mosaics_count
-		buffer_ += self._transfer_transaction_body_reserved_1.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._transfer_transaction_body_reserved_2.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += ArrayHelpers.write_array(self._mosaics, lambda e: e.mosaic_id)
-		buffer_ += self._message
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._verifiable_entity_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signature.serialize()
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._fee.serialize()
+		buffer += self._deadline.serialize()
+		buffer += self._recipient_address.serialize()
+		buffer += len(self._message).to_bytes(2, byteorder='little', signed=False)  # message_size
+		buffer += len(self._mosaics).to_bytes(1, byteorder='little', signed=False)  # mosaics_count
+		buffer += self._transfer_transaction_body_reserved_1.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._transfer_transaction_body_reserved_2.to_bytes(4, byteorder='little', signed=False)
+		buffer += ArrayHelpers.write_array(self._mosaics, lambda e: e.mosaic_id)
+		buffer += self._message
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -16827,41 +16827,41 @@ class EmbeddedTransferTransaction:
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> EmbeddedTransferTransaction:
-		buffer_ = memoryview(payload)
-		size_ = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
-		buffer_ = buffer_[:size_ - 4]
+		buffer = memoryview(payload)
+		size_ = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
+		buffer = buffer[:size_ - 4]
 		del size_
-		embedded_transaction_header_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		embedded_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert embedded_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({embedded_transaction_header_reserved_1})'
-		signer_public_key = PublicKey.deserialize(buffer_)
-		buffer_ = buffer_[signer_public_key.size:]
-		entity_body_reserved_1 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		signer_public_key = PublicKey.deserialize(buffer)
+		buffer = buffer[signer_public_key.size:]
+		entity_body_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert entity_body_reserved_1 == 0, f'Invalid value of reserved field ({entity_body_reserved_1})'
-		version = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		network = NetworkType.deserialize(buffer_)
-		buffer_ = buffer_[network.size:]
-		type_ = TransactionType.deserialize(buffer_)
-		buffer_ = buffer_[type_.size:]
-		recipient_address = UnresolvedAddress.deserialize(buffer_)
-		buffer_ = buffer_[recipient_address.size:]
-		message_size = int.from_bytes(buffer_[:2], byteorder='little', signed=False)
-		buffer_ = buffer_[2:]
-		mosaics_count = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
-		transfer_transaction_body_reserved_1 = int.from_bytes(buffer_[:1], byteorder='little', signed=False)
-		buffer_ = buffer_[1:]
+		version = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		network = NetworkType.deserialize(buffer)
+		buffer = buffer[network.size:]
+		type_ = TransactionType.deserialize(buffer)
+		buffer = buffer[type_.size:]
+		recipient_address = UnresolvedAddress.deserialize(buffer)
+		buffer = buffer[recipient_address.size:]
+		message_size = int.from_bytes(buffer[:2], byteorder='little', signed=False)
+		buffer = buffer[2:]
+		mosaics_count = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
+		transfer_transaction_body_reserved_1 = int.from_bytes(buffer[:1], byteorder='little', signed=False)
+		buffer = buffer[1:]
 		assert transfer_transaction_body_reserved_1 == 0, f'Invalid value of reserved field ({transfer_transaction_body_reserved_1})'
-		transfer_transaction_body_reserved_2 = int.from_bytes(buffer_[:4], byteorder='little', signed=False)
-		buffer_ = buffer_[4:]
+		transfer_transaction_body_reserved_2 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
+		buffer = buffer[4:]
 		assert transfer_transaction_body_reserved_2 == 0, f'Invalid value of reserved field ({transfer_transaction_body_reserved_2})'
-		mosaics = ArrayHelpers.read_array_count(buffer_, UnresolvedMosaic, mosaics_count, lambda e: e.mosaic_id)
-		buffer_ = buffer_[sum(map(lambda e: e.size, mosaics)):]
-		message = ArrayHelpers.get_bytes(buffer_, message_size)
-		buffer_ = buffer_[message_size:]
+		mosaics = ArrayHelpers.read_array_count(buffer, UnresolvedMosaic, mosaics_count, lambda e: e.mosaic_id)
+		buffer = buffer[sum(map(lambda e: e.size, mosaics)):]
+		message = ArrayHelpers.get_bytes(buffer, message_size)
+		buffer = buffer[message_size:]
 
 		instance = EmbeddedTransferTransaction()
 		instance._signer_public_key = signer_public_key
@@ -16874,22 +16874,22 @@ class EmbeddedTransferTransaction:
 		return instance
 
 	def serialize(self) -> bytes:
-		buffer_ = bytes()
-		buffer_ += self.size.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._signer_public_key.serialize()
-		buffer_ += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += self._version.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._network.serialize()
-		buffer_ += self._type_.serialize()
-		buffer_ += self._recipient_address.serialize()
-		buffer_ += len(self._message).to_bytes(2, byteorder='little', signed=False)  # message_size
-		buffer_ += len(self._mosaics).to_bytes(1, byteorder='little', signed=False)  # mosaics_count
-		buffer_ += self._transfer_transaction_body_reserved_1.to_bytes(1, byteorder='little', signed=False)
-		buffer_ += self._transfer_transaction_body_reserved_2.to_bytes(4, byteorder='little', signed=False)
-		buffer_ += ArrayHelpers.write_array(self._mosaics, lambda e: e.mosaic_id)
-		buffer_ += self._message
-		return buffer_
+		buffer = bytes()
+		buffer += self.size.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._embedded_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._signer_public_key.serialize()
+		buffer += self._entity_body_reserved_1.to_bytes(4, byteorder='little', signed=False)
+		buffer += self._version.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._network.serialize()
+		buffer += self._type_.serialize()
+		buffer += self._recipient_address.serialize()
+		buffer += len(self._message).to_bytes(2, byteorder='little', signed=False)  # message_size
+		buffer += len(self._mosaics).to_bytes(1, byteorder='little', signed=False)  # mosaics_count
+		buffer += self._transfer_transaction_body_reserved_1.to_bytes(1, byteorder='little', signed=False)
+		buffer += self._transfer_transaction_body_reserved_2.to_bytes(4, byteorder='little', signed=False)
+		buffer += ArrayHelpers.write_array(self._mosaics, lambda e: e.mosaic_id)
+		buffer += self._message
+		return buffer
 
 	def __str__(self) -> str:
 		result = '('
@@ -16907,8 +16907,8 @@ class EmbeddedTransferTransaction:
 class TransactionFactory:
 	@classmethod
 	def deserialize(cls, payload: bytes) -> Transaction:
-		buffer_ = bytes(payload)
-		parent = Transaction.deserialize(buffer_)
+		buffer = bytes(payload)
+		parent = Transaction.deserialize(buffer)
 		mapping = {
 			(AccountKeyLinkTransaction.TRANSACTION_TYPE): AccountKeyLinkTransaction,
 			(NodeKeyLinkTransaction.TRANSACTION_TYPE): NodeKeyLinkTransaction,
@@ -16938,7 +16938,7 @@ class TransactionFactory:
 		}
 		discriminator = (parent.type_)
 		factory_class = mapping[discriminator]
-		return factory_class.deserialize(buffer_)
+		return factory_class.deserialize(buffer)
 
 	@classmethod
 	def create_by_name(cls, entity_name: str) -> Transaction:
@@ -16979,8 +16979,8 @@ class TransactionFactory:
 class EmbeddedTransactionFactory:
 	@classmethod
 	def deserialize(cls, payload: bytes) -> EmbeddedTransaction:
-		buffer_ = bytes(payload)
-		parent = EmbeddedTransaction.deserialize(buffer_)
+		buffer = bytes(payload)
+		parent = EmbeddedTransaction.deserialize(buffer)
 		mapping = {
 			(EmbeddedAccountKeyLinkTransaction.TRANSACTION_TYPE): EmbeddedAccountKeyLinkTransaction,
 			(EmbeddedNodeKeyLinkTransaction.TRANSACTION_TYPE): EmbeddedNodeKeyLinkTransaction,
@@ -17008,7 +17008,7 @@ class EmbeddedTransactionFactory:
 		}
 		discriminator = (parent.type_)
 		factory_class = mapping[discriminator]
-		return factory_class.deserialize(buffer_)
+		return factory_class.deserialize(buffer)
 
 	@classmethod
 	def create_by_name(cls, entity_name: str) -> EmbeddedTransaction:
@@ -17047,8 +17047,8 @@ class EmbeddedTransactionFactory:
 class BlockFactory:
 	@classmethod
 	def deserialize(cls, payload: bytes) -> Block:
-		buffer_ = bytes(payload)
-		parent = Block.deserialize(buffer_)
+		buffer = bytes(payload)
+		parent = Block.deserialize(buffer)
 		mapping = {
 			(NemesisBlock.BLOCK_TYPE): NemesisBlock,
 			(NormalBlock.BLOCK_TYPE): NormalBlock,
@@ -17056,7 +17056,7 @@ class BlockFactory:
 		}
 		discriminator = (parent.type_)
 		factory_class = mapping[discriminator]
-		return factory_class.deserialize(buffer_)
+		return factory_class.deserialize(buffer)
 
 	@classmethod
 	def create_by_name(cls, entity_name: str) -> Block:
@@ -17075,8 +17075,8 @@ class BlockFactory:
 class ReceiptFactory:
 	@classmethod
 	def deserialize(cls, payload: bytes) -> Receipt:
-		buffer_ = bytes(payload)
-		parent = Receipt.deserialize(buffer_)
+		buffer = bytes(payload)
+		parent = Receipt.deserialize(buffer)
 		mapping = {
 			(HarvestFeeReceipt.RECEIPT_TYPE): HarvestFeeReceipt,
 			(InflationReceipt.RECEIPT_TYPE): InflationReceipt,
@@ -17094,7 +17094,7 @@ class ReceiptFactory:
 		}
 		discriminator = (parent.type_)
 		factory_class = mapping[discriminator]
-		return factory_class.deserialize(buffer_)
+		return factory_class.deserialize(buffer)
 
 	@classmethod
 	def create_by_name(cls, entity_name: str) -> Receipt:


### PR DESCRIPTION
## What is the current behavior?
generated code is using `buffer_` instead of `buffer`

## What's the issue?
`buffer` is not a reserved word

## How have you changed the behavior?
replaced `buffer` with `buffer_`

## How was this change tested?
yes