### PR TITLE
[linters] fix: pylint 2.14 reports unknown options

### DIFF
--- a/linters/python/.pylintrc
+++ b/linters/python/.pylintrc
@@ -22,7 +22,7 @@ jobs=1
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=pylint.extensions.no_self_use
 
 # Pickle collected data for later comparisons.
 persistent=yes
@@ -51,7 +51,7 @@ confidence=
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
 #disable=print-statement,parameter-unpacking,unpacking-in-except,old-raise-syntax,backtick,long-suffix,old-ne-operator,old-octal-literal,import-star-module-level,raw-checker-failed,bad-inline-option,locally-disabled,locally-enabled,file-ignored,suppressed-message,useless-suppression,deprecated-pragma,apply-builtin,basestring-builtin,buffer-builtin,cmp-builtin,coerce-builtin,execfile-builtin,file-builtin,long-builtin,raw_input-builtin,reduce-builtin,standarderror-builtin,unicode-builtin,xrange-builtin,coerce-method,delslice-method,getslice-method,setslice-method,no-absolute-import,old-division,dict-iter-method,dict-view-method,next-method-called,metaclass-assignment,indexing-exception,raising-string,reload-builtin,oct-method,hex-method,nonzero-method,cmp-method,input-builtin,round-builtin,intern-builtin,unichr-builtin,map-builtin-not-iterating,zip-builtin-not-iterating,range-builtin-not-iterating,filter-builtin-not-iterating,using-cmp-argument,eq-without-hash,div-method,idiv-method,rdiv-method,exception-message-attribute,invalid-str-codec,sys-max-int,bad-python3-import,deprecated-string-function,deprecated-str-translate-call
-disable=missing-docstring,misplaced-comparison-constant
+disable=missing-docstring
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
@@ -93,14 +93,8 @@ max-nested-blocks=5
 
 [BASIC]
 
-# Naming hint for argument names
-argument-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
-
 # Regular expression matching correct argument names
 argument-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
-
-# Naming hint for attribute names
-attr-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct attribute names
 attr-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
@@ -108,20 +102,11 @@ attr-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 # Bad variable names which should always be refused, separated by a comma
 bad-names=foo,bar,baz,toto,tutu,tata
 
-# Naming hint for class attribute names
-class-attribute-name-hint=([A-Z][a-zA-Z0-9_]{2,30}|(__.*__))$
-
 # Regular expression matching correct class attribute names
 class-attribute-rgx=([A-Z][a-zA-Z0-9_]{2,30}|(__.*__))$
 
-# Naming hint for class names
-class-name-hint=[A-Z_][a-zA-Z0-9]+$
-
 # Regular expression matching correct class names
 class-rgx=[A-Z_][a-zA-Z0-9]+$
-
-# Naming hint for constant names
-const-name-hint=(([A-Z_][A-Z0-9_]*)|(t_[A-Z0-9_]+)|(__.*__))$
 
 # Regular expression matching correct constant names
 const-rgx=(([A-Z_][A-Z0-9_]*)|(t_[A-Z0-9_]+)|(__.*__))$
@@ -129,9 +114,6 @@ const-rgx=(([A-Z_][A-Z0-9_]*)|(t_[A-Z0-9_]+)|(__.*__))$
 # Minimum line length for functions/classes that require docstrings, shorter
 # ones are exempt.
 docstring-min-length=100
-
-# Naming hint for function names
-function-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct function names
 function-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
@@ -142,20 +124,11 @@ good-names=i,j,k,ex,Run,_
 # Include a hint for the correct naming format with invalid-name
 include-naming-hint=no
 
-# Naming hint for inline iteration names
-inlinevar-name-hint=[A-Za-z_][a-z0-9_]*$
-
 # Regular expression matching correct inline iteration names
 inlinevar-rgx=[A-Za-z_][a-z0-9_]*$
 
-# Naming hint for method names
-method-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
-
 # Regular expression matching correct method names
 method-rgx=(([a-z][a-z0-9_]{2,30})|(test_[a-z0-9_]+)|(_[a-z0-9_]*))$
-
-# Naming hint for module names
-module-name-hint=(([a-z_][a-z0-9_]*)|([A-Z][a-zA-Z0-9_]+)|(__main__))$
 
 # Regular expression matching correct module names
 module-rgx=((test_)?([A-Za-z][a-zA-Z0-9_]+)|(__main__))$
@@ -171,9 +144,6 @@ no-docstring-rgx=.
 # List of decorators that produce properties, such as abc.abstractproperty. Add
 # to this list to register other decorators that produce valid properties.
 property-classes=abc.abstractproperty
-
-# Naming hint for variable names
-variable-name-hint=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
 
 # Regular expression matching correct variable names
 variable-rgx=(([a-z][a-z0-9_]{2,30})|(_[a-z0-9_]*))$
@@ -199,12 +169,6 @@ max-line-length=140
 
 # Maximum number of lines in a module
 max-module-lines=1000
-
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,dict-separator
 
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.

--- a/linters/python/lint_requirements.txt
+++ b/linters/python/lint_requirements.txt
@@ -1,4 +1,4 @@
 isort==5.10.1
 pycodestyle==2.8.0
-pylint==2.13.9
+pylint==2.14.1
 pylint-quotes==0.2.3

--- a/sdk/python/scripts/ci/lint.sh
+++ b/sdk/python/scripts/ci/lint.sh
@@ -10,7 +10,7 @@ find . -type f -name "*.py" -print0 | PYTHONPATH=. xargs -0 python3 -m isort \
 	--check-only
 find . -name "nc" -prune -o -name "sc" -prune -o -type f -name "*.py" -print0 | PYTHONPATH=. xargs -0 python3 -m pycodestyle \
 	--config="$(git rev-parse --show-toplevel)/linters/python/.pycodestyle"
-find . -name "nc" -prune -o -name "sc" -prune -o -type f -name "*.py" -print0 | PYTHONPATH=".:$(git rev-parse --show-toplevel)/catbuffer/parser" xargs -0 python3 -m pylint \
+find . -name "nc" -prune -o -name "sc" -prune -o -name "external" -prune -o -type f -name "*.py" -print0 | PYTHONPATH=".:$(git rev-parse --show-toplevel)/catbuffer/parser" xargs -0 python3 -m pylint \
 	--rcfile "$(git rev-parse --show-toplevel)/linters/python/.pylintrc" \
 	--load-plugins pylint_quotes
 
@@ -18,7 +18,7 @@ find . -name "nc" -prune -o -name "sc" -prune -o -type f -name "*.py" -print0 | 
 find . -name "nc" -o -name "sc" -o -type f -name "*.py" -print0 | PYTHONPATH=. xargs -0 python3 -m pycodestyle \
 	--config="$(git rev-parse --show-toplevel)/linters/python/.pycodestyle" \
 	--max-line-length=210
-find . -name "nc" -o -name "sc" -o -type f -name "*.py" -print0 | PYTHONPATH=".:$(git rev-parse --show-toplevel)/catbuffer/parser" xargs -0 python3 -m pylint \
+find . -name "external" -prune -name "nc" -o -name "sc" -o -type f -name "*.py" -print0 | PYTHONPATH=".:$(git rev-parse --show-toplevel)/catbuffer/parser" xargs -0 python3 -m pylint \
 	--rcfile "$(git rev-parse --show-toplevel)/linters/python/.pylintrc" \
 	--load-plugins pylint_quotes \
 	--disable=duplicate-code

--- a/sdk/python/scripts/ci/lint.sh
+++ b/sdk/python/scripts/ci/lint.sh
@@ -10,7 +10,7 @@ find . -type f -name "*.py" -print0 | PYTHONPATH=. xargs -0 python3 -m isort \
 	--check-only
 find . -name "nc" -prune -o -name "sc" -prune -o -type f -name "*.py" -print0 | PYTHONPATH=. xargs -0 python3 -m pycodestyle \
 	--config="$(git rev-parse --show-toplevel)/linters/python/.pycodestyle"
-find . -name "nc" -prune -o -name "sc" -prune -o -name "external" -prune -o -type f -name "*.py" -print0 | PYTHONPATH=".:$(git rev-parse --show-toplevel)/catbuffer/parser" xargs -0 python3 -m pylint \
+find . -name "nc" -prune -o -name "sc" -prune -o -type f -name "*.py" -print0 | PYTHONPATH=".:$(git rev-parse --show-toplevel)/catbuffer/parser" xargs -0 python3 -m pylint \
 	--rcfile "$(git rev-parse --show-toplevel)/linters/python/.pylintrc" \
 	--load-plugins pylint_quotes
 
@@ -18,7 +18,7 @@ find . -name "nc" -prune -o -name "sc" -prune -o -name "external" -prune -o -typ
 find . -name "nc" -o -name "sc" -o -type f -name "*.py" -print0 | PYTHONPATH=. xargs -0 python3 -m pycodestyle \
 	--config="$(git rev-parse --show-toplevel)/linters/python/.pycodestyle" \
 	--max-line-length=210
-find . -name "external" -prune -name "nc" -o -name "sc" -o -type f -name "*.py" -print0 | PYTHONPATH=".:$(git rev-parse --show-toplevel)/catbuffer/parser" xargs -0 python3 -m pylint \
+find . -name "nc" -o -name "sc" -o -type f -name "*.py" -print0 | PYTHONPATH=".:$(git rev-parse --show-toplevel)/catbuffer/parser" xargs -0 python3 -m pylint \
 	--rcfile "$(git rev-parse --show-toplevel)/linters/python/.pylintrc" \
 	--load-plugins pylint_quotes \
 	--disable=duplicate-code

--- a/sdk/python/symbolchain/nem/external/ed25519.py
+++ b/sdk/python/symbolchain/nem/external/ed25519.py
@@ -30,7 +30,7 @@ disclose data to an attacker.  We rely on Python's long-integer
 arithmetic, so we cannot handle secrets without risking their disclosure.
 """
 
-# pylint: disable=invalid-name,too-many-locals,unused-variable,arguments-out-of-order
+# pylint: disable=invalid-name,too-many-locals,unused-variable,arguments-out-of-order,consider-using-generator
 
 import hashlib
 import operator


### PR DESCRIPTION
## What is the current behavior?
pylint 2.13.x does not report deprecated options

## What's the issue?
Starting with pylint  2.14 unknown options are reported and will fail if try to disable them

## How have you changed the behavior?
pylint 2.14.0 starts reporting options which has been removed.
1. ``no-self-use`` was moved an extension so load it.
    https://pylint.pycqa.org/en/latest/whatsnew/2/2.14/summary.html#removed-checkers
2. The ``*-name-hint`` options were replaced with ``*-naming-style``.
    The rgx options are still available, and they overrides the *-naming-style.
    Thus removing ``*-name-hint`` options as they are not needed.
3. ``no-space-check`` option was removed in pylint 2.6 - https://pylint.pycqa.org/en/v2.11.1/whatsnew/2.6.html
4. ``misplaced-comparison-constant`` was moved to an extension but since this option was disabled so removed.
5. In python sdk exclude linting of external code

## How was this change tested?
Yes, tested locally by running scripts