### PR TITLE
[monorepo] fix: add threshold for code coverage drop

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -8,26 +8,31 @@ coverage:
 
       catbuffer-parser:
         target: auto
+        threshold: 1%
         flags:
           - catbuffer-parser
 
       client-catapult:
         target: auto
+        threshold: 1%
         flags:
           - client-catapult
 
       client-rest:
         target: auto
+        threshold: 1%
         flags:
           - client-rest
 
       sdk-javascript:
         target: auto
+        threshold: 1%
         flags:
           - sdk-javascript
 
       sdk-python:
         target: auto
+        threshold: 1%
         flags:
           - sdk-python
 


### PR DESCRIPTION
## What is the current behavior?
codecov check will fail if code coverage percentage drops.

## What's the issue?
codecov check is failing when there is a 0.5% drop in codecoverage

## How have you changed the behavior?
Add threshold value to codecov config to allow 1% drop in code coverage