### PR TITLE
[catbuffer/parser] build: update changelog to include all unreleased changes

### DIFF
--- a/catbuffer/parser/CHANGELOG.md
+++ b/catbuffer/parser/CHANGELOG.md
@@ -3,6 +3,23 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [3.2.0] - CURRENT
+
+### Added
+- add 'is_bitwise' enum attribute to indicate than an enumeration contains flags and should support bitwise operations
+- generators module providing utility functions for generator authors
+- struct attribute: is_aligned
+
+### Changed
+- added back one-pass code generation support and deprecated YAML generation
+- rename 'implicit_size' attribute to 'is_size_implicit'
+
+### Fixed
+- serialization of signed integers (#7)
+
+### Removed
+- YAML generation
+
 ## [3.1.0] - 22-Dec-2021
 
 ### Added
@@ -64,9 +81,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 ### Added
  - initial code release
 
-[3.1.0]: https://github.com/symbol/catbuffer-parser/compare/v3.0.2...v3.1.0
-[3.0.2]: https://github.com/symbol/catbuffer-parser/compare/v2.0.2...v3.0.2
-[2.0.2]: https://github.com/symbol/catbuffer-parser/compare/v2.0.1...v2.0.2
-[2.0.1]: https://github.com/symbol/catbuffer-parser/compare/v2.0.0...v2.0.1
-[2.0.0]: https://github.com/symbol/catbuffer-parser/compare/v1.0.0...v2.0.0
-[1.0.0]: https://github.com/symbol/catbuffer-parser/releases/tag/v1.0.0
+[3.2.0]: https://github.com/symbol/symbol/compare/catbuffer/parser/v3.1.0...dev
+[3.1.0]: https://github.com/symbol/symbol/compare/catbuffer/parser/v3.0.2...catbuffer/parser/v3.1.0
+[3.0.2]: https://github.com/symbol/symbol/compare/catbuffer/parser/v1.0.0...catbuffer/parser/v3.0.2
+[1.0.0]: https://github.com/symbol/symbol/releases/tag/catbuffer/parser/v1.0.0

--- a/catbuffer/parser/pyproject.toml
+++ b/catbuffer/parser/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'catparser'
-version = '3.1.0'
+version = '3.2.0'
 description = 'Symbol Catbuffer Parser'
 authors = ['Symbol Contributors <contributors@symbol.dev>']
 maintainers = ['Symbol Contributors <contributors@symbol.dev>']


### PR DESCRIPTION
## What is the current behavior?
changelog is out of date

## What's the issue?
changelog is out of date

## How have you changed the behavior?
updated changelog with changes since last release and fixed links

## How was this change tested?
N/A