### PR TITLE
[jenkins] fix: cd pipeline agent is separated to support non-container agent

### DIFF
--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -32,15 +32,7 @@ void call(Closure body) {
 			booleanParam name: 'SHOULD_PUBLISH_IMAGE', description: 'true to publish image', defaultValue: false
 		}
 
-		agent {
-			dockerfile {
-				// PLATFORM can be null on first job due to https://issues.jenkins.io/browse/JENKINS-41929
-				label env.PLATFORM == null ? "${params.platform[0]}-agent" : "${env.PLATFORM}-agent"
-
-				dir 'jenkins/docker'
-				filename "${params.ciBuildDockerfile}"
-			}
-		}
+		agent any
 
 		options {
 			ansiColor('css')
@@ -73,6 +65,18 @@ void call(Closure body) {
 
 		stages {
 			stage('CI pipeline') {
+				agent {
+					dockerfile {
+						// PLATFORM can be null on first job due to https://issues.jenkins.io/browse/JENKINS-41929
+						label env.PLATFORM == null ? "${params.platform[0]}-agent" : "${env.PLATFORM}-agent"
+
+						dir 'jenkins/docker'
+						filename "${params.ciBuildDockerfile}"
+						
+						// using the same node and the same workspace mounted to the container
+						reuseNode true
+					}
+				}
 				stages {
 					stage('display environment') {
 						steps {

--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -32,7 +32,10 @@ void call(Closure body) {
 			booleanParam name: 'SHOULD_PUBLISH_IMAGE', description: 'true to publish image', defaultValue: false
 		}
 
-		agent any
+		agent {
+			// PLATFORM can be null on first job due to https://issues.jenkins.io/browse/JENKINS-41929
+			label env.PLATFORM == null ? "${params.platform[0]}-agent" : "${env.PLATFORM}-agent"
+		}
 
 		options {
 			ansiColor('css')
@@ -67,9 +70,6 @@ void call(Closure body) {
 			stage('CI pipeline') {
 				agent {
 					dockerfile {
-						// PLATFORM can be null on first job due to https://issues.jenkins.io/browse/JENKINS-41929
-						label env.PLATFORM == null ? "${params.platform[0]}-agent" : "${env.PLATFORM}-agent"
-
 						dir 'jenkins/docker'
 						filename "${params.ciBuildDockerfile}"
 						


### PR DESCRIPTION
## What is the current behavior?
`CI` and `CD` are running in the same Docker container.

## What's the issue?
Docker build and publishing is failing due to `docker: not found` error since the `CD` is running in the docker container.

## How have you changed the behavior?
Moved the `dockerfile agent` definition to the `CI` pipeline stage, set it to reuse the same node and left the `CD` pipeline to work with the default agent instead of the container agent.