### PR TITLE
[client/catapult] fix: manual build documentation

### DIFF
--- a/client/catapult/docs/BUILD-manual.md
+++ b/client/catapult/docs/BUILD-manual.md
@@ -25,8 +25,8 @@ apt -y install git gcc g++ cmake curl libssl-dev ninja-build pkg-config python3-
 As usual, clone the git repository:
 
 ```sh
-git clone https://github.com/symbol/catapult-client.git
-cd catapult-client
+git clone https://github.com/symbol/symbol.git
+cd symbol/client/catapult
 ```
 
 ## Step 2: Download, build and install all dependencies from source
@@ -37,9 +37,9 @@ Type this into a terminal:
 > If you want to build with clang, add the `--use-clang` flag.
 
 ```sh
-PYTHONPATH="./scripts/build" python3 "./scripts/build/installDepsLocal.py" \
+PYTHONPATH="../../jenkins/catapult/" python3 "../../jenkins/catapult/installDepsLocal.py" \
 	--target "./_deps" \
-	--versions "./scripts/build/versions.properties" \
+	--versions "../../jenkins/catapult/versions.properties" \
 	--download \
 	--build
 ```

--- a/jenkins/catapult/installDepsLocal.py
+++ b/jenkins/catapult/installDepsLocal.py
@@ -26,7 +26,7 @@ class Downloader:
 
 	def download_git_dependency(self, organization, project):
 		version = self.versions[f'{organization}_{project}']
-		repository = f'git://github.com/{organization}/{project}.git'
+		repository = f'https://github.com/{organization}/{project}.git'
 		self.process_manager.dispatch_subprocess(['git', 'clone', '-b', version, repository])
 
 


### PR DESCRIPTION
## What is the current behavior?
The paths in the build steps does not match on the symbol repo.

## What's the issue?
Following the manual build steps failed as the path does not match.

## How have you changed the behavior?
Update the paths in the build steps to match the symbol repo.
Update the checkout protocol from git to https to fix the below
```
git clone -b release-1.10.0 git://github.com/google/googletest.git
Cloning into 'googletest'...
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```

## How was this change tested?
yes