### PR TITLE
[sdk/javascript] fix: braces are being output in duplicate

### DIFF
--- a/sdk/javascript/src/nem/TransactionFactory.js
+++ b/sdk/javascript/src/nem/TransactionFactory.js
@@ -66,7 +66,7 @@ class TransactionFactory {
 
 		const transactionHex = uint8ToHex(this.toNonVerifiableTransaction(transaction).serialize());
 		const signatureHex = signature.toString();
-		const jsonPayload = `{{"data":"${transactionHex}", "signature":"${signatureHex}"}}`;
+		const jsonPayload = `{"data":"${transactionHex}", "signature":"${signatureHex}"}`;
 		return jsonPayload;
 	}
 

--- a/sdk/javascript/src/symbol/TransactionFactory.js
+++ b/sdk/javascript/src/symbol/TransactionFactory.js
@@ -66,7 +66,7 @@ class TransactionFactory {
 
 		const transactionBuffer = transaction.serialize();
 		const hexPayload = uint8ToHex(transactionBuffer);
-		const jsonPayload = `{{"payload": "${hexPayload}"}}`;
+		const jsonPayload = `{"payload": "${hexPayload}"}`;
 		return jsonPayload;
 	}
 

--- a/sdk/javascript/test/nem/TransactionFactory_spec.js
+++ b/sdk/javascript/test/nem/TransactionFactory_spec.js
@@ -24,7 +24,7 @@ describe('transaction factory (NEM)', () => {
 		assertSignature: (transaction, signature, signedTransactionPayload) => {
 			const transactionHex = uint8ToHex(TransactionFactory.toNonVerifiableTransaction(transaction).serialize());
 			const signatureHex = signature.toString();
-			const expectedJsonString = `{{"data":"${transactionHex}", "signature":"${signatureHex}"}}`;
+			const expectedJsonString = `{"data":"${transactionHex}", "signature":"${signatureHex}"}`;
 			expect(signedTransactionPayload).to.equal(expectedJsonString);
 		}
 	};

--- a/sdk/javascript/test/symbol/TransactionFactory_spec.js
+++ b/sdk/javascript/test/symbol/TransactionFactory_spec.js
@@ -171,7 +171,7 @@ describe('transaction factory (Symbol)', () => {
 			assertTransaction: assertTransfer,
 			assertSignature: (transaction, signature, signedTransactionPayload) => {
 				const transactionHex = uint8ToHex(transaction.serialize());
-				const expectedJsonString = `{{"payload": "${transactionHex}"}}`;
+				const expectedJsonString = `{"payload": "${transactionHex}"}`;
 				expect(signedTransactionPayload).to.equal(expectedJsonString);
 			}
 		};


### PR DESCRIPTION
## What is the current behavior?
sdk javascript is outputting braces in JSON in duplicate

## What's the issue?
this is invalid JSON 

## How have you changed the behavior?
output only single brace(s)

## How was this change tested?
yes