### PR TITLE
[sdk/python] message encoder

### DIFF
--- a/sdk/python/symbolchain/impl/CipherHelpers.py
+++ b/sdk/python/symbolchain/impl/CipherHelpers.py
@@ -1,0 +1,57 @@
+import secrets
+
+from symbolchain.Cipher import AesCbcCipher, AesGcmCipher
+
+GCM_IV_SIZE = 12
+CBC_IV_SIZE = 16
+SALT_SIZE = 32
+
+
+def _decode(tag_or_salt_size, iv_size, encoded_message):
+	tag_or_salt = encoded_message[:tag_or_salt_size]
+	initialization_vector = encoded_message[tag_or_salt_size:tag_or_salt_size + iv_size]
+	encoded_message_data = encoded_message[tag_or_salt_size + iv_size:]
+
+	return tag_or_salt, initialization_vector, encoded_message_data
+
+
+def decode_aes_gcm(shared_key_class, key_pair, recipient_public_key, encoded_message):
+	tag, initialization_vector, encoded_message_data = _decode(AesGcmCipher.TAG_SIZE, GCM_IV_SIZE, encoded_message)
+
+	shared_key = shared_key_class.derive_shared_key(key_pair, recipient_public_key)
+	cipher = AesGcmCipher(shared_key)
+
+	return cipher.decrypt(encoded_message_data + tag, initialization_vector)
+
+
+def decode_aes_cbc(shared_key_class, key_pair, recipient_public_key, encoded_message):
+	salt, initialization_vector, encoded_message_data = _decode(SALT_SIZE, CBC_IV_SIZE, encoded_message)
+
+	shared_key = shared_key_class.derive_shared_key_deprecated(key_pair, recipient_public_key, salt)
+	cipher = AesCbcCipher(shared_key)
+
+	return cipher.decrypt(encoded_message_data, initialization_vector)
+
+
+def encode_aes_gcm(shared_key_class, key_pair, recipient_public_key, message):
+	shared_key = shared_key_class.derive_shared_key(key_pair, recipient_public_key)
+	cipher = AesGcmCipher(shared_key)
+
+	initialization_vector = secrets.token_bytes(GCM_IV_SIZE)
+	cipher_text = cipher.encrypt(message, initialization_vector)
+
+	tag_start_offset = len(cipher_text) - AesGcmCipher.TAG_SIZE
+	tag = cipher_text[tag_start_offset:]
+
+	return tag, initialization_vector, cipher_text[:tag_start_offset]
+
+
+def encode_aes_cbc(shared_key_class, key_pair, recipient_public_key, message):
+	salt = secrets.token_bytes(SALT_SIZE)
+	shared_key = shared_key_class.derive_shared_key_deprecated(key_pair, recipient_public_key, salt)
+	cipher = AesCbcCipher(shared_key)
+
+	initialization_vector = secrets.token_bytes(CBC_IV_SIZE)
+	cipher_text = cipher.encrypt(message, initialization_vector)
+
+	return salt, initialization_vector, cipher_text

--- a/sdk/python/symbolchain/nem/MessageEncoder.py
+++ b/sdk/python/symbolchain/nem/MessageEncoder.py
@@ -1,0 +1,63 @@
+import cryptography
+
+from symbolchain.CryptoTypes import PublicKey
+from symbolchain.impl.CipherHelpers import decode_aes_cbc, decode_aes_gcm, encode_aes_cbc, encode_aes_gcm
+from symbolchain.nc import Message, MessageType
+from symbolchain.nem.KeyPair import KeyPair
+from symbolchain.nem.SharedKey import SharedKey
+
+
+class MessageEncoder:
+	"""Encrypts and encodes messages between two parties."""
+
+	def __init__(self, key_pair: KeyPair):
+		"""Creates message encoder around key pair."""
+		self.key_pair = key_pair
+
+	def try_decode(self, recipient_public_key, encoded_message: Message):
+		"""Tries to decode encoded message, returns tuple:
+		* True, message - if message has been decoded and decrypted
+		* False, encoded_message - otherwise
+		"""
+
+		if MessageType.ENCRYPTED != encoded_message.message_type:
+			raise RuntimeError('invalid message format')
+
+		try:
+			message = decode_aes_gcm(SharedKey, self.key_pair, recipient_public_key, encoded_message.message)
+			return True, message
+		except cryptography.exceptions.InvalidTag:
+			pass
+
+		try:
+			message = decode_aes_cbc(SharedKey, self.key_pair, recipient_public_key, encoded_message.message)
+			return True, message
+		except ValueError as exception:
+			exceptions = [
+				'Invalid padding bytes',
+				'Invalid IV size',
+				'The length of the provided data is not a multiple of the block length']
+			if not any(map(lambda message: message in str(exception), exceptions)):
+				raise
+
+		return False, encoded_message
+
+	def encode_deprecated(self, recipient_public_key: PublicKey, message: bytes):
+		"""Encodes message to recipient using deprecated encryption and key derivation."""
+
+		salt, initialization_vector, cipher_text = encode_aes_cbc(SharedKey, self.key_pair, recipient_public_key, message)
+
+		encoded_messsage = Message()
+		encoded_messsage.message_type = MessageType.ENCRYPTED
+		encoded_messsage.message = salt + initialization_vector + cipher_text
+		return encoded_messsage
+
+	def encode(self, recipient_public_key: PublicKey, message: bytes):
+		"""Encodes message to recipient using recommended format."""
+
+		tag, initialization_vector, cipher_text = encode_aes_gcm(SharedKey, self.key_pair, recipient_public_key, message)
+
+		encoded_messsage = Message()
+		encoded_messsage.message_type = MessageType.ENCRYPTED
+		encoded_messsage.message = tag + initialization_vector + cipher_text
+		return encoded_messsage

--- a/sdk/python/symbolchain/symbol/MessageEncoder.py
+++ b/sdk/python/symbolchain/symbol/MessageEncoder.py
@@ -1,0 +1,59 @@
+from binascii import unhexlify
+
+import cryptography
+
+from symbolchain.CryptoTypes import PrivateKey, PublicKey
+from symbolchain.impl.CipherHelpers import decode_aes_gcm, encode_aes_gcm
+from symbolchain.symbol.KeyPair import KeyPair
+from symbolchain.symbol.SharedKey import SharedKey
+
+DELEGATION_MARKER = unhexlify('FE2A8061577301E2')
+
+
+class MessageEncoder:
+	"""Encrypts and encodes messages between two parties."""
+
+	def __init__(self, key_pair: KeyPair):
+		"""Creates message encoder around key pair."""
+		self.key_pair = key_pair
+
+	def try_decode(self, recipient_public_key, encoded_message):
+		"""Tries to decode encoded message, returns tuple:
+		* True, message - if message has been decoded and decrypted
+		* False, encoded_message - otherwise
+		"""
+		if 1 == encoded_message[0]:
+			try:
+				message = decode_aes_gcm(SharedKey, self.key_pair, recipient_public_key, encoded_message[1:])
+				return True, message
+			except cryptography.exceptions.InvalidTag:
+				pass
+		elif 0xFE == encoded_message[0] and DELEGATION_MARKER == encoded_message[:8]:
+			try:
+				ephemeral_public_key = PublicKey(encoded_message[len(DELEGATION_MARKER):len(DELEGATION_MARKER) + PublicKey.SIZE])
+				message = decode_aes_gcm(SharedKey, self.key_pair, ephemeral_public_key, encoded_message[len(DELEGATION_MARKER) + PublicKey.SIZE:])
+				return True, message
+			except cryptography.exceptions.InvalidTag:
+				pass
+			except ValueError as exception:
+				exceptions = ['point is not in main subgroup']
+				if not any(map(lambda message: message in str(exception), exceptions)):
+					raise
+
+		return False, encoded_message
+
+	@staticmethod
+	def encode_persistent_harvesting_delegation(node_public_key, remote_key_pair, vrf_root_key_pair):  # pylint: disable=invalid-name
+		"""Encodes persistent harvesting delegation to node."""
+		ephemeral_key_pair = KeyPair(PrivateKey.random())
+
+		message = remote_key_pair.private_key.bytes + vrf_root_key_pair.private_key.bytes
+		tag, initialization_vector, cipher_text = encode_aes_gcm(SharedKey, ephemeral_key_pair, node_public_key, message)
+
+		return DELEGATION_MARKER + ephemeral_key_pair.public_key.bytes + tag + initialization_vector + cipher_text
+
+	def encode(self, recipient_public_key: PublicKey, message: bytes):
+		"""Encodes message to recipient using recommended format."""
+
+		tag, initialization_vector, cipher_text = encode_aes_gcm(SharedKey, self.key_pair, recipient_public_key, message)
+		return b'\1' + tag + initialization_vector + cipher_text

--- a/sdk/python/tests/nem/test_MessageEncoder.py
+++ b/sdk/python/tests/nem/test_MessageEncoder.py
@@ -1,0 +1,58 @@
+import unittest
+
+from symbolchain.CryptoTypes import PrivateKey, PublicKey
+from symbolchain.nc import Message, MessageType
+from symbolchain.nem.KeyPair import KeyPair
+from symbolchain.nem.MessageEncoder import MessageEncoder
+
+from ..test.BasicMessageEncoderTest import BasicMessageEncoderTest, MessageEncoderTestInterface
+
+
+def malform_message(encoded):
+	crafted_byte = encoded.message[-1] ^ 0xFF
+	encoded.message = encoded.message[:-1] + bytes([crafted_byte])
+	return encoded
+
+
+class MessageEncoderDeprecatedTests(BasicMessageEncoderTest, unittest.TestCase):
+	def get_basic_test_interface(self):
+		return MessageEncoderTestInterface(
+			KeyPair,
+			MessageEncoder,
+			lambda encoder: encoder.encode_deprecated,
+			malform_message)
+
+
+class MessageEncoderTests(BasicMessageEncoderTest, unittest.TestCase):
+	def get_basic_test_interface(self):
+		return MessageEncoderTestInterface(
+			KeyPair,
+			MessageEncoder,
+			lambda encoder: encoder.encode,
+			malform_message)
+
+	def test_decode_falls_back_to_input_when_cbc_block_size_is_invalid(self):
+		# Arrange:
+		encoder = MessageEncoder(KeyPair(PrivateKey.random()))
+		recipient_public_key = KeyPair(PrivateKey.random()).public_key
+
+		encoded_message = Message()
+		encoded_message.message_type = MessageType.ENCRYPTED
+		encoded_message.message = bytes(16 + 32 + 1)
+
+		# Act:
+		result, decoded = encoder.try_decode(recipient_public_key, encoded_message)
+
+		# Assert
+		self.assertFalse(result)
+		self.assertEqual(decoded, encoded_message)
+
+	def test_decode_throws_when_message_type_is_invalid(self):
+		# Arrange:
+		encoder = MessageEncoder(KeyPair(PrivateKey.random()))
+		encoded_message = Message()
+		encoded_message.message_type = MessageType.PLAIN
+
+		# Act + Assert:
+		with self.assertRaises(RuntimeError):
+			encoder.try_decode(PublicKey(bytes(PublicKey.SIZE)), encoded_message)

--- a/sdk/python/tests/symbol/test_MessageEncoder.py
+++ b/sdk/python/tests/symbol/test_MessageEncoder.py
@@ -1,0 +1,82 @@
+from binascii import unhexlify
+import unittest
+
+from symbolchain.CryptoTypes import PrivateKey, PublicKey
+from symbolchain.symbol.KeyPair import KeyPair
+from symbolchain.symbol.MessageEncoder import MessageEncoder
+
+from ..test.BasicMessageEncoderTest import BasicMessageEncoderTest, MessageEncoderDecodeFailureTest, MessageEncoderTestInterface
+
+
+def fake_delegation(encoder):
+	def fake_delegation_encoder(public_key, message):
+		encoded = encoder.encode(public_key, message)
+		return unhexlify('FE2A8061577301E2') + public_key.bytes + encoded[1:]
+
+	return fake_delegation_encoder
+
+class MessageEncoderFakeDelegationTests(MessageEncoderDecodeFailureTest, unittest.TestCase):
+	def get_basic_test_interface(self):
+		return MessageEncoderTestInterface(
+			KeyPair,
+			MessageEncoder,
+			fake_delegation,
+			lambda encoded: encoded[:-1] + bytes([encoded[-1] ^ 0xFF]))
+
+
+class MessageEncoderTests(BasicMessageEncoderTest, unittest.TestCase):
+	def get_basic_test_interface(self):
+		return MessageEncoderTestInterface(
+			KeyPair,
+			MessageEncoder,
+			lambda encoder: encoder.encode,
+			lambda encoded: encoded[:-1] + bytes([encoded[-1] ^ 0xFF]))
+
+	# note: there's no sender decode test for persistent harvesting delegation, cause sender does not have ephemeral key pair
+
+	def test_recipient_can_decode_encoded_persistent_harvesting_delegation(self):
+		# Arrange:
+		key_pair = KeyPair(PrivateKey.random())
+		node_key_pair = KeyPair(PrivateKey.random())
+		remote_key_pair = KeyPair(PrivateKey('11223344556677889900AABBCCDDEEFF11223344556677889900AABBCCDDEEFF'))
+		vrf_key_pair = KeyPair(PrivateKey('11223344556677889900AABBCCDDEEFF11223344556677889900AABBCCDDEEFF'))
+		encoder = MessageEncoder(key_pair)
+		encoded = encoder.encode_persistent_harvesting_delegation(node_key_pair.public_key, remote_key_pair, vrf_key_pair)
+
+		# Act:
+		decoder = MessageEncoder(node_key_pair)
+		result, decoded = decoder.try_decode(PublicKey(bytes(PublicKey.SIZE)), encoded)
+
+		# Assert:
+		self.assertTrue(result)
+		self.assertEqual(remote_key_pair.private_key.bytes + vrf_key_pair.private_key.bytes, decoded)
+
+	def test_decode_falls_back_to_input_when_ephemeral_public_key_is_not_valid(self):
+		# Arrange:
+		key_pair = KeyPair(PrivateKey.random())
+		node_key_pair = KeyPair(PrivateKey.random())
+		remote_key_pair = KeyPair(PrivateKey.random())
+		vrf_key_pair = KeyPair(PrivateKey.random())
+		encoder = MessageEncoder(key_pair)
+		encoded = encoder.encode_persistent_harvesting_delegation(node_key_pair.public_key, remote_key_pair, vrf_key_pair)
+
+		encoded = encoded[0:8] + bytes(32) + encoded[8+32:]
+
+		# Act:
+		decoder = MessageEncoder(node_key_pair)
+		result, decoded = decoder.try_decode(PublicKey(bytes(PublicKey.SIZE)), encoded)
+
+		# Assert:
+		self.assertFalse(result)
+		self.assertEqual(encoded, decoded)
+
+	def test_decode_falls_back_to_input_when_message_has_unknown_type(self):
+		# Arrange:
+		encoder = MessageEncoder(KeyPair(PrivateKey.random()))
+
+		# Act:
+		result, message = encoder.try_decode(PublicKey(bytes(PublicKey.SIZE)), b'\2hello')
+
+		# Assert:
+		self.assertFalse(result)
+		self.assertEqual(b'\2hello', message)

--- a/sdk/python/tests/test/BasicMessageEncoderTest.py
+++ b/sdk/python/tests/test/BasicMessageEncoderTest.py
@@ -1,0 +1,71 @@
+from abc import abstractmethod
+from collections import namedtuple
+from unittest import TestLoader
+
+from symbolchain.CryptoTypes import PrivateKey
+
+MessageEncoderTestInterface = namedtuple('MessageEncoderTestInterface', ['key_pair_class', 'encoder_class', 'encode', 'malform'])
+
+
+class MessageEncoderDecodeFailureTest:
+	# pylint: disable=no-member
+	def assert_decode_falls_back_to_input_when_decoding_failed(self, message):
+		# Arrange:
+		interface = self.get_basic_test_interface()
+		key_pair = interface.key_pair_class(PrivateKey.random())
+		recipient_public_key = interface.key_pair_class(PrivateKey.random()).public_key
+		encoder = interface.encoder_class(key_pair)
+		encoded = interface.encode(encoder)(recipient_public_key, message)
+
+		encoded = interface.malform(encoded)
+
+		# Act:
+		result, decoded = encoder.try_decode(recipient_public_key, encoded)
+
+		# Assert:
+		self.assertFalse(result)
+		self.assertEqual(decoded, encoded)
+
+	def test_decode_falls_back_to_input_when_decoding_failed_short(self):
+		self.assert_decode_falls_back_to_input_when_decoding_failed(b'hello world')
+
+	def test_decode_falls_back_to_input_when_decoding_failed_long(self):
+		self.assert_decode_falls_back_to_input_when_decoding_failed(b'bit longer message that should span upon multiple encryption blocks')
+
+	@abstractmethod
+	def get_basic_test_interface(self):
+		pass
+
+class BasicMessageEncoderTest(MessageEncoderDecodeFailureTest):
+	# pylint: disable=no-member
+
+	def test_sender_can_decode_encoded_message(self):
+		# Arrange:
+		interface = self.get_basic_test_interface()
+		key_pair = interface.key_pair_class(PrivateKey.random())
+		recipient_public_key = interface.key_pair_class(PrivateKey.random()).public_key
+		encoder = interface.encoder_class(key_pair)
+		encoded = interface.encode(encoder)(recipient_public_key, b'hello world')
+
+		# Act:
+		result, decoded = encoder.try_decode(recipient_public_key, encoded)
+
+		# Assert:
+		self.assertTrue(result)
+		self.assertEqual(decoded, b'hello world')
+
+	def test_recipient_can_decode_encoded_message(self):
+		# Arrange:
+		interface = self.get_basic_test_interface()
+		key_pair = interface.key_pair_class(PrivateKey.random())
+		recipient_key_pair = interface.key_pair_class(PrivateKey.random())
+		encoder = interface.encoder_class(key_pair)
+		encoded = interface.encode(encoder)(recipient_key_pair.public_key, b'hello world')
+
+		# Act:
+		decoder = interface.encoder_class(recipient_key_pair)
+		result, decoded = decoder.try_decode(key_pair.public_key, encoded)
+
+		# Assert:
+		self.assertTrue(result)
+		self.assertEqual(decoded, b'hello world')


### PR DESCRIPTION
message encoder is a helper around encrypted (and encoded) messages

## What's the issue?

This is a helper to handle most common use cases of encryption in nem and symbol.

## How was this change tested?
 * the change uses already tested elements
 * there are additional tests used that check encoding (structuring)