### PR TITLE
[jenkins] task: add java dockerfile

### DIFF
--- a/jenkins/docker/java.Dockerfile
+++ b/jenkins/docker/java.Dockerfile
@@ -1,0 +1,25 @@
+FROM ubuntu:20.04
+
+# install dependencies (install tzdata first to prevent 'geographic area' prompt)
+RUN apt-get update \
+  && apt-get install -y tzdata \
+  && apt-get install -y openjdk-11-jdk-headless git curl libssl-dev maven ca-certificates \
+  && update-ca-certificates
+
+# install python
+RUN apt-get install -y python3-pip
+
+# install shellcheck and gitlint
+RUN apt-get install -y shellcheck \
+	&& pip install gitlint
+
+# codecov uploader
+RUN curl -Os https://uploader.codecov.io/latest/linux/codecov \
+	&& chmod +x codecov \
+	&& mv codecov /usr/local/bin
+
+# add ubuntu user (used by jenkins)
+RUN useradd --uid 1000 -ms /bin/bash ubuntu
+
+WORKDIR /home/ubuntu
+

--- a/jenkins/docker/java.Dockerfile
+++ b/jenkins/docker/java.Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get install -y shellcheck \
 	&& pip install gitlint
 
 # codecov uploader
-RUN curl -Os https://uploader.codecov.io/latest/linux/codecov \
+RUN curl -Os https://uploader.codecov.io/v0.1.20/linux/codecov \
 	&& chmod +x codecov \
 	&& mv codecov /usr/local/bin
 

--- a/jenkins/docker/java.Dockerfile
+++ b/jenkins/docker/java.Dockerfile
@@ -2,9 +2,9 @@ FROM ubuntu:20.04
 
 # install dependencies (install tzdata first to prevent 'geographic area' prompt)
 RUN apt-get update \
-  && apt-get install -y tzdata \
-  && apt-get install -y openjdk-11-jdk-headless git curl libssl-dev maven ca-certificates \
-  && update-ca-certificates
+	&& apt-get install -y tzdata \
+	&& apt-get install -y openjdk-11-jdk-headless git curl libssl-dev maven ca-certificates \
+	&& update-ca-certificates
 
 # install python
 RUN apt-get install -y python3-pip
@@ -22,4 +22,3 @@ RUN curl -Os https://uploader.codecov.io/latest/linux/codecov \
 RUN useradd --uid 1000 -ms /bin/bash ubuntu
 
 WORKDIR /home/ubuntu
-


### PR DESCRIPTION
# What is the current behavior?
There is no java dockerfile for Jenkins

## What's the issue?
Unable to run to CI for Java projects

## How have you changed the behavior?
Add a Java docker file

## How was this change tested?
Yes