### PR TITLE
[monorepo] fix: checkout submodule on seed job.

### DIFF
--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -85,7 +85,7 @@ void call(Closure body) {
 							script {
 								sh "git checkout ${helper.resolveBranchName(env.MANUAL_GIT_BRANCH)}"
 								sh "git reset --hard origin/${helper.resolveBranchName(env.MANUAL_GIT_BRANCH)}"
-								runInitializeScriptIfPresent()
+								helper.runInitializeScriptIfPresent()
 							}
 						}
 					}
@@ -301,12 +301,4 @@ String resolvePath(String rootPath, String path) {
 
 Boolean shouldPublishImage(String shouldPublish) {
 	return shouldPublish == null ? false : shouldPublish.toBoolean()
-}
-
-void runInitializeScriptIfPresent() {
-	String initFile = 'init.sh'
-	if (fileExists(initFile)) {
-		println 'Running initialize script'
-		sh "bash ${initFile}"
-	}
 }

--- a/jenkins/shared-library/vars/helper.groovy
+++ b/jenkins/shared-library/vars/helper.groovy
@@ -14,3 +14,11 @@ String resolveRepoName() {
 	// groovylint-disable-next-line UnnecessaryGetter
 	return scm.getUserRemoteConfigs()[0].getUrl().tokenize('/').last()
 }
+
+void runInitializeScriptIfPresent() {
+	String initFile = 'init.sh'
+	if (fileExists(initFile)) {
+		logger.logInfo('Running initialize script')
+		sh "bash ${initFile}"
+	}
+}

--- a/jenkins/shared-library/vars/monorepoSeedPipeline.groovy
+++ b/jenkins/shared-library/vars/monorepoSeedPipeline.groovy
@@ -48,6 +48,7 @@ void call(Closure body) {
 				steps {
 					script {
 						gitCheckout(helper.resolveBranchName(env.MANUAL_GIT_BRANCH), env.GITHUB_CREDENTIALS_ID, env.GIT_URL)
+						helper.runInitializeScriptIfPresent()
 					}
 				}
 			}


### PR DESCRIPTION
## What is the current behavior?
The seed job did not require access to the submodule  to run correctly

## What's the issue?
The seed job is moved to the jenkins folder thus requires access to the ``_symbol`` submodule 

## How have you changed the behavior?
The seed job needs access to the ``jenkins`` folder in the submodule.