### PR TITLE
[monorepo] fix: update common modules

### DIFF
--- a/linters/scripts/lint_last_commit.sh
+++ b/linters/scripts/lint_last_commit.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-GITLINT_COMMON_MODULES="dependency"
+GITLINT_COMMON_MODULES="dependency|jenkins|monorepo"
 GITLINT_MODULES="${GITLINT_COMMON_MODULES}|$(cat "$(git rev-parse --show-toplevel)"/.gitlintmodules)"
 GITLINT_CATEGORIES="feat|bug|fix|build|perf|task"
 gitlint \


### PR DESCRIPTION
## What is the current behavior?
Each new repo setup in Jenkins, we are adding ``jenkins`` and/or ``monorepo`` to the modules

## What's the issue?
Does follow the DRY principle

## How have you changed the behavior?
add ``jenkins`` and ``monorepo`` to the common modules so future repo will not need to add these locally.

## How was this change tested?
Yes, by running the ``lint_last_commit.sh`` script locally