### PR TITLE
[jenkins] fix: add linters project as a dependency to all other projects

### DIFF
--- a/.github/buildConfiguration.yaml
+++ b/.github/buildConfiguration.yaml
@@ -1,25 +1,35 @@
 builds:
   - name: Catbuffer Parser
     path: catbuffer/parser
+    dependsOn:
+      - linters
 
   - name: Catapult Client
     path: client/catapult
+    dependsOn:
+      - linters
 
   - name: Rest Gateway
     path: client/rest
+    dependsOn:
+      - linters
 
   - name: Sdk Python
     path: sdk/python
     dependsOn:
       - catbuffer/parser
+      - linters
 
   - name: Sdk Javascript
     path: sdk/javascript
     dependsOn:
       - catbuffer/parser
+      - linters
 
   - name: Jenkins
     path: jenkins
+    dependsOn:
+      - linters
 
   - name: Linters
     path: linters

--- a/sdk/python/tests/test_RuleBasedTransactionFactory.py
+++ b/sdk/python/tests/test_RuleBasedTransactionFactory.py
@@ -145,7 +145,7 @@ class RuleBasedTransactionFactoryTest(unittest.TestCase):
 	def test_flags_parser_can_handle_multiple_string_flags(self):
 		self._assert_flags_parser(
 			'supply_mutable restrictable revokable',
-			Module.MosaicFlags.SUPPLY_MUTABLE | Module.MosaicFlags.RESTRICTABLE | Module.MosaicFlags.REVOKABLE)
+			Module.MosaicFlags.SUPPLY_MUTABLE | (Module.MosaicFlags.RESTRICTABLE | Module.MosaicFlags.REVOKABLE))
 
 	def test_flags_parser_fails_if_any_string_is_unknown(self):
 		# Arrange:
@@ -161,7 +161,7 @@ class RuleBasedTransactionFactoryTest(unittest.TestCase):
 		self._assert_flags_parser(9, Module.MosaicFlags.SUPPLY_MUTABLE | Module.MosaicFlags.REVOKABLE)
 
 	def test_flags_parser_passes_non_parsed_values_as_is(self):
-		value = Module.MosaicFlags.SUPPLY_MUTABLE | Module.MosaicFlags.RESTRICTABLE | Module.MosaicFlags.REVOKABLE
+		value = Module.MosaicFlags.SUPPLY_MUTABLE | (Module.MosaicFlags.RESTRICTABLE | Module.MosaicFlags.REVOKABLE)
 		self._assert_flags_parser(value, value)
 		self._assert_flags_parser(1.2, 1.2)
 		self._assert_flags_parser([1, 2, 3, 4], [1, 2, 3, 4])


### PR DESCRIPTION
## What is the current behavior?
linters folder gets updated but other projects are not run

## What's the issue?
linters can be upgraded and cause failures in other projects

## How have you changed the behavior?
If the linters gets upgraded rerun all other projects
Also create workaround for the python sdk pylint failure and open this issue - ``https://github.com/PyCQA/pylint/issues/7381``