### PR TITLE
[monorepo] fix: trigger all jobs on configuration change

### DIFF
--- a/jenkins/shared-library/vars/createMonorepoMultibranchJobs.groovy
+++ b/jenkins/shared-library/vars/createMonorepoMultibranchJobs.groovy
@@ -44,7 +44,9 @@ void generatePackageMultibranchJobs(Object buildConfiguration, Map jobConfigurat
 		String pipelineName = build.path.tokenize(pathSeparator).last()
 		jobConfiguration.jobName = Paths.get(jobConfiguration.fullBranchFolder.toString()).resolve(pipelineName).toString()
 		jobConfiguration.jenkinsfilePath = Paths.get(build.path).resolve('Jenkinsfile').toString()
-		jobConfiguration.packageIncludePaths = addPathAndDependsOnFolder(build).join('\n')
+		pathList = addPathAndDependsOnFolder(build)
+		pathList.add(helper.resolveBuildConfigurationFile())
+		jobConfiguration.packageIncludePaths = pathList.join('\n')
 		jobConfiguration.displayName = build.name
 		jobConfiguration.packageFolder = Paths.get(jobConfiguration.repositoryName.toString()).resolve(build.path).toString()
 		createMultibranchJob(jobConfiguration)

--- a/jenkins/shared-library/vars/helper.groovy
+++ b/jenkins/shared-library/vars/helper.groovy
@@ -28,3 +28,7 @@ void configureGitHub() {
 	// groovylint-disable-next-line GStringExpressionWithinString
 	runScript('git config user.email "${GITHUB_EMAIL}"')
 }
+
+String resolveBuildConfigurationFile() {
+	return '.github/buildConfiguration.yaml'
+}

--- a/jenkins/shared-library/vars/monorepoSeedPipeline.groovy
+++ b/jenkins/shared-library/vars/monorepoSeedPipeline.groovy
@@ -67,7 +67,7 @@ void call(Closure body) {
 }
 
 String resolveBuildConfigurationFile()  {
-	filepath = helper.resolveBuildConfigurationFile()
+	String filepath = helper.resolveBuildConfigurationFile()
 	logger.logInfo("build configuration file: ${filepath}")
 	return filepath
 }

--- a/jenkins/shared-library/vars/monorepoSeedPipeline.groovy
+++ b/jenkins/shared-library/vars/monorepoSeedPipeline.groovy
@@ -1,5 +1,3 @@
-import java.nio.file.Paths
-
 void call(Closure body) {
 	Map params = [:]
 	body.resolveStrategy = Closure.DELEGATE_FIRST
@@ -31,7 +29,6 @@ void call(Closure body) {
 
 		environment {
 			JENKINS_ROOT_FOLDER	  = "${params.organizationName}/generated"
-			BUILD_CONFIGURATION_FILE = 'buildConfiguration.yaml'
 			GITHUB_CREDENTIALS_ID = "${params.gitHubId}"
 		}
 
@@ -55,12 +52,12 @@ void call(Closure body) {
 			stage('create pipeline jobs') {
 				when {
 					expression {
-						return fileExists(resolveBuildConfigurationFile(env.BUILD_CONFIGURATION_FILE))
+						return fileExists(resolveBuildConfigurationFile())
 					}
 				}
 				steps {
 					script {
-						buildConfiguration = yamlHelper.readYamlFromFile(resolveBuildConfigurationFile(env.BUILD_CONFIGURATION_FILE))
+						buildConfiguration = yamlHelper.readYamlFromFile(resolveBuildConfigurationFile())
 						createMonorepoMultibranchJobs(buildConfiguration, env.GIT_URL, env.JENKINS_ROOT_FOLDER, env.GITHUB_CREDENTIALS_ID)
 					}
 				}
@@ -69,8 +66,8 @@ void call(Closure body) {
 	}
 }
 
-String resolveBuildConfigurationFile(String configurationFile)  {
-	String filepath = Paths.get('.github').resolve(configurationFile)
+String resolveBuildConfigurationFile()  {
+	filepath = helper.resolveBuildConfigurationFile()
 	logger.logInfo("build configuration file: ${filepath}")
 	return filepath
 }


### PR DESCRIPTION
## What is the current behavior?
When the build configuration file is updated all job are not run.

## What's the issue?
When the build configuration file is updated need to verify that all job still runs

## How have you changed the behavior?
Trigger all Jenkins jobs for the repo when the build configuration is updated.

## How was this change tested?
Yes