### PR TITLE
[monorepo] fix: increase pr title length

### DIFF
--- a/linters/git/.gitlint
+++ b/linters/git/.gitlint
@@ -8,7 +8,7 @@ words=wip
 min-length=20
 
 [title-max-length]
-line-length=80
+line-length=100
 
 [body-min-length]
 min-length=5


### PR DESCRIPTION
# What is the current behavior?
Jenkins job fails if PR title is greater than 80

## What's the issue?
Some dependabot commit title are longer than 80 characters

## How have you changed the behavior?
Update the PR limit to 100