### PR TITLE
[catbuffer/parser]: extend alignment attribute to specify padding of last element

### DIFF
--- a/catbuffer/parser/CHANGELOG.md
+++ b/catbuffer/parser/CHANGELOG.md
@@ -13,6 +13,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 ### Changed
 - added back one-pass code generation support and deprecated YAML generation
 - rename 'implicit_size' attribute to 'is_size_implicit'
+- added 'pad_last' and 'not pad_last' qualifiers to 'alignment' attribute
 
 ### Fixed
 - serialization of signed integers (#7)

--- a/catbuffer/parser/catparser/AstPostProcessor.py
+++ b/catbuffer/parser/catparser/AstPostProcessor.py
@@ -24,7 +24,7 @@ class AstPostProcessor:
 					if not hasattr(field.field_type, attribute.name):
 						raise AstException(f'field {field.name} ({field.field_type}) does not have property {attribute.name}')
 
-					setattr(field.field_type, attribute.name, attribute.value)
+					setattr(field.field_type, attribute.name, attribute.values)
 
 	def _structs(self):
 		return [model for _, model in self.type_descriptor_map.items() if isinstance(model, Struct)]

--- a/catbuffer/parser/catparser/grammar/catbuffer.lark
+++ b/catbuffer/parser/catparser/grammar/catbuffer.lark
@@ -30,11 +30,12 @@ enum_value: CONST_PROPERTY_NAME "=" _dec_or_hex_number _NL
 field_attributes: field_attribute+
 field_attribute: "@" ( \
 	FIELD_ATTRIBUTE_NAME_ZERO_PARAMS \
-	| FIELD_ATTRIBUTE_NAME_SINGLE_PARAM_NUMERIC "(" _dec_or_hex_number ")" \
+	| FIELD_ATTRIBUTE_NAME_ALIGNMENT "(" _dec_or_hex_number ["," [NEGATION_OPERATOR] FIELD_ATTRIBUTE_NAME_ALIGNMENT_OPTION] ")" \
 	| FIELD_ATTRIBUTE_NAME_SINGLE_PARAM_PROPERTY "(" PROPERTY_NAME ")" \
 ) _NL
 FIELD_ATTRIBUTE_NAME_ZERO_PARAMS.1: "is_byte_constrained"
-FIELD_ATTRIBUTE_NAME_SINGLE_PARAM_NUMERIC.1: "alignment"
+FIELD_ATTRIBUTE_NAME_ALIGNMENT.1: "alignment"
+FIELD_ATTRIBUTE_NAME_ALIGNMENT_OPTION.1: "pad_last"
 FIELD_ATTRIBUTE_NAME_SINGLE_PARAM_PROPERTY.1: "sort_key"
 
 struct_attributes: struct_attribute+
@@ -76,6 +77,7 @@ ARRAY_SIZE_FILL_PLACEHOLDER: "__FILL__"
 
 conditional_expression: "if" (_dec_or_hex_number | CONST_PROPERTY_NAME) CONDITIONAL_OPERATION PROPERTY_NAME
 CONDITIONAL_OPERATION: "not equals" | "equals" | "in" | "not in"
+NEGATION_OPERATOR: "not"
 
 _integer_or_enum_const: (FIXED_SIZE_INTEGER "," _dec_or_hex_number | USER_TYPE_NAME "," CONST_PROPERTY_NAME)
 

--- a/catbuffer/parser/docs/cats_dsl.md
+++ b/catbuffer/parser/docs/cats_dsl.md
@@ -241,8 +241,12 @@ Notice that `TRANSPORT_MODE` can be defined in any derived structure.
 
 Array fields support the following attributes:
 1. `is_byte_constrained`: indicates the size value should be interpreted as a byte value instead of an element count.
-1. `alignment(x)`: indicates that elements should be padded so that they start on `x`-aligned boundaries.
+1. `alignment(x, [[not] pad_last])`: indicates that elements should be padded so that they start on `x`-aligned boundaries.
 1. `sort_key(x)`: indicates that elements within the array should be sorted by the `x` property.
+
+When alignment is specified, by default, the final element is padded to end on an `x`-aligned boundary.
+This can be made explicit by including the `pad_last` qualifier.
+This can be disabled by including the `not pad_last` qualifier, which will not pad the last element to an `x`-aligned boundary.
 
 For example, to sort vehicles by `weight`:
 ```cpp

--- a/catbuffer/parser/tests/test_AstValidator.py
+++ b/catbuffer/parser/tests/test_AstValidator.py
@@ -260,7 +260,7 @@ class AstValidatorTests(unittest.TestCase):
 	def test_can_validate_struct_containing_array_with_known_sort_key_field(self):
 		# Arrange:
 		array_model = Array(['ElementType', 10])
-		array_model.sort_key = 'weight'
+		array_model.sort_key = ['weight']
 
 		validator = AstValidator([
 			Struct([None, 'ElementType', StructField(['weight', FixedSizeInteger('uint16')])]),
@@ -273,7 +273,7 @@ class AstValidatorTests(unittest.TestCase):
 	def test_cannot_validate_struct_containing_array_with_unknown_sort_key_field(self):
 		# Arrange:
 		array_model = Array(['ElementType', 10])
-		array_model.sort_key = 'height'
+		array_model.sort_key = ['height']
 
 		validator = AstValidator([
 			Struct([None, 'ElementType', StructField(['weight', FixedSizeInteger('uint16')])]),
@@ -288,7 +288,7 @@ class AstValidatorTests(unittest.TestCase):
 	def test_cannot_validate_struct_containing_array_with_unknown_element_type_and_unknown_sort_key_field(self):
 		# Arrange:
 		array_model = Array(['ElementType', 10])
-		array_model.sort_key = 'height'
+		array_model.sort_key = ['height']
 
 		validator = AstValidator([
 			Struct([None, 'FooBar', StructField(['alpha', array_model])])

--- a/catbuffer/schemas/symbol/block.cats
+++ b/catbuffer/schemas/symbol/block.cats
@@ -97,7 +97,7 @@ struct NemesisBlock
 	inline ImportanceBlockFooter
 
 	# variable sized transaction data
-	@alignment(8)
+	@alignment(8, not pad_last)
 	transactions = array(Transaction, __FILL__)
 
 # binary layout for a normal block header
@@ -111,7 +111,7 @@ struct NormalBlock
 	block_header_reserved_1 = make_reserved(uint32, 0)
 
 	# variable sized transaction data
-	@alignment(8)
+	@alignment(8, not pad_last)
 	transactions = array(Transaction, __FILL__)
 
 # binary layout for an importance block header
@@ -123,5 +123,5 @@ struct ImportanceBlock
 	inline ImportanceBlockFooter
 
 	# variable sized transaction data
-	@alignment(8)
+	@alignment(8, not pad_last)
 	transactions = array(Transaction, __FILL__)


### PR DESCRIPTION
## What is the current behavior?
there is no way to specify padding of last element in an aligned array

## What's the issue?
within a block, the last transaction is NOT padded
within an aggregate, the last transaction is padded

## How have you changed the behavior?
add optional `[not] pad_last` qualifier to alignment attribute

## How was this change tested?
yes