### PR TITLE
[jenkins] feat: catapult code coverage job

### DIFF
--- a/jenkins/catapult/BasicBuildManager.py
+++ b/jenkins/catapult/BasicBuildManager.py
@@ -10,6 +10,7 @@ class BasicBuildManager:
 		self.stl = compiler_configuration.stl
 		self.sanitizers = compiler_configuration.sanitizers
 		self.architecture = compiler_configuration.architecture
+		self.enable_code_coverage = compiler_configuration.enable_code_coverage
 
 		self.build_disposition = build_configuration.disposition
 		self.use_conan = build_configuration.use_conan

--- a/jenkins/catapult/configuration.py
+++ b/jenkins/catapult/configuration.py
@@ -31,7 +31,7 @@ def load_compiler_configuration(filepath):
 
 		sanitizers = configuration_yaml['sanitizers'].split(',') if 'sanitizers' in configuration_yaml else []
 		architecture = configuration_yaml['architecture']
-		enable_code_coverage = configuration_yaml['enable_code_coverage'] if 'enable_code_coverage' in configuration_yaml else False
+		enable_code_coverage = configuration_yaml.get('enable_code_coverage', False)
 
 		configuration_keys = ['compiler', 'stl', 'sanitizers', 'architecture', 'enable_code_coverage']
 		return namedtuple('CompilerConfiguration', configuration_keys)(compiler, stl, sanitizers, architecture, enable_code_coverage)

--- a/jenkins/catapult/configuration.py
+++ b/jenkins/catapult/configuration.py
@@ -31,9 +31,10 @@ def load_compiler_configuration(filepath):
 
 		sanitizers = configuration_yaml['sanitizers'].split(',') if 'sanitizers' in configuration_yaml else []
 		architecture = configuration_yaml['architecture']
+		enable_code_coverage = configuration_yaml['enable_code_coverage'] if 'enable_code_coverage' in configuration_yaml else False
 
-		configuration_keys = ['compiler', 'stl', 'sanitizers', 'architecture']
-		return namedtuple('CompilerConfiguration', configuration_keys)(compiler, stl, sanitizers, architecture)
+		configuration_keys = ['compiler', 'stl', 'sanitizers', 'architecture', 'enable_code_coverage']
+		return namedtuple('CompilerConfiguration', configuration_keys)(compiler, stl, sanitizers, architecture, enable_code_coverage)
 
 
 def load_build_configuration(filepath):

--- a/jenkins/catapult/configurations/gcc-10-code-coverage.yaml
+++ b/jenkins/catapult/configurations/gcc-10-code-coverage.yaml
@@ -1,0 +1,3 @@
+compiler: ../compilers/gcc-10.yaml
+architecture: skylake
+enable_code_coverage: true

--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project-daily.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project-daily.groovy
@@ -73,6 +73,13 @@ pipeline {
 						}
 					}
 				}
+				stage('code coverage') {
+					steps {
+						script {
+							dispatch_build_job('gcc-10-code-coverage', 'tests-diagnostics')
+						}
+					}
+				}
 			}
 		}
 	}

--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project-daily.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project-daily.groovy
@@ -76,7 +76,7 @@ pipeline {
 				stage('code coverage') {
 					steps {
 						script {
-							dispatch_build_job('gcc-10-code-coverage', 'tests-diagnostics')
+							dispatch_build_job('gcc-10-code-coverage', 'tests-metal')
 						}
 					}
 				}

--- a/jenkins/catapult/runDockerBuild.py
+++ b/jenkins/catapult/runDockerBuild.py
@@ -45,6 +45,9 @@ class OptionsManager(BasicBuildManager):
 
 	@property
 	def ccache_path(self):
+		if self.enable_code_coverage:
+			return Path(CCACHE_ROOT) / 'cc'
+
 		return Path(CCACHE_ROOT) / ('release' if self.is_release else 'all')
 
 	@property


### PR DESCRIPTION
## What is the current behavior?
There is no code coverage job for catapult client

## What's the issue?
Currently code coverage for the catapult client is generated manually.

## How have you changed the behavior?
created a daily code coverage job for the catapult client.
It is base on gcc 10 until update all the test images


## How was this change tested?
Yes
