### PR TITLE
[client/catapult] fix: ZeroMQ tests failing on Windows

### DIFF
--- a/client/catapult/extensions/zeromq/tests/ZeroMqEntityPublisherTests.cpp
+++ b/client/catapult/extensions/zeromq/tests/ZeroMqEntityPublisherTests.cpp
@@ -109,9 +109,9 @@ namespace catapult { namespace zeromq {
 	}
 
 	namespace {
-		void AssertCanUseCustomListenInterface(const std::string& listenInterface) {
+		void AssertCanUseCustomListenInterface(const std::string& listenInterface, const std::string& connectInterface) {
 			// Arrange:
-			EntityPublisherContext context(listenInterface);
+			EntityPublisherContext context(listenInterface, connectInterface);
 			context.subscribe(BlockMarker::Drop_Blocks_Marker);
 
 			// Act:
@@ -126,13 +126,13 @@ namespace catapult { namespace zeromq {
 	}
 
 	TEST(TEST_CLASS, CanUseCustomListenInterface_IPv4) {
-		AssertCanUseCustomListenInterface("0.0.0.0");
-		AssertCanUseCustomListenInterface("127.0.0.1");
+		AssertCanUseCustomListenInterface("0.0.0.0", "127.0.0.1");
+		AssertCanUseCustomListenInterface("127.0.0.1", "127.0.0.1");
 	}
 
 	TEST(TEST_CLASS, CanUseCustomListenInterface_IPv6) {
-		AssertCanUseCustomListenInterface("::");
-		AssertCanUseCustomListenInterface("::1");
+		AssertCanUseCustomListenInterface("::", "::1");
+		AssertCanUseCustomListenInterface("::1", "::1");
 	}
 
 	// endregion

--- a/client/catapult/extensions/zeromq/tests/test/ZeroMqTestUtils.h
+++ b/client/catapult/extensions/zeromq/tests/test/ZeroMqTestUtils.h
@@ -125,7 +125,7 @@ namespace catapult { namespace test {
 	class MqContext {
 	public:
 		/// Creates a message queue context around \a listenInterface.
-		explicit MqContext(const std::string& listenInterface = std::string("127.0.0.1"))
+		MqContext(const std::string& listenInterface, const std::string& connectInterface)
 				: m_registry(mocks::CreateDefaultTransactionRegistry())
 				, m_pZeroMqEntityPublisher(std::make_shared<zeromq::ZeroMqEntityPublisher>(
 						listenInterface,
@@ -137,9 +137,12 @@ namespace catapult { namespace test {
 				m_zmqSocket.set(zmq::sockopt::ipv6, 1);
 
 			std::ostringstream out;
-			out << "tcp://[" << listenInterface<< "]:" << GetDefaultLocalHostZmqPort();
+			out << "tcp://[" << connectInterface << "]:" << GetDefaultLocalHostZmqPort();
 			m_zmqSocket.connect(out.str());
 		}
+
+		explicit MqContext(const std::string& listenInterface = std::string("127.0.0.1")) : MqContext(listenInterface, listenInterface)
+				{}
 
 	public:
 		/// Subscribes to \a topic.

--- a/client/catapult/extensions/zeromq/tests/test/ZeroMqTestUtils.h
+++ b/client/catapult/extensions/zeromq/tests/test/ZeroMqTestUtils.h
@@ -142,7 +142,7 @@ namespace catapult { namespace test {
 		}
 
 		explicit MqContext(const std::string& listenInterface = std::string("127.0.0.1")) : MqContext(listenInterface, listenInterface)
-				{}
+		{}
 
 	public:
 		/// Subscribes to \a topic.


### PR DESCRIPTION
## What is the current behavior?
On Windows ZeroMQ cannot connect to any address using 0.0.0.0 or ::.  It does not fail either.

## What's the issue?
Windows does not allow connecting to any address but ZeroMQ does not failed.
On Linux it seems to work by connecting to localhost.
See bug for more information - ``https://github.com/zeromq/cppzmq/issues/527``

## How have you changed the behavior?
Update the ZeroMQ tests to connect to a specific address

## How was this change tested?
Yes, ran the tests on Windows and Linux.