### PR TITLE
[monorepo] feat: Auto-merge of dependabot prs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -8,6 +8,8 @@ updates:
       day: sunday
     target-branch: dev
     labels: [catbuffer-parser]
+    commit-message:
+      prefix: '[monorepo] fix'
 
   - package-ecosystem: pip
     directory: /client/catapult/scripts
@@ -16,6 +18,8 @@ updates:
       day: sunday
     target-branch: dev
     labels: [catapult]
+    commit-message:
+      prefix: '[monorepo] fix'
 
   - package-ecosystem: npm
     directory: /client/rest
@@ -25,6 +29,8 @@ updates:
     target-branch: dev
     labels: [rest]
     versioning-strategy: increase
+    commit-message:
+      prefix: '[monorepo] fix'
 
   - package-ecosystem: pip
     directory: /jenkins/catapult
@@ -33,6 +39,8 @@ updates:
       day: sunday
     target-branch: dev
     labels: [jenkins]
+    commit-message:
+      prefix: '[jenkins] fix'
 
   - package-ecosystem: pip
     directory: /linters/cpp
@@ -41,6 +49,8 @@ updates:
       day: sunday
     target-branch: dev
     labels: [linters]
+    commit-message:
+      prefix: '[linters] fix'
 
   - package-ecosystem: pip
     directory: /linters/python
@@ -49,6 +59,8 @@ updates:
       day: sunday
     target-branch: dev
     labels: [linters]
+    commit-message:
+      prefix: '[linters] fix'
 
   - package-ecosystem: npm
     directory: /sdk/javascript
@@ -58,6 +70,8 @@ updates:
     target-branch: dev
     labels: [sdk-javascript]
     versioning-strategy: increase
+    commit-message:
+      prefix: '[sdk] fix'
 
   - package-ecosystem: pip
     directory: /sdk/javascript/generator
@@ -66,6 +80,8 @@ updates:
       day: sunday
     target-branch: dev
     labels: [sdk-javascript]
+    commit-message:
+      prefix: '[sdk] fix'
 
   - package-ecosystem: pip
     directory: /sdk/python
@@ -74,3 +90,5 @@ updates:
       day: sunday
     target-branch: dev
     labels: [sdk-python]
+    commit-message:
+      prefix: '[sdk] fix'

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,0 +1,32 @@
+name: Dependabot auto-approve-merge
+
+# yamllint disable-line rule:truthy
+on: pull_request
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve a PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --squash --subject "$PR_TITLE" "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,7 +1,6 @@
 name: Dependabot auto-approve-merge
 
-# yamllint disable-line rule:truthy
-on: pull_request
+'on': pull_request
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## What is the current behavior?
Dependabot PRs are manually merge into GitHub

## What's the issue?
Merge of PR is manual

## How have you changed the behavior?
Add a GitHub action which will auto merge all PRs from dependabot after the CI checks pass.

Note: commit-message prefix field is limited to 15 characters, monorepo was used in such case.

## How was this change tested?
Tested the auto merge of Dependabot PR