### PR TITLE
[jenkins] fix: add .local/bin to path for python package

### DIFF
--- a/jenkins/docker/linter.Dockerfile
+++ b/jenkins/docker/linter.Dockerfile
@@ -24,5 +24,6 @@ RUN apt-get install -y ripgrep \
 
 # add ubuntu user (used by jenkins)
 RUN useradd --uid 1000 -ms /bin/bash ubuntu
+ENV PATH=$PATH:/home/ubuntu/.local/bin
 
 WORKDIR /home/ubuntu


### PR DESCRIPTION
## What is the current behavior?
``sphinx-build: not found`` even after the package was installed.

## What's the issue?
The script not in the path
When installing sphinx, the errors below showed in the logs.
```
[2022-02-24T05:46:11.255Z]   WARNING: The scripts inv and invoke are installed in '/home/ubuntu/.local/bin' which is not on PATH.

[2022-02-24T05:46:11.255Z]   Consider adding this directory to PATH or, if you prefer to suppress this warning, use --no-warn-script-location.
```

## How have you changed the behavior?
The sphinx package will be in the PATH variable.