### PR TITLE
[sdk/javascript]: expose 'hexToUint8' and 'uint8ToHex' from library

### DIFF
--- a/sdk/javascript/src/index.js
+++ b/sdk/javascript/src/index.js
@@ -17,6 +17,7 @@ const SymbolNetworkTimestamp = require('./symbol/NetworkTimestamp');
 const SymbolTransactionFactory = require('./symbol/TransactionFactory');
 const SymbolIdGenerator = require('./symbol/idGenerator');
 const SymbolModels = require('./symbol/models');
+const { hexToUint8, uint8ToHex } = require('./utils/converter');
 
 module.exports = {
 	BaseValue,
@@ -46,5 +47,10 @@ module.exports = {
 		...SymbolNetworkTimestamp,
 		...SymbolTransactionFactory,
 		...SymbolIdGenerator
+	},
+
+	utils: {
+		hexToUint8,
+		uint8ToHex
 	}
 };


### PR DESCRIPTION
 problem: javascript doesn't have a standard way of converting hex string <=> Uint8Array.
          the sdk has two functions that perform this conversion.
          optin/reporting needed to reimplement them externally.

solution: export the functions so that they can be imported via
          `const { hexToUint8, uint8ToHex } require('symbol-sdk').utils;`

   issue: #215