### PR TITLE
[client/catapult] fix: build documentation

### DIFF
--- a/client/catapult/docs/BUILD-conan.md
+++ b/client/catapult/docs/BUILD-conan.md
@@ -6,10 +6,11 @@ Following instructions should work on Mac, Linux (Ubuntu 20.04) and Windows.
 
 * **On Linux**:
 
-  1. Install the compiler:
+  1. Install the compiler and build dependencies:
 
      ```sh
-     sudo apt install build-essential git cmake ninja-build
+     sudo apt update
+     sudo apt install build-essential git cmake ninja-build pkg-config
      ```
 
   2. Install [Conan](https://conan.io/downloads.html).
@@ -64,8 +65,8 @@ as this will probably take *a bit*.
 ```sh
 conan remote add nemtech https://catapult.jfrog.io/artifactory/api/conan/symbol-conan
 
-git clone https://github.com/symbol/catapult-client.git
-cd catapult-client
+git clone https://github.com/symbol/symbol.git
+cd symbol/client/catapult
 
 mkdir _build && cd _build
 CONAN_REVISIONS_ENABLED=1 conan install .. --build missing

--- a/client/catapult/docs/BUILD-manual.md
+++ b/client/catapult/docs/BUILD-manual.md
@@ -17,7 +17,7 @@ On an Ubuntu system, all prerequisites can be installed with the following comma
 ```sh
 apt update
 apt -y upgrade
-apt -y install git gcc g++ cmake curl libssl-dev ninja-build pkg-config python3-pip
+apt -y install git gcc g++ cmake curl libssl-dev libgtest-dev ninja-build pkg-config python3-pip
 ```
 
 ## Step 1: Clone catapult-client
@@ -61,9 +61,19 @@ ninja publish
 ninja
 ```
 
+Once the build finishes successfully, the tools in ``_build/bin`` are ready to use. However, the dependencies in ``_deps/boost/lib`` and ``_build/lib`` must be accessible so make sure to add these folders to the ``LD_LIBRARY_PATH`` environment variable.
+
+One way of doing this is by running this from the ``symbol/client/catapult`` directory:
+
+  ```sh
+  export LD_LIBRARY_PATH=$PWD/_deps/boost/lib:$PWD/_build/lib
+  ```
+
+You will need to run this line every new session, unless you add it at the end of your ``~/.bashrc`` or ``~/.profile`` files.
+
 ## Step 4: Verification
 
-Verify that the tools are working correctly by running:
+Verify that the tools are working correctly by running (from ``_build`` directory):
 
 ```sh
 ./bin/catapult.tools.address --help


### PR DESCRIPTION
## What is the current behavior?
The repository paths in the Conan build steps does not match. There are also missing dependencies - for manual (`libgtest-dev`) and Conan (`pkg-config`) builds.

## What's the issue?
- Following the Conan build steps failed as the path does not match.
```
git clone https://github.com/symbol/catapult-client.git
```
- There is a missing dependency `pkg-config` for Linux Conan builds steps:

```
-- Looking for strlcpy - found
CMake Error at /opt/homebrew/Cellar/cmake/3.20.5/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find PkgConfig (missing: PKG_CONFIG_EXECUTABLE)
```
- There is missing dependency `libgtest-dev` for Linux manual build steps:

```
> ninja

In file included from /root/build/symbol/client/catapult/tests/TestHarness.h:26,
                 from /root/build/symbol/client/catapult/tests/catapult/local/server/FileStateChangeStorageTests.cpp:28:
/root/build/symbol/client/catapult/tests/test/nodeps/Stress.h:26:10: fatal error: gtest/gtest.h: No such file or directory
   26 | #include <gtest/gtest.h>
      |          ^~~~~~~~~~~~~~~
compilation terminated.
[241/2147] Building CXX object src/catapult/process/recovery/CMakeFiles/catapult.recovery.dir/main.cpp.o
ninja: build stopped: subcommand failed.
```

## How have you changed the behavior?
Update the paths in the Conan build steps to match the monorepo.
Update required dependencies for Linux in manual and Conan build steps.
Add information about setting LD_LIBRARY_PATH environment variable.

## How was this change tested?
Tested on Ubuntu 20.04