### PR TITLE
[sdk] actually read/write block transactions properly

### DIFF
--- a/sdk/javascript/src/nem/models.js
+++ b/sdk/javascript/src/nem/models.js
@@ -741,7 +741,7 @@ class Block {
 		size += this.previousBlockHash.size;
 		size += this.height.size;
 		size += 4;
-		size += this.transactions.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.transactions);
 		return size;
 	}
 
@@ -778,7 +778,7 @@ class Block {
 		const transactionsCount = converter.bytesToInt(view.buffer, 4, false);
 		view.shiftRight(4);
 		const transactions = arrayHelpers.readArrayCount(view.buffer, Transaction, transactionsCount);
-		view.shiftRight(transactions.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(transactions));
 
 		const instance = new Block();
 		instance._type = type;
@@ -1884,7 +1884,7 @@ class MosaicDefinition {
 		size += 4;
 		size += this._description.length;
 		size += 4;
-		size += this.properties.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.properties);
 		size += 4;
 		if (0 !== this.levySize)
 			size += this.levy.size;
@@ -1912,7 +1912,7 @@ class MosaicDefinition {
 		const propertiesCount = converter.bytesToInt(view.buffer, 4, false);
 		view.shiftRight(4);
 		const properties = arrayHelpers.readArrayCount(view.buffer, SizePrefixedMosaicProperty, propertiesCount);
-		view.shiftRight(properties.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(properties));
 		const levySize = converter.bytesToInt(view.buffer, 4, false);
 		view.shiftRight(4);
 		let levy;
@@ -3206,7 +3206,7 @@ class MultisigAccountModificationTransactionV1 {
 		size += this.fee.size;
 		size += this.deadline.size;
 		size += 4;
-		size += this.modifications.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.modifications);
 		return size;
 	}
 
@@ -3243,7 +3243,7 @@ class MultisigAccountModificationTransactionV1 {
 		const modificationsCount = converter.bytesToInt(view.buffer, 4, false);
 		view.shiftRight(4);
 		const modifications = arrayHelpers.readArrayCount(view.buffer, SizePrefixedMultisigAccountModification, modificationsCount);
-		view.shiftRight(modifications.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(modifications));
 
 		const instance = new MultisigAccountModificationTransactionV1();
 		instance._type = type;
@@ -3396,7 +3396,7 @@ class NonVerifiableMultisigAccountModificationTransactionV1 {
 		size += this.fee.size;
 		size += this.deadline.size;
 		size += 4;
-		size += this.modifications.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.modifications);
 		return size;
 	}
 
@@ -3427,7 +3427,7 @@ class NonVerifiableMultisigAccountModificationTransactionV1 {
 		const modificationsCount = converter.bytesToInt(view.buffer, 4, false);
 		view.shiftRight(4);
 		const modifications = arrayHelpers.readArrayCount(view.buffer, SizePrefixedMultisigAccountModification, modificationsCount);
-		view.shiftRight(modifications.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(modifications));
 
 		const instance = new NonVerifiableMultisigAccountModificationTransactionV1();
 		instance._type = type;
@@ -3599,7 +3599,7 @@ class MultisigAccountModificationTransaction {
 		size += this.fee.size;
 		size += this.deadline.size;
 		size += 4;
-		size += this.modifications.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.modifications);
 		size += 4;
 		size += 4;
 		return size;
@@ -3638,7 +3638,7 @@ class MultisigAccountModificationTransaction {
 		const modificationsCount = converter.bytesToInt(view.buffer, 4, false);
 		view.shiftRight(4);
 		const modifications = arrayHelpers.readArrayCount(view.buffer, SizePrefixedMultisigAccountModification, modificationsCount);
-		view.shiftRight(modifications.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(modifications));
 		const minApprovalDeltaSize = converter.bytesToInt(view.buffer, 4, false);
 		view.shiftRight(4);
 		if (4 !== minApprovalDeltaSize)
@@ -3811,7 +3811,7 @@ class NonVerifiableMultisigAccountModificationTransaction {
 		size += this.fee.size;
 		size += this.deadline.size;
 		size += 4;
-		size += this.modifications.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.modifications);
 		size += 4;
 		size += 4;
 		return size;
@@ -3844,7 +3844,7 @@ class NonVerifiableMultisigAccountModificationTransaction {
 		const modificationsCount = converter.bytesToInt(view.buffer, 4, false);
 		view.shiftRight(4);
 		const modifications = arrayHelpers.readArrayCount(view.buffer, SizePrefixedMultisigAccountModification, modificationsCount);
-		view.shiftRight(modifications.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(modifications));
 		const minApprovalDeltaSize = converter.bytesToInt(view.buffer, 4, false);
 		view.shiftRight(4);
 		if (4 !== minApprovalDeltaSize)
@@ -4316,7 +4316,7 @@ class MultisigTransaction {
 		size += 4;
 		size += this.innerTransaction.size;
 		size += 4;
-		size += this.cosignatures.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.cosignatures);
 		return size;
 	}
 
@@ -4358,7 +4358,7 @@ class MultisigTransaction {
 		const cosignaturesCount = converter.bytesToInt(view.buffer, 4, false);
 		view.shiftRight(4);
 		const cosignatures = arrayHelpers.readArrayCount(view.buffer, SizePrefixedCosignature, cosignaturesCount);
-		view.shiftRight(cosignatures.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(cosignatures));
 
 		const instance = new MultisigTransaction();
 		instance._type = type;
@@ -5708,7 +5708,7 @@ class TransferTransaction {
 			size += this.message.size;
 
 		size += 4;
-		size += this.mosaics.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.mosaics);
 		return size;
 	}
 
@@ -5760,7 +5760,7 @@ class TransferTransaction {
 		const mosaicsCount = converter.bytesToInt(view.buffer, 4, false);
 		view.shiftRight(4);
 		const mosaics = arrayHelpers.readArrayCount(view.buffer, SizePrefixedMosaic, mosaicsCount);
-		view.shiftRight(mosaics.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(mosaics));
 
 		const instance = new TransferTransaction();
 		instance._type = type;
@@ -5977,7 +5977,7 @@ class NonVerifiableTransferTransaction {
 			size += this.message.size;
 
 		size += 4;
-		size += this.mosaics.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.mosaics);
 		return size;
 	}
 
@@ -6023,7 +6023,7 @@ class NonVerifiableTransferTransaction {
 		const mosaicsCount = converter.bytesToInt(view.buffer, 4, false);
 		view.shiftRight(4);
 		const mosaics = arrayHelpers.readArrayCount(view.buffer, SizePrefixedMosaic, mosaicsCount);
-		view.shiftRight(mosaics.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(mosaics));
 
 		const instance = new NonVerifiableTransferTransaction();
 		instance._type = type;

--- a/sdk/javascript/src/symbol/models.js
+++ b/sdk/javascript/src/symbol/models.js
@@ -1660,7 +1660,7 @@ class NemesisBlock {
 		size += 8;
 		size += this.totalVotingBalance.size;
 		size += this.previousImportanceBlockHash.size;
-		size += this.transactions.slice(0, -1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0) + this.transactions.slice(-1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.transactions, 8, true);
 		return size;
 	}
 
@@ -1715,8 +1715,8 @@ class NemesisBlock {
 		view.shiftRight(totalVotingBalance.size);
 		const previousImportanceBlockHash = Hash256.deserialize(view.buffer);
 		view.shiftRight(previousImportanceBlockHash.size);
-		const transactions = arrayHelpers.readVariableSizeElements(view.buffer, TransactionFactory, 8);
-		view.shiftRight(transactions.slice(0, -1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0) + transactions.slice(-1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0));
+		const transactions = arrayHelpers.readVariableSizeElements(view.buffer, TransactionFactory, 8, true);
+		view.shiftRight(arrayHelpers.size(transactions, 8, true));
 
 		const instance = new NemesisBlock();
 		instance._signature = signature;
@@ -1766,7 +1766,7 @@ class NemesisBlock {
 		buffer.write(converter.intToBytes(this._harvestingEligibleAccountsCount, 8, false));
 		buffer.write(this._totalVotingBalance.serialize());
 		buffer.write(this._previousImportanceBlockHash.serialize());
-		arrayHelpers.writeVariableSizeElements(buffer, this._transactions, 8);
+		arrayHelpers.writeVariableSizeElements(buffer, this._transactions, 8, true);
 		return buffer.storage;
 	}
 
@@ -1991,7 +1991,7 @@ class NormalBlock {
 		size += this.beneficiaryAddress.size;
 		size += this.feeMultiplier.size;
 		size += 4;
-		size += this.transactions.slice(0, -1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0) + this.transactions.slice(-1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.transactions, 8, true);
 		return size;
 	}
 
@@ -2042,8 +2042,8 @@ class NormalBlock {
 		view.shiftRight(4);
 		if (0 !== blockHeaderReserved_1)
 			throw RangeError(`Invalid value of reserved field (${blockHeaderReserved_1})`);
-		const transactions = arrayHelpers.readVariableSizeElements(view.buffer, TransactionFactory, 8);
-		view.shiftRight(transactions.slice(0, -1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0) + transactions.slice(-1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0));
+		const transactions = arrayHelpers.readVariableSizeElements(view.buffer, TransactionFactory, 8, true);
+		view.shiftRight(arrayHelpers.size(transactions, 8, true));
 
 		const instance = new NormalBlock();
 		instance._signature = signature;
@@ -2086,7 +2086,7 @@ class NormalBlock {
 		buffer.write(this._beneficiaryAddress.serialize());
 		buffer.write(this._feeMultiplier.serialize());
 		buffer.write(converter.intToBytes(this._blockHeaderReserved_1, 4, false));
-		arrayHelpers.writeVariableSizeElements(buffer, this._transactions, 8);
+		arrayHelpers.writeVariableSizeElements(buffer, this._transactions, 8, true);
 		return buffer.storage;
 	}
 
@@ -2347,7 +2347,7 @@ class ImportanceBlock {
 		size += 8;
 		size += this.totalVotingBalance.size;
 		size += this.previousImportanceBlockHash.size;
-		size += this.transactions.slice(0, -1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0) + this.transactions.slice(-1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.transactions, 8, true);
 		return size;
 	}
 
@@ -2402,8 +2402,8 @@ class ImportanceBlock {
 		view.shiftRight(totalVotingBalance.size);
 		const previousImportanceBlockHash = Hash256.deserialize(view.buffer);
 		view.shiftRight(previousImportanceBlockHash.size);
-		const transactions = arrayHelpers.readVariableSizeElements(view.buffer, TransactionFactory, 8);
-		view.shiftRight(transactions.slice(0, -1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0) + transactions.slice(-1).map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0));
+		const transactions = arrayHelpers.readVariableSizeElements(view.buffer, TransactionFactory, 8, true);
+		view.shiftRight(arrayHelpers.size(transactions, 8, true));
 
 		const instance = new ImportanceBlock();
 		instance._signature = signature;
@@ -2453,7 +2453,7 @@ class ImportanceBlock {
 		buffer.write(converter.intToBytes(this._harvestingEligibleAccountsCount, 8, false));
 		buffer.write(this._totalVotingBalance.serialize());
 		buffer.write(this._previousImportanceBlockHash.serialize());
-		arrayHelpers.writeVariableSizeElements(buffer, this._transactions, 8);
+		arrayHelpers.writeVariableSizeElements(buffer, this._transactions, 8, true);
 		return buffer.storage;
 	}
 
@@ -4314,7 +4314,7 @@ class AddressResolutionStatement {
 		let size = 0;
 		size += this.unresolved.size;
 		size += 4;
-		size += this.resolutionEntries.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.resolutionEntries);
 		return size;
 	}
 
@@ -4325,7 +4325,7 @@ class AddressResolutionStatement {
 		const resolutionEntriesCount = converter.bytesToInt(view.buffer, 4, false);
 		view.shiftRight(4);
 		const resolutionEntries = arrayHelpers.readArrayCount(view.buffer, AddressResolutionEntry, resolutionEntriesCount);
-		view.shiftRight(resolutionEntries.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(resolutionEntries));
 
 		const instance = new AddressResolutionStatement();
 		instance._unresolved = unresolved;
@@ -4444,7 +4444,7 @@ class MosaicResolutionStatement {
 		let size = 0;
 		size += this.unresolved.size;
 		size += 4;
-		size += this.resolutionEntries.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.resolutionEntries);
 		return size;
 	}
 
@@ -4455,7 +4455,7 @@ class MosaicResolutionStatement {
 		const resolutionEntriesCount = converter.bytesToInt(view.buffer, 4, false);
 		view.shiftRight(4);
 		const resolutionEntries = arrayHelpers.readArrayCount(view.buffer, MosaicResolutionEntry, resolutionEntriesCount);
-		view.shiftRight(resolutionEntries.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(resolutionEntries));
 
 		const instance = new MosaicResolutionStatement();
 		instance._unresolved = unresolved;
@@ -4520,7 +4520,7 @@ class TransactionStatement {
 		size += 4;
 		size += 4;
 		size += 4;
-		size += this.receipts.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.receipts);
 		return size;
 	}
 
@@ -4533,7 +4533,7 @@ class TransactionStatement {
 		const receiptCount = converter.bytesToInt(view.buffer, 4, false);
 		view.shiftRight(4);
 		const receipts = arrayHelpers.readArrayCount(view.buffer, Receipt, receiptCount);
-		view.shiftRight(receipts.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(receipts));
 
 		const instance = new TransactionStatement();
 		instance._primaryId = primaryId;
@@ -4601,11 +4601,11 @@ class BlockStatement {
 	get size() { // eslint-disable-line class-methods-use-this
 		let size = 0;
 		size += 4;
-		size += this.transactionStatements.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.transactionStatements);
 		size += 4;
-		size += this.addressResolutionStatements.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.addressResolutionStatements);
 		size += 4;
-		size += this.mosaicResolutionStatements.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.mosaicResolutionStatements);
 		return size;
 	}
 
@@ -4614,15 +4614,15 @@ class BlockStatement {
 		const transactionStatementCount = converter.bytesToInt(view.buffer, 4, false);
 		view.shiftRight(4);
 		const transactionStatements = arrayHelpers.readArrayCount(view.buffer, TransactionStatement, transactionStatementCount);
-		view.shiftRight(transactionStatements.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(transactionStatements));
 		const addressResolutionStatementCount = converter.bytesToInt(view.buffer, 4, false);
 		view.shiftRight(4);
 		const addressResolutionStatements = arrayHelpers.readArrayCount(view.buffer, AddressResolutionStatement, addressResolutionStatementCount);
-		view.shiftRight(addressResolutionStatements.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(addressResolutionStatements));
 		const mosaicResolutionStatementCount = converter.bytesToInt(view.buffer, 4, false);
 		view.shiftRight(4);
 		const mosaicResolutionStatements = arrayHelpers.readArrayCount(view.buffer, MosaicResolutionStatement, mosaicResolutionStatementCount);
-		view.shiftRight(mosaicResolutionStatements.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(mosaicResolutionStatements));
 
 		const instance = new BlockStatement();
 		instance._transactionStatements = transactionStatements;
@@ -5050,14 +5050,14 @@ class HeightActivityBuckets {
 
 	get size() { // eslint-disable-line class-methods-use-this
 		let size = 0;
-		size += this.buckets.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.buckets);
 		return size;
 	}
 
 	static deserialize(payload) {
 		const view = new BufferView(payload);
 		const buckets = arrayHelpers.readArrayCount(view.buffer, HeightActivityBucket, 5);
-		view.shiftRight(buckets.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(buckets));
 
 		const instance = new HeightActivityBuckets();
 		instance._buckets = buckets;
@@ -5254,7 +5254,7 @@ class AccountState {
 		if (this.supplementalPublicKeysMask.has(AccountKeyTypeFlags.VRF))
 			size += this.vrfPublicKey.size;
 
-		size += this.votingPublicKeys.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.votingPublicKeys);
 		if (AccountStateFormat.HIGH_VALUE === this.format)
 			size += this.importanceSnapshots.size;
 
@@ -5262,7 +5262,7 @@ class AccountState {
 			size += this.activityBuckets.size;
 
 		size += 2;
-		size += this.balances.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.balances);
 		return size;
 	}
 
@@ -5302,7 +5302,7 @@ class AccountState {
 			view.shiftRight(vrfPublicKey.size);
 		}
 		const votingPublicKeys = arrayHelpers.readArrayCount(view.buffer, PinnedVotingKey, votingPublicKeysCount);
-		view.shiftRight(votingPublicKeys.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(votingPublicKeys));
 		let importanceSnapshots;
 		if (AccountStateFormat.HIGH_VALUE === format) {
 			importanceSnapshots = ImportanceSnapshot.deserialize(view.buffer);
@@ -5316,7 +5316,7 @@ class AccountState {
 		const balancesCount = converter.bytesToInt(view.buffer, 2, false);
 		view.shiftRight(2);
 		const balances = arrayHelpers.readArrayCount(view.buffer, Mosaic, balancesCount);
-		view.shiftRight(balances.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(balances));
 
 		const instance = new AccountState();
 		instance._version = version;
@@ -6280,9 +6280,9 @@ class MultisigEntry {
 		size += 4;
 		size += this.accountAddress.size;
 		size += 8;
-		size += this.cosignatoryAddresses.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.cosignatoryAddresses);
 		size += 8;
-		size += this.multisigAddresses.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.multisigAddresses);
 		return size;
 	}
 
@@ -6299,11 +6299,11 @@ class MultisigEntry {
 		const cosignatoryAddressesCount = converter.bytesToInt(view.buffer, 8, false);
 		view.shiftRight(8);
 		const cosignatoryAddresses = arrayHelpers.readArrayCount(view.buffer, Address, cosignatoryAddressesCount);
-		view.shiftRight(cosignatoryAddresses.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(cosignatoryAddresses));
 		const multisigAddressesCount = converter.bytesToInt(view.buffer, 8, false);
 		view.shiftRight(8);
 		const multisigAddresses = arrayHelpers.readArrayCount(view.buffer, Address, multisigAddressesCount);
-		view.shiftRight(multisigAddresses.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(multisigAddresses));
 
 		const instance = new MultisigEntry();
 		instance._version = version;
@@ -6579,7 +6579,7 @@ class NamespacePath {
 	get size() { // eslint-disable-line class-methods-use-this
 		let size = 0;
 		size += 1;
-		size += this.path.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.path);
 		size += this.alias.size;
 		return size;
 	}
@@ -6589,7 +6589,7 @@ class NamespacePath {
 		const pathSize = converter.bytesToInt(view.buffer, 1, false);
 		view.shiftRight(1);
 		const path = arrayHelpers.readArrayCount(view.buffer, NamespaceId, pathSize);
-		view.shiftRight(path.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(path));
 		const alias = NamespaceAlias.deserialize(view.buffer);
 		view.shiftRight(alias.size);
 
@@ -6690,7 +6690,7 @@ class RootNamespaceHistory {
 		size += this.lifetime.size;
 		size += this.rootAlias.size;
 		size += 8;
-		size += this.paths.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.paths);
 		return size;
 	}
 
@@ -6709,7 +6709,7 @@ class RootNamespaceHistory {
 		const childrenCount = converter.bytesToInt(view.buffer, 8, false);
 		view.shiftRight(8);
 		const paths = arrayHelpers.readArrayCount(view.buffer, NamespacePath, childrenCount, e => e.path.value);
-		view.shiftRight(paths.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(paths));
 
 		const instance = new RootNamespaceHistory();
 		instance._version = version;
@@ -6816,7 +6816,7 @@ class AccountRestrictionAddressValue {
 	get size() { // eslint-disable-line class-methods-use-this
 		let size = 0;
 		size += 8;
-		size += this.restrictionValues.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.restrictionValues);
 		return size;
 	}
 
@@ -6825,7 +6825,7 @@ class AccountRestrictionAddressValue {
 		const restrictionValuesCount = converter.bytesToInt(view.buffer, 8, false);
 		view.shiftRight(8);
 		const restrictionValues = arrayHelpers.readArrayCount(view.buffer, Address, restrictionValuesCount);
-		view.shiftRight(restrictionValues.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(restrictionValues));
 
 		const instance = new AccountRestrictionAddressValue();
 		instance._restrictionValues = restrictionValues;
@@ -6867,7 +6867,7 @@ class AccountRestrictionMosaicValue {
 	get size() { // eslint-disable-line class-methods-use-this
 		let size = 0;
 		size += 8;
-		size += this.restrictionValues.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.restrictionValues);
 		return size;
 	}
 
@@ -6876,7 +6876,7 @@ class AccountRestrictionMosaicValue {
 		const restrictionValuesCount = converter.bytesToInt(view.buffer, 8, false);
 		view.shiftRight(8);
 		const restrictionValues = arrayHelpers.readArrayCount(view.buffer, MosaicId, restrictionValuesCount);
-		view.shiftRight(restrictionValues.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(restrictionValues));
 
 		const instance = new AccountRestrictionMosaicValue();
 		instance._restrictionValues = restrictionValues;
@@ -6918,7 +6918,7 @@ class AccountRestrictionTransactionTypeValue {
 	get size() { // eslint-disable-line class-methods-use-this
 		let size = 0;
 		size += 8;
-		size += this.restrictionValues.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.restrictionValues);
 		return size;
 	}
 
@@ -6927,7 +6927,7 @@ class AccountRestrictionTransactionTypeValue {
 		const restrictionValuesCount = converter.bytesToInt(view.buffer, 8, false);
 		view.shiftRight(8);
 		const restrictionValues = arrayHelpers.readArrayCount(view.buffer, TransactionType, restrictionValuesCount);
-		view.shiftRight(restrictionValues.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(restrictionValues));
 
 		const instance = new AccountRestrictionTransactionTypeValue();
 		instance._restrictionValues = restrictionValues;
@@ -7112,7 +7112,7 @@ class AccountRestrictions {
 		size += 2;
 		size += this.address.size;
 		size += 8;
-		size += this.restrictions.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.restrictions);
 		return size;
 	}
 
@@ -7125,7 +7125,7 @@ class AccountRestrictions {
 		const restrictionsCount = converter.bytesToInt(view.buffer, 8, false);
 		view.shiftRight(8);
 		const restrictions = arrayHelpers.readArrayCount(view.buffer, AccountRestrictionsInfo, restrictionsCount);
-		view.shiftRight(restrictions.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(restrictions));
 
 		const instance = new AccountRestrictions();
 		instance._version = version;
@@ -7354,7 +7354,7 @@ class AddressKeyValueSet {
 	get size() { // eslint-disable-line class-methods-use-this
 		let size = 0;
 		size += 1;
-		size += this.keys.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.keys);
 		return size;
 	}
 
@@ -7363,7 +7363,7 @@ class AddressKeyValueSet {
 		const keyValueCount = converter.bytesToInt(view.buffer, 1, false);
 		view.shiftRight(1);
 		const keys = arrayHelpers.readArrayCount(view.buffer, AddressKeyValue, keyValueCount, e => e.key.value);
-		view.shiftRight(keys.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(keys));
 
 		const instance = new AddressKeyValueSet();
 		instance._keys = keys;
@@ -7546,7 +7546,7 @@ class GlobalKeyValueSet {
 	get size() { // eslint-disable-line class-methods-use-this
 		let size = 0;
 		size += 1;
-		size += this.keys.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.keys);
 		return size;
 	}
 
@@ -7555,7 +7555,7 @@ class GlobalKeyValueSet {
 		const keyValueCount = converter.bytesToInt(view.buffer, 1, false);
 		view.shiftRight(1);
 		const keys = arrayHelpers.readArrayCount(view.buffer, GlobalKeyValue, keyValueCount, e => e.key.value);
-		view.shiftRight(keys.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(keys));
 
 		const instance = new GlobalKeyValueSet();
 		instance._keys = keys;
@@ -9029,8 +9029,8 @@ class AggregateCompleteTransaction {
 		size += this.transactionsHash.size;
 		size += 4;
 		size += 4;
-		size += this.transactions.map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0);
-		size += this.cosignatures.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.transactions, 8, false);
+		size += arrayHelpers.size(this.cosignatures);
 		return size;
 	}
 
@@ -9069,10 +9069,10 @@ class AggregateCompleteTransaction {
 		view.shiftRight(4);
 		if (0 !== aggregateTransactionHeaderReserved_1)
 			throw RangeError(`Invalid value of reserved field (${aggregateTransactionHeaderReserved_1})`);
-		const transactions = arrayHelpers.readVariableSizeElements(view.window(payloadSize), EmbeddedTransactionFactory, 8);
+		const transactions = arrayHelpers.readVariableSizeElements(view.window(payloadSize), EmbeddedTransactionFactory, 8, false);
 		view.shiftRight(payloadSize);
 		const cosignatures = arrayHelpers.readArray(view.buffer, Cosignature);
-		view.shiftRight(cosignatures.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(cosignatures));
 
 		const instance = new AggregateCompleteTransaction();
 		instance._signature = signature;
@@ -9101,9 +9101,9 @@ class AggregateCompleteTransaction {
 		buffer.write(this._fee.serialize());
 		buffer.write(this._deadline.serialize());
 		buffer.write(this._transactionsHash.serialize());
-		buffer.write(converter.intToBytes(this.transactions.map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0), 4, false)); // bound: payload_size
+		buffer.write(converter.intToBytes(arrayHelpers.size(this.transactions, 8, false), 4, false)); // bound: payload_size
 		buffer.write(converter.intToBytes(this._aggregateTransactionHeaderReserved_1, 4, false));
-		arrayHelpers.writeVariableSizeElements(buffer, this._transactions, 8);
+		arrayHelpers.writeVariableSizeElements(buffer, this._transactions, 8, false);
 		arrayHelpers.writeArray(buffer, this._cosignatures);
 		return buffer.storage;
 	}
@@ -9253,8 +9253,8 @@ class AggregateBondedTransaction {
 		size += this.transactionsHash.size;
 		size += 4;
 		size += 4;
-		size += this.transactions.map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0);
-		size += this.cosignatures.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.transactions, 8, false);
+		size += arrayHelpers.size(this.cosignatures);
 		return size;
 	}
 
@@ -9293,10 +9293,10 @@ class AggregateBondedTransaction {
 		view.shiftRight(4);
 		if (0 !== aggregateTransactionHeaderReserved_1)
 			throw RangeError(`Invalid value of reserved field (${aggregateTransactionHeaderReserved_1})`);
-		const transactions = arrayHelpers.readVariableSizeElements(view.window(payloadSize), EmbeddedTransactionFactory, 8);
+		const transactions = arrayHelpers.readVariableSizeElements(view.window(payloadSize), EmbeddedTransactionFactory, 8, false);
 		view.shiftRight(payloadSize);
 		const cosignatures = arrayHelpers.readArray(view.buffer, Cosignature);
-		view.shiftRight(cosignatures.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(cosignatures));
 
 		const instance = new AggregateBondedTransaction();
 		instance._signature = signature;
@@ -9325,9 +9325,9 @@ class AggregateBondedTransaction {
 		buffer.write(this._fee.serialize());
 		buffer.write(this._deadline.serialize());
 		buffer.write(this._transactionsHash.serialize());
-		buffer.write(converter.intToBytes(this.transactions.map(e => arrayHelpers.alignUp(e.size, 8)).reduce((a, b) => a + b, 0), 4, false)); // bound: payload_size
+		buffer.write(converter.intToBytes(arrayHelpers.size(this.transactions, 8, false), 4, false)); // bound: payload_size
 		buffer.write(converter.intToBytes(this._aggregateTransactionHeaderReserved_1, 4, false));
-		arrayHelpers.writeVariableSizeElements(buffer, this._transactions, 8);
+		arrayHelpers.writeVariableSizeElements(buffer, this._transactions, 8, false);
 		arrayHelpers.writeArray(buffer, this._cosignatures);
 		return buffer.storage;
 	}
@@ -13951,8 +13951,8 @@ class MultisigAccountModificationTransaction {
 		size += 1;
 		size += 1;
 		size += 4;
-		size += this.addressAdditions.map(e => e.size).reduce((a, b) => a + b, 0);
-		size += this.addressDeletions.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.addressAdditions);
+		size += arrayHelpers.size(this.addressDeletions);
 		return size;
 	}
 
@@ -13996,9 +13996,9 @@ class MultisigAccountModificationTransaction {
 		if (0 !== multisigAccountModificationTransactionBodyReserved_1)
 			throw RangeError(`Invalid value of reserved field (${multisigAccountModificationTransactionBodyReserved_1})`);
 		const addressAdditions = arrayHelpers.readArrayCount(view.buffer, UnresolvedAddress, addressAdditionsCount);
-		view.shiftRight(addressAdditions.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(addressAdditions));
 		const addressDeletions = arrayHelpers.readArrayCount(view.buffer, UnresolvedAddress, addressDeletionsCount);
-		view.shiftRight(addressDeletions.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(addressDeletions));
 
 		const instance = new MultisigAccountModificationTransaction();
 		instance._signature = signature;
@@ -14160,8 +14160,8 @@ class EmbeddedMultisigAccountModificationTransaction {
 		size += 1;
 		size += 1;
 		size += 4;
-		size += this.addressAdditions.map(e => e.size).reduce((a, b) => a + b, 0);
-		size += this.addressDeletions.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.addressAdditions);
+		size += arrayHelpers.size(this.addressDeletions);
 		return size;
 	}
 
@@ -14199,9 +14199,9 @@ class EmbeddedMultisigAccountModificationTransaction {
 		if (0 !== multisigAccountModificationTransactionBodyReserved_1)
 			throw RangeError(`Invalid value of reserved field (${multisigAccountModificationTransactionBodyReserved_1})`);
 		const addressAdditions = arrayHelpers.readArrayCount(view.buffer, UnresolvedAddress, addressAdditionsCount);
-		view.shiftRight(addressAdditions.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(addressAdditions));
 		const addressDeletions = arrayHelpers.readArrayCount(view.buffer, UnresolvedAddress, addressDeletionsCount);
-		view.shiftRight(addressDeletions.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(addressDeletions));
 
 		const instance = new EmbeddedMultisigAccountModificationTransaction();
 		instance._signerPublicKey = signerPublicKey;
@@ -15626,8 +15626,8 @@ class AccountAddressRestrictionTransaction {
 		size += 1;
 		size += 1;
 		size += 4;
-		size += this.restrictionAdditions.map(e => e.size).reduce((a, b) => a + b, 0);
-		size += this.restrictionDeletions.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.restrictionAdditions);
+		size += arrayHelpers.size(this.restrictionDeletions);
 		return size;
 	}
 
@@ -15669,9 +15669,9 @@ class AccountAddressRestrictionTransaction {
 		if (0 !== accountRestrictionTransactionBodyReserved_1)
 			throw RangeError(`Invalid value of reserved field (${accountRestrictionTransactionBodyReserved_1})`);
 		const restrictionAdditions = arrayHelpers.readArrayCount(view.buffer, UnresolvedAddress, restrictionAdditionsCount);
-		view.shiftRight(restrictionAdditions.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(restrictionAdditions));
 		const restrictionDeletions = arrayHelpers.readArrayCount(view.buffer, UnresolvedAddress, restrictionDeletionsCount);
-		view.shiftRight(restrictionDeletions.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(restrictionDeletions));
 
 		const instance = new AccountAddressRestrictionTransaction();
 		instance._signature = signature;
@@ -15821,8 +15821,8 @@ class EmbeddedAccountAddressRestrictionTransaction {
 		size += 1;
 		size += 1;
 		size += 4;
-		size += this.restrictionAdditions.map(e => e.size).reduce((a, b) => a + b, 0);
-		size += this.restrictionDeletions.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.restrictionAdditions);
+		size += arrayHelpers.size(this.restrictionDeletions);
 		return size;
 	}
 
@@ -15858,9 +15858,9 @@ class EmbeddedAccountAddressRestrictionTransaction {
 		if (0 !== accountRestrictionTransactionBodyReserved_1)
 			throw RangeError(`Invalid value of reserved field (${accountRestrictionTransactionBodyReserved_1})`);
 		const restrictionAdditions = arrayHelpers.readArrayCount(view.buffer, UnresolvedAddress, restrictionAdditionsCount);
-		view.shiftRight(restrictionAdditions.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(restrictionAdditions));
 		const restrictionDeletions = arrayHelpers.readArrayCount(view.buffer, UnresolvedAddress, restrictionDeletionsCount);
-		view.shiftRight(restrictionDeletions.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(restrictionDeletions));
 
 		const instance = new EmbeddedAccountAddressRestrictionTransaction();
 		instance._signerPublicKey = signerPublicKey;
@@ -16034,8 +16034,8 @@ class AccountMosaicRestrictionTransaction {
 		size += 1;
 		size += 1;
 		size += 4;
-		size += this.restrictionAdditions.map(e => e.size).reduce((a, b) => a + b, 0);
-		size += this.restrictionDeletions.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.restrictionAdditions);
+		size += arrayHelpers.size(this.restrictionDeletions);
 		return size;
 	}
 
@@ -16077,9 +16077,9 @@ class AccountMosaicRestrictionTransaction {
 		if (0 !== accountRestrictionTransactionBodyReserved_1)
 			throw RangeError(`Invalid value of reserved field (${accountRestrictionTransactionBodyReserved_1})`);
 		const restrictionAdditions = arrayHelpers.readArrayCount(view.buffer, UnresolvedMosaicId, restrictionAdditionsCount);
-		view.shiftRight(restrictionAdditions.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(restrictionAdditions));
 		const restrictionDeletions = arrayHelpers.readArrayCount(view.buffer, UnresolvedMosaicId, restrictionDeletionsCount);
-		view.shiftRight(restrictionDeletions.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(restrictionDeletions));
 
 		const instance = new AccountMosaicRestrictionTransaction();
 		instance._signature = signature;
@@ -16229,8 +16229,8 @@ class EmbeddedAccountMosaicRestrictionTransaction {
 		size += 1;
 		size += 1;
 		size += 4;
-		size += this.restrictionAdditions.map(e => e.size).reduce((a, b) => a + b, 0);
-		size += this.restrictionDeletions.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.restrictionAdditions);
+		size += arrayHelpers.size(this.restrictionDeletions);
 		return size;
 	}
 
@@ -16266,9 +16266,9 @@ class EmbeddedAccountMosaicRestrictionTransaction {
 		if (0 !== accountRestrictionTransactionBodyReserved_1)
 			throw RangeError(`Invalid value of reserved field (${accountRestrictionTransactionBodyReserved_1})`);
 		const restrictionAdditions = arrayHelpers.readArrayCount(view.buffer, UnresolvedMosaicId, restrictionAdditionsCount);
-		view.shiftRight(restrictionAdditions.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(restrictionAdditions));
 		const restrictionDeletions = arrayHelpers.readArrayCount(view.buffer, UnresolvedMosaicId, restrictionDeletionsCount);
-		view.shiftRight(restrictionDeletions.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(restrictionDeletions));
 
 		const instance = new EmbeddedAccountMosaicRestrictionTransaction();
 		instance._signerPublicKey = signerPublicKey;
@@ -16442,8 +16442,8 @@ class AccountOperationRestrictionTransaction {
 		size += 1;
 		size += 1;
 		size += 4;
-		size += this.restrictionAdditions.map(e => e.size).reduce((a, b) => a + b, 0);
-		size += this.restrictionDeletions.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.restrictionAdditions);
+		size += arrayHelpers.size(this.restrictionDeletions);
 		return size;
 	}
 
@@ -16485,9 +16485,9 @@ class AccountOperationRestrictionTransaction {
 		if (0 !== accountRestrictionTransactionBodyReserved_1)
 			throw RangeError(`Invalid value of reserved field (${accountRestrictionTransactionBodyReserved_1})`);
 		const restrictionAdditions = arrayHelpers.readArrayCount(view.buffer, TransactionType, restrictionAdditionsCount);
-		view.shiftRight(restrictionAdditions.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(restrictionAdditions));
 		const restrictionDeletions = arrayHelpers.readArrayCount(view.buffer, TransactionType, restrictionDeletionsCount);
-		view.shiftRight(restrictionDeletions.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(restrictionDeletions));
 
 		const instance = new AccountOperationRestrictionTransaction();
 		instance._signature = signature;
@@ -16637,8 +16637,8 @@ class EmbeddedAccountOperationRestrictionTransaction {
 		size += 1;
 		size += 1;
 		size += 4;
-		size += this.restrictionAdditions.map(e => e.size).reduce((a, b) => a + b, 0);
-		size += this.restrictionDeletions.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.restrictionAdditions);
+		size += arrayHelpers.size(this.restrictionDeletions);
 		return size;
 	}
 
@@ -16674,9 +16674,9 @@ class EmbeddedAccountOperationRestrictionTransaction {
 		if (0 !== accountRestrictionTransactionBodyReserved_1)
 			throw RangeError(`Invalid value of reserved field (${accountRestrictionTransactionBodyReserved_1})`);
 		const restrictionAdditions = arrayHelpers.readArrayCount(view.buffer, TransactionType, restrictionAdditionsCount);
-		view.shiftRight(restrictionAdditions.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(restrictionAdditions));
 		const restrictionDeletions = arrayHelpers.readArrayCount(view.buffer, TransactionType, restrictionDeletionsCount);
-		view.shiftRight(restrictionDeletions.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(restrictionDeletions));
 
 		const instance = new EmbeddedAccountOperationRestrictionTransaction();
 		instance._signerPublicKey = signerPublicKey;
@@ -17788,7 +17788,7 @@ class TransferTransaction {
 		size += 1;
 		size += 1;
 		size += 4;
-		size += this.mosaics.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.mosaics);
 		size += this._message.length;
 		return size;
 	}
@@ -17835,7 +17835,7 @@ class TransferTransaction {
 		if (0 !== transferTransactionBodyReserved_2)
 			throw RangeError(`Invalid value of reserved field (${transferTransactionBodyReserved_2})`);
 		const mosaics = arrayHelpers.readArrayCount(view.buffer, UnresolvedMosaic, mosaicsCount, e => e.mosaicId.value);
-		view.shiftRight(mosaics.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(mosaics));
 		const message = new Uint8Array(view.buffer.buffer, view.buffer.byteOffset, messageSize);
 		view.shiftRight(messageSize);
 
@@ -17990,7 +17990,7 @@ class EmbeddedTransferTransaction {
 		size += 1;
 		size += 1;
 		size += 4;
-		size += this.mosaics.map(e => e.size).reduce((a, b) => a + b, 0);
+		size += arrayHelpers.size(this.mosaics);
 		size += this._message.length;
 		return size;
 	}
@@ -18031,7 +18031,7 @@ class EmbeddedTransferTransaction {
 		if (0 !== transferTransactionBodyReserved_2)
 			throw RangeError(`Invalid value of reserved field (${transferTransactionBodyReserved_2})`);
 		const mosaics = arrayHelpers.readArrayCount(view.buffer, UnresolvedMosaic, mosaicsCount, e => e.mosaicId.value);
-		view.shiftRight(mosaics.map(e => e.size).reduce((a, b) => a + b, 0));
+		view.shiftRight(arrayHelpers.size(mosaics));
 		const message = new Uint8Array(view.buffer.buffer, view.buffer.byteOffset, messageSize);
 		view.shiftRight(messageSize);
 

--- a/sdk/javascript/src/utils/arrayHelpers.js
+++ b/sdk/javascript/src/utils/arrayHelpers.js
@@ -34,6 +34,8 @@ const writeArrayImpl = (output, elements, count, accessor = null) => {
 	}
 };
 
+const sum = numbers => numbers.reduce((a, b) => a + b, 0);
+
 const arrayHelpers = {
 	/**
 	 * Calculates aligned size.
@@ -42,6 +44,23 @@ const arrayHelpers = {
 	 * @returns {number} Size rounded up to alignment.
 	 */
 	alignUp: (size, alignment) => Math.floor((size + alignment - 1) / alignment) * alignment,
+
+	/**
+	 * Calculates size of variable size objects.
+	 * @param {array<object>} elements Serializable elements.
+	 * @param {number} alignment Alignment used for calculations.
+	 * @param {boolean} skipLastElementPadding true if last element should not be aligned.
+	 * @returns {number} Computed size.
+	 */
+	size: (elements, alignment = 0, skipLastElementPadding = undefined) => {
+		if (!alignment)
+			return sum(elements.map(e => e.size));
+
+		if (!skipLastElementPadding)
+			return sum(elements.map(e => arrayHelpers.alignUp(e.size, alignment)));
+
+		return sum(elements.slice(0, -1).map(e => arrayHelpers.alignUp(e.size, alignment))) + sum(elements.slice(-1).map(e => e.size));
+	},
 
 	/**
 	 * Reads array of objects.
@@ -71,9 +90,10 @@ const arrayHelpers = {
 	 * @param {Uint8Array} bufferInput A uint8 array.
 	 * @param {type} FactoryClass Factory used to deserialize objects.
 	 * @param {number} alignment Alignment used to make sure each object is at boundary.
+	 * @param {boolean} skipLastElementPadding true if last element is not aligned/padded.
 	 * @returns {array<object>} Array of deserialized objects.
 	 */
-	readVariableSizeElements: (bufferInput, FactoryClass, alignment) => {
+	readVariableSizeElements: (bufferInput, FactoryClass, alignment, skipLastElementPadding = false) => {
 		const view = new BufferView(bufferInput);
 		const elements = [];
 		while (0 < view.buffer.length) {
@@ -84,7 +104,9 @@ const arrayHelpers = {
 
 			elements.push(element);
 
-			const alignedSize = arrayHelpers.alignUp(element.size, alignment);
+			const alignedSize = (skipLastElementPadding && element.size >= view.buffer.length)
+				? element.size
+				: arrayHelpers.alignUp(element.size, alignment);
 			if (alignedSize > view.buffer.length)
 				throw RangeError('unexpected buffer length');
 
@@ -118,13 +140,16 @@ const arrayHelpers = {
 	 * @param {Writer} output An output sink.
 	 * @param {array<object>} elements Serializable elements.
 	 * @param {number} alignment Alignment used to make sure each object is at boundary.
+	 * @param {boolean} skipLastElementPadding true if last element should not be aligned/padded.
 	 */
-	writeVariableSizeElements: (output, elements, alignment) => {
-		elements.forEach(element => {
+	writeVariableSizeElements: (output, elements, alignment, skipLastElementPadding = false) => {
+		elements.forEach((element, index) => {
 			output.write(element.serialize());
-			const alignedSize = arrayHelpers.alignUp(element.size, alignment);
-			if (alignedSize - element.size)
-				output.write(new Uint8Array(alignedSize - element.size));
+			if (!skipLastElementPadding || elements.length - 1 !== index) {
+				const alignedSize = arrayHelpers.alignUp(element.size, alignment);
+				if (alignedSize - element.size)
+					output.write(new Uint8Array(alignedSize - element.size));
+			}
 		});
 	}
 };

--- a/sdk/python/symbolchain/ArrayHelpers.py
+++ b/sdk/python/symbolchain/ArrayHelpers.py
@@ -48,6 +48,17 @@ class ArrayHelpers:
 		return (size + alignment - 1) // alignment * alignment
 
 	@staticmethod
+	def size(elements, alignment=0, skip_last_element_padding=False):
+		"""Calculates size of variable size objects."""
+		if not alignment:
+			return sum(map(lambda e: e.size, elements))
+
+		if not skip_last_element_padding:
+			return sum(map(lambda e: ArrayHelpers.align_up(e.size, alignment), elements))
+
+		return sum(map(lambda e: ArrayHelpers.align_up(e.size, alignment), elements[:-1])) + sum(map(lambda e: e.size, elements[-1:]))
+
+	@staticmethod
 	def read_array(view, factory_class, accessor=None):
 		"""Reads array of objects."""
 		return read_array_impl(view, factory_class, accessor, lambda _, view: len(view) > 0)
@@ -58,7 +69,7 @@ class ArrayHelpers:
 		return read_array_impl(view, factory_class, accessor, lambda index, _: count > index)
 
 	@staticmethod
-	def read_variable_size_elements(view, factory_class, alignment):
+	def read_variable_size_elements(view, factory_class, alignment, skip_last_element_padding=False):
 		"""Reads array of variable size objects."""
 		elements = []
 		while len(view) > 0:
@@ -70,6 +81,9 @@ class ArrayHelpers:
 			elements.append(element)
 
 			aligned_size = ArrayHelpers.align_up(element.size, alignment)
+			if skip_last_element_padding and element.size >= len(view):
+				aligned_size = element.size
+
 			if aligned_size > len(view):
 				raise ValueError('unexpected buffer length')
 
@@ -88,14 +102,15 @@ class ArrayHelpers:
 		return write_array_impl(elements, count, accessor)
 
 	@staticmethod
-	def write_variable_size_elements(elements, alignment):
+	def write_variable_size_elements(elements, alignment, skip_last_element_padding=False):
 		"""Writes array of variable size objects."""
 		output_buffer = bytes()
-		for element in elements:
+		for index, element in enumerate(elements):
 			output_buffer += element.serialize()
 
-			aligned_size = ArrayHelpers.align_up(element.size, alignment)
-			if aligned_size != element.size:
-				output_buffer += bytes(aligned_size - element.size)
+			if not skip_last_element_padding or len(elements) - 1 != index:
+				aligned_size = ArrayHelpers.align_up(element.size, alignment)
+				if aligned_size != element.size:
+					output_buffer += bytes(aligned_size - element.size)
 
 		return output_buffer

--- a/sdk/python/symbolchain/nc/__init__.py
+++ b/sdk/python/symbolchain/nc/__init__.py
@@ -641,7 +641,7 @@ class Block:
 		size += self.previous_block_hash.size
 		size += self.height.size
 		size += 4
-		size += sum(map(lambda e: e.size, self.transactions))
+		size += ArrayHelpers.size(self.transactions)
 		return size
 
 	@classmethod
@@ -675,7 +675,7 @@ class Block:
 		transactions_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
 		buffer = buffer[4:]
 		transactions = ArrayHelpers.read_array_count(buffer, Transaction, transactions_count)
-		buffer = buffer[sum(map(lambda e: e.size, transactions)):]
+		buffer = buffer[ArrayHelpers.size(transactions):]
 
 		instance = Block()
 		instance._type_ = type_
@@ -1685,7 +1685,7 @@ class MosaicDefinition:
 		size += 4
 		size += len(self._description)
 		size += 4
-		size += sum(map(lambda e: e.size, self.properties))
+		size += ArrayHelpers.size(self.properties)
 		size += 4
 		if 0 != self.levy_size:
 			size += self.levy.size
@@ -1711,7 +1711,7 @@ class MosaicDefinition:
 		properties_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
 		buffer = buffer[4:]
 		properties = ArrayHelpers.read_array_count(buffer, SizePrefixedMosaicProperty, properties_count)
-		buffer = buffer[sum(map(lambda e: e.size, properties)):]
+		buffer = buffer[ArrayHelpers.size(properties):]
 		levy_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
 		buffer = buffer[4:]
 		levy = None
@@ -2904,7 +2904,7 @@ class MultisigAccountModificationTransactionV1:
 		size += self.fee.size
 		size += self.deadline.size
 		size += 4
-		size += sum(map(lambda e: e.size, self.modifications))
+		size += ArrayHelpers.size(self.modifications)
 		return size
 
 	@classmethod
@@ -2938,7 +2938,7 @@ class MultisigAccountModificationTransactionV1:
 		modifications_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
 		buffer = buffer[4:]
 		modifications = ArrayHelpers.read_array_count(buffer, SizePrefixedMultisigAccountModification, modifications_count)
-		buffer = buffer[sum(map(lambda e: e.size, modifications)):]
+		buffer = buffer[ArrayHelpers.size(modifications):]
 
 		instance = MultisigAccountModificationTransactionV1()
 		instance._type_ = type_
@@ -3086,7 +3086,7 @@ class NonVerifiableMultisigAccountModificationTransactionV1:
 		size += self.fee.size
 		size += self.deadline.size
 		size += 4
-		size += sum(map(lambda e: e.size, self.modifications))
+		size += ArrayHelpers.size(self.modifications)
 		return size
 
 	@classmethod
@@ -3115,7 +3115,7 @@ class NonVerifiableMultisigAccountModificationTransactionV1:
 		modifications_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
 		buffer = buffer[4:]
 		modifications = ArrayHelpers.read_array_count(buffer, SizePrefixedMultisigAccountModification, modifications_count)
-		buffer = buffer[sum(map(lambda e: e.size, modifications)):]
+		buffer = buffer[ArrayHelpers.size(modifications):]
 
 		instance = NonVerifiableMultisigAccountModificationTransactionV1()
 		instance._type_ = type_
@@ -3282,7 +3282,7 @@ class MultisigAccountModificationTransaction:
 		size += self.fee.size
 		size += self.deadline.size
 		size += 4
-		size += sum(map(lambda e: e.size, self.modifications))
+		size += ArrayHelpers.size(self.modifications)
 		size += 4
 		size += 4
 		return size
@@ -3318,7 +3318,7 @@ class MultisigAccountModificationTransaction:
 		modifications_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
 		buffer = buffer[4:]
 		modifications = ArrayHelpers.read_array_count(buffer, SizePrefixedMultisigAccountModification, modifications_count)
-		buffer = buffer[sum(map(lambda e: e.size, modifications)):]
+		buffer = buffer[ArrayHelpers.size(modifications):]
 		min_approval_delta_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
 		buffer = buffer[4:]
 		assert min_approval_delta_size == 4, f'Invalid value of reserved field ({min_approval_delta_size})'
@@ -3485,7 +3485,7 @@ class NonVerifiableMultisigAccountModificationTransaction:
 		size += self.fee.size
 		size += self.deadline.size
 		size += 4
-		size += sum(map(lambda e: e.size, self.modifications))
+		size += ArrayHelpers.size(self.modifications)
 		size += 4
 		size += 4
 		return size
@@ -3516,7 +3516,7 @@ class NonVerifiableMultisigAccountModificationTransaction:
 		modifications_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
 		buffer = buffer[4:]
 		modifications = ArrayHelpers.read_array_count(buffer, SizePrefixedMultisigAccountModification, modifications_count)
-		buffer = buffer[sum(map(lambda e: e.size, modifications)):]
+		buffer = buffer[ArrayHelpers.size(modifications):]
 		min_approval_delta_size = int.from_bytes(buffer[:4], byteorder='little', signed=False)
 		buffer = buffer[4:]
 		assert min_approval_delta_size == 4, f'Invalid value of reserved field ({min_approval_delta_size})'
@@ -3968,7 +3968,7 @@ class MultisigTransaction:
 		size += 4
 		size += self.inner_transaction.size
 		size += 4
-		size += sum(map(lambda e: e.size, self.cosignatures))
+		size += ArrayHelpers.size(self.cosignatures)
 		return size
 
 	@classmethod
@@ -4007,7 +4007,7 @@ class MultisigTransaction:
 		cosignatures_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
 		buffer = buffer[4:]
 		cosignatures = ArrayHelpers.read_array_count(buffer, SizePrefixedCosignature, cosignatures_count)
-		buffer = buffer[sum(map(lambda e: e.size, cosignatures)):]
+		buffer = buffer[ArrayHelpers.size(cosignatures):]
 
 		instance = MultisigTransaction()
 		instance._type_ = type_
@@ -5271,7 +5271,7 @@ class TransferTransaction:
 		if 0 != self.message_envelope_size:
 			size += self.message.size
 		size += 4
-		size += sum(map(lambda e: e.size, self.mosaics))
+		size += ArrayHelpers.size(self.mosaics)
 		return size
 
 	@classmethod
@@ -5318,7 +5318,7 @@ class TransferTransaction:
 		mosaics_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
 		buffer = buffer[4:]
 		mosaics = ArrayHelpers.read_array_count(buffer, SizePrefixedMosaic, mosaics_count)
-		buffer = buffer[sum(map(lambda e: e.size, mosaics)):]
+		buffer = buffer[ArrayHelpers.size(mosaics):]
 
 		instance = TransferTransaction()
 		instance._type_ = type_
@@ -5527,7 +5527,7 @@ class NonVerifiableTransferTransaction:
 		if 0 != self.message_envelope_size:
 			size += self.message.size
 		size += 4
-		size += sum(map(lambda e: e.size, self.mosaics))
+		size += ArrayHelpers.size(self.mosaics)
 		return size
 
 	@classmethod
@@ -5569,7 +5569,7 @@ class NonVerifiableTransferTransaction:
 		mosaics_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
 		buffer = buffer[4:]
 		mosaics = ArrayHelpers.read_array_count(buffer, SizePrefixedMosaic, mosaics_count)
-		buffer = buffer[sum(map(lambda e: e.size, mosaics)):]
+		buffer = buffer[ArrayHelpers.size(mosaics):]
 
 		instance = NonVerifiableTransferTransaction()
 		instance._type_ = type_

--- a/sdk/python/symbolchain/sc/__init__.py
+++ b/sdk/python/symbolchain/sc/__init__.py
@@ -1469,7 +1469,7 @@ class NemesisBlock:
 		size += 8
 		size += self.total_voting_balance.size
 		size += self.previous_importance_block_hash.size
-		size += sum(map(lambda e: ArrayHelpers.align_up(e.size, 8), self.transactions[:-1])) + sum(map(lambda e: e.size, self.transactions[-1:]))
+		size += ArrayHelpers.size(self.transactions, 8, skip_last_element_padding=True)
 		return size
 
 	@classmethod
@@ -1523,8 +1523,8 @@ class NemesisBlock:
 		buffer = buffer[total_voting_balance.size:]
 		previous_importance_block_hash = Hash256.deserialize(buffer)
 		buffer = buffer[previous_importance_block_hash.size:]
-		transactions = ArrayHelpers.read_variable_size_elements(buffer, TransactionFactory, 8)
-		buffer = buffer[sum(map(lambda e: ArrayHelpers.align_up(e.size, 8), transactions[:-1])) + sum(map(lambda e: e.size, transactions[-1:])):]
+		transactions = ArrayHelpers.read_variable_size_elements(buffer, TransactionFactory, 8, skip_last_element_padding=True)
+		buffer = buffer[ArrayHelpers.size(transactions, 8, skip_last_element_padding=True):]
 
 		instance = NemesisBlock()
 		instance._signature = signature
@@ -1573,7 +1573,7 @@ class NemesisBlock:
 		buffer += self._harvesting_eligible_accounts_count.to_bytes(8, byteorder='little', signed=False)
 		buffer += self._total_voting_balance.serialize()
 		buffer += self._previous_importance_block_hash.serialize()
-		buffer += ArrayHelpers.write_variable_size_elements(self._transactions, 8)
+		buffer += ArrayHelpers.write_variable_size_elements(self._transactions, 8, skip_last_element_padding=True)
 		return buffer
 
 	def __str__(self) -> str:
@@ -1794,7 +1794,7 @@ class NormalBlock:
 		size += self.beneficiary_address.size
 		size += self.fee_multiplier.size
 		size += 4
-		size += sum(map(lambda e: ArrayHelpers.align_up(e.size, 8), self.transactions[:-1])) + sum(map(lambda e: e.size, self.transactions[-1:]))
+		size += ArrayHelpers.size(self.transactions, 8, skip_last_element_padding=True)
 		return size
 
 	@classmethod
@@ -1843,8 +1843,8 @@ class NormalBlock:
 		block_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
 		buffer = buffer[4:]
 		assert block_header_reserved_1 == 0, f'Invalid value of reserved field ({block_header_reserved_1})'
-		transactions = ArrayHelpers.read_variable_size_elements(buffer, TransactionFactory, 8)
-		buffer = buffer[sum(map(lambda e: ArrayHelpers.align_up(e.size, 8), transactions[:-1])) + sum(map(lambda e: e.size, transactions[-1:])):]
+		transactions = ArrayHelpers.read_variable_size_elements(buffer, TransactionFactory, 8, skip_last_element_padding=True)
+		buffer = buffer[ArrayHelpers.size(transactions, 8, skip_last_element_padding=True):]
 
 		instance = NormalBlock()
 		instance._signature = signature
@@ -1886,7 +1886,7 @@ class NormalBlock:
 		buffer += self._beneficiary_address.serialize()
 		buffer += self._fee_multiplier.serialize()
 		buffer += self._block_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer += ArrayHelpers.write_variable_size_elements(self._transactions, 8)
+		buffer += ArrayHelpers.write_variable_size_elements(self._transactions, 8, skip_last_element_padding=True)
 		return buffer
 
 	def __str__(self) -> str:
@@ -2143,7 +2143,7 @@ class ImportanceBlock:
 		size += 8
 		size += self.total_voting_balance.size
 		size += self.previous_importance_block_hash.size
-		size += sum(map(lambda e: ArrayHelpers.align_up(e.size, 8), self.transactions[:-1])) + sum(map(lambda e: e.size, self.transactions[-1:]))
+		size += ArrayHelpers.size(self.transactions, 8, skip_last_element_padding=True)
 		return size
 
 	@classmethod
@@ -2197,8 +2197,8 @@ class ImportanceBlock:
 		buffer = buffer[total_voting_balance.size:]
 		previous_importance_block_hash = Hash256.deserialize(buffer)
 		buffer = buffer[previous_importance_block_hash.size:]
-		transactions = ArrayHelpers.read_variable_size_elements(buffer, TransactionFactory, 8)
-		buffer = buffer[sum(map(lambda e: ArrayHelpers.align_up(e.size, 8), transactions[:-1])) + sum(map(lambda e: e.size, transactions[-1:])):]
+		transactions = ArrayHelpers.read_variable_size_elements(buffer, TransactionFactory, 8, skip_last_element_padding=True)
+		buffer = buffer[ArrayHelpers.size(transactions, 8, skip_last_element_padding=True):]
 
 		instance = ImportanceBlock()
 		instance._signature = signature
@@ -2247,7 +2247,7 @@ class ImportanceBlock:
 		buffer += self._harvesting_eligible_accounts_count.to_bytes(8, byteorder='little', signed=False)
 		buffer += self._total_voting_balance.serialize()
 		buffer += self._previous_importance_block_hash.serialize()
-		buffer += ArrayHelpers.write_variable_size_elements(self._transactions, 8)
+		buffer += ArrayHelpers.write_variable_size_elements(self._transactions, 8, skip_last_element_padding=True)
 		return buffer
 
 	def __str__(self) -> str:
@@ -3954,7 +3954,7 @@ class AddressResolutionStatement:
 		size = 0
 		size += self.unresolved.size
 		size += 4
-		size += sum(map(lambda e: e.size, self.resolution_entries))
+		size += ArrayHelpers.size(self.resolution_entries)
 		return size
 
 	@classmethod
@@ -3965,7 +3965,7 @@ class AddressResolutionStatement:
 		resolution_entries_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
 		buffer = buffer[4:]
 		resolution_entries = ArrayHelpers.read_array_count(buffer, AddressResolutionEntry, resolution_entries_count)
-		buffer = buffer[sum(map(lambda e: e.size, resolution_entries)):]
+		buffer = buffer[ArrayHelpers.size(resolution_entries):]
 
 		instance = AddressResolutionStatement()
 		instance._unresolved = unresolved
@@ -4078,7 +4078,7 @@ class MosaicResolutionStatement:
 		size = 0
 		size += self.unresolved.size
 		size += 4
-		size += sum(map(lambda e: e.size, self.resolution_entries))
+		size += ArrayHelpers.size(self.resolution_entries)
 		return size
 
 	@classmethod
@@ -4089,7 +4089,7 @@ class MosaicResolutionStatement:
 		resolution_entries_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
 		buffer = buffer[4:]
 		resolution_entries = ArrayHelpers.read_array_count(buffer, MosaicResolutionEntry, resolution_entries_count)
-		buffer = buffer[sum(map(lambda e: e.size, resolution_entries)):]
+		buffer = buffer[ArrayHelpers.size(resolution_entries):]
 
 		instance = MosaicResolutionStatement()
 		instance._unresolved = unresolved
@@ -4151,7 +4151,7 @@ class TransactionStatement:
 		size += 4
 		size += 4
 		size += 4
-		size += sum(map(lambda e: e.size, self.receipts))
+		size += ArrayHelpers.size(self.receipts)
 		return size
 
 	@classmethod
@@ -4164,7 +4164,7 @@ class TransactionStatement:
 		receipt_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
 		buffer = buffer[4:]
 		receipts = ArrayHelpers.read_array_count(buffer, Receipt, receipt_count)
-		buffer = buffer[sum(map(lambda e: e.size, receipts)):]
+		buffer = buffer[ArrayHelpers.size(receipts):]
 
 		instance = TransactionStatement()
 		instance._primary_id = primary_id
@@ -4229,11 +4229,11 @@ class BlockStatement:
 	def size(self) -> int:
 		size = 0
 		size += 4
-		size += sum(map(lambda e: e.size, self.transaction_statements))
+		size += ArrayHelpers.size(self.transaction_statements)
 		size += 4
-		size += sum(map(lambda e: e.size, self.address_resolution_statements))
+		size += ArrayHelpers.size(self.address_resolution_statements)
 		size += 4
-		size += sum(map(lambda e: e.size, self.mosaic_resolution_statements))
+		size += ArrayHelpers.size(self.mosaic_resolution_statements)
 		return size
 
 	@classmethod
@@ -4242,15 +4242,15 @@ class BlockStatement:
 		transaction_statement_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
 		buffer = buffer[4:]
 		transaction_statements = ArrayHelpers.read_array_count(buffer, TransactionStatement, transaction_statement_count)
-		buffer = buffer[sum(map(lambda e: e.size, transaction_statements)):]
+		buffer = buffer[ArrayHelpers.size(transaction_statements):]
 		address_resolution_statement_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
 		buffer = buffer[4:]
 		address_resolution_statements = ArrayHelpers.read_array_count(buffer, AddressResolutionStatement, address_resolution_statement_count)
-		buffer = buffer[sum(map(lambda e: e.size, address_resolution_statements)):]
+		buffer = buffer[ArrayHelpers.size(address_resolution_statements):]
 		mosaic_resolution_statement_count = int.from_bytes(buffer[:4], byteorder='little', signed=False)
 		buffer = buffer[4:]
 		mosaic_resolution_statements = ArrayHelpers.read_array_count(buffer, MosaicResolutionStatement, mosaic_resolution_statement_count)
-		buffer = buffer[sum(map(lambda e: e.size, mosaic_resolution_statements)):]
+		buffer = buffer[ArrayHelpers.size(mosaic_resolution_statements):]
 
 		instance = BlockStatement()
 		instance._transaction_statements = transaction_statements
@@ -4583,14 +4583,14 @@ class HeightActivityBuckets:
 	@property
 	def size(self) -> int:
 		size = 0
-		size += sum(map(lambda e: e.size, self.buckets))
+		size += ArrayHelpers.size(self.buckets)
 		return size
 
 	@classmethod
 	def deserialize(cls, payload: ByteString) -> HeightActivityBuckets:
 		buffer = memoryview(payload)
 		buckets = ArrayHelpers.read_array_count(buffer, HeightActivityBucket, 5)
-		buffer = buffer[sum(map(lambda e: e.size, buckets)):]
+		buffer = buffer[ArrayHelpers.size(buckets):]
 
 		instance = HeightActivityBuckets()
 		instance._buckets = buckets
@@ -4781,13 +4781,13 @@ class AccountState:
 			size += self.node_public_key.size
 		if AccountKeyTypeFlags.VRF in self.supplemental_public_keys_mask:
 			size += self.vrf_public_key.size
-		size += sum(map(lambda e: e.size, self.voting_public_keys))
+		size += ArrayHelpers.size(self.voting_public_keys)
 		if AccountStateFormat.HIGH_VALUE == self.format:
 			size += self.importance_snapshots.size
 		if AccountStateFormat.HIGH_VALUE == self.format:
 			size += self.activity_buckets.size
 		size += 2
-		size += sum(map(lambda e: e.size, self.balances))
+		size += ArrayHelpers.size(self.balances)
 		return size
 
 	@classmethod
@@ -4824,7 +4824,7 @@ class AccountState:
 			vrf_public_key = PublicKey.deserialize(buffer)
 			buffer = buffer[vrf_public_key.size:]
 		voting_public_keys = ArrayHelpers.read_array_count(buffer, PinnedVotingKey, voting_public_keys_count)
-		buffer = buffer[sum(map(lambda e: e.size, voting_public_keys)):]
+		buffer = buffer[ArrayHelpers.size(voting_public_keys):]
 		importance_snapshots = None
 		if AccountStateFormat.HIGH_VALUE == format:
 			importance_snapshots = ImportanceSnapshot.deserialize(buffer)
@@ -4836,7 +4836,7 @@ class AccountState:
 		balances_count = int.from_bytes(buffer[:2], byteorder='little', signed=False)
 		buffer = buffer[2:]
 		balances = ArrayHelpers.read_array_count(buffer, Mosaic, balances_count)
-		buffer = buffer[sum(map(lambda e: e.size, balances)):]
+		buffer = buffer[ArrayHelpers.size(balances):]
 
 		instance = AccountState()
 		instance._version = version
@@ -5655,9 +5655,9 @@ class MultisigEntry:
 		size += 4
 		size += self.account_address.size
 		size += 8
-		size += sum(map(lambda e: e.size, self.cosignatory_addresses))
+		size += ArrayHelpers.size(self.cosignatory_addresses)
 		size += 8
-		size += sum(map(lambda e: e.size, self.multisig_addresses))
+		size += ArrayHelpers.size(self.multisig_addresses)
 		return size
 
 	@classmethod
@@ -5674,11 +5674,11 @@ class MultisigEntry:
 		cosignatory_addresses_count = int.from_bytes(buffer[:8], byteorder='little', signed=False)
 		buffer = buffer[8:]
 		cosignatory_addresses = ArrayHelpers.read_array_count(buffer, Address, cosignatory_addresses_count)
-		buffer = buffer[sum(map(lambda e: e.size, cosignatory_addresses)):]
+		buffer = buffer[ArrayHelpers.size(cosignatory_addresses):]
 		multisig_addresses_count = int.from_bytes(buffer[:8], byteorder='little', signed=False)
 		buffer = buffer[8:]
 		multisig_addresses = ArrayHelpers.read_array_count(buffer, Address, multisig_addresses_count)
-		buffer = buffer[sum(map(lambda e: e.size, multisig_addresses)):]
+		buffer = buffer[ArrayHelpers.size(multisig_addresses):]
 
 		instance = MultisigEntry()
 		instance._version = version
@@ -5909,7 +5909,7 @@ class NamespacePath:
 	def size(self) -> int:
 		size = 0
 		size += 1
-		size += sum(map(lambda e: e.size, self.path))
+		size += ArrayHelpers.size(self.path)
 		size += self.alias.size
 		return size
 
@@ -5919,7 +5919,7 @@ class NamespacePath:
 		path_size = int.from_bytes(buffer[:1], byteorder='little', signed=False)
 		buffer = buffer[1:]
 		path = ArrayHelpers.read_array_count(buffer, NamespaceId, path_size)
-		buffer = buffer[sum(map(lambda e: e.size, path)):]
+		buffer = buffer[ArrayHelpers.size(path):]
 		alias = NamespaceAlias.deserialize(buffer)
 		buffer = buffer[alias.size:]
 
@@ -6017,7 +6017,7 @@ class RootNamespaceHistory:
 		size += self.lifetime.size
 		size += self.root_alias.size
 		size += 8
-		size += sum(map(lambda e: e.size, self.paths))
+		size += ArrayHelpers.size(self.paths)
 		return size
 
 	@classmethod
@@ -6036,7 +6036,7 @@ class RootNamespaceHistory:
 		children_count = int.from_bytes(buffer[:8], byteorder='little', signed=False)
 		buffer = buffer[8:]
 		paths = ArrayHelpers.read_array_count(buffer, NamespacePath, children_count, lambda e: e.path)
-		buffer = buffer[sum(map(lambda e: e.size, paths)):]
+		buffer = buffer[ArrayHelpers.size(paths):]
 
 		instance = RootNamespaceHistory()
 		instance._version = version
@@ -6112,7 +6112,7 @@ class AccountRestrictionAddressValue:
 	def size(self) -> int:
 		size = 0
 		size += 8
-		size += sum(map(lambda e: e.size, self.restriction_values))
+		size += ArrayHelpers.size(self.restriction_values)
 		return size
 
 	@classmethod
@@ -6121,7 +6121,7 @@ class AccountRestrictionAddressValue:
 		restriction_values_count = int.from_bytes(buffer[:8], byteorder='little', signed=False)
 		buffer = buffer[8:]
 		restriction_values = ArrayHelpers.read_array_count(buffer, Address, restriction_values_count)
-		buffer = buffer[sum(map(lambda e: e.size, restriction_values)):]
+		buffer = buffer[ArrayHelpers.size(restriction_values):]
 
 		instance = AccountRestrictionAddressValue()
 		instance._restriction_values = restriction_values
@@ -6160,7 +6160,7 @@ class AccountRestrictionMosaicValue:
 	def size(self) -> int:
 		size = 0
 		size += 8
-		size += sum(map(lambda e: e.size, self.restriction_values))
+		size += ArrayHelpers.size(self.restriction_values)
 		return size
 
 	@classmethod
@@ -6169,7 +6169,7 @@ class AccountRestrictionMosaicValue:
 		restriction_values_count = int.from_bytes(buffer[:8], byteorder='little', signed=False)
 		buffer = buffer[8:]
 		restriction_values = ArrayHelpers.read_array_count(buffer, MosaicId, restriction_values_count)
-		buffer = buffer[sum(map(lambda e: e.size, restriction_values)):]
+		buffer = buffer[ArrayHelpers.size(restriction_values):]
 
 		instance = AccountRestrictionMosaicValue()
 		instance._restriction_values = restriction_values
@@ -6208,7 +6208,7 @@ class AccountRestrictionTransactionTypeValue:
 	def size(self) -> int:
 		size = 0
 		size += 8
-		size += sum(map(lambda e: e.size, self.restriction_values))
+		size += ArrayHelpers.size(self.restriction_values)
 		return size
 
 	@classmethod
@@ -6217,7 +6217,7 @@ class AccountRestrictionTransactionTypeValue:
 		restriction_values_count = int.from_bytes(buffer[:8], byteorder='little', signed=False)
 		buffer = buffer[8:]
 		restriction_values = ArrayHelpers.read_array_count(buffer, TransactionType, restriction_values_count)
-		buffer = buffer[sum(map(lambda e: e.size, restriction_values)):]
+		buffer = buffer[ArrayHelpers.size(restriction_values):]
 
 		instance = AccountRestrictionTransactionTypeValue()
 		instance._restriction_values = restriction_values
@@ -6384,7 +6384,7 @@ class AccountRestrictions:
 		size += 2
 		size += self.address.size
 		size += 8
-		size += sum(map(lambda e: e.size, self.restrictions))
+		size += ArrayHelpers.size(self.restrictions)
 		return size
 
 	@classmethod
@@ -6397,7 +6397,7 @@ class AccountRestrictions:
 		restrictions_count = int.from_bytes(buffer[:8], byteorder='little', signed=False)
 		buffer = buffer[8:]
 		restrictions = ArrayHelpers.read_array_count(buffer, AccountRestrictionsInfo, restrictions_count)
-		buffer = buffer[sum(map(lambda e: e.size, restrictions)):]
+		buffer = buffer[ArrayHelpers.size(restrictions):]
 
 		instance = AccountRestrictions()
 		instance._version = version
@@ -6559,7 +6559,7 @@ class AddressKeyValueSet:
 	def size(self) -> int:
 		size = 0
 		size += 1
-		size += sum(map(lambda e: e.size, self.keys))
+		size += ArrayHelpers.size(self.keys)
 		return size
 
 	@classmethod
@@ -6568,7 +6568,7 @@ class AddressKeyValueSet:
 		key_value_count = int.from_bytes(buffer[:1], byteorder='little', signed=False)
 		buffer = buffer[1:]
 		keys = ArrayHelpers.read_array_count(buffer, AddressKeyValue, key_value_count, lambda e: e.key)
-		buffer = buffer[sum(map(lambda e: e.size, keys)):]
+		buffer = buffer[ArrayHelpers.size(keys):]
 
 		instance = AddressKeyValueSet()
 		instance._keys = keys
@@ -6742,7 +6742,7 @@ class GlobalKeyValueSet:
 	def size(self) -> int:
 		size = 0
 		size += 1
-		size += sum(map(lambda e: e.size, self.keys))
+		size += ArrayHelpers.size(self.keys)
 		return size
 
 	@classmethod
@@ -6751,7 +6751,7 @@ class GlobalKeyValueSet:
 		key_value_count = int.from_bytes(buffer[:1], byteorder='little', signed=False)
 		buffer = buffer[1:]
 		keys = ArrayHelpers.read_array_count(buffer, GlobalKeyValue, key_value_count, lambda e: e.key)
-		buffer = buffer[sum(map(lambda e: e.size, keys)):]
+		buffer = buffer[ArrayHelpers.size(keys):]
 
 		instance = GlobalKeyValueSet()
 		instance._keys = keys
@@ -8142,8 +8142,8 @@ class AggregateCompleteTransaction:
 		size += self.transactions_hash.size
 		size += 4
 		size += 4
-		size += sum(map(lambda e: ArrayHelpers.align_up(e.size, 8), self.transactions))
-		size += sum(map(lambda e: e.size, self.cosignatures))
+		size += ArrayHelpers.size(self.transactions, 8, skip_last_element_padding=False)
+		size += ArrayHelpers.size(self.cosignatures)
 		return size
 
 	@classmethod
@@ -8180,10 +8180,10 @@ class AggregateCompleteTransaction:
 		aggregate_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
 		buffer = buffer[4:]
 		assert aggregate_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({aggregate_transaction_header_reserved_1})'
-		transactions = ArrayHelpers.read_variable_size_elements(buffer[:payload_size], EmbeddedTransactionFactory, 8)
+		transactions = ArrayHelpers.read_variable_size_elements(buffer[:payload_size], EmbeddedTransactionFactory, 8, skip_last_element_padding=False)
 		buffer = buffer[payload_size:]
 		cosignatures = ArrayHelpers.read_array(buffer, Cosignature)
-		buffer = buffer[sum(map(lambda e: e.size, cosignatures)):]
+		buffer = buffer[ArrayHelpers.size(cosignatures):]
 
 		instance = AggregateCompleteTransaction()
 		instance._signature = signature
@@ -8211,9 +8211,9 @@ class AggregateCompleteTransaction:
 		buffer += self._fee.serialize()
 		buffer += self._deadline.serialize()
 		buffer += self._transactions_hash.serialize()
-		buffer += sum(map(lambda e: ArrayHelpers.align_up(e.size, 8), self.transactions)).to_bytes(4, byteorder='little', signed=False)  # payload_size
+		buffer += ArrayHelpers.size(self.transactions, 8, skip_last_element_padding=False).to_bytes(4, byteorder='little', signed=False)  # payload_size
 		buffer += self._aggregate_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer += ArrayHelpers.write_variable_size_elements(self._transactions, 8)
+		buffer += ArrayHelpers.write_variable_size_elements(self._transactions, 8, skip_last_element_padding=False)
 		buffer += ArrayHelpers.write_array(self._cosignatures)
 		return buffer
 
@@ -8359,8 +8359,8 @@ class AggregateBondedTransaction:
 		size += self.transactions_hash.size
 		size += 4
 		size += 4
-		size += sum(map(lambda e: ArrayHelpers.align_up(e.size, 8), self.transactions))
-		size += sum(map(lambda e: e.size, self.cosignatures))
+		size += ArrayHelpers.size(self.transactions, 8, skip_last_element_padding=False)
+		size += ArrayHelpers.size(self.cosignatures)
 		return size
 
 	@classmethod
@@ -8397,10 +8397,10 @@ class AggregateBondedTransaction:
 		aggregate_transaction_header_reserved_1 = int.from_bytes(buffer[:4], byteorder='little', signed=False)
 		buffer = buffer[4:]
 		assert aggregate_transaction_header_reserved_1 == 0, f'Invalid value of reserved field ({aggregate_transaction_header_reserved_1})'
-		transactions = ArrayHelpers.read_variable_size_elements(buffer[:payload_size], EmbeddedTransactionFactory, 8)
+		transactions = ArrayHelpers.read_variable_size_elements(buffer[:payload_size], EmbeddedTransactionFactory, 8, skip_last_element_padding=False)
 		buffer = buffer[payload_size:]
 		cosignatures = ArrayHelpers.read_array(buffer, Cosignature)
-		buffer = buffer[sum(map(lambda e: e.size, cosignatures)):]
+		buffer = buffer[ArrayHelpers.size(cosignatures):]
 
 		instance = AggregateBondedTransaction()
 		instance._signature = signature
@@ -8428,9 +8428,9 @@ class AggregateBondedTransaction:
 		buffer += self._fee.serialize()
 		buffer += self._deadline.serialize()
 		buffer += self._transactions_hash.serialize()
-		buffer += sum(map(lambda e: ArrayHelpers.align_up(e.size, 8), self.transactions)).to_bytes(4, byteorder='little', signed=False)  # payload_size
+		buffer += ArrayHelpers.size(self.transactions, 8, skip_last_element_padding=False).to_bytes(4, byteorder='little', signed=False)  # payload_size
 		buffer += self._aggregate_transaction_header_reserved_1.to_bytes(4, byteorder='little', signed=False)
-		buffer += ArrayHelpers.write_variable_size_elements(self._transactions, 8)
+		buffer += ArrayHelpers.write_variable_size_elements(self._transactions, 8, skip_last_element_padding=False)
 		buffer += ArrayHelpers.write_array(self._cosignatures)
 		return buffer
 
@@ -12918,8 +12918,8 @@ class MultisigAccountModificationTransaction:
 		size += 1
 		size += 1
 		size += 4
-		size += sum(map(lambda e: e.size, self.address_additions))
-		size += sum(map(lambda e: e.size, self.address_deletions))
+		size += ArrayHelpers.size(self.address_additions)
+		size += ArrayHelpers.size(self.address_deletions)
 		return size
 
 	@classmethod
@@ -12961,9 +12961,9 @@ class MultisigAccountModificationTransaction:
 		buffer = buffer[4:]
 		assert multisig_account_modification_transaction_body_reserved_1 == 0, f'Invalid value of reserved field ({multisig_account_modification_transaction_body_reserved_1})'
 		address_additions = ArrayHelpers.read_array_count(buffer, UnresolvedAddress, address_additions_count)
-		buffer = buffer[sum(map(lambda e: e.size, address_additions)):]
+		buffer = buffer[ArrayHelpers.size(address_additions):]
 		address_deletions = ArrayHelpers.read_array_count(buffer, UnresolvedAddress, address_deletions_count)
-		buffer = buffer[sum(map(lambda e: e.size, address_deletions)):]
+		buffer = buffer[ArrayHelpers.size(address_deletions):]
 
 		instance = MultisigAccountModificationTransaction()
 		instance._signature = signature
@@ -13120,8 +13120,8 @@ class EmbeddedMultisigAccountModificationTransaction:
 		size += 1
 		size += 1
 		size += 4
-		size += sum(map(lambda e: e.size, self.address_additions))
-		size += sum(map(lambda e: e.size, self.address_deletions))
+		size += ArrayHelpers.size(self.address_additions)
+		size += ArrayHelpers.size(self.address_deletions)
 		return size
 
 	@classmethod
@@ -13157,9 +13157,9 @@ class EmbeddedMultisigAccountModificationTransaction:
 		buffer = buffer[4:]
 		assert multisig_account_modification_transaction_body_reserved_1 == 0, f'Invalid value of reserved field ({multisig_account_modification_transaction_body_reserved_1})'
 		address_additions = ArrayHelpers.read_array_count(buffer, UnresolvedAddress, address_additions_count)
-		buffer = buffer[sum(map(lambda e: e.size, address_additions)):]
+		buffer = buffer[ArrayHelpers.size(address_additions):]
 		address_deletions = ArrayHelpers.read_array_count(buffer, UnresolvedAddress, address_deletions_count)
-		buffer = buffer[sum(map(lambda e: e.size, address_deletions)):]
+		buffer = buffer[ArrayHelpers.size(address_deletions):]
 
 		instance = EmbeddedMultisigAccountModificationTransaction()
 		instance._signer_public_key = signer_public_key
@@ -14531,8 +14531,8 @@ class AccountAddressRestrictionTransaction:
 		size += 1
 		size += 1
 		size += 4
-		size += sum(map(lambda e: e.size, self.restriction_additions))
-		size += sum(map(lambda e: e.size, self.restriction_deletions))
+		size += ArrayHelpers.size(self.restriction_additions)
+		size += ArrayHelpers.size(self.restriction_deletions)
 		return size
 
 	@classmethod
@@ -14572,9 +14572,9 @@ class AccountAddressRestrictionTransaction:
 		buffer = buffer[4:]
 		assert account_restriction_transaction_body_reserved_1 == 0, f'Invalid value of reserved field ({account_restriction_transaction_body_reserved_1})'
 		restriction_additions = ArrayHelpers.read_array_count(buffer, UnresolvedAddress, restriction_additions_count)
-		buffer = buffer[sum(map(lambda e: e.size, restriction_additions)):]
+		buffer = buffer[ArrayHelpers.size(restriction_additions):]
 		restriction_deletions = ArrayHelpers.read_array_count(buffer, UnresolvedAddress, restriction_deletions_count)
-		buffer = buffer[sum(map(lambda e: e.size, restriction_deletions)):]
+		buffer = buffer[ArrayHelpers.size(restriction_deletions):]
 
 		instance = AccountAddressRestrictionTransaction()
 		instance._signature = signature
@@ -14719,8 +14719,8 @@ class EmbeddedAccountAddressRestrictionTransaction:
 		size += 1
 		size += 1
 		size += 4
-		size += sum(map(lambda e: e.size, self.restriction_additions))
-		size += sum(map(lambda e: e.size, self.restriction_deletions))
+		size += ArrayHelpers.size(self.restriction_additions)
+		size += ArrayHelpers.size(self.restriction_deletions)
 		return size
 
 	@classmethod
@@ -14754,9 +14754,9 @@ class EmbeddedAccountAddressRestrictionTransaction:
 		buffer = buffer[4:]
 		assert account_restriction_transaction_body_reserved_1 == 0, f'Invalid value of reserved field ({account_restriction_transaction_body_reserved_1})'
 		restriction_additions = ArrayHelpers.read_array_count(buffer, UnresolvedAddress, restriction_additions_count)
-		buffer = buffer[sum(map(lambda e: e.size, restriction_additions)):]
+		buffer = buffer[ArrayHelpers.size(restriction_additions):]
 		restriction_deletions = ArrayHelpers.read_array_count(buffer, UnresolvedAddress, restriction_deletions_count)
-		buffer = buffer[sum(map(lambda e: e.size, restriction_deletions)):]
+		buffer = buffer[ArrayHelpers.size(restriction_deletions):]
 
 		instance = EmbeddedAccountAddressRestrictionTransaction()
 		instance._signer_public_key = signer_public_key
@@ -14925,8 +14925,8 @@ class AccountMosaicRestrictionTransaction:
 		size += 1
 		size += 1
 		size += 4
-		size += sum(map(lambda e: e.size, self.restriction_additions))
-		size += sum(map(lambda e: e.size, self.restriction_deletions))
+		size += ArrayHelpers.size(self.restriction_additions)
+		size += ArrayHelpers.size(self.restriction_deletions)
 		return size
 
 	@classmethod
@@ -14966,9 +14966,9 @@ class AccountMosaicRestrictionTransaction:
 		buffer = buffer[4:]
 		assert account_restriction_transaction_body_reserved_1 == 0, f'Invalid value of reserved field ({account_restriction_transaction_body_reserved_1})'
 		restriction_additions = ArrayHelpers.read_array_count(buffer, UnresolvedMosaicId, restriction_additions_count)
-		buffer = buffer[sum(map(lambda e: e.size, restriction_additions)):]
+		buffer = buffer[ArrayHelpers.size(restriction_additions):]
 		restriction_deletions = ArrayHelpers.read_array_count(buffer, UnresolvedMosaicId, restriction_deletions_count)
-		buffer = buffer[sum(map(lambda e: e.size, restriction_deletions)):]
+		buffer = buffer[ArrayHelpers.size(restriction_deletions):]
 
 		instance = AccountMosaicRestrictionTransaction()
 		instance._signature = signature
@@ -15113,8 +15113,8 @@ class EmbeddedAccountMosaicRestrictionTransaction:
 		size += 1
 		size += 1
 		size += 4
-		size += sum(map(lambda e: e.size, self.restriction_additions))
-		size += sum(map(lambda e: e.size, self.restriction_deletions))
+		size += ArrayHelpers.size(self.restriction_additions)
+		size += ArrayHelpers.size(self.restriction_deletions)
 		return size
 
 	@classmethod
@@ -15148,9 +15148,9 @@ class EmbeddedAccountMosaicRestrictionTransaction:
 		buffer = buffer[4:]
 		assert account_restriction_transaction_body_reserved_1 == 0, f'Invalid value of reserved field ({account_restriction_transaction_body_reserved_1})'
 		restriction_additions = ArrayHelpers.read_array_count(buffer, UnresolvedMosaicId, restriction_additions_count)
-		buffer = buffer[sum(map(lambda e: e.size, restriction_additions)):]
+		buffer = buffer[ArrayHelpers.size(restriction_additions):]
 		restriction_deletions = ArrayHelpers.read_array_count(buffer, UnresolvedMosaicId, restriction_deletions_count)
-		buffer = buffer[sum(map(lambda e: e.size, restriction_deletions)):]
+		buffer = buffer[ArrayHelpers.size(restriction_deletions):]
 
 		instance = EmbeddedAccountMosaicRestrictionTransaction()
 		instance._signer_public_key = signer_public_key
@@ -15319,8 +15319,8 @@ class AccountOperationRestrictionTransaction:
 		size += 1
 		size += 1
 		size += 4
-		size += sum(map(lambda e: e.size, self.restriction_additions))
-		size += sum(map(lambda e: e.size, self.restriction_deletions))
+		size += ArrayHelpers.size(self.restriction_additions)
+		size += ArrayHelpers.size(self.restriction_deletions)
 		return size
 
 	@classmethod
@@ -15360,9 +15360,9 @@ class AccountOperationRestrictionTransaction:
 		buffer = buffer[4:]
 		assert account_restriction_transaction_body_reserved_1 == 0, f'Invalid value of reserved field ({account_restriction_transaction_body_reserved_1})'
 		restriction_additions = ArrayHelpers.read_array_count(buffer, TransactionType, restriction_additions_count)
-		buffer = buffer[sum(map(lambda e: e.size, restriction_additions)):]
+		buffer = buffer[ArrayHelpers.size(restriction_additions):]
 		restriction_deletions = ArrayHelpers.read_array_count(buffer, TransactionType, restriction_deletions_count)
-		buffer = buffer[sum(map(lambda e: e.size, restriction_deletions)):]
+		buffer = buffer[ArrayHelpers.size(restriction_deletions):]
 
 		instance = AccountOperationRestrictionTransaction()
 		instance._signature = signature
@@ -15507,8 +15507,8 @@ class EmbeddedAccountOperationRestrictionTransaction:
 		size += 1
 		size += 1
 		size += 4
-		size += sum(map(lambda e: e.size, self.restriction_additions))
-		size += sum(map(lambda e: e.size, self.restriction_deletions))
+		size += ArrayHelpers.size(self.restriction_additions)
+		size += ArrayHelpers.size(self.restriction_deletions)
 		return size
 
 	@classmethod
@@ -15542,9 +15542,9 @@ class EmbeddedAccountOperationRestrictionTransaction:
 		buffer = buffer[4:]
 		assert account_restriction_transaction_body_reserved_1 == 0, f'Invalid value of reserved field ({account_restriction_transaction_body_reserved_1})'
 		restriction_additions = ArrayHelpers.read_array_count(buffer, TransactionType, restriction_additions_count)
-		buffer = buffer[sum(map(lambda e: e.size, restriction_additions)):]
+		buffer = buffer[ArrayHelpers.size(restriction_additions):]
 		restriction_deletions = ArrayHelpers.read_array_count(buffer, TransactionType, restriction_deletions_count)
-		buffer = buffer[sum(map(lambda e: e.size, restriction_deletions)):]
+		buffer = buffer[ArrayHelpers.size(restriction_deletions):]
 
 		instance = EmbeddedAccountOperationRestrictionTransaction()
 		instance._signer_public_key = signer_public_key
@@ -16627,7 +16627,7 @@ class TransferTransaction:
 		size += 1
 		size += 1
 		size += 4
-		size += sum(map(lambda e: e.size, self.mosaics))
+		size += ArrayHelpers.size(self.mosaics)
 		size += len(self._message)
 		return size
 
@@ -16671,7 +16671,7 @@ class TransferTransaction:
 		buffer = buffer[4:]
 		assert transfer_transaction_body_reserved_2 == 0, f'Invalid value of reserved field ({transfer_transaction_body_reserved_2})'
 		mosaics = ArrayHelpers.read_array_count(buffer, UnresolvedMosaic, mosaics_count, lambda e: e.mosaic_id)
-		buffer = buffer[sum(map(lambda e: e.size, mosaics)):]
+		buffer = buffer[ArrayHelpers.size(mosaics):]
 		message = ArrayHelpers.get_bytes(buffer, message_size)
 		buffer = buffer[message_size:]
 
@@ -16821,7 +16821,7 @@ class EmbeddedTransferTransaction:
 		size += 1
 		size += 1
 		size += 4
-		size += sum(map(lambda e: e.size, self.mosaics))
+		size += ArrayHelpers.size(self.mosaics)
 		size += len(self._message)
 		return size
 
@@ -16859,7 +16859,7 @@ class EmbeddedTransferTransaction:
 		buffer = buffer[4:]
 		assert transfer_transaction_body_reserved_2 == 0, f'Invalid value of reserved field ({transfer_transaction_body_reserved_2})'
 		mosaics = ArrayHelpers.read_array_count(buffer, UnresolvedMosaic, mosaics_count, lambda e: e.mosaic_id)
-		buffer = buffer[sum(map(lambda e: e.size, mosaics)):]
+		buffer = buffer[ArrayHelpers.size(mosaics):]
 		message = ArrayHelpers.get_bytes(buffer, message_size)
 		buffer = buffer[message_size:]
 


### PR DESCRIPTION
## What is the current behavior?
 * Among other things #126 introduced bug 😬 

## What's the issue?
 * #126 changed how sizes are calculated, but reading and writing still happened in padded version, so after adding block vectors, tests were obviously failing

## How have you changed the behavior?
 * Added "exclude_last" flag in read/write variable in both SDKs
 * using them in both generators
 * on top of this simplified array size calculations inside generator (fixed accidental bug in the process)

## How was this change tested?
 * unittests added
 * on top of that tested on newly created block vectors
