### PR TITLE
[client/catapult] fix: upgrade to boost 1.80

### DIFF
--- a/client/catapult/CMakeLists.txt
+++ b/client/catapult/CMakeLists.txt
@@ -30,7 +30,7 @@ endfunction()
 
 ### setup boost
 message("--- locating boost dependencies ---")
-find_package(Boost 1.79.0 EXACT COMPONENTS ${CATAPULT_BOOST_COMPONENTS} REQUIRED)
+find_package(Boost 1.80.0 EXACT COMPONENTS ${CATAPULT_BOOST_COMPONENTS} REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIR})
 
 message("boost     ver: ${Boost_VERSION}")

--- a/client/catapult/conanfile.txt
+++ b/client/catapult/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 # release dependencies
-boost/1.79.0
+boost/1.80.0
 cppzmq/4.8.1@nemtech/stable
 mongo-cxx-driver/3.6.7@nemtech/stable
 openssl/1.1.1q@nemtech/stable

--- a/jenkins/catapult/compilers/ubuntu-clang/Dockerfile
+++ b/jenkins/catapult/compilers/ubuntu-clang/Dockerfile
@@ -25,5 +25,5 @@ RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /etc/
 	update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${COMPILER_VERSION} 100 && \
 	update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${COMPILER_VERSION} 100 && \
 	update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100 && \
-	update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100 \
+	update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100 && \
 	rm -rf /var/lib/apt/lists/*

--- a/jenkins/catapult/jenkins/catapult-client-build-base-image-all.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-base-image-all.groovy
@@ -39,7 +39,7 @@ pipeline {
 				stage('gcc 10 [debian]') {
 					steps {
 						script {
-							dispatchBuildBaseImageJob('gcc-10', 'debian', false)
+							dispatchBuildBaseImageJob('gcc-debian', 'debian', false)
 						}
 					}
 				}

--- a/jenkins/catapult/jenkins/catapult-client-build-base-image.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-base-image.groovy
@@ -2,7 +2,7 @@ pipeline {
 	parameters {
 		gitParameter branchFilter: 'origin/(.*)', defaultValue: 'dev', name: 'MANUAL_GIT_BRANCH', type: 'PT_BRANCH'
 		choice name: 'COMPILER_CONFIGURATION',
-			choices: ['gcc-latest', 'gcc-prior', 'gcc-10', 'gcc-westmere', 'clang-latest', 'clang-prior', 'clang-ausan', 'clang-tsan', 'msvc-latest', 'msvc-prior'],
+			choices: ['gcc-latest', 'gcc-prior', 'gcc-debian', 'gcc-westmere', 'clang-latest', 'clang-prior', 'clang-ausan', 'clang-tsan', 'msvc-latest', 'msvc-prior'],
 			description: 'compiler configuration'
 		choice name: 'OPERATING_SYSTEM',
 			choices: ['ubuntu', 'fedora', 'debian', 'windows'],

--- a/jenkins/catapult/jenkins/catapult-client-build-compiler-image.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-compiler-image.groovy
@@ -2,7 +2,7 @@ pipeline {
 	parameters {
 		gitParameter branchFilter: 'origin/(.*)', defaultValue: 'dev', name: 'MANUAL_GIT_BRANCH', type: 'PT_BRANCH'
 		choice name: 'COMPILER_CONFIGURATION',
-			choices: ['gcc-latest', 'gcc-prior', 'gcc-10', 'clang-latest', 'clang-prior', 'msvc-latest', 'msvc-prior'],
+			choices: ['gcc-latest', 'gcc-prior', 'gcc-debian', 'clang-latest', 'clang-prior', 'msvc-latest', 'msvc-prior'],
 			description: 'compiler version'
 		choice name: 'OPERATING_SYSTEM',
 			choices: ['ubuntu', 'fedora', 'debian', 'windows'],

--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -5,7 +5,7 @@ fedora = 36
 debian = 11.4
 windows = 2022
 
-boost = 79
+boost = 80
 cmake = 3.23.2
 gosu = 1.14
 


### PR DESCRIPTION
## What's the issue?
Upgrade to boost 1.80

## How have you changed the behavior?
catapult client will not use boost 1.80
change name from gcc-10 -> gcc-debian

## How was this change tested?
Running tests in Jenkins now.  Will verify in the morning.