### PR TITLE
[client\catatpult] fix: Windows tests failing

### DIFF
--- a/client/catapult/CMakeGlobalSettings.cmake
+++ b/client/catapult/CMakeGlobalSettings.cmake
@@ -265,7 +265,6 @@ endif()
 if(MSVC)
 	function(set_win_version_definitions WIN_TARGET_NAME WIN_FILETYPE)
 		add_definitions(-DCATAPULT_VERSION_DESCRIPTION="${CATAPULT_VERSION_DESCRIPTION}")
-		add_definitions(-DWIN_TARGET_NAME=${WIN_TARGET_NAME})
 		add_definitions(-DWIN_FILETYPE=${WIN_FILETYPE})
 
 		if(CATAPULT_BUILD_RELEASE)

--- a/client/catapult/extensions/mongo/plugins/lock_hash/tests/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/lock_hash/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.14)
 set(TARGET_NAME tests.catapult.mongo.plugins.lockhash)
 
 include_directories(${PROJECT_SOURCE_DIR}/plugins/txes/lock_hash)
-catapult_mongo_plugin_tests_with_deps(${TARGET_NAME} mappers)
+catapult_mongo_plugin_tests_no_deps(${TARGET_NAME} mappers)
 
 add_subdirectory(int)
 add_subdirectory(test)

--- a/client/catapult/extensions/mongo/plugins/lock_secret/tests/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/lock_secret/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.14)
 set(TARGET_NAME tests.catapult.mongo.plugins.locksecret)
 
 include_directories(${PROJECT_SOURCE_DIR}/plugins/txes/lock_secret)
-catapult_mongo_plugin_tests_with_deps(${TARGET_NAME} mappers)
+catapult_mongo_plugin_tests_no_deps(${TARGET_NAME} mappers)
 
 add_subdirectory(int)
 add_subdirectory(test)

--- a/client/catapult/tests/catapult/utils/CatapultExceptionTests.cpp
+++ b/client/catapult/tests/catapult/utils/CatapultExceptionTests.cpp
@@ -79,12 +79,12 @@ namespace catapult {
 
 		// Boost function name got updated and now return in the form below.  This function coverts the function name to the
 		// expected value in the exception.
-		// Clang does not include the traits information in the function name.
+		// Only gcc includes the traits information in the exception function name.
 		// void catapult::CatapultExceptionTests_CanCopyConstructException() [with TTraits = catapult::{anonymous}::RuntimeErrorTraits]
 		std::string ConvertToExceptionFunctionName(const std::string& functionFullName) {
 			CATAPULT_LOG(debug) << "function: " << functionFullName;
 
-			std::size_t functionNameEnd = functionFullName.find("(");
+			std::size_t functionNameEnd = functionFullName.find_first_of("<(");
 			if (std::string::npos == functionNameEnd)
 				return functionFullName;
 
@@ -92,7 +92,7 @@ namespace catapult {
 			functionNameStart = (std::string::npos != functionNameStart) ? functionNameStart + 2 : 0;
 			std::ostringstream oss(functionFullName.substr(functionNameStart, functionNameEnd - functionNameStart), std::ios_base::ate);
 
-#ifndef __clang__
+#if defined(__GNUC__) && !defined(__clang__)
 			auto foundTraits = functionFullName.find("=", functionNameEnd);
 			if (std::string::npos != foundTraits) {
 				auto traitsEnd = functionFullName.find("]", foundTraits);
@@ -109,7 +109,7 @@ namespace catapult {
 			// Arrange:
 			std::vector<std::string> expectedDiagLines{
 				"Throw in function " + ConvertToExceptionFunctionName(expected.FunctionName),
-				"Dynamic exception type: " CLASSPREFIX "boost::wrapexcept<" + std::string(TTraits::Exception_Fqn) + " >",
+				"Dynamic exception type: " STRUCTPREFIX "boost::wrapexcept<" + std::string(TTraits::Exception_Fqn) + " >",
 				"std::exception::what: " + expected.What
 			};
 


### PR DESCRIPTION
## What is the current behavior?
Catapult client building on Windows is failing

## What's the issue?
There are couple of errors
1. warning RC4005: 'WIN_TARGET_NAME' : redefinition
2. fatal error LNK1169: one or more multiply defined symbols found

## How have you changed the behavior?
1. remove the WIN_TARGET_NAME to fix the ``warning RC4005: 'WIN_TARGET_NAME' : redefinition``
2. update cmake files to use no deps for lock hash and lock secret tests to fix ``fatal error LNK1169: one or more multiply defined symbols found``
3. update the ConvertToExceptionFunctionName() to fix the exception tests with msvc

## How was this change tested?
Tested both on Windows and locally with gcc/clang