### PR TITLE
[monorepo] fix: update codecov parameters

### DIFF
--- a/jenkins/docker/javascript.Dockerfile
+++ b/jenkins/docker/javascript.Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get install -y shellcheck \
 	&& pip install gitlint
 
 # codecov uploader
-RUN curl -Os https://uploader.codecov.io/latest/linux/codecov \
+RUN curl -Os https://uploader.codecov.io/v0.1.20/linux/codecov \
 	&& chmod +x codecov \
 	&& mv codecov /usr/local/bin
 

--- a/jenkins/docker/python.Dockerfile
+++ b/jenkins/docker/python.Dockerfile
@@ -19,7 +19,7 @@ RUN pip install poetry
 RUN apt-get install -y zbar-tools
 
 # codecov uploader
-RUN curl -Os https://uploader.codecov.io/latest/linux/codecov \
+RUN curl -Os https://uploader.codecov.io/v0.1.20/linux/codecov \
 	&& chmod +x codecov \
 	&& mv codecov /usr/local/bin
 

--- a/jenkins/shared-library/vars/codeCoverage.groovy
+++ b/jenkins/shared-library/vars/codeCoverage.groovy
@@ -7,7 +7,7 @@ void uploadCodeCoverage(String flag) {
 	String repoName = env.GIT_URL.tokenize('/').last().split('\\.')[0].toUpperCase()
 	withCredentials([string(credentialsId: "${repoName}_CODECOV_ID", variable: 'CODECOV_TOKEN')]) {
 		logger.logInfo("Uploading code coverage for ${flag}")
-		runScript("codecov --required --root ${env.WORKSPACE} --flags ${flag} .")
+		runScript("codecov --verbose --nonZero --rootDir ${env.WORKSPACE} --flags ${flag} --dir .")
 	}
 }
 


### PR DESCRIPTION
## What is the current behavior?
when codecov fails to upload code coverage data the Jenkins job is not failing. 

## What's the issue?
The latest codecov uploader tool have new parameters.

## How have you changed the behavior?
When codecov fails to upload coverage data it fails the Jenkins job.

## How was this change tested?
Yes