### PR TITLE
[jenkins] fix: add stage name and exception message to Discord message for Jenkins failed jobs

### DIFF
--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -285,7 +285,8 @@ void call(Closure body) {
 					if (null != env.SHOULD_PUBLISH_FAIL_JOB_STATUS && env.SHOULD_PUBLISH_FAIL_JOB_STATUS.toBoolean()) {
 						helper.sendDiscordNotification(
 							"Jenkins Job Failed for ${currentBuild.fullDisplayName}",
-							"Build#${env.BUILD_NUMBER} has result of ${currentBuild.currentResult}.",
+							"Build#${env.BUILD_NUMBER} has result of ${currentBuild.currentResult} in stage **${FAILED_STAGE_NAME}** with" +
+									" message: **${env.FAILURE_MESSAGE}**.",
 							env.BUILD_URL,
 							currentBuild.currentResult
 						)
@@ -297,8 +298,15 @@ void call(Closure body) {
 }
 
 void runStepRelativeToPackageRoot(String rootPath, Closure body) {
-	dir(rootPath) {
-		body()
+	try {	
+		dir(rootPath) {
+			body()
+		}
+	} catch (Exception exception) {
+		echo "Caught: ${exception.toString()}"
+		env.FAILURE_MESSAGE = exception.getMessage()
+		env.FAILED_STAGE_NAME = STAGE_NAME
+		throw exception
 	}
 }
 

--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -285,8 +285,8 @@ void call(Closure body) {
 					if (null != env.SHOULD_PUBLISH_FAIL_JOB_STATUS && env.SHOULD_PUBLISH_FAIL_JOB_STATUS.toBoolean()) {
 						helper.sendDiscordNotification(
 							"Jenkins Job Failed for ${currentBuild.fullDisplayName}",
-							"Build#${env.BUILD_NUMBER} has result of ${currentBuild.currentResult} in stage **${FAILED_STAGE_NAME}** with" +
-									" message: **${env.FAILURE_MESSAGE}**.",
+							"Build#${env.BUILD_NUMBER} has result of ${currentBuild.currentResult} in stage **${env.FAILED_STAGE_NAME}** " +
+									"with message: **${env.FAILURE_MESSAGE}**.",
 							env.BUILD_URL,
 							currentBuild.currentResult
 						)
@@ -305,7 +305,7 @@ void runStepRelativeToPackageRoot(String rootPath, Closure body) {
 	} catch (Exception exception) {
 		echo "Caught: ${exception.toString()}"
 		env.FAILURE_MESSAGE = exception.getMessage()
-		env.FAILED_STAGE_NAME = STAGE_NAME
+		env.FAILED_STAGE_NAME = env.STAGE_NAME
 		throw exception
 	}
 }


### PR DESCRIPTION
## What's the issue?
Discord message for fail Jenkins job need more information on the failure.

## How have you changed the behavior?
Add the stage name plus exception message to the discord message

## How was this change tested?
Ran this in Jenkins.
