### PR TITLE
[sdk]: allow facades to be constructed around arbitrary network

### DIFF
--- a/sdk/javascript/src/facade/NemFacade.js
+++ b/sdk/javascript/src/facade/NemFacade.js
@@ -19,10 +19,10 @@ class NemFacade {
 
 	/**
 	 * Creates a NEM facade.
-	 * @param {string} nemNetworkName NEM network name.
+	 * @param {string|Network} network NEM network or network name.
 	 */
-	constructor(nemNetworkName) {
-		this.network = NetworkLocator.findByName(Network.NETWORKS, nemNetworkName);
+	constructor(network) {
+		this.network = 'string' === typeof network ? NetworkLocator.findByName(Network.NETWORKS, network) : network;
 		this.transactionFactory = new TransactionFactory(this.network);
 	}
 

--- a/sdk/javascript/src/facade/SymbolFacade.js
+++ b/sdk/javascript/src/facade/SymbolFacade.js
@@ -54,10 +54,10 @@ class SymbolFacade {
 
 	/**
 	 * Creates a Symbol facade.
-	 * @param {string} symbolNetworkName Symbol network name.
+	 * @param {string|Network} network Symbol network or network name.
 	 */
-	constructor(symbolNetworkName) {
-		this.network = NetworkLocator.findByName(Network.NETWORKS, symbolNetworkName);
+	constructor(network) {
+		this.network = 'string' === typeof network ? NetworkLocator.findByName(Network.NETWORKS, network) : network;
 		this.transactionFactory = new TransactionFactory(this.network);
 	}
 

--- a/sdk/javascript/test/facade/NemFacade_spec.js
+++ b/sdk/javascript/test/facade/NemFacade_spec.js
@@ -3,6 +3,7 @@ const {
 	Hash256, PrivateKey, PublicKey, Signature
 } = require('../../src/CryptoTypes');
 const { NemFacade } = require('../../src/facade/NemFacade');
+const { Network } = require('../../src/nem/Network');
 const { expect } = require('chai');
 const crypto = require('crypto');
 
@@ -42,7 +43,7 @@ describe('NEM Facade', () => {
 
 	// region constructor
 
-	it('can create around known network', () => {
+	it('can create around known network by name', () => {
 		// Act:
 		const facade = new NemFacade('testnet');
 		const transaction = facade.transactionFactory.create({
@@ -58,10 +59,29 @@ describe('NEM Facade', () => {
 		expect(transaction.version).to.equal(2);
 	});
 
-	it('cannot create around unknown network', () => {
+	it('cannot create around unknown network by name', () => {
 		expect(() => {
 			new NemFacade('foo'); // eslint-disable-line no-new
 		}).to.throw('no network found with name \'foo\'');
+	});
+
+	it('can create around unknown network', () => {
+		// Arrange:
+		const network = new Network('foo', 0xDE);
+
+		// Act:
+		const facade = new NemFacade(network);
+		const transaction = facade.transactionFactory.create({
+			type: 'transfer_transaction',
+			signerPublicKey: new Uint32Array(PublicKey.SIZE)
+		});
+
+		// Assert:
+		expect(facade.network.name).to.equal('foo');
+		expect(facade.network.identifier).to.equal(0xDE);
+
+		expect(transaction.type.value).to.equal(0x0101);
+		expect(transaction.version).to.equal(2);
 	});
 
 	// endregion

--- a/sdk/javascript/test/facade/SymbolFacade_spec.js
+++ b/sdk/javascript/test/facade/SymbolFacade_spec.js
@@ -3,6 +3,7 @@ const {
 	Hash256, PrivateKey, PublicKey, Signature
 } = require('../../src/CryptoTypes');
 const { SymbolFacade } = require('../../src/facade/SymbolFacade');
+const { Network } = require('../../src/symbol/Network');
 const { expect } = require('chai');
 const crypto = require('crypto');
 
@@ -103,7 +104,7 @@ describe('Symbol Facade', () => {
 
 	// region constructor
 
-	it('can create around known network', () => {
+	it('can create around known network by name', () => {
 		// Act:
 		const facade = new SymbolFacade('testnet');
 		const transaction = facade.transactionFactory.create({
@@ -119,10 +120,29 @@ describe('Symbol Facade', () => {
 		expect(transaction.version).to.equal(1);
 	});
 
-	it('cannot create around unknown network', () => {
+	it('cannot create around unknown network by name', () => {
 		expect(() => {
 			new SymbolFacade('foo'); // eslint-disable-line no-new
 		}).to.throw('no network found with name \'foo\'');
+	});
+
+	it('can create around unknown network', () => {
+		// Arrange:
+		const network = new Network('foo', 0xDE);
+
+		// Act:
+		const facade = new SymbolFacade(network);
+		const transaction = facade.transactionFactory.create({
+			type: 'transfer_transaction',
+			signerPublicKey: new Uint32Array(PublicKey.SIZE)
+		});
+
+		// Assert:
+		expect(facade.network.name).to.equal('foo');
+		expect(facade.network.identifier).to.equal(0xDE);
+
+		expect(transaction.type.value).to.equal(0x4154);
+		expect(transaction.version).to.equal(1);
 	});
 
 	// endregion

--- a/sdk/python/symbolchain/facade/NemFacade.py
+++ b/sdk/python/symbolchain/facade/NemFacade.py
@@ -12,13 +12,13 @@ class NemFacade:
 
 	BIP32_CURVE_NAME = 'ed25519-keccak'
 
-	Address = Address
-	KeyPair = KeyPair
-	Verifier = Verifier
+	Address = Address  # pylint: disable=duplicate-code
+	KeyPair = KeyPair  # pylint: disable=duplicate-code
+	Verifier = Verifier  # pylint: disable=duplicate-code
 
-	def __init__(self, nem_network_name, account_descriptor_repository=None):
+	def __init__(self, network, account_descriptor_repository=None):
 		"""Creates a NEM facade."""
-		self.network = NetworkLocator.find_by_name(Network.NETWORKS, nem_network_name)
+		self.network = NetworkLocator.find_by_name(Network.NETWORKS, network) if isinstance(network, str) else network
 		self.account_descriptor_repository = account_descriptor_repository
 		self.transaction_factory = self._create_nem_transaction_factory()
 

--- a/sdk/python/symbolchain/facade/SymbolFacade.py
+++ b/sdk/python/symbolchain/facade/SymbolFacade.py
@@ -29,13 +29,13 @@ class SymbolFacade:
 
 	BIP32_CURVE_NAME = 'ed25519'
 
-	Address = Address
-	KeyPair = KeyPair
-	Verifier = Verifier
+	Address = Address  # pylint: disable=duplicate-code
+	KeyPair = KeyPair  # pylint: disable=duplicate-code
+	Verifier = Verifier  # pylint: disable=duplicate-code
 
-	def __init__(self, symbol_network_name, account_descriptor_repository=None):
+	def __init__(self, network, account_descriptor_repository=None):
 		"""Creates a Symbol facade."""
-		self.network = NetworkLocator.find_by_name(Network.NETWORKS, symbol_network_name)
+		self.network = NetworkLocator.find_by_name(Network.NETWORKS, network) if isinstance(network, str) else network
 		self.account_descriptor_repository = account_descriptor_repository
 		self.transaction_factory = self._create_symbol_transaction_factory()
 

--- a/sdk/python/tests/facade/test_NemFacade.py
+++ b/sdk/python/tests/facade/test_NemFacade.py
@@ -4,6 +4,7 @@ from symbolchain.AccountDescriptorRepository import AccountDescriptorRepository
 from symbolchain.Bip32 import Bip32
 from symbolchain.CryptoTypes import Hash256, PrivateKey, PublicKey, Signature
 from symbolchain.facade.NemFacade import NemFacade
+from symbolchain.nem.Network import Network
 
 from ..test.TestUtils import TestUtils
 
@@ -48,7 +49,7 @@ class NemFacadeTest(unittest.TestCase):
 
 	# region constructor
 
-	def test_can_create_around_known_network(self):
+	def test_can_create_around_known_network_by_name(self):
 		# Act:
 		facade = NemFacade('testnet')
 		transaction = facade.transaction_factory.create({
@@ -63,9 +64,27 @@ class NemFacadeTest(unittest.TestCase):
 		self.assertEqual(0x0101, transaction.type_.value)
 		self.assertEqual(2, transaction.version)
 
-	def test_cannot_create_around_unknown_network(self):
+	def test_cannot_create_around_unknown_network_by_name(self):
 		with self.assertRaises(StopIteration):
 			NemFacade('foo')
+
+	def test_can_create_around_unknown_network(self):
+		# Arrange:
+		network = Network('foo', 0x98, None)
+
+		# Act:
+		facade = NemFacade(network)
+		transaction = facade.transaction_factory.create({
+			'type': 'transfer_transaction',
+			'signer_public_key': bytes(PublicKey.SIZE)
+		})
+
+		# Assert:
+		self.assertEqual('foo', facade.network.name)
+		self.assertEqual(0x98, transaction.network.value)
+
+		self.assertEqual(0x0101, transaction.type_.value)
+		self.assertEqual(2, transaction.version)
 
 	def test_can_create_via_repository(self):
 		# Act:

--- a/sdk/python/tests/facade/test_SymbolFacade.py
+++ b/sdk/python/tests/facade/test_SymbolFacade.py
@@ -4,6 +4,7 @@ from symbolchain.AccountDescriptorRepository import AccountDescriptorRepository
 from symbolchain.Bip32 import Bip32
 from symbolchain.CryptoTypes import Hash256, PrivateKey, PublicKey, Signature
 from symbolchain.facade.SymbolFacade import SymbolFacade
+from symbolchain.symbol.Network import Network
 
 from ..test.TestUtils import TestUtils
 
@@ -113,12 +114,12 @@ class SymbolFacadeTest(unittest.TestCase):
 
 	# region constructor
 
-	def test_can_create_around_known_network(self):
+	def test_can_create_around_known_network_by_name(self):
 		# Act:
 		facade = SymbolFacade('testnet')
 		transaction = facade.transaction_factory.create({
 			'type': 'transfer_transaction',
-			'signer_public_key': TestUtils.random_byte_array(PublicKey)
+			'signer_public_key': bytes(PublicKey.SIZE)
 		})
 
 		# Assert:
@@ -128,9 +129,27 @@ class SymbolFacadeTest(unittest.TestCase):
 		self.assertEqual(0x4154, transaction.type_.value)
 		self.assertEqual(1, transaction.version)
 
-	def test_cannot_create_around_unknown_network(self):
+	def test_cannot_create_around_unknown_network_by_name(self):
 		with self.assertRaises(StopIteration):
 			SymbolFacade('foo')
+
+	def test_can_create_around_unknown_network(self):
+		# Arrange:
+		network = Network('foo', 0x98, None)
+
+		# Act:
+		facade = SymbolFacade(network)
+		transaction = facade.transaction_factory.create({
+			'type': 'transfer_transaction',
+			'signer_public_key': bytes(PublicKey.SIZE)
+		})
+
+		# Assert:
+		self.assertEqual('foo', facade.network.name)
+		self.assertEqual(0x98, transaction.network.value)
+
+		self.assertEqual(0x4154, transaction.type_.value)
+		self.assertEqual(1, transaction.version)
 
 	def test_can_create_via_repository(self):
 		# Act:


### PR DESCRIPTION
 problem: facades look up well known networks by name, so custom networks cannot be used
solution: allow facades to be constructed around a network object in addition to a network name

  issues: #245, #246
