### PR TITLE
[client\catapult] fix: rocksdb metal build and clang failure

### DIFF
--- a/client/catapult/tests/bench/crypto/hashers/HashersBench.cpp
+++ b/client/catapult/tests/bench/crypto/hashers/HashersBench.cpp
@@ -67,7 +67,7 @@ namespace catapult { namespace crypto {
 				TTraits::HashFunc(buffer, hash);
 			}
 
-			state.SetBytesProcessed(static_cast<int64_t>(static_cast<int64_t>(buffer.size()) * state.iterations()));
+			state.SetBytesProcessed(static_cast<int64_t>(buffer.size()) * state.iterations());
 		}
 
 		void AddDefaultArguments(benchmark::internal::Benchmark& benchmark) {

--- a/client/catapult/tests/bench/crypto/hashers/HashersBench.cpp
+++ b/client/catapult/tests/bench/crypto/hashers/HashersBench.cpp
@@ -67,7 +67,7 @@ namespace catapult { namespace crypto {
 				TTraits::HashFunc(buffer, hash);
 			}
 
-			state.SetBytesProcessed(static_cast<int64_t>(buffer.size() * state.iterations()));
+			state.SetBytesProcessed(static_cast<int64_t>(static_cast<int64_t>(buffer.size()) * state.iterations()));
 		}
 
 		void AddDefaultArguments(benchmark::internal::Benchmark& benchmark) {

--- a/jenkins/catapult/baseImageDockerfileGenerator.py
+++ b/jenkins/catapult/baseImageDockerfileGenerator.py
@@ -129,9 +129,7 @@ class OptionsManager:
 	def rocks(self):
 		descriptor = self.OptionsDescriptor()
 		descriptor.options += DEPENDENCY_FLAGS['facebook_rocksdb']
-
-		if 'undefined' in self.sanitizers:
-			descriptor.options += ['-DUSE_RTTI=1']
+		descriptor.options += ['-DUSE_RTTI=1']
 
 		return self._cmake(descriptor)
 

--- a/jenkins/catapult/runDockerTestsInnerTest.py
+++ b/jenkins/catapult/runDockerTestsInnerTest.py
@@ -45,6 +45,7 @@ class SanitizerEnvironment:
 	def prepare_thread_sanitizer(self):
 		with open(TSAN_SUPPRESSIONS_PATH, 'wt', encoding='utf8') as outfile:
 			outfile.write('race:~weak_ptr\n')
+			outfile.write('race:weak_ptr::lock()\n')
 			outfile.write('race:~executor\n')
 			outfile.write('race:global_logger::get()')
 


### PR DESCRIPTION
## What is the current behavior?
Clang and metal builds are failing.

## What's the issue?

Metal builds requires rtti enable for rocksDB.
```
22:36:42  /usr/bin/ld: lib/libcatapult.cache_db.a(RocksPruningFilter.cpp.o):(.data.rel.ro._ZTIN7rocksdb16CompactionFilterE[_ZTIN7rocksdb16CompactionFilterE]+0x10): undefined reference to `typeinfo for rocksdb::Customizable'
22:36:42  collect2: error: ld returned 1 exit status
```

Clang fails due to implicit conversion.
```
22:36:25  /catapult-src/client/catapult/tests/bench/crypto/hashers/HashersBench.cpp:70:71: error: implicit conversion changes signedness: 'benchmark::IterationCount' (aka 'long') to 'unsigned long' [-Werror,-Wsign-conversion]
22:36:25                          state.SetBytesProcessed(static_cast<int64_t>(buffer.size() * state.iterations()));
22:36:25                                                                                     ~ ~~~~~~^~~~~~~~~~~~
```

## How have you changed the behavior?
Enabled rtti for the RocksDB build.
Clang change to an explicit conversion.

## How was this change tested?
Tested in Jenkins.