### PR TITLE
[client/catapult]: MosaicSupplyRevocation SourceAddress is not linked as interacting address

### DIFF
--- a/client/catapult/plugins/txes/mosaic/src/plugins/MosaicSupplyRevocationTransactionPlugin.cpp
+++ b/client/catapult/plugins/txes/mosaic/src/plugins/MosaicSupplyRevocationTransactionPlugin.cpp
@@ -40,6 +40,8 @@ namespace catapult { namespace plugins {
 				// consequently, MosaicSupplyRevocation transactions will be rejected until then because of Revokable flag requirement
 				sub.notify(MosaicRequiredNotification(context.SignerAddress, transaction.Mosaic.MosaicId, requiredMosaicFlags));
 
+				sub.notify(AddressInteractionNotification(context.SignerAddress, transaction.Type, { transaction.SourceAddress }));
+
 				sub.notify(BalanceTransferNotification(
 						transaction.SourceAddress,
 						context.SignerAddress,

--- a/client/catapult/plugins/txes/mosaic/tests/plugins/MosaicSupplyRevocationTransactionPluginTests.cpp
+++ b/client/catapult/plugins/txes/mosaic/tests/plugins/MosaicSupplyRevocationTransactionPluginTests.cpp
@@ -65,6 +65,7 @@ namespace catapult { namespace plugins {
 			// Act + Assert:
 			test::TransactionPluginTestUtils<TTraits>::AssertNotificationTypes(transaction, {
 				MosaicRequiredNotification::Notification_Type,
+				AddressInteractionNotification::Notification_Type,
 				BalanceTransferNotification::Notification_Type
 			}, utils::ParseByteArray<Address>(Nemesis_Address));
 		}
@@ -96,6 +97,11 @@ namespace catapult { namespace plugins {
 				EXPECT_EQ(GetSignerAddress(transaction), notification.Owner.resolved());
 				EXPECT_EQ(transaction.Mosaic.MosaicId, notification.MosaicId.unresolved());
 				EXPECT_EQ(utils::to_underlying_type(expectedPropertyFlagMask), notification.PropertyFlagMask);
+			});
+			builder.template addExpectation<AddressInteractionNotification>([&transaction](const auto& notification) {
+				EXPECT_EQ(GetSignerAddress(transaction), notification.Source);
+				EXPECT_EQ(transaction.Type, notification.TransactionType);
+				EXPECT_EQ(UnresolvedAddressSet{ transaction.SourceAddress }, notification.ParticipantsByAddress);
 			});
 			builder.template addExpectation<BalanceTransferNotification>([&transaction](const auto& notification) {
 				EXPECT_FALSE(notification.Sender.isResolved());


### PR DESCRIPTION
… 
 problem: MosaicSupplyRevocationTransactionPlugin is not raising an AddressInteractionNotification that would link
          the SourceAddress to the transaction as an affected account
solution: raise an AddressInteractionNotification with SourceAddress

   issue: #108 