### PR TITLE
[sdk/javascript] fix: Replace js-sha3 with @noble/hashes

### DIFF
--- a/sdk/javascript/package-lock.json
+++ b/sdk/javascript/package-lock.json
@@ -9,8 +9,8 @@
       "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
+        "@noble/hashes": "^1.0.0",
         "bitcore-mnemonic": "^8.25.28",
-        "js-sha3": "^0.8.0",
         "ripemd160": "^2.0.2",
         "tweetnacl": "^1.0.3"
       },
@@ -628,6 +628,11 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.0.0.tgz",
+      "integrity": "sha512-DZVbtY62kc3kkBtMHqwCOfXrT/hnoORy5BJ4+HU1IR59X0KWAOqsfzQPcUl/lQLlG7qXbe/fZ3r/emxtAl+sqg=="
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -2757,11 +2762,6 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
       "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
-    },
-    "node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -5068,6 +5068,11 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "@noble/hashes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.0.0.tgz",
+      "integrity": "sha512-DZVbtY62kc3kkBtMHqwCOfXrT/hnoORy5BJ4+HU1IR59X0KWAOqsfzQPcUl/lQLlG7qXbe/fZ3r/emxtAl+sqg=="
+    },
     "@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -6679,11 +6684,6 @@
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz",
       "integrity": "sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA=="
-    },
-    "js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -27,8 +27,8 @@
     "yargs": "^17.5.1"
   },
   "dependencies": {
+    "@noble/hashes": "^1.0.0",
     "bitcore-mnemonic": "^8.25.28",
-    "js-sha3": "^0.8.0",
     "ripemd160": "^2.0.2",
     "tweetnacl": "^1.0.3"
   }

--- a/sdk/javascript/src/Network.js
+++ b/sdk/javascript/src/Network.js
@@ -26,7 +26,7 @@ class Network {
 	publicKeyToAddress(publicKey) {
 		const partOneHashBuilder = this.addressHasher();
 		partOneHashBuilder.update(publicKey.bytes);
-		const partOneHash = new Uint8Array(partOneHashBuilder.arrayBuffer());
+		const partOneHash = partOneHashBuilder.digest();
 
 		const partTwoHash = new Ripemd160().update(Buffer.from(partOneHash)).digest();
 
@@ -34,7 +34,7 @@ class Network {
 
 		const partThreeHashBuilder = this.addressHasher();
 		partThreeHashBuilder.update(version);
-		const checksum = new Uint8Array(partThreeHashBuilder.arrayBuffer()).subarray(0, 4);
+		const checksum = partThreeHashBuilder.digest().subarray(0, 4);
 
 		return this.createAddress(version, checksum);
 	}
@@ -52,7 +52,7 @@ class Network {
 		hashBuilder.update(address.bytes.subarray(0, 1 + 20));
 
 		const checkSumFromAddress = address.bytes.subarray(1 + 20);
-		const calculatedChecksum = new Uint8Array(hashBuilder.arrayBuffer()).subarray(0, checkSumFromAddress.length);
+		const calculatedChecksum = hashBuilder.digest().subarray(0, checkSumFromAddress.length);
 
 		for (let i = 0; i < checkSumFromAddress.length; ++i) {
 			if (checkSumFromAddress[i] !== calculatedChecksum[i])

--- a/sdk/javascript/src/facade/NemFacade.js
+++ b/sdk/javascript/src/facade/NemFacade.js
@@ -3,7 +3,7 @@ const { NetworkLocator } = require('../Network');
 const { KeyPair, Verifier } = require('../nem/KeyPair');
 const { Address, Network } = require('../nem/Network');
 const { TransactionFactory } = require('../nem/TransactionFactory');
-const { keccak_256 } = require('js-sha3');
+const { keccak_256 } = require('@noble/hashes/sha3');
 
 /**
  * Facade used to interact with NEM blockchain.
@@ -37,7 +37,7 @@ class NemFacade {
 	 */
 	hashTransaction(transaction) { // eslint-disable-line class-methods-use-this
 		const nonVerifiableTransaction = TransactionFactory.toNonVerifiableTransaction(transaction);
-		return new Hash256(new Uint8Array(keccak_256.create().update(nonVerifiableTransaction.serialize()).arrayBuffer()));
+		return new Hash256(keccak_256(nonVerifiableTransaction.serialize()));
 	}
 
 	/**

--- a/sdk/javascript/src/facade/SymbolFacade.js
+++ b/sdk/javascript/src/facade/SymbolFacade.js
@@ -7,7 +7,7 @@ const { MerkleHashBuilder } = require('../symbol/MerkleHashBuilder');
 const { Address, Network } = require('../symbol/Network');
 const { TransactionFactory } = require('../symbol/TransactionFactory');
 const { TransactionType } = require('../symbol/models');
-const { sha3_256 } = require('js-sha3');
+const { sha3_256 } = require('@noble/hashes/sha3');
 
 const TRANSACTION_HEADER_SIZE = [
 	4, // size
@@ -74,7 +74,7 @@ class SymbolFacade {
 		hasher.update(transaction.signerPublicKey.bytes);
 		hasher.update(this.network.generationHashSeed.bytes);
 		hasher.update(transactionDataBuffer(transaction.serialize()));
-		return new Hash256(new Uint8Array(hasher.arrayBuffer()));
+		return new Hash256(hasher.digest());
 	}
 
 	/**
@@ -112,7 +112,7 @@ class SymbolFacade {
 	static hashEmbeddedTransactions(embeddedTransactions) {
 		const hashBuilder = new MerkleHashBuilder();
 		embeddedTransactions.forEach(embeddedTransaction => {
-			hashBuilder.update(new Hash256(sha3_256.create().update(embeddedTransaction.serialize()).digest()));
+			hashBuilder.update(new Hash256(sha3_256(embeddedTransaction.serialize())));
 		});
 
 		return hashBuilder.final();

--- a/sdk/javascript/src/nem/Network.js
+++ b/sdk/javascript/src/nem/Network.js
@@ -1,7 +1,7 @@
 const { ByteArray } = require('../ByteArray');
 const BasicNetwork = require('../Network').Network;
 const base32 = require('../utils/base32');
-const { keccak_256 } = require('js-sha3');
+const { keccak_256 } = require('@noble/hashes/sha3');
 
 /**
  * Represents a NEM address.

--- a/sdk/javascript/src/nem/external/tweetnacl-nacl-fast-keccak.js
+++ b/sdk/javascript/src/nem/external/tweetnacl-nacl-fast-keccak.js
@@ -1,6 +1,6 @@
 // this file is the same as tweetnacl/nacl-fast except that it implements a custom `crypto_hash` function
 // that uses keccak_512 instead of sha_512
-const { keccak_512 } = require('js-sha3');
+const { keccak_512 } = require('@noble/hashes/sha3');
 
 (function(nacl) {
 'use strict';
@@ -1815,7 +1815,7 @@ function crypto_hashblocks_hl(hh, hl, m, n) {
 function crypto_hash(out, m, n) {
 	const hashBuilder = keccak_512.create();
 	hashBuilder.update(m.subarray(0, n));
-	const hash = new Uint8Array(hashBuilder.arrayBuffer());
+	const hash = hashBuilder.digest();
 
 	for (let i = 0; i < out.length; ++i)
 		out[i] = hash[i];

--- a/sdk/javascript/src/symbol/MerkleHashBuilder.js
+++ b/sdk/javascript/src/symbol/MerkleHashBuilder.js
@@ -1,5 +1,5 @@
 const { Hash256 } = require('../CryptoTypes');
-const { sha3_256 } = require('js-sha3');
+const { sha3_256 } = require('@noble/hashes/sha3');
 
 /**
  * Builder for creating a merkle hash.

--- a/sdk/javascript/src/symbol/Network.js
+++ b/sdk/javascript/src/symbol/Network.js
@@ -2,7 +2,7 @@ const { ByteArray } = require('../ByteArray');
 const { Hash256 } = require('../CryptoTypes');
 const BasicNetwork = require('../Network').Network;
 const base32 = require('../utils/base32');
-const { sha3_256 } = require('js-sha3');
+const { sha3_256 } = require('@noble/hashes/sha3');
 
 /**
  * Represents a Symbol address.

--- a/sdk/javascript/src/symbol/idGenerator.js
+++ b/sdk/javascript/src/symbol/idGenerator.js
@@ -1,4 +1,4 @@
-const { sha3_256 } = require('js-sha3');
+const { sha3_256 } = require('@noble/hashes/sha3');
 
 const NAMESPACE_FLAG = 1n << 63n;
 
@@ -27,7 +27,7 @@ const generateMosaicId = (ownerAddress, nonce) => {
 	const hasher = sha3_256.create();
 	hasher.update(uint32ToBytes(nonce));
 	hasher.update(ownerAddress.bytes);
-	const digest = new Uint8Array(hasher.arrayBuffer());
+	const digest = hasher.digest();
 
 	let result = digestToBigInt(digest);
 	if (result & NAMESPACE_FLAG)


### PR DESCRIPTION
## What is the current behavior?
* https://github.com/symbol/symbol/issues/221

## What's the issue?
* js-sha3 in dependencies looks no longer maintained.

## How have you changed the behavior?
* Replace js-sha3 with [@noble/hashes](https://www.npmjs.com/package/@noble/hashes/v/1.0.0).

## How was this change tested?
* Run `npm run test`.
