### PR TITLE
[client/catapult] fix: update catapult build docs for Conan

### DIFF
--- a/client/catapult/docs/BUILD-conan.md
+++ b/client/catapult/docs/BUILD-conan.md
@@ -19,8 +19,18 @@ Following instructions should work on Mac, Linux (Ubuntu 20.04) and Windows.
 
      ```sh
      conan profile new default --detect
-     conan profile update settings.compiler.libcxx=libstdc++11 default
+     conan config set general.revisions_enabled=True
      ```
+     
+    For gcc compiler:
+    ```sh
+    conan profile update settings.compiler.libcxx=libstdc++11 default
+    ```
+
+    For clang compiler:
+    ```sh
+    conan profile update settings.compiler.libcxx=libc++ default
+    ```
 
 * **On Windows**:
 
@@ -79,23 +89,23 @@ CONAN_REVISIONS_ENABLED=1 conan install .. --build missing
 > **NOTE:**
 > Make sure to use the correct ``PYTHON_EXECUTABLE`` path! Python3 is required for the build to produce some header files. If Python3 cannot be found you won't notice until more than one hour into the build process because of some missing headers. You can find your Python3 path by running ``where python3``.
 
+* Generate project files for Visual Studio 2022:
+
+  ```sh
+  cmake -G "Visual Studio 17 2022" -A x64 -DUSE_CONAN=ON -DPYTHON_EXECUTABLE:FILEPATH=X:/python3x/python.exe ..
+  ```
+
 * Generate project files for Visual Studio 2019:
 
   ```sh
-  cmake -G "Visual Studio 16 2019" -A x64 -DUSE_CONAN=ON -DPYTHON_EXECUTABLE:FILEPATH=X:/python3x/python.exe ..
-  ```
-
-* Generate project files for Visual Studio 2017:
-
-  ```sh
-  cmake -G "Visual Studio 15 2017 Win64" -DUSE_CONAN=ON -DPYTHON_EXECUTABLE:FILEPATH=X:/python3x/python.exe ..
+  cmake -G "Visual Studio 16 2019"  -A x64 -DUSE_CONAN=ON -DPYTHON_EXECUTABLE:FILEPATH=X:/python3x/python.exe ..
   ```
 
 * Build:
 
   ```sh
   cmake --build . --target publish
-  msbuild /p:Configuration=RelWithDebInfo /p:Platform=x64 ALL_BUILD.vcxproj
+  msbuild /p:Configuration=RelWithDebInfo /p:Platform=x64 /m ALL_BUILD.vcxproj
   ```
 
   After building successfully, the tools in ``_build\bin`` are ready to use. All runtime dependencies have been copied into the same folder so Windows will find them.


### PR DESCRIPTION
## What's the issue?
The Conan build docs are incorrect for clang.

## How have you changed the behavior?
Update docs to specify the correct library for Clang.
Update VS compiler version

## How was this change tested?
Locally with the updated steps