### PR TITLE
[sdk] fix block handling

### DIFF
--- a/catbuffer/schemas/symbol/block.cats
+++ b/catbuffer/schemas/symbol/block.cats
@@ -96,6 +96,7 @@ struct NemesisBlock
 	inline ImportanceBlockFooter
 
 	# variable sized transaction data
+	@alignment(8)
 	transactions = array(Transaction, __FILL__)
 
 # binary layout for a normal block header
@@ -109,6 +110,7 @@ struct NormalBlock
 	block_header_reserved_1 = make_reserved(uint32, 0)
 
 	# variable sized transaction data
+	@alignment(8)
 	transactions = array(Transaction, __FILL__)
 
 # binary layout for an importance block header
@@ -120,4 +122,5 @@ struct ImportanceBlock
 	inline ImportanceBlockFooter
 
 	# variable sized transaction data
+	@alignment(8)
 	transactions = array(Transaction, __FILL__)

--- a/sdk/javascript/src/symbol/models.js
+++ b/sdk/javascript/src/symbol/models.js
@@ -1660,7 +1660,7 @@ class NemesisBlock {
 		size += 8;
 		size += this.totalVotingBalance.size;
 		size += this.previousImportanceBlockHash.size;
-		size += this.transactions.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += this.transactions.slice(0, -1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0) + this.transactions.slice(-1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0);
 		return size;
 	}
 
@@ -1715,8 +1715,8 @@ class NemesisBlock {
 		view.shiftRight(totalVotingBalance.size);
 		const previousImportanceBlockHash = Hash256.deserialize(view.buffer);
 		view.shiftRight(previousImportanceBlockHash.size);
-		const transactions = arrayHelpers.readArray(view.buffer, Transaction);
-		view.shiftRight(transactions.map(e => e.size).reduce((a, b) => a + b, 0));
+		const transactions = arrayHelpers.readVariableSizeElements(view.buffer, TransactionFactory, 8);
+		view.shiftRight(transactions.slice(0, -1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0) + transactions.slice(-1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0));
 
 		const instance = new NemesisBlock();
 		instance._signature = signature;
@@ -1766,7 +1766,7 @@ class NemesisBlock {
 		buffer.write(converter.intToBytes(this._harvestingEligibleAccountsCount, 8, false));
 		buffer.write(this._totalVotingBalance.serialize());
 		buffer.write(this._previousImportanceBlockHash.serialize());
-		arrayHelpers.writeArray(buffer, this._transactions);
+		arrayHelpers.writeVariableSizeElements(buffer, this._transactions, 8);
 		return buffer.storage;
 	}
 
@@ -1991,7 +1991,7 @@ class NormalBlock {
 		size += this.beneficiaryAddress.size;
 		size += this.feeMultiplier.size;
 		size += 4;
-		size += this.transactions.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += this.transactions.slice(0, -1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0) + this.transactions.slice(-1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0);
 		return size;
 	}
 
@@ -2042,8 +2042,8 @@ class NormalBlock {
 		view.shiftRight(4);
 		if (0 !== blockHeaderReserved_1)
 			throw RangeError(`Invalid value of reserved field (${blockHeaderReserved_1})`);
-		const transactions = arrayHelpers.readArray(view.buffer, Transaction);
-		view.shiftRight(transactions.map(e => e.size).reduce((a, b) => a + b, 0));
+		const transactions = arrayHelpers.readVariableSizeElements(view.buffer, TransactionFactory, 8);
+		view.shiftRight(transactions.slice(0, -1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0) + transactions.slice(-1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0));
 
 		const instance = new NormalBlock();
 		instance._signature = signature;
@@ -2086,7 +2086,7 @@ class NormalBlock {
 		buffer.write(this._beneficiaryAddress.serialize());
 		buffer.write(this._feeMultiplier.serialize());
 		buffer.write(converter.intToBytes(this._blockHeaderReserved_1, 4, false));
-		arrayHelpers.writeArray(buffer, this._transactions);
+		arrayHelpers.writeVariableSizeElements(buffer, this._transactions, 8);
 		return buffer.storage;
 	}
 
@@ -2347,7 +2347,7 @@ class ImportanceBlock {
 		size += 8;
 		size += this.totalVotingBalance.size;
 		size += this.previousImportanceBlockHash.size;
-		size += this.transactions.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += this.transactions.slice(0, -1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0) + this.transactions.slice(-1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0);
 		return size;
 	}
 
@@ -2402,8 +2402,8 @@ class ImportanceBlock {
 		view.shiftRight(totalVotingBalance.size);
 		const previousImportanceBlockHash = Hash256.deserialize(view.buffer);
 		view.shiftRight(previousImportanceBlockHash.size);
-		const transactions = arrayHelpers.readArray(view.buffer, Transaction);
-		view.shiftRight(transactions.map(e => e.size).reduce((a, b) => a + b, 0));
+		const transactions = arrayHelpers.readVariableSizeElements(view.buffer, TransactionFactory, 8);
+		view.shiftRight(transactions.slice(0, -1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0) + transactions.slice(-1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0));
 
 		const instance = new ImportanceBlock();
 		instance._signature = signature;
@@ -2453,7 +2453,7 @@ class ImportanceBlock {
 		buffer.write(converter.intToBytes(this._harvestingEligibleAccountsCount, 8, false));
 		buffer.write(this._totalVotingBalance.serialize());
 		buffer.write(this._previousImportanceBlockHash.serialize());
-		arrayHelpers.writeArray(buffer, this._transactions);
+		arrayHelpers.writeVariableSizeElements(buffer, this._transactions, 8);
 		return buffer.storage;
 	}
 

--- a/sdk/python/symbolchain/sc/__init__.py
+++ b/sdk/python/symbolchain/sc/__init__.py
@@ -1469,7 +1469,7 @@ class NemesisBlock:
 		size += 8
 		size += self.total_voting_balance.size
 		size += self.previous_importance_block_hash.size
-		size += sum(map(lambda e: e.size, self.transactions))
+		size += sum(map(lambda e: ArrayHelpers.align_up(e.size, 8), self.transactions[:-1])) + sum(map(lambda e: e.size, self.transactions[-1:]))
 		return size
 
 	@classmethod
@@ -1523,8 +1523,8 @@ class NemesisBlock:
 		buffer = buffer[total_voting_balance.size:]
 		previous_importance_block_hash = Hash256.deserialize(buffer)
 		buffer = buffer[previous_importance_block_hash.size:]
-		transactions = ArrayHelpers.read_array(buffer, Transaction)
-		buffer = buffer[sum(map(lambda e: e.size, transactions)):]
+		transactions = ArrayHelpers.read_variable_size_elements(buffer, TransactionFactory, 8)
+		buffer = buffer[sum(map(lambda e: ArrayHelpers.align_up(e.size, 8), transactions[:-1])) + sum(map(lambda e: e.size, transactions[-1:])):]
 
 		instance = NemesisBlock()
 		instance._signature = signature
@@ -1573,7 +1573,7 @@ class NemesisBlock:
 		buffer += self._harvesting_eligible_accounts_count.to_bytes(8, byteorder='little', signed=False)
 		buffer += self._total_voting_balance.serialize()
 		buffer += self._previous_importance_block_hash.serialize()
-		buffer += ArrayHelpers.write_array(self._transactions)
+		buffer += ArrayHelpers.write_variable_size_elements(self._transactions, 8)
 		return buffer
 
 	def __str__(self) -> str:
@@ -1794,7 +1794,7 @@ class NormalBlock:
 		size += self.beneficiary_address.size
 		size += self.fee_multiplier.size
 		size += 4
-		size += sum(map(lambda e: e.size, self.transactions))
+		size += sum(map(lambda e: ArrayHelpers.align_up(e.size, 8), self.transactions[:-1])) + sum(map(lambda e: e.size, self.transactions[-1:]))
 		return size
 
 	@classmethod
@@ -1843,8 +1843,8 @@ class NormalBlock:
 		block_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
 		buffer = buffer[4:]
 		assert block_header_reserved_1 == 0, f'Invalid value of reserved field ({block_header_reserved_1})'
-		transactions = ArrayHelpers.read_array(buffer, Transaction)
-		buffer = buffer[sum(map(lambda e: e.size, transactions)):]
+		transactions = ArrayHelpers.read_variable_size_elements(buffer, TransactionFactory, 8)
+		buffer = buffer[sum(map(lambda e: ArrayHelpers.align_up(e.size, 8), transactions[:-1])) + sum(map(lambda e: e.size, transactions[-1:])):]
 
 		instance = NormalBlock()
 		instance._signature = signature
@@ -1886,7 +1886,7 @@ class NormalBlock:
 		buffer += self._beneficiary_address.serialize()
 		buffer += self._fee_multiplier.serialize()
 		buffer += self._block_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer += ArrayHelpers.write_array(self._transactions)
+		buffer += ArrayHelpers.write_variable_size_elements(self._transactions, 8)
 		return buffer
 
 	def __str__(self) -> str:
@@ -2143,7 +2143,7 @@ class ImportanceBlock:
 		size += 8
 		size += self.total_voting_balance.size
 		size += self.previous_importance_block_hash.size
-		size += sum(map(lambda e: e.size, self.transactions))
+		size += sum(map(lambda e: ArrayHelpers.align_up(e.size, 8), self.transactions[:-1])) + sum(map(lambda e: e.size, self.transactions[-1:]))
 		return size
 
 	@classmethod
@@ -2197,8 +2197,8 @@ class ImportanceBlock:
 		buffer = buffer[total_voting_balance.size:]
 		previous_importance_block_hash = Hash256.deserialize(buffer)
 		buffer = buffer[previous_importance_block_hash.size:]
-		transactions = ArrayHelpers.read_array(buffer, Transaction)
-		buffer = buffer[sum(map(lambda e: e.size, transactions)):]
+		transactions = ArrayHelpers.read_variable_size_elements(buffer, TransactionFactory, 8)
+		buffer = buffer[sum(map(lambda e: ArrayHelpers.align_up(e.size, 8), transactions[:-1])) + sum(map(lambda e: e.size, transactions[-1:])):]
 
 		instance = ImportanceBlock()
 		instance._signature = signature
@@ -2247,7 +2247,7 @@ class ImportanceBlock:
 		buffer += self._harvesting_eligible_accounts_count.to_bytes(8, byteorder='little', signed=False)
 		buffer += self._total_voting_balance.serialize()
 		buffer += self._previous_importance_block_hash.serialize()
-		buffer += ArrayHelpers.write_array(self._transactions)
+		buffer += ArrayHelpers.write_variable_size_elements(self._transactions, 8)
 		return buffer
 
 	def __str__(self) -> str:


### PR DESCRIPTION
## What's the issue?
* `@alignment` was missing on `block.transactions`
* besides that, wrong code was generated because only `is_byte_constrained` was handled correctly

## How have you changed the behavior?
 * added missing attribute
 * modified both js and py generator appropriately

## How was this change tested?
 * Manually verified that generated code seems fine and that only block handling has changed.

