### PR TITLE
[linters]: upgrade py linter to 2.13.4

### DIFF
--- a/linters/python/lint_requirements.txt
+++ b/linters/python/lint_requirements.txt
@@ -1,4 +1,4 @@
 isort==5.10.1
 pycodestyle==2.8.0
-pylint==2.12.2
+pylint==2.13.4
 pylint-quotes==0.2.3

--- a/sdk/javascript/generator/AbstractTypeFormatter.py
+++ b/sdk/javascript/generator/AbstractTypeFormatter.py
@@ -16,8 +16,8 @@ class AbstractTypeFormatter(ABC):
 	def typename(self):
 		raise NotImplementedError('need to override method')
 
-	@staticmethod
-	def get_base_class():
+	def get_base_class(self):
+		# pylint: disable=no-self-use
 		return ''
 
 	@abstractmethod
@@ -36,14 +36,14 @@ class AbstractTypeFormatter(ABC):
 	def get_size_descriptor(self) -> MethodDescriptor:
 		pass
 
-	@abstractmethod
-	def get_getter_setter_descriptors(self) -> MethodDescriptor:
-		pass
+	def get_getter_setter_descriptors(self):
+		# pylint: disable=no-self-use
+		return []
 
-	@abstractmethod
 	def get_str_descriptor(self) -> MethodDescriptor:
-		pass
+		# pylint: disable=no-self-use
+		return None
 
-	@staticmethod
-	def get_fields():
+	def get_fields(self):
+		# pylint: disable=no-self-use
 		return []

--- a/sdk/javascript/generator/EnumTypeFormatter.py
+++ b/sdk/javascript/generator/EnumTypeFormatter.py
@@ -15,9 +15,6 @@ class EnumTypeFormatter(AbstractTypeFormatter):
 	def typename(self):
 		return self.enum_type.name
 
-	def get_base_class(self):
-		return None
-
 	def get_fields(self):
 		return list(
 			map(
@@ -26,8 +23,7 @@ class EnumTypeFormatter(AbstractTypeFormatter):
 			)
 		)
 
-	@staticmethod
-	def get_ctor_descriptor():
+	def get_ctor_descriptor(self):
 		arguments = ['value']
 		body = 'this.value = value;\n'
 		return MethodDescriptor(body=body, arguments=arguments)

--- a/sdk/javascript/generator/FactoryFormatter.py
+++ b/sdk/javascript/generator/FactoryFormatter.py
@@ -52,7 +52,7 @@ class FactoryFormatter(AbstractTypeFormatter):
 		self.factory_descriptor = factory_map.get(self.abstract.name)
 
 	def get_ctor_descriptor(self):
-		return None
+		raise NotImplementedError('`get_ctor_descriptor` not supported by FactoryFormatter')
 
 	@property
 	def typename(self):
@@ -131,6 +131,3 @@ return values.map(n => BigInt(n)).reduce((accumulator, value) => (accumulator <<
 '''
 		methods.append(MethodDescriptor(method_name='static toKey', arguments=['values'], body=body))
 		return methods
-
-	def get_str_descriptor(self):
-		raise RuntimeError('not required')

--- a/sdk/javascript/generator/PodTypeFormatter.py
+++ b/sdk/javascript/generator/PodTypeFormatter.py
@@ -55,10 +55,3 @@ class PodTypeFormatter(AbstractTypeFormatter):
 
 		body = f'return {self.pod.size};\n'
 		return MethodDescriptor(body=body)
-
-	@staticmethod
-	def get_getter_setter_descriptors():
-		return []
-
-	def get_str_descriptor(self):
-		return None

--- a/sdk/python/generator/AbstractTypeFormatter.py
+++ b/sdk/python/generator/AbstractTypeFormatter.py
@@ -16,8 +16,8 @@ class AbstractTypeFormatter(ABC):
 	def typename(self):
 		raise NotImplementedError('need to override method')
 
-	@staticmethod
-	def get_base_class():
+	def get_base_class(self):
+		# pylint: disable=no-self-use
 		return ''
 
 	@abstractmethod
@@ -36,14 +36,18 @@ class AbstractTypeFormatter(ABC):
 	def get_size_descriptor(self) -> MethodDescriptor:
 		pass
 
-	@abstractmethod
-	def get_getter_descriptors(self) -> MethodDescriptor:
-		pass
+	def get_getter_descriptors(self):
+		# pylint: disable=no-self-use
+		return []
 
-	@abstractmethod
+	def get_setter_descriptors(self):
+		# pylint: disable=no-self-use
+		return []
+
 	def get_str_descriptor(self) -> MethodDescriptor:
-		pass
+		# pylint: disable=no-self-use
+		return None
 
-	@staticmethod
-	def get_fields():
+	def get_fields(self):
+		# pylint: disable=no-self-use
 		return []

--- a/sdk/python/generator/EnumTypeFormatter.py
+++ b/sdk/python/generator/EnumTypeFormatter.py
@@ -26,8 +26,7 @@ class EnumTypeFormatter(AbstractTypeFormatter):
 			)
 		)
 
-	@staticmethod
-	def get_ctor_descriptor():
+	def get_ctor_descriptor(self):
 		return None
 
 	def get_deserialize_descriptor(self):
@@ -44,15 +43,3 @@ class EnumTypeFormatter(AbstractTypeFormatter):
 	def get_size_descriptor(self):
 		body = f'return {self.enum_type.size}\n'
 		return MethodDescriptor(body=body)
-
-	@staticmethod
-	def get_getter_descriptors():
-		return []
-
-	@staticmethod
-	def get_setter_descriptors():
-		return []
-
-	@staticmethod
-	def get_str_descriptor():
-		return None

--- a/sdk/python/generator/FactoryFormatter.py
+++ b/sdk/python/generator/FactoryFormatter.py
@@ -47,7 +47,7 @@ class FactoryFormatter(AbstractTypeFormatter):
 		self.factory_descriptor = factory_map.get(self.abstract.name, None)
 
 	def get_ctor_descriptor(self):
-		return None
+		raise NotImplementedError('`get_ctor_descriptor` not supported by FactoryFormatter')
 
 	@property
 	def typename(self):
@@ -105,10 +105,4 @@ return mapping[entity_name]()
 		raise RuntimeError('not required')
 
 	def get_size_descriptor(self):
-		raise RuntimeError('not required')
-
-	def get_getter_descriptors(self):
-		return []
-
-	def get_str_descriptor(self):
 		raise RuntimeError('not required')

--- a/sdk/python/generator/PodTypeFormatter.py
+++ b/sdk/python/generator/PodTypeFormatter.py
@@ -55,13 +55,3 @@ class PodTypeFormatter(AbstractTypeFormatter):
 
 		body = f'return {self.pod.size}\n'
 		return MethodDescriptor(body=body)
-
-	def get_getter_descriptors(self):
-		return []
-
-	@staticmethod
-	def get_setter_descriptors():
-		return []
-
-	def get_str_descriptor(self):
-		return None

--- a/sdk/python/tests/nem/test_NetworkTimestamp.py
+++ b/sdk/python/tests/nem/test_NetworkTimestamp.py
@@ -7,8 +7,7 @@ from ..test.BasicNetworkTimestampTest import BasicNetworkTimestampTest, NetworkT
 
 
 class NetworkTimestampTest(BasicNetworkTimestampTest, unittest.TestCase):
-	@staticmethod
-	def get_test_descriptor():
+	def get_test_descriptor(self):
 		epoch_time = datetime.datetime(2015, 3, 29, 0, 6, 25, tzinfo=datetime.timezone.utc)
 		return NetworkTimestampTestDescriptor(NetworkTimestamp, epoch_time, 'seconds')
 

--- a/sdk/python/tests/symbol/test_NetworkTimestamp.py
+++ b/sdk/python/tests/symbol/test_NetworkTimestamp.py
@@ -7,8 +7,7 @@ from ..test.BasicNetworkTimestampTest import BasicNetworkTimestampTest, NetworkT
 
 
 class NetworkTimestampTest(BasicNetworkTimestampTest, unittest.TestCase):
-	@staticmethod
-	def get_test_descriptor():
+	def get_test_descriptor(self):
 		epoch_time = datetime.datetime(2021, 3, 16, 0, 6, 25, tzinfo=datetime.timezone.utc)
 		return NetworkTimestampTestDescriptor(NetworkTimestamp, epoch_time, 'milliseconds')
 

--- a/sdk/python/tests/symbol/test_TransactionFactory.py
+++ b/sdk/python/tests/symbol/test_TransactionFactory.py
@@ -139,7 +139,8 @@ class EmbeddedTransactionFactoryTest(BasicTransactionFactoryExSignatureTest, Sym
 	def create_factory(self, type_rule_overrides=None):
 		return TransactionFactory(Network.TESTNET, type_rule_overrides)
 
-	def create_transaction(self, factory):
+	@staticmethod
+	def create_transaction(factory):
 		return factory.create_embedded
 
 


### PR DESCRIPTION
## What's the issue?
pylint is currently an old version

## How have you changed the behavior?
upgraded pylint and fixed warnings

## How was this change tested?
jenkins