### PR TITLE
[monorepo] fix: rest codecov flag name

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -6,10 +6,10 @@ coverage:
       default:
         target: 70%  # overall project / repo coverage
 
-      rest-gateway:
+      client-rest:
         target: auto
         flags:
-          - rest-gateway
+          - client-rest
 
       catbuffer-parser:
         target: auto
@@ -33,7 +33,7 @@ coverage:
 # monorepo.  This allows code coverage per package.
 
 flags:
-  rest-gateway:
+  client-rest:
     paths:
       - client/rest
     carryforward: true


### PR DESCRIPTION
## What is the current behavior?
The current Rest Codecov flag is ``rest-gateway``

## What's the issue?
The Codecov flag used for Rest client is incorrect.

## How have you changed the behavior?
Rest client Codecov's flag name should be ``client-rest`` to match the package id.
