### PR TITLE
[client/catapult] build: fix clang warnings

### DIFF
--- a/client/catapult/extensions/timesync/tests/ImportanceAwareNodeSelectorTests.cpp
+++ b/client/catapult/extensions/timesync/tests/ImportanceAwareNodeSelectorTests.cpp
@@ -282,12 +282,9 @@ namespace catapult { namespace timesync {
 					const std::vector<ionet::Node>& nodes,
 					const std::vector<uint64_t>& rawWeights,
 					uint64_t numIterations) {
-				uint64_t cummulativeWeight = 0u;
 				std::vector<Importance> importances;
-				for (auto weight : rawWeights) {
-					cummulativeWeight += weight;
+				for (auto weight : rawWeights)
 					importances.push_back(Importance(weight));
-				}
 
 				std::vector<Key> keys;
 				for (const auto& node : nodes)

--- a/client/catapult/tests/int/stress/CacheIntegrityTests.cpp
+++ b/client/catapult/tests/int/stress/CacheIntegrityTests.cpp
@@ -399,8 +399,8 @@ namespace catapult { namespace cache {
 		auto keys = CreateKeys(Num_Operations, test::Random);
 
 		// Act:
-		auto value = InsertAccounts(keys, Num_Operations, cache);
-		value += InsertAccounts(addresses, Num_Operations, cache);
+		InsertAccounts(keys, Num_Operations, cache);
+		InsertAccounts(addresses, Num_Operations, cache);
 
 		// Assert:
 		EXPECT_EQ(2 * Num_Operations, cache.createView()->size());

--- a/client/catapult/tools/addressgen/main.cpp
+++ b/client/catapult/tools/addressgen/main.cpp
@@ -59,15 +59,15 @@ namespace catapult { namespace tools { namespace addressgen {
 				});
 			}
 
-		void matchAll(MultiAddressMatcher& matcher, bool showProgress) const {
-			runGenerator([&matcher, showProgress, &printer = m_printer](const auto& mnemonic, auto&& keyPair) {
-				auto matchResult = matcher.accept(std::move(keyPair));
-				if (matchResult.second || (showProgress && matchResult.first))
-					printer.print(mnemonic, *matchResult.first);
+			void matchAll(MultiAddressMatcher& matcher, bool showProgress) const {
+				runGenerator([&matcher, showProgress, &printer = m_printer](const auto& mnemonic, auto&& keyPair) {
+					auto matchResult = matcher.accept(std::move(keyPair));
+					if (matchResult.second || (showProgress && matchResult.first))
+						printer.print(mnemonic, *matchResult.first);
 
-				return !matcher.isComplete();
-			});
-		}
+					return !matcher.isComplete();
+				});
+			}
 
 		private:
 			void runGenerator(const predicate<const std::string&, crypto::KeyPair&&>& acceptKeyPair) const {


### PR DESCRIPTION
## What is the current behavior?
client/catapult fails to build with latest clang

## What's the issue?
variable set but not used warnings

## How have you changed the behavior?
fixed the warnings 

## How was this change tested?
jenkins