### PR TITLE
[catbuffer/parser] task: add struct is_aligned field

### DIFF
--- a/catbuffer/parser/catparser/ast.py
+++ b/catbuffer/parser/catparser/ast.py
@@ -298,6 +298,11 @@ class Struct(Statement):
 		return 'inline' == self.disposition
 
 	@property
+	def is_aligned(self):
+		"""Returns true if this structure is composed exclusively of aligned fields."""
+		return _lookup_attribute_value(self.attributes, 'is_aligned')
+
+	@property
 	def is_size_implicit(self):
 		"""Returns true if this structure can be used in a `sizeof` expression."""
 		return _lookup_attribute_value(self.attributes, 'is_size_implicit')
@@ -347,7 +352,7 @@ class Struct(Statement):
 			'layout': [field.to_legacy_descriptor() for field in self.fields]
 		}
 
-		for property_name in ['disposition', 'factory_type', 'is_size_implicit', 'size', 'discriminator']:
+		for property_name in ['disposition', 'factory_type', 'is_aligned', 'is_size_implicit', 'size', 'discriminator']:
 			_set_if(self, type_descriptor, property_name)
 
 		if self.initializers:

--- a/catbuffer/parser/catparser/grammar/catbuffer.lark
+++ b/catbuffer/parser/catparser/grammar/catbuffer.lark
@@ -15,9 +15,6 @@
 
 import: "import" ESCAPED_STRING _NL
 
-comment: MULTILINE_SH_COMMENT _NL
-MULTILINE_SH_COMMENT: /#[^\n]*(\r?\n[\t ]*#[^\n]*)*/
-
 alias: "using" USER_TYPE_NAME "=" (FIXED_SIZE_INTEGER | fixed_size_buffer) _NL
 
 enum_attributes: enum_attribute+
@@ -47,7 +44,7 @@ struct_attribute: "@" ( \
 	| STRUCT_ATTRIBUTE_NAME_TWO_PARAMS "(" PROPERTY_NAME "," CONST_PROPERTY_NAME ")" \
 	| STRUCT_ATTRIBUTE_NAME_MULTI_PARAM "(" PROPERTY_NAME ("," PROPERTY_NAME)* ")" \
 ) _NL
-STRUCT_ATTRIBUTE_NAME_ZERO_PARAMS.1: "is_size_implicit"
+STRUCT_ATTRIBUTE_NAME_ZERO_PARAMS.1: "is_aligned" | "is_size_implicit"
 STRUCT_ATTRIBUTE_NAME_SINGLE_PARAM.1: "size"
 STRUCT_ATTRIBUTE_NAME_TWO_PARAMS.1: "initializes"
 STRUCT_ATTRIBUTE_NAME_MULTI_PARAM.1: "discriminator"
@@ -93,5 +90,8 @@ CONST_PROPERTY_NAME: UCASE_LETTER (UCASE_LETTER | DIGIT | "_")+
 PROPERTY_NAME: LCASE_LETTER (LCASE_LETTER | DIGIT | "_")+
 USER_TYPE_NAME: UCASE_LETTER LCASE_LETTER (UCASE_LETTER | LCASE_LETTER | DIGIT)*
 VALUE_PROPERTY_NAME_PLACEHOLDER: "__value__"
+
+comment: MULTILINE_SH_COMMENT _NL
+MULTILINE_SH_COMMENT: /#[^\n]*(\r?\n[\t ]*#[^\n]*)*/
 
 _NL: /(\r?\n[\t ]*)+/ // must include continuation characters

--- a/catbuffer/parser/docs/cats_dsl.md
+++ b/catbuffer/parser/docs/cats_dsl.md
@@ -219,6 +219,7 @@ So, `__value__` becomes `friendly_name` and `size` becomes  `friendly_name ` + `
 Hints can be attached to structures using attributes.
 
 Structures support the following attributes:
+1. `is_aligned`: indicates that all structure fields are positioned on aligned boundaries.
 1. `is_size_implicit`: indicates that the structure could be referenced in a `sizeof(x)` statement and must support a size calculation.
 1. `size(x)`: indicates that the `x` field contains the full size of the (variable sized) structure.
 1. `initializes(x, Y)`: indicates that the `x` field should be initialized with the `Y` constant.

--- a/catbuffer/parser/tests/test_ast.py
+++ b/catbuffer/parser/tests/test_ast.py
@@ -317,6 +317,7 @@ class StructTests(unittest.TestCase):
 		self.assertEqual(DisplayType.STRUCT, model.display_type)
 
 	def _assert_attributes(self, model, **kwargs):
+		self.assertEqual(kwargs.get('is_aligned', None), model.is_aligned)
 		self.assertEqual(kwargs.get('is_size_implicit', None), model.is_size_implicit)
 		self.assertEqual(kwargs.get('size', None), model.size)
 		self.assertEqual(kwargs.get('discriminator', None), model.discriminator)
@@ -408,6 +409,24 @@ class StructTests(unittest.TestCase):
 			'factory_type': 'Dust'
 		}, model.to_legacy_descriptor())
 		self.assertEqual('struct FooBar  # 2 field(s)', str(model))
+
+	def test_can_create_struct_with_attribute_is_aligned(self):
+		# Act:
+		model = Struct([None, 'FooBar', StructField(['alpha', 'MyCustomType']), StructField(['beta', FixedSizeInteger('uint16')])])
+		model.attributes = [Attribute(['is_aligned'])]
+
+		# Assert:
+		self.assertEqual('FooBar', model.name)
+		self.assertEqual(['alpha', 'beta'], [field.name for field in model.fields])
+		self._assert_disposition(model)
+		self._assert_attributes(model, is_aligned=True)
+		self.assertEqual({
+			'name': 'FooBar',
+			'type': 'struct',
+			'layout': [{'name': 'alpha', 'type': 'MyCustomType'}, {'name': 'beta', 'size': 2, 'type': 'byte', 'signedness': 'unsigned'}],
+			'is_aligned': True
+		}, model.to_legacy_descriptor())
+		self.assertEqual('@is_aligned\nstruct FooBar  # 2 field(s)', str(model))
 
 	def test_can_create_struct_with_attribute_is_size_implicit(self):
 		# Act:

--- a/catbuffer/schemas/symbol/block.cats
+++ b/catbuffer/schemas/symbol/block.cats
@@ -84,6 +84,7 @@ inline struct ImportanceBlockFooter
 @initializes(version, BLOCK_VERSION)
 @initializes(type, BLOCK_TYPE)
 @discriminator(type)
+@is_aligned
 abstract struct Block
 	inline BlockHeader
 

--- a/catbuffer/schemas/symbol/receipts.cats
+++ b/catbuffer/schemas/symbol/receipts.cats
@@ -5,6 +5,7 @@ import "receipt_type.cats"
 @size(size)
 @initializes(type, RECEIPT_TYPE)
 @discriminator(type)
+@is_aligned
 abstract struct Receipt
 	inline SizePrefixedEntity
 

--- a/catbuffer/schemas/symbol/transaction.cats
+++ b/catbuffer/schemas/symbol/transaction.cats
@@ -6,6 +6,7 @@ import "transaction_type.cats"
 @initializes(version, TRANSACTION_VERSION)
 @initializes(type, TRANSACTION_TYPE)
 @discriminator(type)
+@is_aligned
 abstract struct Transaction
 	inline SizePrefixedEntity
 	inline VerifiableEntity
@@ -32,6 +33,7 @@ inline struct EmbeddedTransactionHeader
 @initializes(version, TRANSACTION_VERSION)
 @initializes(type, TRANSACTION_TYPE)
 @discriminator(type)
+@is_aligned
 abstract struct EmbeddedTransaction
 	inline EmbeddedTransactionHeader
 	inline EntityBody


### PR DESCRIPTION
## What is the current behavior?
There is no way to indicate if a struct as aligned fields or not [ issue #101 ]

## What's the issue?
This prevents generators from making certain optimizations.

## How have you changed the behavior?
Added is_aligned struct attribute and applied it to schemas appropriately. 

## How was this change tested?
yes