### PR TITLE
[sdk/python]: initialize optional fields to None to match deserializer

### DIFF
--- a/sdk/javascript/examples/descriptors/nem_namespace.js
+++ b/sdk/javascript/examples/descriptors/nem_namespace.js
@@ -4,7 +4,6 @@ const descriptorFactory = () => ([
 		type: 'namespace_registration_transaction',
 		rentalFeeSink: 'TAMESPACEWH4MKFMBCVFERDPOOP4FK7MTDJEYP35',
 		rentalFee: 50000n * 1000000n,
-		parentName: '',
 		name: 'roger'
 	},
 

--- a/sdk/javascript/src/nem/TransactionFactory.js
+++ b/sdk/javascript/src/nem/TransactionFactory.js
@@ -30,7 +30,7 @@ class TransactionFactory {
 		});
 
 		// hack: explicitly translate transfer message
-		if (nc.TransactionType.TRANSFER === transaction.type && 'string' === typeof (transaction.message.message))
+		if (nc.TransactionType.TRANSFER === transaction.type && transaction.message && 'string' === typeof (transaction.message.message))
 			transaction.message.message = new TextEncoder().encode(transaction.message.message);
 
 		return transaction;

--- a/sdk/javascript/src/nem/models.js
+++ b/sdk/javascript/src/nem/models.js
@@ -1613,7 +1613,7 @@ class MosaicDefinition {
 		this._description = new Uint8Array();
 		this._properties = [];
 		this._levySize = 0;
-		this._levy = new MosaicLevy();
+		this._levy = null;
 		this._ownerPublicKeySize = 32; // reserved field
 	}
 
@@ -1705,7 +1705,7 @@ class MosaicDefinition {
 		view.shiftRight(arrayHelpers.size(properties));
 		const levySize = converter.bytesToIntUnaligned(view.buffer, 4, false);
 		view.shiftRight(4);
-		let levy;
+		let levy = null;
 		if (0 !== levySize) {
 			levy = MosaicLevy.deserialize(view.buffer);
 			view.shiftRight(levy.size);
@@ -4251,7 +4251,7 @@ class NamespaceRegistrationTransaction {
 		this._rentalFeeSink = new Address();
 		this._rentalFee = new Amount();
 		this._name = new Uint8Array();
-		this._parentName = new Uint8Array();
+		this._parentName = null;
 		this._entityBodyReserved_1 = 0; // reserved field
 		this._signerPublicKeySize = 32; // reserved field
 		this._signatureSize = 64; // reserved field
@@ -4423,7 +4423,7 @@ class NamespaceRegistrationTransaction {
 		view.shiftRight(nameSize);
 		const parentNameSize = converter.bytesToIntUnaligned(view.buffer, 4, false);
 		view.shiftRight(4);
-		let parentName;
+		let parentName = null;
 		if (4294967295 !== parentNameSize) {
 			parentName = new Uint8Array(view.buffer.buffer, view.buffer.byteOffset, parentNameSize);
 			view.shiftRight(parentNameSize);
@@ -4520,7 +4520,7 @@ class NonVerifiableNamespaceRegistrationTransaction {
 		this._rentalFeeSink = new Address();
 		this._rentalFee = new Amount();
 		this._name = new Uint8Array();
-		this._parentName = new Uint8Array();
+		this._parentName = null;
 		this._entityBodyReserved_1 = 0; // reserved field
 		this._signerPublicKeySize = 32; // reserved field
 		this._rentalFeeSinkSize = 40; // reserved field
@@ -4675,7 +4675,7 @@ class NonVerifiableNamespaceRegistrationTransaction {
 		view.shiftRight(nameSize);
 		const parentNameSize = converter.bytesToIntUnaligned(view.buffer, 4, false);
 		view.shiftRight(4);
-		let parentName;
+		let parentName = null;
 		if (4294967295 !== parentNameSize) {
 			parentName = new Uint8Array(view.buffer.buffer, view.buffer.byteOffset, parentNameSize);
 			view.shiftRight(parentNameSize);
@@ -4887,7 +4887,7 @@ class TransferTransactionV1 {
 		this._recipientAddress = new Address();
 		this._amount = new Amount();
 		this._messageEnvelopeSize = 0;
-		this._message = new Message();
+		this._message = null;
 		this._entityBodyReserved_1 = 0; // reserved field
 		this._signerPublicKeySize = 32; // reserved field
 		this._signatureSize = 64; // reserved field
@@ -5053,7 +5053,7 @@ class TransferTransactionV1 {
 		view.shiftRight(amount.size);
 		const messageEnvelopeSize = converter.bytesToIntUnaligned(view.buffer, 4, false);
 		view.shiftRight(4);
-		let message;
+		let message = null;
 		if (0 !== messageEnvelopeSize) {
 			message = Message.deserialize(view.buffer);
 			view.shiftRight(message.size);
@@ -5147,7 +5147,7 @@ class NonVerifiableTransferTransactionV1 {
 		this._recipientAddress = new Address();
 		this._amount = new Amount();
 		this._messageEnvelopeSize = 0;
-		this._message = new Message();
+		this._message = null;
 		this._entityBodyReserved_1 = 0; // reserved field
 		this._signerPublicKeySize = 32; // reserved field
 		this._recipientAddressSize = 40; // reserved field
@@ -5296,7 +5296,7 @@ class NonVerifiableTransferTransactionV1 {
 		view.shiftRight(amount.size);
 		const messageEnvelopeSize = converter.bytesToIntUnaligned(view.buffer, 4, false);
 		view.shiftRight(4);
-		let message;
+		let message = null;
 		if (0 !== messageEnvelopeSize) {
 			message = Message.deserialize(view.buffer);
 			view.shiftRight(message.size);
@@ -5389,7 +5389,7 @@ class TransferTransaction {
 		this._recipientAddress = new Address();
 		this._amount = new Amount();
 		this._messageEnvelopeSize = 0;
-		this._message = new Message();
+		this._message = null;
 		this._mosaics = [];
 		this._entityBodyReserved_1 = 0; // reserved field
 		this._signerPublicKeySize = 32; // reserved field
@@ -5566,7 +5566,7 @@ class TransferTransaction {
 		view.shiftRight(amount.size);
 		const messageEnvelopeSize = converter.bytesToIntUnaligned(view.buffer, 4, false);
 		view.shiftRight(4);
-		let message;
+		let message = null;
 		if (0 !== messageEnvelopeSize) {
 			message = Message.deserialize(view.buffer);
 			view.shiftRight(message.size);
@@ -5669,7 +5669,7 @@ class NonVerifiableTransferTransaction {
 		this._recipientAddress = new Address();
 		this._amount = new Amount();
 		this._messageEnvelopeSize = 0;
-		this._message = new Message();
+		this._message = null;
 		this._mosaics = [];
 		this._entityBodyReserved_1 = 0; // reserved field
 		this._signerPublicKeySize = 32; // reserved field
@@ -5829,7 +5829,7 @@ class NonVerifiableTransferTransaction {
 		view.shiftRight(amount.size);
 		const messageEnvelopeSize = converter.bytesToIntUnaligned(view.buffer, 4, false);
 		view.shiftRight(4);
-		let message;
+		let message = null;
 		if (0 !== messageEnvelopeSize) {
 			message = Message.deserialize(view.buffer);
 			view.shiftRight(message.size);

--- a/sdk/javascript/src/symbol/TransactionFactory.js
+++ b/sdk/javascript/src/symbol/TransactionFactory.js
@@ -27,7 +27,8 @@ class TransactionFactory {
 
 		// autogenerate artifact ids
 		if (sc.TransactionType.NAMESPACE_REGISTRATION === transaction.type) {
-			const rawNamespaceId = generateNamespaceId(new TextDecoder().decode(transaction.name), transaction.parentId.value);
+			const parentId = sc.NamespaceRegistrationType.CHILD === transaction.registrationType ? transaction.parentId.value : 0n;
+			const rawNamespaceId = generateNamespaceId(new TextDecoder().decode(transaction.name), parentId);
 			transaction.id = new sc.NamespaceId(rawNamespaceId);
 		} else if (sc.TransactionType.MOSAIC_DEFINITION === transaction.type) {
 			const address = this.network.publicKeyToAddress(new PublicKey(transaction.signerPublicKey.bytes));

--- a/sdk/javascript/src/symbol/models.js
+++ b/sdk/javascript/src/symbol/models.js
@@ -8323,7 +8323,7 @@ class NamespaceRegistrationTransaction {
 		this._fee = new Amount();
 		this._deadline = new Timestamp();
 		this._duration = new BlockDuration();
-		this._parentId = new NamespaceId();
+		this._parentId = null;
 		this._id = new NamespaceId();
 		this._registrationType = NamespaceRegistrationType.ROOT;
 		this._name = new Uint8Array();
@@ -8488,11 +8488,11 @@ class NamespaceRegistrationTransaction {
 		view.shiftRight(id.size);
 		const registrationType = NamespaceRegistrationType.deserializeAligned(view.buffer);
 		view.shiftRight(registrationType.size);
-		let duration;
+		let duration = null;
 		if (NamespaceRegistrationType.ROOT === registrationType)
 			duration = BlockDuration.deserializeAligned(registration_type_condition);
 
-		let parentId;
+		let parentId = null;
 		if (NamespaceRegistrationType.CHILD === registrationType)
 			parentId = NamespaceId.deserializeAligned(registration_type_condition);
 
@@ -8587,7 +8587,7 @@ class EmbeddedNamespaceRegistrationTransaction {
 		this._network = NetworkType.MAINNET;
 		this._type = EmbeddedNamespaceRegistrationTransaction.TRANSACTION_TYPE;
 		this._duration = new BlockDuration();
-		this._parentId = new NamespaceId();
+		this._parentId = null;
 		this._id = new NamespaceId();
 		this._registrationType = NamespaceRegistrationType.ROOT;
 		this._name = new Uint8Array();
@@ -8719,11 +8719,11 @@ class EmbeddedNamespaceRegistrationTransaction {
 		view.shiftRight(id.size);
 		const registrationType = NamespaceRegistrationType.deserializeAligned(view.buffer);
 		view.shiftRight(registrationType.size);
-		let duration;
+		let duration = null;
 		if (NamespaceRegistrationType.ROOT === registrationType)
 			duration = BlockDuration.deserializeAligned(registration_type_condition);
 
-		let parentId;
+		let parentId = null;
 		if (NamespaceRegistrationType.CHILD === registrationType)
 			parentId = NamespaceId.deserializeAligned(registration_type_condition);
 

--- a/sdk/javascript/vectors/catbuffer.js
+++ b/sdk/javascript/vectors/catbuffer.js
@@ -209,6 +209,44 @@ describe('catbuffer vectors', () => {
 
 	// endregion
 
+	// region create from constructor
+
+	describe('create from constructor', () => {
+		const assertCreateFromConstructor = (schemaName, module) => {
+			// Arrange:
+			const SchemaClass = module[schemaName];
+
+			// Act:
+			const transaction = new SchemaClass();
+
+			const { size } = transaction;
+			const transactionBuffer = transaction.serialize();
+
+			// Assert:
+			expect(size).to.not.equal(0);
+			expect(transactionBuffer.length).to.not.equal(0);
+			expect(size).to.equal(transactionBuffer.length);
+		};
+
+		describe('NEM', () => {
+			new Set(prepareTestCases('nem').map(item => item.schema_name)).forEach(schemaName => {
+				it(`can create from constructor ${schemaName}`, () => {
+					assertCreateFromConstructor(schemaName, nc);
+				});
+			});
+		});
+
+		describe('Symbol', () => {
+			new Set(prepareTestCases('symbol').map(item => item.schema_name)).forEach(schemaName => {
+				it(`can create from constructor ${schemaName}`, () => {
+					assertCreateFromConstructor(schemaName, sc);
+				});
+			});
+		});
+	});
+
+	// endregion
+
 	// region roundtrip
 
 	describe('roundtrip', () => {

--- a/sdk/python/examples/descriptors/nem_namespace.py
+++ b/sdk/python/examples/descriptors/nem_namespace.py
@@ -5,7 +5,6 @@ def descriptor_factory():
 			'type': 'namespace_registration_transaction',
 			'rental_fee_sink': 'TAMESPACEWH4MKFMBCVFERDPOOP4FK7MTDJEYP35',
 			'rental_fee': 50000 * 1000000,
-			'parent_name': '',
 			'name': 'roger'
 		},
 

--- a/sdk/python/generator/StructTypeFormatter.py
+++ b/sdk/python/generator/StructTypeFormatter.py
@@ -103,7 +103,18 @@ class StructFormatter(AbstractTypeFormatter):
 			if const_field:
 				body += f'{field_name} = {self.typename}.{const_field.name}\n'
 			else:
-				body += f'{field_name} = {field.extensions.printer.get_default_value()}\n'
+				value = field.extensions.printer.get_default_value()
+				if field.is_conditional:
+					conditional = field.value
+					condition_field_name = conditional.linked_field_name
+					condition_field = next(f for f in self.non_const_fields() if condition_field_name == f.name)
+					condition_model = condition_field.extensions.type_model
+
+					# only initialize default implicit union field in constructor
+					if f'{condition_model.name}.{conditional.value}' != condition_field.extensions.printer.get_default_value():
+						value = 'None'
+
+				body += f'{field_name} = {value}\n'
 
 		body += '\n'.join(
 			map(

--- a/sdk/python/symbolchain/nc/__init__.py
+++ b/sdk/python/symbolchain/nc/__init__.py
@@ -1412,7 +1412,7 @@ class MosaicDefinition:
 		self._description = bytes()
 		self._properties = []
 		self._levy_size = 0
-		self._levy = MosaicLevy()
+		self._levy = None
 		self._owner_public_key_size = 32  # reserved field
 
 	@property
@@ -3882,7 +3882,7 @@ class NamespaceRegistrationTransaction:
 		self._rental_fee_sink = Address()
 		self._rental_fee = Amount()
 		self._name = bytes()
-		self._parent_name = bytes()
+		self._parent_name = None
 		self._entity_body_reserved_1 = 0  # reserved field
 		self._signer_public_key_size = 32  # reserved field
 		self._signature_size = 64  # reserved field
@@ -4138,7 +4138,7 @@ class NonVerifiableNamespaceRegistrationTransaction:
 		self._rental_fee_sink = Address()
 		self._rental_fee = Amount()
 		self._name = bytes()
-		self._parent_name = bytes()
+		self._parent_name = None
 		self._entity_body_reserved_1 = 0  # reserved field
 		self._signer_public_key_size = 32  # reserved field
 		self._rental_fee_sink_size = 40  # reserved field
@@ -4458,7 +4458,7 @@ class TransferTransactionV1:
 		self._recipient_address = Address()
 		self._amount = Amount()
 		self._message_envelope_size = 0
-		self._message = Message()
+		self._message = None
 		self._entity_body_reserved_1 = 0  # reserved field
 		self._signer_public_key_size = 32  # reserved field
 		self._signature_size = 64  # reserved field
@@ -4705,7 +4705,7 @@ class NonVerifiableTransferTransactionV1:
 		self._recipient_address = Address()
 		self._amount = Amount()
 		self._message_envelope_size = 0
-		self._message = Message()
+		self._message = None
 		self._entity_body_reserved_1 = 0  # reserved field
 		self._signer_public_key_size = 32  # reserved field
 		self._recipient_address_size = 40  # reserved field
@@ -4935,7 +4935,7 @@ class TransferTransaction:
 		self._recipient_address = Address()
 		self._amount = Amount()
 		self._message_envelope_size = 0
-		self._message = Message()
+		self._message = None
 		self._mosaics = []
 		self._entity_body_reserved_1 = 0  # reserved field
 		self._signer_public_key_size = 32  # reserved field
@@ -5202,7 +5202,7 @@ class NonVerifiableTransferTransaction:
 		self._recipient_address = Address()
 		self._amount = Amount()
 		self._message_envelope_size = 0
-		self._message = Message()
+		self._message = None
 		self._mosaics = []
 		self._entity_body_reserved_1 = 0  # reserved field
 		self._signer_public_key_size = 32  # reserved field

--- a/sdk/python/symbolchain/nem/TransactionFactory.py
+++ b/sdk/python/symbolchain/nem/TransactionFactory.py
@@ -23,7 +23,7 @@ class TransactionFactory:
 		})
 
 		# hack: explicitly translate transfer message
-		if nc.TransactionType.TRANSFER == transaction.type_ and isinstance(transaction.message.message, str):
+		if nc.TransactionType.TRANSFER == transaction.type_ and transaction.message and isinstance(transaction.message.message, str):
 			transaction.message.message = transaction.message.message.encode('utf8')
 
 		return transaction

--- a/sdk/python/symbolchain/sc/__init__.py
+++ b/sdk/python/symbolchain/sc/__init__.py
@@ -7708,7 +7708,7 @@ class NamespaceRegistrationTransaction:
 		self._fee = Amount()
 		self._deadline = Timestamp()
 		self._duration = BlockDuration()
-		self._parent_id = NamespaceId()
+		self._parent_id = None
 		self._id = NamespaceId()
 		self._registration_type = NamespaceRegistrationType.ROOT
 		self._name = bytes()
@@ -7960,7 +7960,7 @@ class EmbeddedNamespaceRegistrationTransaction:
 		self._network = NetworkType.MAINNET
 		self._type_ = EmbeddedNamespaceRegistrationTransaction.TRANSACTION_TYPE
 		self._duration = BlockDuration()
-		self._parent_id = NamespaceId()
+		self._parent_id = None
 		self._id = NamespaceId()
 		self._registration_type = NamespaceRegistrationType.ROOT
 		self._name = bytes()

--- a/sdk/python/symbolchain/symbol/TransactionFactory.py
+++ b/sdk/python/symbolchain/symbol/TransactionFactory.py
@@ -24,7 +24,8 @@ class TransactionFactory:
 
 		# autogenerate artifact ids
 		if sc.TransactionType.NAMESPACE_REGISTRATION == transaction.type_:
-			transaction.id = sc.NamespaceId(generate_namespace_id(transaction.name.decode('utf8'), transaction.parent_id.value))
+			parent_id = transaction.parent_id.value if sc.NamespaceRegistrationType.CHILD == transaction.registration_type else 0
+			transaction.id = sc.NamespaceId(generate_namespace_id(transaction.name.decode('utf8'), parent_id))
 		elif sc.TransactionType.MOSAIC_DEFINITION == transaction.type_:
 			address = self.network.public_key_to_address(PublicKey(transaction.signer_public_key.bytes))
 			transaction.id = sc.MosaicId(generate_mosaic_id(address, transaction.nonce.value))

--- a/sdk/python/tests/facade/test_BatchOperations.py
+++ b/sdk/python/tests/facade/test_BatchOperations.py
@@ -72,7 +72,7 @@ class BatchOperationsTest(unittest.TestCase):
 		self.assertEqual(TEST_PUBLIC_KEY.bytes, transactions[1].signer_public_key.bytes)
 		self.assertEqual(str(BOB_ADDRESS).encode('utf8'), transactions[1].recipient_address.bytes)
 		self.assertEqual(1000000, transactions[1].amount.value)
-		self.assertEqual(b'', transactions[1].message.message)
+		self.assertEqual(None, transactions[1].message)
 
 	# endregion
 

--- a/sdk/python/tests/vectors/catbuffer.py
+++ b/sdk/python/tests/vectors/catbuffer.py
@@ -42,8 +42,8 @@ def to_hex_string(binary):
 def generate_pretty_id(val):
 	return val['test_name']
 
-
 # endregion
+
 
 # region create from descriptor
 
@@ -139,8 +139,38 @@ def test_create_from_descriptor_nem(item):
 def test_create_from_descriptor_symbol(item):  # pylint: disable=invalid-name
 	assert_create_from_descriptor(item, importlib.import_module('symbolchain.sc'), 'SymbolFacade', fixup_descriptor_symbol)
 
+# endregion
+
+
+# region create from constructor
+
+def assert_create_from_constructor(schema_name, module):
+	# Arrange:
+	schema_class = getattr(module, schema_name)
+
+	# Act:
+	transaction = schema_class()
+
+	size = transaction.size
+	transaction_buffer = transaction.serialize()
+
+	# Assert:
+	assert 0 != size
+	assert 0 != len(transaction_buffer)
+	assert size == len(transaction_buffer)
+
+
+@pytest.mark.parametrize('item', set(test_case['schema_name'] for test_case in prepare_test_cases('nem')))
+def test_create_from_constructor_nem(item):
+	assert_create_from_constructor(item, importlib.import_module('symbolchain.nc'))
+
+
+@pytest.mark.parametrize('item', set(test_case['schema_name'] for test_case in prepare_test_cases('symbol')))
+def test_create_from_constructor_symbol(item):  # pylint: disable=invalid-name
+	assert_create_from_constructor(item, importlib.import_module('symbolchain.sc'))
 
 # endregion
+
 
 # region roundtrip
 


### PR DESCRIPTION
 problem: deserializer sets missing optional field to None but constructor sets it to default value
solution: initial optional fields with None in constructor too