### PR TITLE
[client/catapult] fix: increase timeout for multiple readerWriter locks

### DIFF
--- a/client/catapult/tests/catapult/utils/SpinReaderWriterLockTests.cpp
+++ b/client/catapult/tests/catapult/utils/SpinReaderWriterLockTests.cpp
@@ -266,7 +266,7 @@ namespace catapult { namespace utils {
 
 		// - wait for the counter to be incremented by all readers
 		CATAPULT_LOG(debug) << "waiting for readers";
-		WAIT_FOR_VALUE(test::Num_Default_Lock_Threads, counter);
+		WAIT_FOR_VALUE_SECONDS(test::Num_Default_Lock_Threads, counter, 20);
 
 		// Assert: all threads were able to access the counter
 		EXPECT_EQ(test::Num_Default_Lock_Threads, counter);


### PR DESCRIPTION
## What's the issue?
MultipleThreadsCanAcquireReaderLock test take long time to run in Windows containter. This cause the test to timeout and fail.

## How have you changed the behavior?
Increase the wait time for the MultipleThreadsCanAcquireReaderLock test case.

## How was this change tested?
Yes, tested locally on Windows and Linux 