### PR TITLE
[jenkins] fix: client catapult jobs

### DIFF
--- a/jenkins/catapult/jenkins/catapult-client-build-base-image.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-base-image.groovy
@@ -34,10 +34,10 @@ pipeline {
 							dest_image_name = "symbolplatform/symbol-server-build-base:${OPERATING_SYSTEM}-${COMPILER_CONFIGURATION}"
 
 							base_image_dockerfile_generator_command = """
-								python3 ./scripts/build/baseImageDockerfileGenerator.py \
-									--compiler-configuration scripts/build/configurations/${COMPILER_CONFIGURATION}.yaml \
+								python3 ./jenkins/catapult/baseImageDockerfileGenerator.py \
+									--compiler-configuration jenkins/catapult/configurations/${COMPILER_CONFIGURATION}.yaml \
 									--operating-system ${OPERATING_SYSTEM} \
-									--versions ./scripts/build/versions.properties \
+									--versions ./jenkins/catapult/versions.properties \
 							"""
 						}
 					}

--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project.groovy
@@ -81,7 +81,7 @@ pipeline {
 					steps {
 						dir('catapult-src') {
 							git branch: "${get_branch_name()}",
-								url: 'https://github.com/symbol/catapult-client.git'
+								url: 'https://github.com/symbol/symbol.git'
 						}
 					}
 				}
@@ -96,12 +96,13 @@ pipeline {
 					steps {
 						script {
 							run_docker_build_command = """
-								python3 catapult-src/scripts/build/runDockerBuild.py \
-									--compiler-configuration catapult-src/scripts/build/configurations/${COMPILER_CONFIGURATION}.yaml \
-									--build-configuration catapult-src/scripts/build/configurations/${BUILD_CONFIGURATION}.yaml \
+								python3 catapult-src/jenkins/catapult/runDockerBuild.py \
+									--compiler-configuration catapult-src/jenkins/catapult/configurations/${COMPILER_CONFIGURATION}.yaml \
+									--build-configuration catapult-src/jenkins/catapult/configurations/${BUILD_CONFIGURATION}.yaml \
 									--operating-system ${OPERATING_SYSTEM} \
 									--user ${fully_qualified_user} \
 									--destination-image-label ${build_image_label} \
+									--source-path catapult-src/client/catapult \
 							"""
 						}
 					}
@@ -124,11 +125,13 @@ pipeline {
 				stage('lint') {
 					steps {
 						sh """
-							python3 catapult-src/scripts/build/runDockerTests.py \
+							python3 catapult-src/jenkins/catapult/runDockerTests.py \
 								--image registry.hub.docker.com/symbolplatform/symbol-server-test-base:${OPERATING_SYSTEM} \
-								--compiler-configuration catapult-src/scripts/build/configurations/${COMPILER_CONFIGURATION}.yaml \
+								--compiler-configuration catapult-src/jenkins/catapult/configurations/${COMPILER_CONFIGURATION}.yaml \
 								--user ${fully_qualified_user} \
-								--mode lint
+								--mode lint \
+								--source-path catapult-src/client/catapult \
+								--linter-path catapult-src/linters
 						"""
 					}
 				}
@@ -187,12 +190,13 @@ pipeline {
 								test_image_name = "symbolplatform/symbol-server-test:${build_image_label}"
 
 							sh """
-								python3 catapult-src/scripts/build/runDockerTests.py \
+								python3 catapult-src/jenkins/catapult/runDockerTests.py \
 									--image ${test_image_name} \
-									--compiler-configuration catapult-src/scripts/build/configurations/${COMPILER_CONFIGURATION}.yaml \
+									--compiler-configuration catapult-src/jenkins/catapult/configurations/${COMPILER_CONFIGURATION}.yaml \
 									--user ${fully_qualified_user} \
 									--mode ${TEST_MODE} \
-									--verbosity ${TEST_VERBOSITY}
+									--verbosity ${TEST_VERBOSITY} \
+									--source-path catapult-src/client/catapult
 							"""
 						}
 					}

--- a/jenkins/catapult/jenkins/catapult-client-release-build.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-release-build.groovy
@@ -87,7 +87,7 @@ pipeline {
 					steps {
 						dir('catapult-src') {
 							git branch: "${get_branch_name()}",
-								url: 'https://github.com/symbol/catapult-client.git'
+								url: 'https://github.com/symbol/symbol.git'
 						}
 					}
 				}
@@ -99,12 +99,13 @@ pipeline {
 					steps {
 						script {
 							run_docker_build_command = """
-								python3 catapult-src/scripts/build/runDockerBuild.py \
-									--compiler-configuration catapult-src/scripts/build/configurations/${COMPILER_CONFIGURATION}.yaml \
-									--build-configuration catapult-src/scripts/build/configurations/${BUILD_CONFIGURATION}.yaml \
+								python3 catapult-src/jenkins/catapult/runDockerBuild.py \
+									--compiler-configuration catapult-src/jenkins/catapult/configurations/${COMPILER_CONFIGURATION}.yaml \
+									--build-configuration catapult-src/jenkins/catapult/configurations/${BUILD_CONFIGURATION}.yaml \
 									--operating-system ${OPERATING_SYSTEM} \
 									--user ${fully_qualified_user} \
 									--destination-image-label ${build_image_label} \
+									--source-path catapult-src/client/catapult \
 							"""
 						}
 					}

--- a/jenkins/catapult/runDockerTestsInnerTest.py
+++ b/jenkins/catapult/runDockerTestsInnerTest.py
@@ -38,7 +38,7 @@ class SanitizerEnvironment:
 		}
 		options.update(custom_options)
 
-		options_string = ':'.join(map(f'{options.items()[0]}={options.items()[1]}'))
+		options_string = ':'.join(f'{key}={value}' for key, value in options.items())
 		self.environment_manager.set_env_var(f'{name.upper()}_OPTIONS', options_string)
 		print(f'{name} options: {options_string}')
 


### PR DESCRIPTION
## What is the current behavior?
Catapult Jenkins job is using the old repo.

## What's the issue?
Catapult Jenkins job needs to be updated for the symbol repo

## How have you changed the behavior?
Catapult Jenkins jobs are run using the symbol repo

## How was this change tested?
Yes by running the Jenkins jobs

https://jenkins.symboldev.com/job/Symbol/job/server-pipelines/job/catapult-client-build-catapult-project-daily/243/