### PR TITLE
[sdk/*] add function for checking address string validity to sdks

### DIFF
--- a/sdk/javascript/src/Network.js
+++ b/sdk/javascript/src/Network.js
@@ -1,5 +1,7 @@
 const Ripemd160 = require('ripemd160');
 
+const BASE32_RFC4648_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
 /**
  * Represents a network.
  */
@@ -10,12 +12,14 @@ class Network {
 	 * @param {number} identifier Network identifier byte.
 	 * @param {function} addressHasher Gets the primary hasher to use in the public key to address conversion.
 	 * @param {function} createAddress Creates an encoded address from an address without checksum and checksum bytes.
+	 * @param {class} AddressClass Address class associated with this network.
 	 */
-	constructor(name, identifier, addressHasher, createAddress) {
+	constructor(name, identifier, addressHasher, createAddress, AddressClass) {
 		this.name = name;
 		this.identifier = identifier;
 		this.addressHasher = addressHasher;
 		this.createAddress = createAddress;
+		this.AddressClass = AddressClass;
 	}
 
 	/**
@@ -40,8 +44,25 @@ class Network {
 	}
 
 	/**
+	 * Checks if an address string is valid and belongs to this network.
+	 * @param {string} addressString Address to check.
+	 * @returns {boolean} True if address is valid and belongs to this network.
+	 */
+	isValidAddressString(addressString) {
+		if (this.AddressClass.ENCODED_SIZE !== addressString.length)
+			return false;
+
+		for (let i = 0; i < addressString.length; ++i) {
+			if (-1 === BASE32_RFC4648_ALPHABET.indexOf(addressString[i]))
+				return false;
+		}
+
+		return this.isValidAddress(new this.AddressClass(addressString));
+	}
+
+	/**
 	 * Checks if an address is valid and belongs to this network.
-	 * @param {Address} address Address to check
+	 * @param {Address} address Address to check.
 	 * @returns {boolean} True if address is valid and belongs to this network.
 	 */
 	isValidAddress(address) {

--- a/sdk/javascript/src/nem/Network.js
+++ b/sdk/javascript/src/nem/Network.js
@@ -9,6 +9,8 @@ const { keccak_256 } = require('@noble/hashes/sha3');
 class Address extends ByteArray {
 	static SIZE = 25;
 
+	static ENCODED_SIZE = 40;
+
 	/**
 	 * Creates a NEM address.
 	 * @param {Uint8Array|string|Address} address Input string, byte array or address.
@@ -46,7 +48,8 @@ class Network extends BasicNetwork {
 			name,
 			identifier,
 			() => keccak_256.create(),
-			(addressWithoutChecksum, checksum) => new Address(new Uint8Array([...addressWithoutChecksum, ...checksum]))
+			(addressWithoutChecksum, checksum) => new Address(new Uint8Array([...addressWithoutChecksum, ...checksum])),
+			Address
 		);
 	}
 }

--- a/sdk/javascript/src/symbol/Network.js
+++ b/sdk/javascript/src/symbol/Network.js
@@ -10,6 +10,8 @@ const { sha3_256 } = require('@noble/hashes/sha3');
 class Address extends ByteArray {
 	static SIZE = 24;
 
+	static ENCODED_SIZE = 39;
+
 	/**
 	 * Creates a Symbol address.
 	 * @param {Uint8Array|string|Address} address Input string, byte array or address.
@@ -48,7 +50,8 @@ class Network extends BasicNetwork {
 			name,
 			identifier,
 			() => sha3_256.create(),
-			(addressWithoutChecksum, checksum) => new Address(new Uint8Array([...addressWithoutChecksum, ...checksum.subarray(0, 3)]))
+			(addressWithoutChecksum, checksum) => new Address(new Uint8Array([...addressWithoutChecksum, ...checksum.subarray(0, 3)])),
+			Address
 		);
 		this.generationHashSeed = generationHashSeed;
 	}

--- a/sdk/javascript/test/test/networkTests.js
+++ b/sdk/javascript/test/test/networkTests.js
@@ -7,6 +7,7 @@ const runBasicNetworkTests = testDescriptor => {
 
 		// Act + Assert:
 		expect(network.isValidAddress(address)).to.equal(true);
+		expect(network.isValidAddressString(address.toString())).to.equal(true);
 	};
 
 	const mutateBytes = (bytes, signedPosition) => {
@@ -21,27 +22,49 @@ const runBasicNetworkTests = testDescriptor => {
 
 		// Act + Assert:
 		expect(network.isValidAddress(address)).to.equal(false);
+		expect(network.isValidAddressString(address.toString())).to.equal(false);
+	};
+
+	const cannotValidateInvalidAddressString = (network, mutator) => {
+		// Arrange:
+		const address = network.publicKeyToAddress(testDescriptor.deterministicPublicKey);
+		const addressString = mutator(address.toString());
+
+		// Act + Assert:
+		expect(network.isValidAddressString(addressString)).to.equal(false);
 	};
 
 	const addNetworkTests = (network, networkName) => {
 		it(`can convert ${networkName} public key to address`, () => {
 			// Act:
-			const address = testDescriptor.mainnetNetwork.publicKeyToAddress(testDescriptor.deterministicPublicKey);
+			const address = network.publicKeyToAddress(testDescriptor.deterministicPublicKey);
 
 			// Assert:
-			expect(address).to.deep.equal(testDescriptor.expectedMainnetAddress);
+			expect(address).to.deep.equal(testDescriptor[`expected${networkName[0].toUpperCase()}${networkName.substring(1)}Address`]);
 		});
 
 		it(`can validate valid ${networkName} address`, () => {
-			canValidateValidateAddress(testDescriptor.mainnetNetwork);
+			canValidateValidateAddress(network);
 		});
 
 		it(`cannot validate invalid ${networkName} address (begin)`, () => {
-			cannotValidateInvalidAddress(testDescriptor.mainnetNetwork, 1);
+			cannotValidateInvalidAddress(network, 1);
 		});
 
-		it(`can validate invalid ${networkName} address (end)`, () => {
-			cannotValidateInvalidAddress(testDescriptor.mainnetNetwork, -1);
+		it(`cannot validate invalid ${networkName} address (end)`, () => {
+			cannotValidateInvalidAddress(network, -1);
+		});
+
+		it(`cannot validate invalid ${networkName} address string (invalid size)`, () => {
+			cannotValidateInvalidAddressString(network, addressString => `${addressString}A`);
+			cannotValidateInvalidAddressString(network, addressString => addressString.substring(0, addressString.length - 1));
+		});
+
+		it(`cannot validate invalid ${networkName} address string (invalid char)`, () => {
+			cannotValidateInvalidAddressString(
+				network,
+				addressString => `${addressString.substring(0, 10)}@${addressString.substring(11)}`
+			);
 		});
 	};
 

--- a/sdk/python/symbolchain/Network.py
+++ b/sdk/python/symbolchain/Network.py
@@ -1,14 +1,17 @@
 import hashlib
 from abc import abstractmethod
 
+BASE32_RFC4648_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
+
 
 class Network:
 	"""Represents a network."""
 
-	def __init__(self, name, identifier):
+	def __init__(self, name, identifier, address_class):
 		"""Creates a new network with the specified name and identifier byte."""
 		self.name = name
 		self.identifier = identifier
+		self.address_class = address_class
 
 	def public_key_to_address(self, public_key):
 		"""Converts a public key to an address."""
@@ -27,6 +30,16 @@ class Network:
 		checksum = part_three_hash_builder.digest()[0:4]
 
 		return self.create_address(version, checksum)
+
+	def is_valid_address_string(self, address_string):
+		"""Checks if an address string is valid and belongs to this network."""
+		if self.address_class.ENCODED_SIZE != len(address_string):
+			return False
+
+		if any(ch not in BASE32_RFC4648_ALPHABET for ch in address_string):
+			return False
+
+		return self.is_valid_address(self.address_class(address_string))
 
 	def is_valid_address(self, address):
 		"""Checks if an address is valid and belongs to this network."""

--- a/sdk/python/symbolchain/nem/Network.py
+++ b/sdk/python/symbolchain/nem/Network.py
@@ -10,6 +10,7 @@ class Address(ByteArray):
 	"""Represents a nem address."""
 
 	SIZE = 25
+	ENCODED_SIZE = 40
 
 	def __init__(self, address):
 		"""Creates an address from a decoded or encoded address."""
@@ -27,6 +28,10 @@ class Address(ByteArray):
 
 class Network(BasicNetwork):
 	"""Represents a nem network."""
+
+	def __init__(self, name, identifier):
+		"""Creates a new network with the specified name and identifier byte."""
+		super().__init__(name, identifier, Address)
 
 	def address_hasher(self):
 		return sha3.keccak_256()

--- a/sdk/python/symbolchain/symbol/Network.py
+++ b/sdk/python/symbolchain/symbol/Network.py
@@ -11,6 +11,7 @@ class Address(ByteArray):
 	"""Represents a Symbol address."""
 
 	SIZE = 24
+	ENCODED_SIZE = 39
 
 	def __init__(self, address):
 		"""Creates an address from a decoded or encoded address."""
@@ -31,7 +32,7 @@ class Network(BasicNetwork):
 
 	def __init__(self, name, identifier, generation_hash_seed=None):
 		"""Creates a new network with the specified name, identifier byte and generation hash seed."""
-		super().__init__(name, identifier)
+		super().__init__(name, identifier, Address)
 		self.generation_hash_seed = generation_hash_seed
 
 	def address_hasher(self):

--- a/sdk/python/tests/test/BasicNetworkTest.py
+++ b/sdk/python/tests/test/BasicNetworkTest.py
@@ -60,25 +60,43 @@ class BasicNetworkTest:
 		# Assert:
 		self.assertEqual(test_descriptor.expected_testnet_address, address)
 
-	def test_validate_valid_mainnet_address(self):
-		self._test_validate_valid_address('mainnet_network')
+	def test_can_validate_valid_mainnet_address(self):
+		self._test_can_validate_valid_address('mainnet_network')
 
-	def test_validate_valid_testnet_address(self):
-		self._test_validate_valid_address('testnet_network')
+	def test_can_validate_valid_testnet_address(self):
+		self._test_can_validate_valid_address('testnet_network')
 
-	def test_validate_invalid_mainnet_address_begin(self):
-		return self._test_validate_invalid_address('mainnet_network', 1)
+	def test_cannot_validate_invalid_mainnet_address_begin(self):
+		self._test_cannot_validate_invalid_address('mainnet_network', 1)
 
-	def test_validate_invalid_testnet_address_begin(self):
-		return self._test_validate_invalid_address('testnet_network', 1)
+	def test_cannot_validate_invalid_testnet_address_begin(self):
+		self._test_cannot_validate_invalid_address('testnet_network', 1)
 
-	def test_validate_invalid_mainnet_address_end(self):
-		return self._test_validate_invalid_address('mainnet_network', -1)
+	def test_cannot_validate_invalid_mainnet_address_end(self):
+		self._test_cannot_validate_invalid_address('mainnet_network', -1)
 
-	def test_validate_invalid_testnet_address_end(self):
-		return self._test_validate_invalid_address('testnet_network', -1)
+	def test_cannot_validate_invalid_testnet_address_end(self):
+		self._test_cannot_validate_invalid_address('testnet_network', -1)
 
-	def _test_validate_valid_address(self, field_name):
+	def test_cannot_validate_invalid_mainnet_address_string_invalid_size(self):
+		self._test_cannot_validate_invalid_address_string('mainnet_network', lambda address_string: f'{address_string}A')
+		self._test_cannot_validate_invalid_address_string('mainnet_network', lambda address_string: address_string[:-1])
+
+	def test_cannot_validate_invalid_testnet_address_string_invalid_size(self):
+		self._test_cannot_validate_invalid_address_string('testnet_network', lambda address_string: f'{address_string}A')
+		self._test_cannot_validate_invalid_address_string('testnet_network', lambda address_string: address_string[:-1])
+
+	def test_cannot_validate_invalid_mainnet_address_string_invalid_char(self):
+		self._test_cannot_validate_invalid_address_string(
+			'mainnet_network',
+			lambda address_string: f'{address_string[0:10]}@{address_string[11:]}')
+
+	def test_cannot_validate_invalid_testnet_address_string_invalid_char(self):
+		self._test_cannot_validate_invalid_address_string(
+			'testnet_network',
+			lambda address_string: f'{address_string[0:10]}@{address_string[11:]}')
+
+	def _test_can_validate_valid_address(self, field_name):
 		# Arrange:
 		test_descriptor = self.get_test_descriptor()
 		network = getattr(test_descriptor, field_name)
@@ -86,8 +104,9 @@ class BasicNetworkTest:
 
 		# Act + Assert:
 		self.assertTrue(network.is_valid_address(address))
+		self.assertTrue(network.is_valid_address_string(str(address)))
 
-	def _test_validate_invalid_address(self, field_name, position):
+	def _test_cannot_validate_invalid_address(self, field_name, position):
 		# Arrange:
 		test_descriptor = self.get_test_descriptor()
 		network = getattr(test_descriptor, field_name)
@@ -96,6 +115,17 @@ class BasicNetworkTest:
 
 		# Act + Assert:
 		self.assertFalse(network.is_valid_address(address))
+		self.assertFalse(network.is_valid_address_string(str(address)))
+
+	def _test_cannot_validate_invalid_address_string(self, field_name, mutator):
+		# Arrange:
+		test_descriptor = self.get_test_descriptor()
+		network = getattr(test_descriptor, field_name)
+		address = network.public_key_to_address(test_descriptor.deterministic_public_key)
+		address_string = mutator(str(address))
+
+		# Act + Assert:
+		self.assertFalse(network.is_valid_address_string(address_string))
 
 	def _assert_network(self, network, expected_name, expected_identifier):
 		self.assertEqual(expected_name, network.name)

--- a/sdk/python/tests/test_Network.py
+++ b/sdk/python/tests/test_Network.py
@@ -6,19 +6,21 @@ from symbolchain.Network import Network, NetworkLocator
 class NetworkTest(unittest.TestCase):
 	def test_equality_is_supported(self):
 		# Arrange:
-		network = Network('foo', 0x55)
+		network = Network('foo', 0x55, None)
 
 		# Act + Assert:
-		self.assertEqual(network, Network('foo', 0x55))
-		self.assertNotEqual(network, Network('Foo', 0x55))
-		self.assertNotEqual(network, Network('foo', 0x54))
+		self.assertEqual(network, Network('foo', 0x55, None))
+		self.assertEqual(network, Network('foo', 0x55, int))  # address_class is not compared
+
+		self.assertNotEqual(network, Network('Foo', 0x55, None))
+		self.assertNotEqual(network, Network('foo', 0x54, None))
 		self.assertNotEqual(network, None)
 
 	def test_string_is_supported(self):
-		self.assertEqual('foo', str(Network('foo', 0x55)))
+		self.assertEqual('foo', str(Network('foo', 0x55, None)))
 
 
-PREDEFINED_NETWORKS = [Network('foo', 0x55), Network('bar', 0x37)]
+PREDEFINED_NETWORKS = [Network('foo', 0x55, None), Network('bar', 0x37, None)]
 
 
 class NetworkLocatorTest(unittest.TestCase):


### PR DESCRIPTION
    [sdk/javascript] task: add isValidAddressString to network classes
    
     problem: there is no functionality to check if an address string is valid
              the existing isValidAddress requires a typed Address, which implies a properly formed string
    solution: add isValidAddressString to Network classes that accepts and validates string paramteter
    
       issue: #214



    [sdk/python] task: add is_valid_address_string to network classes
    
     problem: there is no functionality to check if an address string is valid
              the existing is_valid_address requires a typed Address, which implies a properly formed string
    solution: add is_valid_address_string to Network classes that accepts and validates string paramteter
    
       issue: #235
