### PR TITLE
[rest] build: switch js-sha3 to noble

### DIFF
--- a/client/rest/package-lock.json
+++ b/client/rest/package-lock.json
@@ -9,8 +9,8 @@
       "version": "0.0.0",
       "license": "ISC",
       "dependencies": {
+        "@noble/hashes": "^1.0.0",
         "ini": "^3.0.0",
-        "js-sha3": "^0.8.0",
         "long": "^5.2.0",
         "mongodb": "^4.6.0",
         "restify": "^8.6.1",
@@ -672,6 +672,11 @@
       "engines": [
         "node >=0.6.0"
       ]
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.0.0.tgz",
+      "integrity": "sha512-DZVbtY62kc3kkBtMHqwCOfXrT/hnoORy5BJ4+HU1IR59X0KWAOqsfzQPcUl/lQLlG7qXbe/fZ3r/emxtAl+sqg=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -3338,11 +3343,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -11130,6 +11130,11 @@
         }
       }
     },
+    "@noble/hashes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.0.0.tgz",
+      "integrity": "sha512-DZVbtY62kc3kkBtMHqwCOfXrT/hnoORy5BJ4+HU1IR59X0KWAOqsfzQPcUl/lQLlG7qXbe/fZ3r/emxtAl+sqg=="
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -13138,11 +13143,6 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
-    },
-    "js-sha3": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/client/rest/package.json
+++ b/client/rest/package.json
@@ -25,8 +25,8 @@
     "sinon": "^14.0.0"
   },
   "dependencies": {
+    "@noble/hashes": "^1.0.0",
     "ini": "^3.0.0",
-    "js-sha3": "^0.8.0",
     "long": "^5.2.0",
     "mongodb": "^4.6.0",
     "restify": "^8.6.1",

--- a/client/rest/src/catapult-sdk/model/address.js
+++ b/client/rest/src/catapult-sdk/model/address.js
@@ -22,7 +22,7 @@
 const arrayUtils = require('../utils/arrayUtils');
 const base32 = require('../utils/base32');
 const convert = require('../utils/convert');
-const jsSha3 = require('js-sha3');
+const { sha3_256 } = require('@noble/hashes/sha3');
 const Ripemd160 = require('ripemd160');
 
 const constants = {
@@ -80,7 +80,7 @@ const address = {
 	 */
 	publicKeyToAddress: (publicKey, networkIdentifier) => {
 		// step 1: sha3 hash of the public key
-		const publicKeyHash = jsSha3.sha3_256.arrayBuffer(publicKey);
+		const publicKeyHash = sha3_256(publicKey);
 
 		// step 2: ripemd160 hash of (1)
 		const ripemdHash = new Ripemd160().update(Buffer.from(publicKeyHash)).digest();
@@ -91,7 +91,7 @@ const address = {
 		arrayUtils.copy(decodedAddress, ripemdHash, constants.sizes.ripemd160, 1);
 
 		// step 4: concatenate (3) and the checksum of (3)
-		const hash = jsSha3.sha3_256.arrayBuffer(decodedAddress.subarray(0, constants.sizes.ripemd160 + 1));
+		const hash = sha3_256(decodedAddress.subarray(0, constants.sizes.ripemd160 + 1));
 		arrayUtils.copy(decodedAddress, arrayUtils.uint8View(hash), constants.sizes.checksum, constants.sizes.ripemd160 + 1);
 
 		return decodedAddress;
@@ -103,11 +103,11 @@ const address = {
 	 * @returns {boolean} true if the decoded address is valid, false otherwise.
 	 */
 	isValidAddress: decoded => {
-		const hash = jsSha3.sha3_256.create();
+		const hash = sha3_256.create();
 		const checksumBegin = constants.sizes.addressDecoded - constants.sizes.checksum;
 		hash.update(decoded.subarray(0, checksumBegin));
 		const checksum = new Uint8Array(constants.sizes.checksum);
-		arrayUtils.copy(checksum, arrayUtils.uint8View(hash.arrayBuffer()), constants.sizes.checksum);
+		arrayUtils.copy(checksum, arrayUtils.uint8View(hash.digest()), constants.sizes.checksum);
 		return arrayUtils.deepEqual(checksum, decoded.subarray(checksumBegin));
 	},
 

--- a/client/rest/src/routes/MerkelTree.js
+++ b/client/rest/src/routes/MerkelTree.js
@@ -20,7 +20,7 @@
  */
 
 const catapult = require('../catapult-sdk/index');
-const { sha3_256 } = require('js-sha3');
+const { sha3_256 } = require('@noble/hashes/sha3');
 
 const { convert } = catapult.utils;
 
@@ -201,9 +201,7 @@ class MerkleTree {
 		links.forEach(link => {
 			branchLinks[parseInt(`0x${link.bit}`, 16)] = link.link;
 		});
-		return sha3_256.update(catapult.utils.convert.hexToUint8(encodedPath + branchLinks.join('')))
-			.hex()
-			.toUpperCase();
+		return catapult.utils.convert.uint8ToHex(sha3_256(catapult.utils.convert.hexToUint8(encodedPath + branchLinks.join(''))));
 	}
 
 	/**
@@ -213,9 +211,7 @@ class MerkleTree {
 	 * @returns {string} leaf hash (Hash(encodedPath + leaf value))
 	 */
 	static getLeafHash(encodedPath, leafValue) {
-		return sha3_256.update(catapult.utils.convert.hexToUint8(encodedPath + leafValue))
-			.hex()
-			.toUpperCase();
+		return catapult.utils.convert.uint8ToHex(sha3_256(catapult.utils.convert.hexToUint8(encodedPath + leafValue)));
 	}
 }
 


### PR DESCRIPTION
 problem: js sdk has been upgraded to use noble for hashing but rest is still using js-sha3

solution: replace js-sha3 with noble
