### PR TITLE
[catapult/client] fix: update dependencies version

### DIFF
--- a/client/catapult/CMakeLists.txt
+++ b/client/catapult/CMakeLists.txt
@@ -42,6 +42,8 @@ if(ENABLE_TESTS)
 	message("--- locating gtest dependencies ---")
 
 	find_package(GTest 1.12.1 EXACT REQUIRED)
+	message("GTest   found: ${GTest_FOUND}")
+	message("GTest     inc: ${GTEST_INCLUDE_DIRS}")
 	message("GTest     ver: ${GTest_VERSION}")
 	message("GTest    libs: ${GTEST_LIBRARIES}")
 endif()

--- a/client/catapult/CMakeLists.txt
+++ b/client/catapult/CMakeLists.txt
@@ -41,7 +41,7 @@ message("boost    libs: ${Boost_LIBRARIES}")
 if(ENABLE_TESTS)
 	message("--- locating gtest dependencies ---")
 
-	find_package(GTest 1.10.0 EXACT REQUIRED)
+	find_package(GTest 1.12.1 EXACT REQUIRED)
 	message("GTest     ver: ${GTest_VERSION}")
 	message("GTest    libs: ${GTEST_LIBRARIES}")
 endif()
@@ -63,7 +63,7 @@ endfunction()
 
 ### setup rocksdb
 message("--- locating rocksdb dependencies ---")
-find_package(RocksDB 6.20.3 EXACT REQUIRED)
+find_package(RocksDB 7.4.3 EXACT REQUIRED)
 
 if(WIN32)
 	set(RocksDB_LIBRARY RocksDB::rocksdb)

--- a/client/catapult/conanfile.txt
+++ b/client/catapult/conanfile.txt
@@ -2,7 +2,7 @@
 # release dependencies
 boost/1.79.0
 cppzmq/4.7.1@nemtech/stable
-mongo-cxx-driver/3.6.3@nemtech/stable
+mongo-cxx-driver/3.6.7@nemtech/stable
 openssl/1.1.1g@nemtech/stable
 rocksdb/6.20.3@nemtech/stable
 

--- a/client/catapult/conanfile.txt
+++ b/client/catapult/conanfile.txt
@@ -1,14 +1,14 @@
 [requires]
 # release dependencies
 boost/1.79.0
-cppzmq/4.7.1@nemtech/stable
+cppzmq/4.8.1@nemtech/stable
 mongo-cxx-driver/3.6.7@nemtech/stable
-openssl/1.1.1g@nemtech/stable
-rocksdb/6.20.3@nemtech/stable
+openssl/1.1.1q@nemtech/stable
+rocksdb/7.4.3@nemtech/stable
 
 # test dependencies
-benchmark/1.5.3@nemtech/stable
-gtest/1.10.0
+benchmark/1.7.0@nemtech/stable
+gtest/1.12.1
 
 [generators]
 cmake

--- a/client/catapult/extensions/mongo/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.14)
 
 message("--- locating mongo dependencies ---")
-find_package(MONGOCXX 3.6.3 EXACT REQUIRED)
-find_package(MONGOC-1.0 1.17.5 EXACT REQUIRED)
+find_package(MONGOCXX 3.6.7 EXACT REQUIRED)
+find_package(MONGOC-1.0 1.22.0 EXACT REQUIRED)
 
 message("mongocxx  ver: ${MONGOCXX_VERSION}")
 message("mongoc    ver: ${MONGOC-1.0_VERSION}")

--- a/client/catapult/extensions/zeromq/CMakeLists.txt
+++ b/client/catapult/extensions/zeromq/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 message("--- locating zeromq dependencies ---")
-find_package(cppzmq 4.7.1 EXACT REQUIRED)
+find_package(cppzmq 4.8.1 EXACT REQUIRED)
 
 message("zeromq    ver: ${ZeroMQ_VERSION}")
 message("zeromq    inc: ${ZeroMQ_INCLUDE_DIR}")

--- a/client/catapult/tests/bench/CMakeLists.txt
+++ b/client/catapult/tests/bench/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 
 # setup benchmark
 message("--- locating bench dependencies ---")
-find_package(benchmark 1.5.3 EXACT REQUIRED)
+find_package(benchmark 1.7.0 EXACT REQUIRED)
 message("bench     ver: ${benchmark_VERSION}")
 
 # add benchmark dependencies

--- a/jenkins/catapult/runDockerBuildInnerBuild.py
+++ b/jenkins/catapult/runDockerBuildInnerBuild.py
@@ -94,7 +94,8 @@ class BuildManager(BasicBuildManager):
 
 	def build(self):
 		self.dispatch_subprocess(['ninja', 'publish'])
-		self.dispatch_subprocess(['ninja'])
+		cpu_count = len(os.sched_getaffinity(0))
+		self.dispatch_subprocess(['ninja', '-j', str(cpu_count if cpu_count > 0 else 1)])
 		self.dispatch_subprocess(['ninja', 'install'])
 
 	def copy_dependencies(self, destination):

--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -5,8 +5,8 @@ fedora = 34
 debian = 10.9
 
 boost = 79
-cmake = 3.20.1
-gosu = 1.7
+cmake = 3.23.2
+gosu = 1.14
 
 facebook_rocksdb = v7.4.3
 

--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -8,13 +8,13 @@ boost = 79
 cmake = 3.20.1
 gosu = 1.7
 
-facebook_rocksdb = v6.20.3
+facebook_rocksdb = v7.4.3
 
-google_googletest = release-1.10.0
-google_benchmark = v1.5.3
+google_googletest = release-1.12.1
+google_benchmark = v1.7.0
 
 mongodb_mongo-c-driver = 1.22.0
 mongodb_mongo-cxx-driver = r3.6.7
 
 zeromq_libzmq = v4.3.4
-zeromq_cppzmq = v4.7.1
+zeromq_cppzmq = v4.8.1

--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -13,8 +13,8 @@ facebook_rocksdb = v6.20.3
 google_googletest = release-1.10.0
 google_benchmark = v1.5.3
 
-mongodb_mongo-c-driver = 1.17.5
-mongodb_mongo-cxx-driver = r3.6.3
+mongodb_mongo-c-driver = 1.22.0
+mongodb_mongo-cxx-driver = r3.6.7
 
 zeromq_libzmq = v4.3.4
 zeromq_cppzmq = v4.7.1

--- a/jenkins/docker/cpp.Dockerfile
+++ b/jenkins/docker/cpp.Dockerfile
@@ -4,19 +4,17 @@ FROM symbolplatform/symbol-server-build-base:ubuntu-gcc-11-conan
 RUN apt-get install -y shellcheck
 RUN pip install gitlint
 
-# mongodb
+# mongodb requires ssl 1.1 but ubuntu 22.04 ships with ssl 3
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC 
 RUN apt-get install -y wget gnupg \
 	&& wget -qO- https://www.mongodb.org/static/pgp/server-5.0.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/mongo.gpg \
 	&& echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" \
 	| tee /etc/apt/sources.list.d/mongodb-org-5.0.list \
-
-# mongodb requires ssl 1.1 but ubuntu 22.04 ships with ssl 3
 	&& wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb \
 	&& dpkg -i ./libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb \
 	&& rm -i ./libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb \
-        && apt-get update \
+	&& apt-get update \
 	&& apt-get install -y mongodb-org
 
 # add ubuntu user (used by jenkins)

--- a/jenkins/docker/cpp.Dockerfile
+++ b/jenkins/docker/cpp.Dockerfile
@@ -5,11 +5,18 @@ RUN apt-get install -y shellcheck
 RUN pip install gitlint
 
 # mongodb
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=Etc/UTC 
 RUN apt-get install -y wget gnupg \
-	&& wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add - \
+	&& wget -qO- https://www.mongodb.org/static/pgp/server-5.0.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/mongo.gpg \
 	&& echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" \
 	| tee /etc/apt/sources.list.d/mongodb-org-5.0.list \
-	&& apt-get update \
+
+# mongodb requires ssl 1.1 but ubuntu 22.04 ships with ssl 3
+	&& wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb \
+	&& dpkg -i ./libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb \
+	&& rm -i ./libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb \
+        && apt-get update \
 	&& apt-get install -y mongodb-org
 
 # add ubuntu user (used by jenkins)


### PR DESCRIPTION
## What is the current behavior?
Catapult client build fails on Ubuntu 22.04

## What's the issue?
Catapult client dependencies needs to be updated.

## How have you changed the behavior?
Catapult client dependencies were updated to the latest version which allow successful build on Ubuntu 22.04

## How was this change tested?
Run the changes in Jenkins.