### PR TITLE
[sdk/javascript]: add cosignTransaction to SymbolFacade

### DIFF
--- a/sdk/javascript/test/facade/SymbolFacade_spec.js
+++ b/sdk/javascript/test/facade/SymbolFacade_spec.js
@@ -4,6 +4,7 @@ const {
 } = require('../../src/CryptoTypes');
 const { SymbolFacade } = require('../../src/facade/SymbolFacade');
 const { Network } = require('../../src/symbol/Network');
+const sc = require('../../src/symbol/models');
 const { expect } = require('chai');
 const crypto = require('crypto');
 
@@ -66,6 +67,32 @@ describe('Symbol Facade', () => {
 			aliasAction: 'link'
 		}
 	].map(descriptor => facade.transactionFactory.createEmbedded(descriptor));
+
+	const createRealAggregateSwap = facade => facade.transactionFactory.create({
+		type: 'aggregate_complete_transaction',
+		signerPublicKey: '4C94E8B0A1DAB8573BCB6632E676F742E0D320FC8102F20FB7FB13BCAE9A9F60',
+		fee: 36000n,
+		deadline: 26443750218n,
+		transactionsHash: '641CB7E431F1D44094A43E1CE8265E6BD1DF1C3B0B64797CDDAA0A375FCD3C08',
+		transactions: [
+			facade.transactionFactory.createEmbedded({
+				type: 'transfer_transaction',
+				signerPublicKey: '29856F43A5C4CBDE42F2FAC775A6F915E9E5638CF458E9352E7B410B662473A3',
+				recipientAddress: 'TBEZ3VKFBMKQSW7APBVL5NWNBEU7RR466PRRTDQ',
+				mosaics: [
+					{ mosaicId: 0xE74B99BA41F4AFEEn, amount: 20000000n }
+				]
+			}),
+			facade.transactionFactory.createEmbedded({
+				type: 'transfer_transaction',
+				signerPublicKey: '4C94E8B0A1DAB8573BCB6632E676F742E0D320FC8102F20FB7FB13BCAE9A9F60',
+				recipientAddress: 'TDFR3Q3H5W4OPOSHALVDY3RF4ZQNH44LIUIHYTQ',
+				mosaics: [
+					{ mosaicId: 0x798A29F48E927C83n, amount: 100n }
+				]
+			})
+		]
+	});
 
 	// endregion
 
@@ -228,6 +255,54 @@ describe('Symbol Facade', () => {
 
 	it('can verify aggregate transaction', () => {
 		assertCanVerifyTransaction(createRealAggregate);
+	});
+
+	// endregion
+
+	// region cosignTransaction
+
+	describe('can cosign transactions', () => {
+		const assertCanCosignTransaction = detached => {
+			// Arrange:
+			const signerPrivateKey = new PrivateKey('F4BC233E183E8CEA08D0A604A3DC67FF3261D1E6EBF84D233488BC53D89C50B7');
+			const cosignerPrivateKey = new PrivateKey('BE7B98F835A896136ADDAF04220F28CB4925D24F0675A21421BF213C180BEF86');
+			const facade = new SymbolFacade('testnet');
+
+			const transaction = createRealAggregateSwap(facade);
+			const signature = facade.signTransaction(new SymbolFacade.KeyPair(signerPrivateKey), transaction);
+			facade.transactionFactory.constructor.attachSignature(transaction, signature);
+
+			// Act:
+			const cosignature = facade.cosignTransaction(new SymbolFacade.KeyPair(cosignerPrivateKey), transaction, detached);
+
+			// Assert: check common fields
+			expect(cosignature.version).to.equal(0n);
+			expect(cosignature.signerPublicKey)
+				.to.deep.equal(new sc.PublicKey('29856F43A5C4CBDE42F2FAC775A6F915E9E5638CF458E9352E7B410B662473A3'));
+			expect(cosignature.signature)
+				.to.deep.equal(new sc.Signature('623A3FE2B9795DB23508A39B4A9586495D6EA9481355B29EB5E9BE1776866956'
+					+ '2818B1AC52AFDD0BE192F19674931E4A6DB59D32E8610CBE3DEA8783CD9B4505'));
+			return cosignature;
+		};
+
+		it('as attached cosignature', () => {
+			// Act:
+			const cosignature = assertCanCosignTransaction();
+
+			// Assert: cosignature should be suitable for attaching to an aggregate
+			expect(cosignature.size).to.equal(104);
+			expect(cosignature.parentHash).to.equal(undefined);
+		});
+
+		it('as detached cosignature', () => {
+			// Act:
+			const cosignature = assertCanCosignTransaction(true);
+
+			// Assert: cosignature should be detached
+			expect(cosignature.size).to.equal(136);
+			expect(cosignature.parentHash)
+				.to.deep.equal(new sc.Hash256('E193D1AADA8982757DECADF1B5B347D49E3D211C5E6CDB64D50EACE185EDA674'));
+		});
 	});
 
 	// endregion


### PR DESCRIPTION
problem: construction of Cosignatures is a bit awkward because it requires direct manipulation of catbuffer POD types

solution: add cosignTransaction helper function to SymbolFacade that hides the gory details
