### PR TITLE
[monorepo] fix: python local apps not in PATH

### DIFF
--- a/jenkins/docker/postgres.Dockerfile
+++ b/jenkins/docker/postgres.Dockerfile
@@ -20,5 +20,6 @@ RUN curl -Os https://uploader.codecov.io/v0.1.20/linux/codecov \
 
 # add ubuntu user (used by jenkins)
 RUN useradd --uid 1000 -ms /bin/bash ubuntu
+ENV PATH=$PATH:/home/ubuntu/.local/bin
 
 WORKDIR /home/ubuntu


### PR DESCRIPTION
## What is the current behavior?
Python apps that gets installed in local, are not in the default PATH.

## What's the issue?
Failed to run coverage python app

## How have you changed the behavior?
Add local bin to the PATH so local apps can be run.

## How was this change tested?
Yes