### PR TITLE
[client/catapult] fix: failing clang tests

### DIFF
--- a/client/catapult/tests/catapult/utils/CatapultExceptionTests.cpp
+++ b/client/catapult/tests/catapult/utils/CatapultExceptionTests.cpp
@@ -79,11 +79,12 @@ namespace catapult {
 
 		// Boost function name got updated and now return in the form below.  This function coverts the function name to the
 		// expected value in the exception.
+		// Clang does not include the traits information in the function name.
 		// void catapult::CatapultExceptionTests_CanCopyConstructException() [with TTraits = catapult::{anonymous}::RuntimeErrorTraits]
 		std::string ConvertToExceptionFunctionName(const std::string& functionFullName) {
 			CATAPULT_LOG(debug) << "function: " << functionFullName;
 
-			std::size_t functionNameEnd = functionFullName.rfind("(");
+			std::size_t functionNameEnd = functionFullName.find("(");
 			if (std::string::npos == functionNameEnd)
 				return functionFullName;
 
@@ -91,12 +92,14 @@ namespace catapult {
 			functionNameStart = (std::string::npos != functionNameStart) ? functionNameStart + 2 : 0;
 			std::ostringstream oss(functionFullName.substr(functionNameStart, functionNameEnd - functionNameStart), std::ios_base::ate);
 
+#ifndef __clang__
 			auto foundTraits = functionFullName.find("=", functionNameEnd);
 			if (std::string::npos != foundTraits) {
 				auto traitsEnd = functionFullName.find("]", foundTraits);
 				auto functionTraits = functionFullName.substr(foundTraits + 2, traitsEnd - foundTraits - 2);
 				oss << "<" << functionTraits << ">";
 			}
+#endif
 
 			return oss.str();
 		}


### PR DESCRIPTION
## What is the current behavior?
With boost 1.79, clang does not include the traits information in the exception function name as gcc.

## What's the issue?
Clang tests are failing

## How have you changed the behavior?
For Clang tests removed traits information from the exception function name.

## How was this change tested?
Ran the Clang tests locally in docker.