### PR TITLE
[sdk]: replace BIP32_COIN_ID constant with network-dependent bip32Path

### DIFF
--- a/sdk/javascript/examples/bip32_keypair.js
+++ b/sdk/javascript/examples/bip32_keypair.js
@@ -10,7 +10,9 @@ const symbolSdk = require('../src/index');
 
 (() => {
 	const deriveKey = (rootNode, facade, change, index) => {
-		const path = [44, facade.constructor.BIP32_COIN_ID, 0, change, index];
+		const path = facade.bip32Path(0);
+		path[path.length - 2] = change;
+		path[path.length - 1] = index;
 
 		const childNode = rootNode.derivePath(path);
 		const childKeyPair = facade.constructor.bip32NodeToKeyPair(childNode);

--- a/sdk/javascript/src/facade/NemFacade.js
+++ b/sdk/javascript/src/facade/NemFacade.js
@@ -9,8 +9,6 @@ const { keccak_256 } = require('@noble/hashes/sha3');
  * Facade used to interact with NEM blockchain.
  */
 class NemFacade {
-	static BIP32_COIN_ID = 43;
-
 	static BIP32_CURVE_NAME = 'ed25519-keccak';
 
 	static Address = Address;
@@ -60,6 +58,16 @@ class NemFacade {
 	verifyTransaction(transaction, signature) { // eslint-disable-line class-methods-use-this
 		const nonVerifiableTransaction = TransactionFactory.toNonVerifiableTransaction(transaction);
 		return new Verifier(transaction.signerPublicKey).verify(nonVerifiableTransaction.serialize(), signature);
+	}
+
+	/**
+	 * Creates a network compatible BIP32 path for the specified account.
+	 *
+	 * @param {int} accountId Id of the account for which to generate a BIP32 path.
+	 * @returns {array<int>} BIP32 path for the specified account.
+	 */
+	bip32Path(accountId) {
+		return [44, 'mainnet' === this.network.name ? 43 : 1, accountId, 0, 0];
 	}
 
 	/**

--- a/sdk/javascript/src/facade/SymbolFacade.js
+++ b/sdk/javascript/src/facade/SymbolFacade.js
@@ -44,8 +44,6 @@ const transactionDataBuffer = transactionBuffer => {
  * Facade used to interact with Symbol blockchain.
  */
 class SymbolFacade {
-	static BIP32_COIN_ID = 4343;
-
 	static BIP32_CURVE_NAME = 'ed25519';
 
 	static Address = Address;
@@ -116,6 +114,16 @@ class SymbolFacade {
 		});
 
 		return hashBuilder.final();
+	}
+
+	/**
+	 * Creates a network compatible BIP32 path for the specified account.
+	 *
+	 * @param {int} accountId Id of the account for which to generate a BIP32 path.
+	 * @returns {array<int>} BIP32 path for the specified account.
+	 */
+	bip32Path(accountId) {
+		return [44, 'mainnet' === this.network.name ? 4343 : 1, accountId, 0, 0];
 	}
 
 	/**

--- a/sdk/javascript/test/facade/NemFacade_spec.js
+++ b/sdk/javascript/test/facade/NemFacade_spec.js
@@ -10,7 +10,6 @@ describe('NEM Facade', () => {
 	// region constants
 
 	it('has correct BIP32 constants', () => {
-		expect(NemFacade.BIP32_COIN_ID).to.equal(43);
 		expect(NemFacade.BIP32_CURVE_NAME).to.equal('ed25519-keccak');
 	});
 
@@ -142,6 +141,32 @@ describe('NEM Facade', () => {
 
 	// endregion
 
+	// region bip32Path
+
+	it('can construct proper BIP32 mainnet path', () => {
+		// Arrange:
+		const facade = new NemFacade('mainnet');
+
+		// Act:
+		const path = facade.bip32Path(2);
+
+		// Act + Assert:
+		expect(path).to.deep.equal([44, 43, 2, 0, 0]);
+	});
+
+	it('can construct proper BIP32 testnet path', () => {
+		// Arrange:
+		const facade = new NemFacade('testnet');
+
+		// Act:
+		const path = facade.bip32Path(2);
+
+		// Act + Assert:
+		expect(path).to.deep.equal([44, 1, 2, 0, 0]);
+	});
+
+	// endregion
+
 	// region bip32NodeToKeyPair
 
 	const assertBip32ChildPublicKeys = (passphrase, expectedChildPublicKeys) => {
@@ -156,7 +181,7 @@ describe('NEM Facade', () => {
 
 		const childPublicKeys = [];
 		for (let i = 0; i < expectedChildPublicKeys.length; ++i) {
-			const childNode = rootNode.derivePath([44, NemFacade.BIP32_COIN_ID, i, 0, 0]);
+			const childNode = rootNode.derivePath(new NemFacade('mainnet').bip32Path(i));
 			const childKeyPair = NemFacade.bip32NodeToKeyPair(childNode);
 			childPublicKeys.push(childKeyPair.publicKey);
 		}

--- a/sdk/javascript/test/facade/SymbolFacade_spec.js
+++ b/sdk/javascript/test/facade/SymbolFacade_spec.js
@@ -71,7 +71,6 @@ describe('Symbol Facade', () => {
 	// region constants
 
 	it('has correct BIP32 constants', () => {
-		expect(SymbolFacade.BIP32_COIN_ID).to.equal(4343);
 		expect(SymbolFacade.BIP32_CURVE_NAME).to.equal('ed25519');
 	});
 
@@ -241,6 +240,32 @@ describe('Symbol Facade', () => {
 
 	// endregion
 
+	// region bip32Path
+
+	it('can construct proper BIP32 mainnet path', () => {
+		// Arrange:
+		const facade = new SymbolFacade('mainnet');
+
+		// Act:
+		const path = facade.bip32Path(2);
+
+		// Act + Assert:
+		expect(path).to.deep.equal([44, 4343, 2, 0, 0]);
+	});
+
+	it('can construct proper BIP32 testnet path', () => {
+		// Arrange:
+		const facade = new SymbolFacade('testnet');
+
+		// Act:
+		const path = facade.bip32Path(2);
+
+		// Act + Assert:
+		expect(path).to.deep.equal([44, 1, 2, 0, 0]);
+	});
+
+	// endregion
+
 	// region bip32NodeToKeyPair
 
 	const assertBip32ChildPublicKeys = (passphrase, expectedChildPublicKeys) => {
@@ -255,7 +280,7 @@ describe('Symbol Facade', () => {
 
 		const childPublicKeys = [];
 		for (let i = 0; i < expectedChildPublicKeys.length; ++i) {
-			const childNode = rootNode.derivePath([44, SymbolFacade.BIP32_COIN_ID, i, 0, 0]);
+			const childNode = rootNode.derivePath(new SymbolFacade('mainnet').bip32Path(i));
 			const childKeyPair = SymbolFacade.bip32NodeToKeyPair(childNode);
 			childPublicKeys.push(childKeyPair.publicKey);
 		}

--- a/sdk/python/examples/bip32_keypair.py
+++ b/sdk/python/examples/bip32_keypair.py
@@ -11,7 +11,7 @@ from symbolchain.facade.SymbolFacade import SymbolFacade
 
 
 def derive_key(root_node, facade, change, index):
-	path = [44, facade.BIP32_COIN_ID, 0, change, index]
+	path = [*facade.bip32_path(0)[:-2], change, index]
 
 	child_node = root_node.derive_path(path)
 	child_key_pair = facade.bip32_node_to_key_pair(child_node)

--- a/sdk/python/symbolchain/facade/NemFacade.py
+++ b/sdk/python/symbolchain/facade/NemFacade.py
@@ -10,7 +10,6 @@ from ..Network import NetworkLocator
 class NemFacade:
 	"""Facade used to interact with NEM blockchain."""
 
-	BIP32_COIN_ID = 43
 	BIP32_CURVE_NAME = 'ed25519-keccak'
 
 	Address = Address
@@ -56,6 +55,10 @@ class NemFacade:
 		"""Verifies a NEM transaction."""
 		non_verifiable_transaction = TransactionFactory.to_non_verifiable_transaction(transaction)
 		return Verifier(transaction.signer_public_key).verify(non_verifiable_transaction.serialize(), signature)
+
+	def bip32_path(self, account_id):
+		"""Creates a network compatible BIP32 path for the specified account."""
+		return [44, 43 if 'mainnet' == self.network.name else 1, account_id, 0, 0]
 
 	@staticmethod
 	def bip32_node_to_key_pair(bip32_node):

--- a/sdk/python/symbolchain/facade/SymbolFacade.py
+++ b/sdk/python/symbolchain/facade/SymbolFacade.py
@@ -27,7 +27,6 @@ AGGREGATE_HASHED_SIZE = sum(field[1] for field in [
 class SymbolFacade:
 	"""Facade used to interact with Symbol blockchain."""
 
-	BIP32_COIN_ID = 4343
 	BIP32_CURVE_NAME = 'ed25519'
 
 	Address = Address
@@ -86,6 +85,10 @@ class SymbolFacade:
 			hash_builder.update(Hash256(sha3.sha3_256(embedded_transaction.serialize()).digest()))
 
 		return hash_builder.final()
+
+	def bip32_path(self, account_id):
+		"""Creates a network compatible BIP32 path for the specified account."""
+		return [44, 4343 if 'mainnet' == self.network.name else 1, account_id, 0, 0]
 
 	@staticmethod
 	def bip32_node_to_key_pair(bip32_node):

--- a/sdk/python/tests/facade/test_NemFacade.py
+++ b/sdk/python/tests/facade/test_NemFacade.py
@@ -19,7 +19,6 @@ class NemFacadeTest(unittest.TestCase):
 	# region constants
 
 	def test_bip32_constants_are_correct(self):
-		self.assertEqual(43, NemFacade.BIP32_COIN_ID)
 		self.assertEqual('ed25519-keccak', NemFacade.BIP32_CURVE_NAME)
 
 	def test_key_pair_is_correct(self):
@@ -159,6 +158,30 @@ class NemFacadeTest(unittest.TestCase):
 
 	# endregion
 
+	# region bip32_path
+
+	def test_can_construct_proper_bip32_mainnet_path(self):
+		# Arrange:
+		facade = NemFacade('mainnet')
+
+		# Act:
+		path = facade.bip32_path(2)
+
+		# Act + Assert:
+		self.assertEqual([44, 43, 2, 0, 0], path)
+
+	def test_can_construct_proper_bip32_testnet_path(self):
+		# Arrange:
+		facade = NemFacade('testnet')
+
+		# Act:
+		path = facade.bip32_path(2)
+
+		# Act + Assert:
+		self.assertEqual([44, 1, 2, 0, 0], path)
+
+	# endregion
+
 	# region bip32_node_to_key_pair
 
 	def _assert_bip32_child_public_keys(self, passphrase, expected_child_public_keys):
@@ -173,7 +196,7 @@ class NemFacadeTest(unittest.TestCase):
 
 		child_public_keys = []
 		for i in range(0, len(expected_child_public_keys)):
-			child_node = root_node.derive_path([44, NemFacade.BIP32_COIN_ID, i, 0, 0])
+			child_node = root_node.derive_path(NemFacade('mainnet').bip32_path(i))
 			child_key_pair = NemFacade.bip32_node_to_key_pair(child_node)
 			child_public_keys.append(child_key_pair.public_key)
 

--- a/sdk/python/tests/facade/test_SymbolFacade.py
+++ b/sdk/python/tests/facade/test_SymbolFacade.py
@@ -84,7 +84,6 @@ class SymbolFacadeTest(unittest.TestCase):
 	# region constants
 
 	def test_bip32_constants_are_correct(self):
-		self.assertEqual(4343, SymbolFacade.BIP32_COIN_ID)
 		self.assertEqual('ed25519', SymbolFacade.BIP32_CURVE_NAME)
 
 	def test_key_pair_is_correct(self):
@@ -262,6 +261,30 @@ class SymbolFacadeTest(unittest.TestCase):
 
 	# endregion
 
+	# region bip32_path
+
+	def test_can_construct_proper_bip32_mainnet_path(self):
+		# Arrange:
+		facade = SymbolFacade('mainnet')
+
+		# Act:
+		path = facade.bip32_path(2)
+
+		# Act + Assert:
+		self.assertEqual([44, 4343, 2, 0, 0], path)
+
+	def test_can_construct_proper_bip32_testnet_path(self):
+		# Arrange:
+		facade = SymbolFacade('testnet')
+
+		# Act:
+		path = facade.bip32_path(2)
+
+		# Act + Assert:
+		self.assertEqual([44, 1, 2, 0, 0], path)
+
+	# endregion
+
 	# region bip32_node_to_key_pair
 
 	def _assert_bip32_child_public_keys(self, passphrase, expected_child_public_keys):
@@ -276,7 +299,7 @@ class SymbolFacadeTest(unittest.TestCase):
 
 		child_public_keys = []
 		for i in range(0, len(expected_child_public_keys)):
-			child_node = root_node.derive_path([44, SymbolFacade.BIP32_COIN_ID, i, 0, 0])
+			child_node = root_node.derive_path(SymbolFacade('mainnet').bip32_path(i))
 			child_key_pair = SymbolFacade.bip32_node_to_key_pair(child_node)
 			child_public_keys.append(child_key_pair.public_key)
 


### PR DESCRIPTION
 problem: BIP32_COIN_ID constant contains mainnet coin id.
          This can be confusing when using testnet where a different coin id should be used.
solution: Drop BIP32_COIN_ID and replace it with a bip32Path function that returns a BIP32 path
          given an account id.

  issues: #241, #242
