### PR TITLE
[sdk/javascript]: js key derivation

### DIFF
--- a/sdk/javascript/src/CryptoTypes.js
+++ b/sdk/javascript/src/CryptoTypes.js
@@ -63,6 +63,21 @@ class PublicKey extends ByteArray {
 }
 
 /**
+ *  Represents a 256-bit symmetric encryption key.
+ */
+class SharedKey256 extends ByteArray {
+	static SIZE = 32;
+
+	/**
+	 * Creates a key from bytes or a hex string.
+	 * @param {Uint8Array|string} sharedKey Input string or byte array.
+	 */
+	constructor(sharedKey) {
+		super(SharedKey256.SIZE, sharedKey);
+	}
+}
+
+/**
  *  Represents a signature.
  */
 class Signature extends ByteArray {
@@ -86,5 +101,5 @@ class Signature extends ByteArray {
 }
 
 module.exports = {
-	Hash256, PrivateKey, PublicKey, Signature
+	Hash256, PrivateKey, PublicKey, SharedKey256, Signature
 };

--- a/sdk/javascript/src/SharedKey.js
+++ b/sdk/javascript/src/SharedKey.js
@@ -1,0 +1,178 @@
+const { SharedKey256 } = require('./CryptoTypes');
+const { hkdf } = require('@noble/hashes/hkdf');
+const { sha256 } = require('@noble/hashes/sha256');
+const tweetnacl = require('tweetnacl');
+
+// order matches order of exported methods
+const {
+	crypto_verify_32, gf, pack25519, unpack25519, pow2523, set25519
+} = tweetnacl.lowlevel;
+
+// region curve operations - unfortunatelly tweetnacl.lowlevel does not expose those functions, so needed to copy them here
+
+const neq25519 = (a, b) => {
+	const c = new Uint8Array(32);
+	const d = new Uint8Array(32);
+	pack25519(c, a);
+	pack25519(d, b);
+	return crypto_verify_32(c, 0, d, 0);
+};
+
+const par25519 = a => {
+	const d = new Uint8Array(32);
+	pack25519(d, a);
+	return d[0] & 1;
+};
+
+const inv25519 = (o, i) => {
+	const { M, S } = tweetnacl.lowlevel;
+
+	const c = gf();
+	for (let a = 0; 16 > a; a++)
+		c[a] = i[a];
+
+	for (let a = 253; 0 <= a; a--) {
+		S(c, c);
+		if (2 !== a && 4 !== a)
+			M(c, c, i);
+	}
+	for (let a = 0; 16 > a; a++)
+		o[a] = c[a];
+};
+
+const pack = (r, p) => {
+	const { M } = tweetnacl.lowlevel;
+	const tx = gf();
+	const ty = gf();
+	const zi = gf();
+
+	inv25519(zi, p[2]);
+	M(tx, p[0], zi);
+	M(ty, p[1], zi);
+	pack25519(r, ty);
+
+	r[31] ^= par25519(tx) << 7;
+};
+
+const unpackNeg = (r, p) => {
+	const {
+		D, M, A, S, Z
+	} = tweetnacl.lowlevel;
+
+	const gf0 = gf();
+	const gf1 = gf([1]);
+	const I = gf([
+		0xa0b0, 0x4a0e, 0x1b27, 0xc4ee, 0xe478, 0xad2f, 0x1806, 0x2f43, 0xd7a7, 0x3dfb, 0x0099, 0x2b4d, 0xdf0b, 0x4fc1, 0x2480, 0x2b83
+	]);
+
+	const t = gf();
+	const chk = gf();
+	const num = gf();
+	const den = gf();
+	const den2 = gf();
+	const den4 = gf();
+	const den6 = gf();
+
+	set25519(r[2], gf1);
+	unpack25519(r[1], p);
+	S(num, r[1]);
+	M(den, num, D);
+	Z(num, num, r[2]);
+	A(den, r[2], den);
+
+	S(den2, den);
+	S(den4, den2);
+	M(den6, den4, den2);
+	M(t, den6, num);
+	M(t, t, den);
+
+	pow2523(t, t);
+	M(t, t, num);
+	M(t, t, den);
+	M(t, t, den);
+	M(r[0], t, den);
+
+	S(chk, r[0]);
+	M(chk, chk, den);
+	if (neq25519(chk, num))
+		M(r[0], r[0], I);
+
+	S(chk, r[0]);
+	M(chk, chk, den);
+	if (neq25519(chk, num))
+		return -1;
+
+	if (par25519(r[0]) === (p[31] >> 7))
+		Z(r[0], gf0, r[0]);
+
+	M(r[3], r[0], r[1]);
+	return 0;
+};
+
+// endregion
+
+// publicKey is canonical if the y coordinate is smaller than 2^255 - 19
+// note: this version is based on server version and should be constant-time
+// note 2: don't touch it, you'll break it
+const isCanonicalKey = publicKey => {
+	const buffer = publicKey.bytes;
+	let a = (buffer[31] & 0x7F) ^ 0x7F;
+	for (let i = 30; 0 < i; --i)
+		a |= buffer[i] ^ 0xFF;
+
+	a = (a - 1) >>> 8;
+
+	const b = (0xED - 1 - buffer[0]) >>> 8;
+	return 0 !== 1 - (a & b & 1);
+};
+
+const isInMainSubgroup = point => {
+	const { scalarmult, L } = tweetnacl.lowlevel;
+	const result = [gf(), gf(), gf(), gf()];
+	// multiply by group order
+	scalarmult(result, point, L);
+
+	// check if result is neutral element
+	const gf0 = gf();
+	const areEqual = neq25519(result[1], result[2]);
+	const isZero = neq25519(gf0, result[0]);
+
+	// yes, this is supposed to be  bit OR
+	return 0 === (areEqual | isZero);
+};
+
+const deriveSharedSecretFactory = cryptoHash => (privateKeyBytes, otherPublicKey) => {
+	const { scalarmult, Z } = tweetnacl.lowlevel;
+	const point = [gf(), gf(), gf(), gf()];
+
+	if (!isCanonicalKey(otherPublicKey) || 0 !== unpackNeg(point, otherPublicKey.bytes) || !isInMainSubgroup(point))
+		throw Error('invalid point');
+
+	// negate point == negate X coordinate and 't'
+	Z(point[0], gf(), point[0]);
+	Z(point[3], gf(), point[3]);
+
+	const scalar = new Uint8Array(64);
+
+	cryptoHash(scalar, privateKeyBytes, 32);
+	scalar[0] &= 248;
+	scalar[31] &= 127;
+	scalar[31] |= 64;
+
+	const result = [gf(), gf(), gf(), gf()];
+	scalarmult(result, point, scalar);
+
+	const sharedSecret = new Uint8Array(32);
+	pack(sharedSecret, result);
+	return sharedSecret;
+};
+
+const deriveSharedKeyFactory = (info, cryptoHash) => {
+	const deriveSharedSecret = deriveSharedSecretFactory(cryptoHash);
+	return (privateKeyBytes, otherPublicKey) => {
+		const sharedSecret = deriveSharedSecret(privateKeyBytes, otherPublicKey);
+		return new SharedKey256(hkdf(sha256, sharedSecret, undefined, info, 32));
+	};
+};
+
+module.exports = { deriveSharedKeyFactory, deriveSharedSecretFactory };

--- a/sdk/javascript/src/facade/NemFacade.js
+++ b/sdk/javascript/src/facade/NemFacade.js
@@ -2,6 +2,7 @@ const { Hash256, PrivateKey } = require('../CryptoTypes');
 const { NetworkLocator } = require('../Network');
 const { KeyPair, Verifier } = require('../nem/KeyPair');
 const { Address, Network } = require('../nem/Network');
+const { deriveSharedKey } = require('../nem/SharedKey');
 const { TransactionFactory } = require('../nem/TransactionFactory');
 const { keccak_256 } = require('@noble/hashes/sha3');
 
@@ -16,6 +17,8 @@ class NemFacade {
 	static KeyPair = KeyPair;
 
 	static Verifier = Verifier;
+
+	static deriveSharedKey = deriveSharedKey;
 
 	/**
 	 * Creates a NEM facade.

--- a/sdk/javascript/src/facade/SymbolFacade.js
+++ b/sdk/javascript/src/facade/SymbolFacade.js
@@ -5,6 +5,7 @@ const { NetworkLocator } = require('../Network');
 const { KeyPair, Verifier } = require('../symbol/KeyPair');
 const { MerkleHashBuilder } = require('../symbol/MerkleHashBuilder');
 const { Address, Network } = require('../symbol/Network');
+const { deriveSharedKey } = require('../symbol/SharedKey');
 const { TransactionFactory } = require('../symbol/TransactionFactory');
 const { TransactionType } = require('../symbol/models');
 const { sha3_256 } = require('@noble/hashes/sha3');
@@ -51,6 +52,8 @@ class SymbolFacade {
 	static KeyPair = KeyPair;
 
 	static Verifier = Verifier;
+
+	static deriveSharedKey = deriveSharedKey;
 
 	/**
 	 * Creates a Symbol facade.

--- a/sdk/javascript/src/nem/SharedKey.js
+++ b/sdk/javascript/src/nem/SharedKey.js
@@ -1,0 +1,46 @@
+const tweetnacl = require('./external/tweetnacl-nacl-fast-keccak');
+const { SharedKey256 } = require('../CryptoTypes');
+const { deriveSharedSecretFactory, deriveSharedKeyFactory } = require('../SharedKey');
+const { keccak_256 } = require('@noble/hashes/sha3');
+
+const { crypto_hash } = tweetnacl.lowlevel;
+const deriveSharedSecretImpl = deriveSharedSecretFactory(crypto_hash);
+const deriveSharedKeyImpl = deriveSharedKeyFactory('nem-nis1', crypto_hash);
+
+/**
+ * Derives shared key from key pair and other party's public key.
+ * @param {KeyPair} keyPair Key pair.
+ * @param {PublicKey} otherPublicKey Other party's public key.
+ * @returns {SharedKey256} Shared encryption key.
+ */
+const deriveSharedKey = (keyPair, otherPublicKey) => {
+	const reversedPrivateKeyBytes = new Uint8Array([...keyPair.privateKey.bytes]);
+	reversedPrivateKeyBytes.reverse();
+
+	return deriveSharedKeyImpl(reversedPrivateKeyBytes, otherPublicKey);
+};
+
+/**
+ * Derives shared key from key pair, other party's public key and salt
+ * @deprecated This is _old_ method of deriving shared key and should not be used in new applications.
+ * @param {KeyPair} keyPair Key pair.
+ * @param {PublicKey} otherPublicKey Other party's public key.
+ * @param {Uint8Array} salt Random salt. Should be unique per every use.
+ * @returns {SharedKey256} Shared encryption key.
+ */
+const deriveSharedKeyDeprecated = (keyPair, otherPublicKey, salt) => {
+	if (SharedKey256.SIZE !== salt.length)
+		throw Error('invalid salt');
+
+	const reversedPrivateKeyBytes = new Uint8Array([...keyPair.privateKey.bytes]);
+	reversedPrivateKeyBytes.reverse();
+
+	const sharedSecret = deriveSharedSecretImpl(reversedPrivateKeyBytes, otherPublicKey);
+	const sharedKeyBytes = new Uint8Array(SharedKey256.SIZE);
+	for (let i = 0; SharedKey256.SIZE > i; ++i)
+		sharedKeyBytes[i] = sharedSecret[i] ^ salt[i];
+
+	return new SharedKey256(keccak_256(sharedKeyBytes));
+};
+
+module.exports = { deriveSharedKey, deriveSharedKeyDeprecated };

--- a/sdk/javascript/src/symbol/SharedKey.js
+++ b/sdk/javascript/src/symbol/SharedKey.js
@@ -1,0 +1,15 @@
+const { deriveSharedKeyFactory } = require('../SharedKey');
+const tweetnacl = require('tweetnacl');
+
+const { crypto_hash } = tweetnacl.lowlevel;
+const deriveSharedKeyImpl = deriveSharedKeyFactory('catapult', crypto_hash);
+
+/**
+ * Derives shared key from key pair and other party's public key.
+ * @param {KeyPair} keyPair Key pair.
+ * @param {PublicKey} otherPublicKey Other party's public key.
+ * @returns {SharedKey256} Shared encryption key.
+ */
+const deriveSharedKey = (keyPair, otherPublicKey) => deriveSharedKeyImpl(keyPair.privateKey.bytes, otherPublicKey);
+
+module.exports = { deriveSharedKey };

--- a/sdk/javascript/test/CryptoTypes_spec.js
+++ b/sdk/javascript/test/CryptoTypes_spec.js
@@ -1,5 +1,5 @@
 const {
-	Hash256, PrivateKey, PublicKey, Signature
+	Hash256, PrivateKey, PublicKey, SharedKey256, Signature
 } = require('../src/CryptoTypes');
 const { expect } = require('chai');
 const crypto = require('crypto');
@@ -87,6 +87,16 @@ describe('CryptoTypes', () => {
 
 			// Assert:
 			expect(byteArray.bytes).to.deep.equal(rawBytes);
+		});
+	});
+
+	describe('SharedKey256', () => {
+		it('can create shared key with correct number of bytes', () => {
+			assertCanCreateByteArrayWithCorrectNumberOfBytes(SharedKey256, 32);
+		});
+
+		it('cannot create shared key with incorrect number of bytes', () => {
+			assertCannotCreateByteArrayWithIncorrectNumberOfBytes(SharedKey256, 32);
 		});
 	});
 

--- a/sdk/javascript/test/nem/SharedKey_spec.js
+++ b/sdk/javascript/test/nem/SharedKey_spec.js
@@ -1,0 +1,32 @@
+const { PrivateKey } = require('../../src/CryptoTypes');
+const { NemFacade } = require('../../src/facade/NemFacade');
+const { KeyPair } = require('../../src/nem/KeyPair');
+const { deriveSharedKeyDeprecated } = require('../../src/nem/SharedKey');
+const { runBasicSharedKeyTests } = require('../test/sharedKeyTests');
+const { expect } = require('chai');
+
+describe('SharedKey (NEM)', () => {
+	runBasicSharedKeyTests({
+		KeyPair,
+		deriveSharedKey: NemFacade.deriveSharedKey
+	});
+});
+
+describe('SharedKey (NEM) (deprecated)', () => {
+	const deterministicSalt = new TextEncoder('utf-8').encode('1234567890ABCDEF1234567890ABCDEF');
+	runBasicSharedKeyTests({
+		KeyPair,
+		deriveSharedKey: (keyPair, publicKey) => deriveSharedKeyDeprecated(keyPair, publicKey, deterministicSalt)
+	});
+
+	it('salt with invalid length is rejected', () => {
+		// Arrange:
+		const keyPair = new KeyPair(PrivateKey.random());
+		const otherPublicKey = new KeyPair(PrivateKey.random()).publicKey;
+
+		// Act:
+		expect(() => deriveSharedKeyDeprecated(keyPair, otherPublicKey, new Uint8Array(31))).to.throw('invalid salt');
+		expect(() => deriveSharedKeyDeprecated(keyPair, otherPublicKey, deterministicSalt.subarray(0, 31))).to.throw('invalid salt');
+		expect(() => deriveSharedKeyDeprecated(keyPair, otherPublicKey, new Uint8Array(33))).to.throw('invalid salt');
+	});
+});

--- a/sdk/javascript/test/symbol/SharedKey_spec.js
+++ b/sdk/javascript/test/symbol/SharedKey_spec.js
@@ -1,0 +1,10 @@
+const { SymbolFacade } = require('../../src/facade/SymbolFacade');
+const { KeyPair } = require('../../src/symbol/KeyPair');
+const { runBasicSharedKeyTests } = require('../test/sharedKeyTests');
+
+describe('SharedKey (Symbol)', () => {
+	runBasicSharedKeyTests({
+		KeyPair,
+		deriveSharedKey: SymbolFacade.deriveSharedKey
+	});
+});

--- a/sdk/javascript/test/test/sharedKeyTests.js
+++ b/sdk/javascript/test/test/sharedKeyTests.js
@@ -1,0 +1,97 @@
+const { PrivateKey, PublicKey } = require('../../src/CryptoTypes');
+const { expect } = require('chai');
+
+const runBasicSharedKeyTests = testDescriptor => {
+	// region mutual shared
+
+	const assertDerivedSharedResult = (mutate, assertion) => {
+		// Arrange:
+		const privateKey1 = PrivateKey.random();
+		const otherPublicKey1 = new testDescriptor.KeyPair(PrivateKey.random()).publicKey;
+
+		const privateKey2Bytes = new Uint8Array(privateKey1.bytes);
+		const otherPublicKey2Bytes = new Uint8Array(otherPublicKey1.bytes);
+
+		mutate(privateKey2Bytes, otherPublicKey2Bytes);
+
+		const keyPair1 = new testDescriptor.KeyPair(privateKey1);
+		const keyPair2 = new testDescriptor.KeyPair(new PrivateKey(privateKey2Bytes));
+
+		// Act:
+		const sharedKey1 = testDescriptor.deriveSharedKey(keyPair1, otherPublicKey1);
+		const sharedKey2 = testDescriptor.deriveSharedKey(keyPair2, new PublicKey(otherPublicKey2Bytes));
+
+		// Assert:
+		assertion(sharedKey1, sharedKey2);
+	};
+
+	it('shared keys generated with same inputs are equal', () => {
+		assertDerivedSharedResult(() => {}, (lhs, rhs) => expect(lhs).to.deep.equal(rhs));
+	});
+
+	it('shared keys generated for different private keys are different', () => {
+		assertDerivedSharedResult(privateKeyBytes => { privateKeyBytes[0] ^= 0xFF; }, (lhs, rhs) => expect(lhs).to.not.deep.equal(rhs));
+	});
+
+	it('shared keys generated for different other public keys are different', () => {
+		//  this test needs to be fired multiple times, so that mutated public key will not to be rejected via subgroup check
+		for (let i = 1; 256 > i; ++i) {
+			try {
+				const mutate = (_, otherPublicKey) => { otherPublicKey[0] ^= i; };
+				assertDerivedSharedResult(mutate, (lhs, rhs) => expect(lhs).to.not.deep.equal(rhs));
+				break;
+			} catch (error) {
+				// comments for eslint purposes, no need to handle this
+			}
+		}
+	});
+
+	it('mutual shared results are equal', () => {
+		// Arrange:
+		const keyPair1 = new testDescriptor.KeyPair(PrivateKey.random());
+		const keyPair2 = new testDescriptor.KeyPair(PrivateKey.random());
+
+		// Act:
+		const sharedKey1 = testDescriptor.deriveSharedKey(keyPair1, keyPair2.publicKey);
+		const sharedKey2 = testDescriptor.deriveSharedKey(keyPair2, keyPair1.publicKey);
+
+		// Assert:
+		expect(sharedKey1).to.deep.equal(sharedKey2);
+	});
+
+	// endregion
+
+	// region invalid public key
+
+	it('public key not on the curve throws', () => {
+		// Arrange:
+		const keyPair1 = new testDescriptor.KeyPair(PrivateKey.random());
+		const keyPair2 = new testDescriptor.KeyPair(PrivateKey.random());
+
+		// this test needs to be fired multiple times, because just setting byte to 1, will likely end up
+		// in a point that will still land on the curve
+		// note: cannot use expect().to.throw
+		let succeeded = false;
+		for (let i = 0; 4 > i; ++i) {
+			const invalidPublicKeyBytes = new Uint8Array(keyPair2.publicKey.bytes);
+			invalidPublicKeyBytes[31] = i;
+
+			// Act + Assert:
+			try {
+				testDescriptor.deriveSharedKey(keyPair1, new PublicKey(invalidPublicKeyBytes));
+			} catch (error) {
+				if (error.message.includes('invalid point')) {
+					succeeded = true;
+					break;
+				}
+			}
+		}
+
+		/* eslint-disable no-unused-expressions */
+		expect(succeeded).to.be.true;
+	});
+
+	// endregion
+};
+
+module.exports = { runBasicSharedKeyTests };

--- a/sdk/python/tests/nem/test_SharedKey.py
+++ b/sdk/python/tests/nem/test_SharedKey.py
@@ -8,19 +8,19 @@ from ..test.BasicSharedKeyTest import BasicSharedKeyTest, SharedKeyTestDescripto
 DETERMINISTIC_SALT = b'1234567890ABCDEF1234567890ABCDEF'
 
 
-class SharedKeyDeprecatedTest(BasicSharedKeyTest, unittest.TestCase):
-	@staticmethod
-	def get_test_descriptor():
-		return SharedKeyTestDescriptor(
-			key_pair_class=KeyPair,
-			derive_shared_key=lambda key_pair, public_key: SharedKey.derive_shared_key_deprecated(key_pair, public_key, DETERMINISTIC_SALT)
-		)
-
-
 class SharedKeyTest(BasicSharedKeyTest, unittest.TestCase):
 	@staticmethod
 	def get_test_descriptor():
 		return SharedKeyTestDescriptor(
 			key_pair_class=KeyPair,
 			derive_shared_key=SharedKey.derive_shared_key
+		)
+
+
+class SharedKeyDeprecatedTest(BasicSharedKeyTest, unittest.TestCase):
+	@staticmethod
+	def get_test_descriptor():
+		return SharedKeyTestDescriptor(
+			key_pair_class=KeyPair,
+			derive_shared_key=lambda key_pair, public_key: SharedKey.derive_shared_key_deprecated(key_pair, public_key, DETERMINISTIC_SALT)
 		)

--- a/sdk/python/tests/vectors/all.py
+++ b/sdk/python/tests/vectors/all.py
@@ -306,9 +306,9 @@ def load_test_suites(blockchain):
 		AddressConversionTester(class_locator),
 		SignTester(class_locator),
 		VerifyTester(class_locator),
+		DeriveTester(class_locator),
 		Bip32DerivationTester(class_locator),
 		Bip39DerivationTester(class_locator),
-		DeriveTester(class_locator),
 		CipherTester(class_locator)
 	]
 


### PR DESCRIPTION
This is change similar to #285 for JS.

All derive test vectors pass, additional tests for SharedKey derivation has been added, that mimic the ones from py version