### PR TITLE
[jenkins] fix: use the same path for all checkout

### DIFF
--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project.groovy
@@ -79,6 +79,7 @@ pipeline {
 						expression { is_manual_build() }
 					}
 					steps {
+						cleanWs()
 						dir('catapult-src') {
 							git branch: "${get_branch_name()}",
 								url: 'https://github.com/symbol/symbol.git'

--- a/jenkins/catapult/jenkins/catapult-client-prepare-base-image.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-prepare-base-image.groovy
@@ -1,5 +1,7 @@
 pipeline {
-	agent any
+	agent {
+		label 'ubuntu-20.04-8cores-16Gig'
+	}
 
 	parameters {
 		gitParameter branchFilter: 'origin/(.*)', defaultValue: 'dev', name: 'MANUAL_GIT_BRANCH', type: 'PT_BRANCH'

--- a/jenkins/catapult/jenkins/catapult-client-release-build.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-release-build.groovy
@@ -85,7 +85,8 @@ pipeline {
 						expression { is_manual_build() }
 					}
 					steps {
-						dir('catapult-src') {
+						cleanWs()
+						dir('symbol-mono') {
 							git branch: "${get_branch_name()}",
 								url: 'https://github.com/symbol/symbol.git'
 						}
@@ -105,7 +106,7 @@ pipeline {
 									--operating-system ${OPERATING_SYSTEM} \
 									--user ${fully_qualified_user} \
 									--destination-image-label ${build_image_label} \
-									--source-path catapult-src \
+									--source-path symbol-mono \
 							"""
 						}
 					}


### PR DESCRIPTION
## What is the current behavior?
There are two checkout for the release build.
1. Jenkins checkout into ``symbol-mono`` to get  the Jenkinfile.  This is configured in the Jenkins job.
2. The source checkout to do the build.
Usually these are the same but can be different like if repo is not the same.

## What's the issue?
The source is checkout in one folder but some of the scripts file was using another

## How have you changed the behavior?
Fix path to the where the source is checkout to be the same as the Jenkins job.
Cleanup the workspace also to make sure the correct source it used.

## How was this change tested?
Yes