### PR TITLE
[sdk/javascript]: update NetworkTimestamp to support Number or BigInt arguments

### DIFF
--- a/sdk/javascript/src/NetworkTimestamp.js
+++ b/sdk/javascript/src/NetworkTimestamp.js
@@ -7,14 +7,14 @@ class NetworkTimestamp {
 	 * @param {number} timestamp Raw network timestamp.
 	 */
 	constructor(timestamp) {
-		this.timestamp = timestamp;
+		this.timestamp = BigInt(timestamp);
 	}
 
 	/**
 	 * Determines if this is the epochal timestamp.
 	 */
 	get isEpochal() {
-		return 0 === this.timestamp;
+		return 0n === this.timestamp;
 	}
 
 	/**
@@ -33,7 +33,7 @@ class NetworkTimestamp {
 	 * @returns {NetworkTimestamp} New timestamp that is the specified number of minutes past this timestamp.
 	 */
 	addMinutes(count) {
-		return this.addSeconds(60 * count);
+		return this.addSeconds(60n * BigInt(count));
 	}
 
 	/**
@@ -42,7 +42,7 @@ class NetworkTimestamp {
 	 * @returns {NetworkTimestamp} New timestamp that is the specified number of hours past this timestamp.
 	 */
 	addHours(count) {
-		return this.addMinutes(60 * count);
+		return this.addMinutes(60n * BigInt(count));
 	}
 
 	/**
@@ -79,7 +79,7 @@ class NetworkTimestampDatetimeConverter {
 	 * @returns {Date} Date representation of the network timestamp.
 	 */
 	toDatetime(rawTimestamp) {
-		return new Date(this.epoch.getTime() + (rawTimestamp * this.timeUnits));
+		return new Date(this.epoch.getTime() + (Number(rawTimestamp) * this.timeUnits));
 	}
 
 	/**

--- a/sdk/javascript/src/nem/NetworkTimestamp.js
+++ b/sdk/javascript/src/nem/NetworkTimestamp.js
@@ -17,7 +17,7 @@ class NetworkTimestamp extends BasicNetworkTimestamp {
 	 * @returns {NetworkTimestamp} New timestamp that is the specified number of seconds past this timestamp.
 	 */
 	addSeconds(count) {
-		return new NetworkTimestamp(this.timestamp + count);
+		return new NetworkTimestamp(this.timestamp + BigInt(count));
 	}
 
 	/**

--- a/sdk/javascript/src/symbol/NetworkTimestamp.js
+++ b/sdk/javascript/src/symbol/NetworkTimestamp.js
@@ -16,7 +16,7 @@ class NetworkTimestamp extends BasicNetworkTimestamp {
 	 * @returns {NetworkTimestamp} New timestamp that is the specified number of milliseconds past this timestamp.
 	 */
 	addMilliseconds(count) {
-		return new NetworkTimestamp(this.timestamp + count);
+		return new NetworkTimestamp(this.timestamp + BigInt(count));
 	}
 
 	/**
@@ -26,7 +26,7 @@ class NetworkTimestamp extends BasicNetworkTimestamp {
 	 * @returns {NetworkTimestamp} New timestamp that is the specified number of seconds past this timestamp.
 	 */
 	addSeconds(count) {
-		return this.addMilliseconds(1000 * count);
+		return this.addMilliseconds(1000n * BigInt(count));
 	}
 
 	/**

--- a/sdk/javascript/test/NetworkTimestamp_spec.js
+++ b/sdk/javascript/test/NetworkTimestamp_spec.js
@@ -2,60 +2,70 @@ const { NetworkTimestamp, NetworkTimestampDatetimeConverter } = require('../src/
 const { expect } = require('chai');
 
 describe('NetworkTimestamp', () => {
-	class ConcreteNetworkTimestamp extends NetworkTimestamp { // needed because NetworkTimestamp is abstract
-		addSeconds(count) {
-			return new ConcreteNetworkTimestamp(this.timestamp + (5 * count));
+	const runTestCases = wrapInt => {
+		class ConcreteNetworkTimestamp extends NetworkTimestamp { // needed because NetworkTimestamp is abstract
+			addSeconds(count) {
+				return new ConcreteNetworkTimestamp(this.timestamp + (5n * BigInt(count)));
+			}
 		}
-	}
 
-	it('can create epochal timestamp', () => {
-		// Act:
-		const timestamp = new ConcreteNetworkTimestamp(0);
+		it('can create epochal timestamp', () => {
+			// Act:
+			const timestamp = new ConcreteNetworkTimestamp(wrapInt(0));
 
-		// Assert:
-		expect(timestamp.isEpochal).to.equal(true);
-		expect(timestamp.timestamp).to.equal(0);
+			// Assert:
+			expect(timestamp.isEpochal).to.equal(true);
+			expect(timestamp.timestamp).to.equal(0n);
+		});
+
+		it('can create non epochal timestamp', () => {
+			// Act:
+			const timestamp = new ConcreteNetworkTimestamp(wrapInt(123));
+
+			// Assert:
+			expect(timestamp.isEpochal).to.equal(false);
+			expect(timestamp.timestamp).to.equal(123n);
+		});
+
+		it('can add minutes', () => {
+			// Arrange:
+			const timestamp = new ConcreteNetworkTimestamp(wrapInt(100));
+
+			// Act:
+			const newTimestamp = timestamp.addMinutes(wrapInt(50));
+
+			// Assert:
+			expect(timestamp.timestamp).to.equal(100n);
+			expect(newTimestamp.timestamp).to.equal(100n + (60n * 5n * 50n));
+		});
+
+		it('can add hours', () => {
+			// Arrange:
+			const timestamp = new ConcreteNetworkTimestamp(wrapInt(100));
+
+			// Act:
+			const newTimestamp = timestamp.addHours(wrapInt(50));
+
+			// Assert:
+			expect(timestamp.timestamp).to.equal(100n);
+			expect(newTimestamp.timestamp).to.equal(100n + (60n * 60n * 5n * 50n));
+		});
+
+		it('supports toString', () => {
+			// Arrange:
+			const timestamp = new ConcreteNetworkTimestamp(wrapInt(123));
+
+			// Act + Assert:
+			expect(timestamp.toString()).to.equal('123');
+		});
+	};
+
+	describe('works with Number', () => {
+		runTestCases(n => n);
 	});
 
-	it('can create non epochal timestamp', () => {
-		// Act:
-		const timestamp = new ConcreteNetworkTimestamp(123);
-
-		// Assert:
-		expect(timestamp.isEpochal).to.equal(false);
-		expect(timestamp.timestamp).to.equal(123);
-	});
-
-	it('can add minutes', () => {
-		// Arrange:
-		const timestamp = new ConcreteNetworkTimestamp(100);
-
-		// Act:
-		const newTimestamp = timestamp.addMinutes(50);
-
-		// Assert:
-		expect(timestamp.timestamp).to.equal(100);
-		expect(newTimestamp.timestamp).to.equal(100 + (60 * 5 * 50));
-	});
-
-	it('can add hours', () => {
-		// Arrange:
-		const timestamp = new ConcreteNetworkTimestamp(100);
-
-		// Act:
-		const newTimestamp = timestamp.addHours(50);
-
-		// Assert:
-		expect(timestamp.timestamp).to.equal(100);
-		expect(newTimestamp.timestamp).to.equal(100 + (60 * 60 * 5 * 50));
-	});
-
-	it('supports toString', () => {
-		// Arrange:
-		const timestamp = new ConcreteNetworkTimestamp(123);
-
-		// Act + Assert:
-		expect(timestamp.toString()).to.equal('123');
+	describe('works with BigInt', () => {
+		runTestCases(n => BigInt(n));
 	});
 });
 

--- a/sdk/javascript/test/nem/NetworkTimestamp_spec.js
+++ b/sdk/javascript/test/nem/NetworkTimestamp_spec.js
@@ -9,15 +9,20 @@ describe('NetworkTimestamp (NEM)', () => {
 		timeUnitMultiplier: 1000
 	});
 
-	it('can add seconds', () => {
-		// Arrange:
-		const timestamp = new NetworkTimestamp(100);
+	const runTestCases = (wrapInt, postfix) => {
+		it(`can add seconds (${postfix})`, () => {
+			// Arrange:
+			const timestamp = new NetworkTimestamp(wrapInt(100));
 
-		// Act:
-		const newTimestamp = timestamp.addSeconds(50);
+			// Act:
+			const newTimestamp = timestamp.addSeconds(wrapInt(50));
 
-		// Assert:
-		expect(timestamp.timestamp).to.equal(100);
-		expect(newTimestamp.timestamp).to.equal(100 + 50);
-	});
+			// Assert:
+			expect(timestamp.timestamp).to.equal(100n);
+			expect(newTimestamp.timestamp).to.equal(100n + 50n);
+		});
+	};
+
+	runTestCases(n => n, 'Number');
+	runTestCases(n => BigInt(n), 'BigInt');
 });

--- a/sdk/javascript/test/symbol/NetworkTimestamp_spec.js
+++ b/sdk/javascript/test/symbol/NetworkTimestamp_spec.js
@@ -9,27 +9,32 @@ describe('NetworkTimestamp (Symbol)', () => {
 		timeUnitMultiplier: 1
 	});
 
-	it('can add milliseconds', () => {
-		// Arrange:
-		const timestamp = new NetworkTimestamp(100);
+	const runTestCases = (wrapInt, postfix) => {
+		it(`can add milliseconds (${postfix})`, () => {
+			// Arrange:
+			const timestamp = new NetworkTimestamp(wrapInt(100));
 
-		// Act:
-		const newTimestamp = timestamp.addMilliseconds(50);
+			// Act:
+			const newTimestamp = timestamp.addMilliseconds(wrapInt(50));
 
-		// Assert:
-		expect(timestamp.timestamp).to.equal(100);
-		expect(newTimestamp.timestamp).to.equal(100 + 50);
-	});
+			// Assert:
+			expect(timestamp.timestamp).to.equal(100n);
+			expect(newTimestamp.timestamp).to.equal(100n + 50n);
+		});
 
-	it('can add seconds', () => {
-		// Arrange:
-		const timestamp = new NetworkTimestamp(100);
+		it(`can add seconds (${postfix})`, () => {
+			// Arrange:
+			const timestamp = new NetworkTimestamp(wrapInt(100));
 
-		// Act:
-		const newTimestamp = timestamp.addSeconds(50);
+			// Act:
+			const newTimestamp = timestamp.addSeconds(wrapInt(50));
 
-		// Assert:
-		expect(timestamp.timestamp).to.equal(100);
-		expect(newTimestamp.timestamp).to.equal(100 + (50 * 1000));
-	});
+			// Assert:
+			expect(timestamp.timestamp).to.equal(100n);
+			expect(newTimestamp.timestamp).to.equal(100n + (50n * 1000n));
+		});
+	};
+
+	runTestCases(n => n, 'Number');
+	runTestCases(n => BigInt(n), 'BigInt');
 });

--- a/sdk/javascript/test/test/networkTimestampTests.js
+++ b/sdk/javascript/test/test/networkTimestampTests.js
@@ -49,7 +49,7 @@ const runBasicNetworkTimestampTests = testDescriptor => {
 
 		// Assert:
 		expect(timestamp.isEpochal).to.equal(true);
-		expect(timestamp.timestamp).to.equal(0);
+		expect(timestamp.timestamp).to.equal(0n);
 	});
 
 	it('can convert datetime to non epochal timestamp', () => {
@@ -59,7 +59,7 @@ const runBasicNetworkTimestampTests = testDescriptor => {
 
 		// Assert:
 		expect(timestamp.isEpochal).to.equal(false);
-		expect(timestamp.timestamp).to.equal(123);
+		expect(timestamp.timestamp).to.equal(123n);
 	});
 
 	it('can convert datetime to epochal timestamp (custom epoch)', () => {
@@ -68,7 +68,7 @@ const runBasicNetworkTimestampTests = testDescriptor => {
 
 		// Assert:
 		expect(timestamp.isEpochal).to.equal(true);
-		expect(timestamp.timestamp).to.equal(0);
+		expect(timestamp.timestamp).to.equal(0n);
 	});
 
 	it('can convert datetime to non epochal timestamp (custom epoch)', () => {
@@ -78,7 +78,7 @@ const runBasicNetworkTimestampTests = testDescriptor => {
 
 		// Assert:
 		expect(timestamp.isEpochal).to.equal(false);
-		expect(timestamp.timestamp).to.equal(123);
+		expect(timestamp.timestamp).to.equal(123n);
 	});
 
 	// endregion


### PR DESCRIPTION
## What is the current behavior?
## What's the issue?
NetworkTimestamp improperly mixes Number and BigInt arguments.

see issue: #195

## How have you changed the behavior?
changed underlying representation to BigInt and wrapping parameter values in BigInt

## How was this change tested?
updated unit tests to run with both Number and BigInt parameters