### PR TITLE
[sdk/javascript]: convert project to use ES6 modules

### DIFF
--- a/sdk/javascript/.eslintrc
+++ b/sdk/javascript/.eslintrc
@@ -2,3 +2,7 @@
 extends:
   - airbnb
   - ../../linters/javascript/default.eslintrc
+rules:
+  import/extensions:
+  - error
+  - ignorePackages

--- a/sdk/javascript/examples/bip32_keypair.js
+++ b/sdk/javascript/examples/bip32_keypair.js
@@ -6,7 +6,7 @@
 // note: this example is *not* generating keys compatible with wallet
 //
 
-const symbolSdk = require('../src/index');
+import symbolSdk from '../src/index.js';
 
 (() => {
 	const deriveKey = (rootNode, facade, change, index) => {

--- a/sdk/javascript/examples/descriptors/nem_account_key_link.js
+++ b/sdk/javascript/examples/descriptors/nem_account_key_link.js
@@ -1,9 +1,7 @@
-const descriptorFactory = () => ([
+export default () => ([
 	{
 		type: 'account_key_link_transaction',
 		linkAction: 'link',
 		remotePublicKey: 'BE0B4CF546B7B4F4BBFCFF9F574FDA527C07A53D3FC76F8BB7DB746F8E8E0A9F'
 	}
 ]);
-
-module.exports = { descriptorFactory };

--- a/sdk/javascript/examples/descriptors/nem_mosaic.js
+++ b/sdk/javascript/examples/descriptors/nem_mosaic.js
@@ -1,6 +1,8 @@
-const { nem } = require('../../src/index');
+import symbolSdk from '../../src/index.js';
 
-const descriptorFactory = () => {
+const { nem } = symbolSdk;
+
+export default () => {
 	const sampleAddress = 'TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C';
 	const textEncoder = new TextEncoder();
 
@@ -81,5 +83,3 @@ const descriptorFactory = () => {
 		}
 	];
 };
-
-module.exports = { descriptorFactory };

--- a/sdk/javascript/examples/descriptors/nem_multisig_account.js
+++ b/sdk/javascript/examples/descriptors/nem_multisig_account.js
@@ -1,4 +1,4 @@
-const descriptorFactory = () => ([
+export default () => ([
 	// V2 add
 	{
 		type: 'multisig_account_modification_transaction',
@@ -58,5 +58,3 @@ const descriptorFactory = () => ([
 		]
 	}
 ]);
-
-module.exports = { descriptorFactory };

--- a/sdk/javascript/examples/descriptors/nem_namespace.js
+++ b/sdk/javascript/examples/descriptors/nem_namespace.js
@@ -1,4 +1,4 @@
-const descriptorFactory = () => ([
+export default () => ([
 	// root namespace
 	{
 		type: 'namespace_registration_transaction',
@@ -16,5 +16,3 @@ const descriptorFactory = () => ([
 		name: 'charlie'
 	}
 ]);
-
-module.exports = { descriptorFactory };

--- a/sdk/javascript/examples/descriptors/nem_transfer.js
+++ b/sdk/javascript/examples/descriptors/nem_transfer.js
@@ -1,4 +1,4 @@
-const descriptorFactory = () => {
+export default () => {
 	const sampleAddress = 'TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C';
 	const textEncoder = new TextEncoder();
 
@@ -71,5 +71,3 @@ const descriptorFactory = () => {
 		}
 	];
 };
-
-module.exports = { descriptorFactory };

--- a/sdk/javascript/examples/descriptors/symbol_alias.js
+++ b/sdk/javascript/examples/descriptors/symbol_alias.js
@@ -1,4 +1,4 @@
-const descriptorFactory = () => {
+export default () => {
 	const sampleAddress = 'TASYMBOLLK6FSL7GSEMQEAWN7VW55ZSZU2Q2Q5Y';
 	const sampleNamespaceId = 0xC01DFEE7FEEDDEADn;
 	const sampleMosaicId = 0x7EDCBA90FEDCBA90n;
@@ -19,5 +19,3 @@ const descriptorFactory = () => {
 		}
 	];
 };
-
-module.exports = { descriptorFactory };

--- a/sdk/javascript/examples/descriptors/symbol_key_link.js
+++ b/sdk/javascript/examples/descriptors/symbol_key_link.js
@@ -1,4 +1,4 @@
-const descriptorFactory = () => {
+export default () => {
 	const samplePublicKey = 'BE0B4CF546B7B4F4BBFCFF9F574FDA527C07A53D3FC76F8BB7DB746F8E8E0A9F';
 
 	return [
@@ -29,5 +29,3 @@ const descriptorFactory = () => {
 		}
 	];
 };
-
-module.exports = { descriptorFactory };

--- a/sdk/javascript/examples/descriptors/symbol_lock.js
+++ b/sdk/javascript/examples/descriptors/symbol_lock.js
@@ -1,6 +1,6 @@
-const { ByteArray, CryptoTypes } = require('../../src/index');
+import symbolSdk from '../../src/index.js';
 
-const descriptorFactory = () => {
+export default () => {
 	const sampleAddress = 'TASYMBOLLK6FSL7GSEMQEAWN7VW55ZSZU2Q2Q5Y';
 	const sampleMosaicId = 0x7EDCBA90FEDCBA90n;
 	const secret = 'C849C5A5F6BCA84EF1829B2A84C0BAC9D765383D000000000000000000000000';
@@ -11,7 +11,7 @@ const descriptorFactory = () => {
 			type: 'hash_lock_transaction',
 			mosaic: { mosaicId: sampleMosaicId, amount: 123_000000n },
 			duration: 123n,
-			hash: CryptoTypes.Hash256.zero()
+			hash: symbolSdk.Hash256.zero()
 		},
 
 		{
@@ -28,9 +28,7 @@ const descriptorFactory = () => {
 			recipientAddress: sampleAddress,
 			secret,
 			hashAlgorithm: 'hash_160',
-			proof: (new ByteArray(4, 'C1ECFDFC')).bytes
+			proof: (new symbolSdk.ByteArray(4, 'C1ECFDFC')).bytes
 		}
 	];
 };
-
-module.exports = { descriptorFactory };

--- a/sdk/javascript/examples/descriptors/symbol_metadata.js
+++ b/sdk/javascript/examples/descriptors/symbol_metadata.js
@@ -1,4 +1,4 @@
-const descriptorFactory = () => {
+export default () => {
 	const sampleAddress = 'TASYMBOLLK6FSL7GSEMQEAWN7VW55ZSZU2Q2Q5Y';
 	const sampleNamespaceId = 0xC01DFEE7FEEDDEADn;
 	const sampleMosaicId = 0x7EDCBA90FEDCBA90n;
@@ -39,5 +39,3 @@ const descriptorFactory = () => {
 		{ ...templates[2], valueSizeDelta: -5, value: value3.substring(0, value3.length - 5) }
 	];
 };
-
-module.exports = { descriptorFactory };

--- a/sdk/javascript/examples/descriptors/symbol_mosaic.js
+++ b/sdk/javascript/examples/descriptors/symbol_mosaic.js
@@ -1,7 +1,9 @@
-const { Address, generateMosaicId } = require('../../src/index').symbol;
+import symbolSdk from '../../src/index.js';
 
-const descriptorFactory = () => {
-	const sampleAddress = new Address('TASYMBOLLK6FSL7GSEMQEAWN7VW55ZSZU2Q2Q5Y');
+const { symbol } = symbolSdk;
+
+export default () => {
+	const sampleAddress = new symbol.Address('TASYMBOLLK6FSL7GSEMQEAWN7VW55ZSZU2Q2Q5Y');
 
 	return [
 		{
@@ -14,11 +16,9 @@ const descriptorFactory = () => {
 
 		{
 			type: 'mosaic_supply_change_transaction',
-			mosaicId: generateMosaicId(sampleAddress, 123),
+			mosaicId: symbol.generateMosaicId(sampleAddress, 123),
 			delta: 1000n * 100n, // assuming divisibility = 2
 			action: 'increase'
 		}
 	];
 };
-
-module.exports = { descriptorFactory };

--- a/sdk/javascript/examples/descriptors/symbol_namespace.js
+++ b/sdk/javascript/examples/descriptors/symbol_namespace.js
@@ -1,6 +1,8 @@
-const { generateNamespaceId } = require('../../src/index').symbol;
+import symbolSdk from '../../src/index.js';
 
-const descriptorFactory = () => ([
+const { symbol } = symbolSdk;
+
+export default () => ([
 	{
 		type: 'namespace_registration_transaction',
 		registrationType: 'root',
@@ -11,9 +13,7 @@ const descriptorFactory = () => ([
 	{
 		type: 'namespace_registration_transaction',
 		registrationType: 'child',
-		parentId: generateNamespaceId('roger'),
+		parentId: symbol.generateNamespaceId('roger'),
 		name: 'charlie'
 	}
 ]);
-
-module.exports = { descriptorFactory };

--- a/sdk/javascript/examples/descriptors/symbol_restriction_account.js
+++ b/sdk/javascript/examples/descriptors/symbol_restriction_account.js
@@ -1,4 +1,4 @@
-const descriptorFactory = () => {
+export default () => {
 	const sampleAddress = 'TASYMBOLLK6FSL7GSEMQEAWN7VW55ZSZU2Q2Q5Y';
 	const sampleMosaicId = 0x7EDCBA90FEDCBA90n;
 
@@ -39,5 +39,3 @@ const descriptorFactory = () => {
 		}
 	];
 };
-
-module.exports = { descriptorFactory };

--- a/sdk/javascript/examples/descriptors/symbol_restriction_mosaic.js
+++ b/sdk/javascript/examples/descriptors/symbol_restriction_mosaic.js
@@ -1,4 +1,4 @@
-const descriptorFactory = () => {
+export default () => {
 	const sampleAddress = 'TASYMBOLLK6FSL7GSEMQEAWN7VW55ZSZU2Q2Q5Y';
 	const sampleMosaicId = 0x7EDCBA90FEDCBA90n;
 
@@ -24,5 +24,3 @@ const descriptorFactory = () => {
 		}
 	];
 };
-
-module.exports = { descriptorFactory };

--- a/sdk/javascript/examples/descriptors/symbol_transfer.js
+++ b/sdk/javascript/examples/descriptors/symbol_transfer.js
@@ -1,4 +1,4 @@
-const descriptorFactory = () => {
+export default () => {
 	const sampleAddress = 'TASYMBOLLK6FSL7GSEMQEAWN7VW55ZSZU2Q2Q5Y';
 	const sampleMosaicId = 0x7EDCBA90FEDCBA90n;
 
@@ -30,5 +30,3 @@ const descriptorFactory = () => {
 		}
 	];
 };
-
-module.exports = { descriptorFactory };

--- a/sdk/javascript/examples/examples_utils.js
+++ b/sdk/javascript/examples/examples_utils.js
@@ -1,7 +1,5 @@
-const symbolSdk = require('../src/index');
-const fs = require('fs');
+import symbolSdk from '../src/index.js';
+import fs from 'fs';
 
-const readContents = filepath => fs.readFileSync(filepath, { encoding: 'utf8', flag: 'r' });
-const readPrivateKey = filepath => new symbolSdk.symbol.KeyPair(new symbolSdk.CryptoTypes.PrivateKey(readContents(filepath).trim()));
-
-module.exports = { readContents, readPrivateKey };
+export const readContents = filepath => fs.readFileSync(filepath, { encoding: 'utf8', flag: 'r' });
+export const readPrivateKey = filepath => new symbolSdk.symbol.KeyPair(new symbolSdk.PrivateKey(readContents(filepath).trim()));

--- a/sdk/javascript/examples/transaction_aggregate.js
+++ b/sdk/javascript/examples/transaction_aggregate.js
@@ -6,19 +6,22 @@
 // Signs aggregate transaction using private key provided in file specified via `--private` switch.
 //
 
-const { readContents, readPrivateKey } = require('./examples_utils');
-const { SymbolFacade } = require('../src/index').facade;
-const yargs = require('yargs');
-const fs = require('fs');
-const path = require('path');
+import { readContents, readPrivateKey } from './examples_utils.js';
+import symbolSdk from '../src/index.js';
+import yargs from 'yargs';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
 (() => {
+	const { SymbolFacade } = symbolSdk.facade;
+
 	const addEmbeddedTransfers = (facade, publicKey) => {
 		const textEncoder = new TextEncoder();
 
 		// obtain recipient from publicKey, so direct all transfers to 'self'
 		const recipientAddress = facade.network.publicKeyToAddress(publicKey);
-		const resourcesDirectory = path.join(__dirname, 'resources');
+		const resourcesDirectory = path.join(path.dirname(fileURLToPath(import.meta.url)), 'resources');
 
 		const filenames = fs.readdirSync(resourcesDirectory).filter(filename => filename.startsWith('part'));
 		filenames.sort();

--- a/sdk/javascript/examples/transaction_multisig.js
+++ b/sdk/javascript/examples/transaction_multisig.js
@@ -4,11 +4,11 @@
 // Shows how to create multisig account.
 //
 
-const symbolSdk = require('../src/index');
+import symbolSdk from '../src/index.js';
 
 (() => {
 	const createKeyPairFromPrivateKey = privateKeyString =>
-		new symbolSdk.symbol.KeyPair(new symbolSdk.CryptoTypes.PrivateKey(privateKeyString));
+		new symbolSdk.symbol.KeyPair(new symbolSdk.PrivateKey(privateKeyString));
 
 	class MultisigAccountModificationSample {
 		constructor() {

--- a/sdk/javascript/generator/Generator.py
+++ b/sdk/javascript/generator/Generator.py
@@ -7,7 +7,6 @@ from catparser.generators.util import build_factory_map, extend_models
 
 from .EnumTypeFormatter import EnumTypeFormatter
 from .FactoryFormatter import FactoryClassFormatter, FactoryFormatter
-from .format import wrap_lines
 from .PodTypeFormatter import PodTypeFormatter
 from .printers import BuiltinPrinter, create_pod_printer
 from .StructTypeFormatter import StructFormatter
@@ -29,29 +28,35 @@ def to_type_formatter_instance(ast_model):
 	return type_formatter_class(ast_model)
 
 
-def generate_module_exports(output_file, all_names):
-	output_file.write(wrap_lines(all_names, '\nmodule.exports = {', '};\n'))
-
-
 def generate_files(ast_models, output_directory: Path):
 	factory_map = build_factory_map(ast_models)
 	extend_models(ast_models, create_printer)
 
 	output_directory.mkdir(exist_ok=True)
 
+	requires_transform = False
+	for ast_model in ast_models:
+		if DisplayType.STRUCT == ast_model.display_type and ast_model.comparer:
+			if any('ripemd_keccak_256' == transform for (_, transform) in ast_model.comparer):
+				requires_transform = True
+
 	with open(output_directory / 'models.js', 'w', encoding='utf8', newline='\n') as output_file:
 		output_file.write(
 			'''/* eslint-disable max-len, object-property-newline, no-underscore-dangle, no-use-before-define */
 
-const { BaseValue } = require('../BaseValue');
-const { ByteArray } = require('../ByteArray');
-const { BufferView } = require('../utils/BufferView');
-const { Writer } = require('../utils/Writer');
-const arrayHelpers = require('../utils/arrayHelpers');
-const converter = require('../utils/converter');
-
+import BaseValue from '../BaseValue.js';
+import ByteArray from '../ByteArray.js';
+import BufferView from '../utils/BufferView.js';
+import Writer from '../utils/Writer.js';
+import * as arrayHelpers from '../utils/arrayHelpers.js';
+import * as converter from '../utils/converter.js';
 '''
 		)
+
+		if requires_transform:
+			output_file.write('import { ripemdKeccak256 } from \'../utils/transforms.js\';\n')
+
+		output_file.write('\n')
 
 		for ast_model in ast_models:
 			generator = TypeFormatter(to_type_formatter_instance(ast_model))
@@ -68,8 +73,6 @@ const converter = require('../utils/converter');
 				factories.append(str(factory_generator))
 
 		output_file.write('\n'.join(factories))
-
-		generate_module_exports(output_file, list(map(lambda ast_model: ast_model.name, ast_models)) + factory_names)
 
 
 class Generator:

--- a/sdk/javascript/generator/StructTypeFormatter.py
+++ b/sdk/javascript/generator/StructTypeFormatter.py
@@ -155,11 +155,7 @@ class StructFormatter(AbstractTypeFormatter):
 		if not self.struct.comparer:
 			return None
 
-		body = ''
-		if any('ripemd_keccak_256' == transform for (_, transform) in self.struct.comparer):
-			body += 'const { ripemdKeccak256 } = require(\'../utils/transforms\'); // eslint-disable-line global-require\n\n'
-
-		body += 'return [\n'
+		body = 'return [\n'
 		for (property_name, transform) in self.struct.comparer:
 			body += '\t'
 			if not transform:

--- a/sdk/javascript/generator/TypeFormatter.py
+++ b/sdk/javascript/generator/TypeFormatter.py
@@ -28,7 +28,7 @@ class ClassFormatter(ABC):
 	def generate_class_header(self):
 		base_class = self.provider.get_base_class()
 		base_class = f' extends {base_class}' if base_class else ''
-		header = f'class {self.provider.typename}{base_class} {{\n'
+		header = f'export class {self.provider.typename}{base_class} {{\n'
 		comment = ''
 		return header + indent(comment)
 

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,7 @@
 {
   "name": "symbol-sdk",
   "version": "3.0.0",
+  "type": "module",
   "description": "JavaScript SDK for Symbol",
   "main": "src/index.js",
   "scripts": {

--- a/sdk/javascript/src/BaseValue.js
+++ b/sdk/javascript/src/BaseValue.js
@@ -27,7 +27,7 @@ const check = (byteSize, value, isSigned) => {
 /**
  * Represents a base integer.
  */
-class BaseValue {
+export default class BaseValue {
 	/**
 	 * Creates a base value.
 	 * @param {number} size Size of the integer.
@@ -56,5 +56,3 @@ class BaseValue {
 		return `0x${unsignedValue.toString(16).toUpperCase().padStart(this.size * 2, '0')}`;
 	}
 }
-
-module.exports = { BaseValue };

--- a/sdk/javascript/src/Bip32.js
+++ b/sdk/javascript/src/Bip32.js
@@ -1,6 +1,6 @@
-const { PrivateKey } = require('./CryptoTypes');
-const Mnemonic = require('bitcore-mnemonic');
-const crypto = require('crypto');
+import { PrivateKey } from './CryptoTypes.js';
+import Mnemonic from 'bitcore-mnemonic';
+import crypto from 'crypto';
 
 /**
  * Representation of a BIP32 node.
@@ -57,7 +57,7 @@ class Bip32Node {
 /**
  * Factory of BIP32 root nodes.
  */
-class Bip32 {
+export default class Bip32 {
 	/**
 	 * Creates a BIP32 root node factory.
 	 * @param {string} curveName Elliptic curve to use.
@@ -98,5 +98,3 @@ class Bip32 {
 		return new Mnemonic(seedLength * 8, wordlist).phrase;
 	}
 }
-
-module.exports = { Bip32 };

--- a/sdk/javascript/src/ByteArray.js
+++ b/sdk/javascript/src/ByteArray.js
@@ -1,9 +1,9 @@
-const converter = require('./utils/converter');
+import { hexToUint8, uint8ToHex } from './utils/converter.js';
 
 /**
  * Represents a fixed size byte array.
  */
-class ByteArray {
+export default class ByteArray {
 	/**
 	 * Creates a byte array.
 	 * @param {number} fixedSize Size of the array.
@@ -12,7 +12,7 @@ class ByteArray {
 	constructor(fixedSize, arrayInput) {
 		let rawBytes = arrayInput;
 		if ('string' === typeof rawBytes)
-			rawBytes = converter.hexToUint8(rawBytes);
+			rawBytes = hexToUint8(rawBytes);
 
 		if (fixedSize !== rawBytes.length)
 			throw RangeError(`bytes was size ${rawBytes.length} but must be ${fixedSize}`);
@@ -25,8 +25,6 @@ class ByteArray {
 	 * @returns {string} String representation of this object
 	 */
 	toString() {
-		return converter.uint8ToHex(this.bytes);
+		return uint8ToHex(this.bytes);
 	}
 }
-
-module.exports = { ByteArray };

--- a/sdk/javascript/src/Cipher.js
+++ b/sdk/javascript/src/Cipher.js
@@ -1,4 +1,4 @@
-const crypto = require('crypto');
+import crypto from 'crypto';
 
 const concatArrays = (lhs, rhs) => {
 	const result = new Uint8Array(lhs.length + rhs.length);
@@ -12,7 +12,7 @@ const concatArrays = (lhs, rhs) => {
 /**
  * Performs AES CBC encryption and decryption with a given key.
  */
-class AesCbcCipher {
+export class AesCbcCipher {
 	/**
 	 * Creates a cipher around an aes shared key.
 	 * @param {SharedKey} aesKey AES shared key.
@@ -59,7 +59,7 @@ class AesCbcCipher {
 /**
  * Performs AES GCM encryption and decryption with a given key.
  */
-class AesGcmCipher {
+export class AesGcmCipher {
 	static TAG_SIZE = 16;
 
 	/**
@@ -106,5 +106,3 @@ class AesGcmCipher {
 }
 
 // endregion
-
-module.exports = { AesCbcCipher, AesGcmCipher };

--- a/sdk/javascript/src/CryptoTypes.js
+++ b/sdk/javascript/src/CryptoTypes.js
@@ -1,10 +1,10 @@
-const { ByteArray } = require('./ByteArray');
-const crypto = require('crypto');
+import ByteArray from './ByteArray.js';
+import crypto from 'crypto';
 
 /**
  *  Represents a 256-bit hash.
  */
-class Hash256 extends ByteArray {
+export class Hash256 extends ByteArray {
 	static SIZE = 32;
 
 	/**
@@ -27,7 +27,7 @@ class Hash256 extends ByteArray {
 /**
  *  Represents a private key.
  */
-class PrivateKey extends ByteArray {
+export class PrivateKey extends ByteArray {
 	static SIZE = 32;
 
 	/**
@@ -50,7 +50,7 @@ class PrivateKey extends ByteArray {
 /**
  *  Represents a public key.
  */
-class PublicKey extends ByteArray {
+export class PublicKey extends ByteArray {
 	static SIZE = 32;
 
 	/**
@@ -65,7 +65,7 @@ class PublicKey extends ByteArray {
 /**
  *  Represents a 256-bit symmetric encryption key.
  */
-class SharedKey256 extends ByteArray {
+export class SharedKey256 extends ByteArray {
 	static SIZE = 32;
 
 	/**
@@ -80,7 +80,7 @@ class SharedKey256 extends ByteArray {
 /**
  *  Represents a signature.
  */
-class Signature extends ByteArray {
+export class Signature extends ByteArray {
 	static SIZE = 64;
 
 	/**
@@ -99,7 +99,3 @@ class Signature extends ByteArray {
 		return new Signature(new Uint8Array(Signature.SIZE));
 	}
 }
-
-module.exports = {
-	Hash256, PrivateKey, PublicKey, SharedKey256, Signature
-};

--- a/sdk/javascript/src/Network.js
+++ b/sdk/javascript/src/Network.js
@@ -1,11 +1,11 @@
-const Ripemd160 = require('ripemd160');
+import Ripemd160 from 'ripemd160';
 
 const BASE32_RFC4648_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
 
 /**
  * Represents a network.
  */
-class Network {
+export class Network {
 	/**
 	 * Creates a new network with the specified name and identifier byte.
 	 * @param {string} name Network name.
@@ -118,7 +118,7 @@ class Network {
 /**
  * Provides utility functions for finding a network.
  */
-const NetworkLocator = {
+export const NetworkLocator = {
 	/**
 	 * Finds a network with a specified name within a list of networks.
 	 * @param {array<Network>} networks List of networks to search.
@@ -149,5 +149,3 @@ const NetworkLocator = {
 		return matchingNetwork;
 	}
 };
-
-module.exports = { Network, NetworkLocator };

--- a/sdk/javascript/src/NetworkTimestamp.js
+++ b/sdk/javascript/src/NetworkTimestamp.js
@@ -1,7 +1,7 @@
 /**
  * Represents a network timestamp.
  */
-class NetworkTimestamp {
+export class NetworkTimestamp {
 	/**
 	 * Creates a timestamp.
 	 * @param {number} timestamp Raw network timestamp.
@@ -57,7 +57,7 @@ class NetworkTimestamp {
 /**
  * Provides utilities for converting between network timestamps and datetimes.
  */
-class NetworkTimestampDatetimeConverter {
+export class NetworkTimestampDatetimeConverter {
 	/**
 	 * Creates a converter given an epoch and base time units.
 	 * @param {Date} epoch Date at which network started.
@@ -94,5 +94,3 @@ class NetworkTimestampDatetimeConverter {
 		return (referenceDatetime - this.epoch) / this.timeUnits;
 	}
 }
-
-module.exports = { NetworkTimestamp, NetworkTimestampDatetimeConverter };

--- a/sdk/javascript/src/RuleBasedTransactionFactory.js
+++ b/sdk/javascript/src/RuleBasedTransactionFactory.js
@@ -1,6 +1,6 @@
-const { BaseValue } = require('./BaseValue');
-const { ByteArray } = require('./ByteArray');
-const { TransactionDescriptorProcessor } = require('./TransactionDescriptorProcessor');
+import BaseValue from './BaseValue.js';
+import ByteArray from './ByteArray.js';
+import TransactionDescriptorProcessor from './TransactionDescriptorProcessor.js';
 
 const buildEnumStringToValueMap = EnumClass => new Map(Object.getOwnPropertyNames(EnumClass)
 	.filter(name => name.toUpperCase() === name)
@@ -56,7 +56,7 @@ const autoEncodeStrings = entity => {
 /**
  * Rule based transaction factory.
  */
-class RuleBasedTransactionFactory {
+export default class RuleBasedTransactionFactory {
 	/**
 	 * Creates a rule based transaction factory for use with catbuffer generated code.
 	 * @param {object} module Catbuffer generated module.
@@ -192,5 +192,3 @@ class RuleBasedTransactionFactory {
 		return new TransactionDescriptorProcessor(descriptor, this.rules, this.typeConverter);
 	}
 }
-
-module.exports = { RuleBasedTransactionFactory };

--- a/sdk/javascript/src/SharedKey.js
+++ b/sdk/javascript/src/SharedKey.js
@@ -1,7 +1,7 @@
-const { SharedKey256 } = require('./CryptoTypes');
-const { hkdf } = require('@noble/hashes/hkdf');
-const { sha256 } = require('@noble/hashes/sha256');
-const tweetnacl = require('tweetnacl');
+import { SharedKey256 } from './CryptoTypes.js';
+import { hkdf } from '@noble/hashes/hkdf';
+import { sha256 } from '@noble/hashes/sha256';
+import tweetnacl from 'tweetnacl';
 
 // order matches order of exported methods
 const {
@@ -141,7 +141,7 @@ const isInMainSubgroup = point => {
 	return 0 === (areEqual | isZero);
 };
 
-const deriveSharedSecretFactory = cryptoHash => (privateKeyBytes, otherPublicKey) => {
+export const deriveSharedSecretFactory = cryptoHash => (privateKeyBytes, otherPublicKey) => {
 	const { scalarmult, Z } = tweetnacl.lowlevel;
 	const point = [gf(), gf(), gf(), gf()];
 
@@ -167,12 +167,10 @@ const deriveSharedSecretFactory = cryptoHash => (privateKeyBytes, otherPublicKey
 	return sharedSecret;
 };
 
-const deriveSharedKeyFactory = (info, cryptoHash) => {
+export const deriveSharedKeyFactory = (info, cryptoHash) => {
 	const deriveSharedSecret = deriveSharedSecretFactory(cryptoHash);
 	return (privateKeyBytes, otherPublicKey) => {
 		const sharedSecret = deriveSharedSecret(privateKeyBytes, otherPublicKey);
 		return new SharedKey256(hkdf(sha256, sharedSecret, undefined, info, 32));
 	};
 };
-
-module.exports = { deriveSharedKeyFactory, deriveSharedSecretFactory };

--- a/sdk/javascript/src/TransactionDescriptorProcessor.js
+++ b/sdk/javascript/src/TransactionDescriptorProcessor.js
@@ -1,7 +1,7 @@
 /**
  * Processes and looks up transaction descriptor properties.
  */
-class TransactionDescriptorProcessor {
+export default class TransactionDescriptorProcessor {
 	/**
 	 * Creates a transaction descriptor processor.
 	 * @param {object} transactionDescriptor Transaction descriptor.
@@ -68,5 +68,3 @@ class TransactionDescriptorProcessor {
 		this.typeHints = typeHints || {};
 	}
 }
-
-module.exports = { TransactionDescriptorProcessor };

--- a/sdk/javascript/src/facade/NemFacade.js
+++ b/sdk/javascript/src/facade/NemFacade.js
@@ -1,15 +1,15 @@
-const { Hash256, PrivateKey } = require('../CryptoTypes');
-const { NetworkLocator } = require('../Network');
-const { KeyPair, Verifier } = require('../nem/KeyPair');
-const { Address, Network } = require('../nem/Network');
-const { deriveSharedKey } = require('../nem/SharedKey');
-const { TransactionFactory } = require('../nem/TransactionFactory');
-const { keccak_256 } = require('@noble/hashes/sha3');
+import { Hash256, PrivateKey } from '../CryptoTypes.js';
+import { NetworkLocator } from '../Network.js';
+import { KeyPair, Verifier } from '../nem/KeyPair.js';
+import { Address, Network } from '../nem/Network.js';
+import { deriveSharedKey } from '../nem/SharedKey.js';
+import TransactionFactory from '../nem/TransactionFactory.js';
+import { keccak_256 } from '@noble/hashes/sha3';
 
 /**
  * Facade used to interact with NEM blockchain.
  */
-class NemFacade {
+export default class NemFacade {
 	static BIP32_CURVE_NAME = 'ed25519-keccak';
 
 	static Address = Address;
@@ -86,5 +86,3 @@ class NemFacade {
 		return new KeyPair(new PrivateKey(reversedPrivateKeyBytes));
 	}
 }
-
-module.exports = { NemFacade };

--- a/sdk/javascript/src/facade/SymbolFacade.js
+++ b/sdk/javascript/src/facade/SymbolFacade.js
@@ -1,14 +1,14 @@
-const {
+import {
 	Hash256, PrivateKey, PublicKey, Signature
-} = require('../CryptoTypes');
-const { NetworkLocator } = require('../Network');
-const { KeyPair, Verifier } = require('../symbol/KeyPair');
-const { Address, Network } = require('../symbol/Network');
-const { deriveSharedKey } = require('../symbol/SharedKey');
-const { TransactionFactory } = require('../symbol/TransactionFactory');
-const { MerkleHashBuilder } = require('../symbol/merkle');
-const sc = require('../symbol/models');
-const { sha3_256 } = require('@noble/hashes/sha3');
+} from '../CryptoTypes.js';
+import { NetworkLocator } from '../Network.js';
+import { KeyPair, Verifier } from '../symbol/KeyPair.js';
+import { Address, Network } from '../symbol/Network.js';
+import { deriveSharedKey } from '../symbol/SharedKey.js';
+import TransactionFactory from '../symbol/TransactionFactory.js';
+import { MerkleHashBuilder } from '../symbol/merkle.js';
+import * as sc from '../symbol/models.js';
+import { sha3_256 } from '@noble/hashes/sha3';
 
 const TRANSACTION_HEADER_SIZE = [
 	4, // size
@@ -44,7 +44,7 @@ const transactionDataBuffer = transactionBuffer => {
 /**
  * Facade used to interact with Symbol blockchain.
  */
-class SymbolFacade {
+export default class SymbolFacade {
 	static BIP32_CURVE_NAME = 'ed25519';
 
 	static Address = Address;
@@ -159,5 +159,3 @@ class SymbolFacade {
 		return new KeyPair(new PrivateKey(bip32Node.privateKey.bytes));
 	}
 }
-
-module.exports = { SymbolFacade };

--- a/sdk/javascript/src/impl/ed25519.js
+++ b/sdk/javascript/src/impl/ed25519.js
@@ -1,6 +1,6 @@
-const {
+import {
 	crypto_sign_keypair, crypto_private_sign, crypto_private_verify, HashMode
-} = require('../../wasm/pkg/symbol_crypto_wasm');
+} from '../../wasm/pkg/symbol_crypto_wasm.js'; // eslint-disable-line import/no-relative-packages
 
 const CRYPTO_SIGN_BYTES = 64;
 const CRYPTO_SIGN_PUBLICKEYBYTES = 32;
@@ -19,4 +19,4 @@ const ed25519 = {
 	verify: (hashMode, message, signature, publicKey) => crypto_private_verify(HashMode[hashMode], publicKey, message, signature)
 };
 
-module.exports = ed25519;
+export default ed25519;

--- a/sdk/javascript/src/index.js
+++ b/sdk/javascript/src/index.js
@@ -1,36 +1,37 @@
-const { BaseValue } = require('./BaseValue');
-const { Bip32 } = require('./Bip32');
-const { ByteArray } = require('./ByteArray');
-const CryptoTypes = require('./CryptoTypes');
-const { NetworkLocator } = require('./Network');
-const NemFacade = require('./facade/NemFacade');
-const SymbolFacade = require('./facade/SymbolFacade');
-const NemKeyPair = require('./nem/KeyPair');
-const NemNetwork = require('./nem/Network');
-const NemTransactionFactory = require('./nem/TransactionFactory');
-const NemModels = require('./nem/models');
-const SymbolKeyPair = require('./symbol/KeyPair');
-const SymbolNetwork = require('./symbol/Network');
-const SymbolTransactionFactory = require('./symbol/TransactionFactory');
-const SymbolIdGenerator = require('./symbol/idGenerator');
-const SymbolMerkle = require('./symbol/merkle');
-const SymbolModels = require('./symbol/models');
-const { hexToUint8, uint8ToHex } = require('./utils/converter');
+import BaseValue from './BaseValue.js';
+import Bip32 from './Bip32.js';
+import ByteArray from './ByteArray.js';
+import * as CryptoTypes from './CryptoTypes.js';
+import { NetworkLocator } from './Network.js';
+import NemFacade from './facade/NemFacade.js';
+import SymbolFacade from './facade/SymbolFacade.js';
+import * as NemKeyPair from './nem/KeyPair.js';
+import * as NemNetwork from './nem/Network.js';
+import * as NemTransactionFactory from './nem/TransactionFactory.js';
+import * as NemModels from './nem/models.js';
+import * as SymbolKeyPair from './symbol/KeyPair.js';
+import * as SymbolNetwork from './symbol/Network.js';
+import * as SymbolTransactionFactory from './symbol/TransactionFactory.js';
+import * as SymbolIdGenerator from './symbol/idGenerator.js';
+import * as SymbolMerkle from './symbol/merkle.js';
+import * as SymbolModels from './symbol/models.js';
+import { hexToUint8, uint8ToHex } from './utils/converter.js';
 
-module.exports = {
+const sdk = {
 	BaseValue,
 	Bip32,
 	ByteArray,
-	CryptoTypes,
+	...CryptoTypes,
 	NetworkLocator,
 
 	facade: {
-		...NemFacade,
-		...SymbolFacade
+		NemFacade,
+		SymbolFacade
 	},
 
 	nem: {
 		...NemModels, // must be before Network to promote Address from Network
+
 		...NemKeyPair,
 		...NemNetwork,
 		...NemTransactionFactory
@@ -38,6 +39,7 @@ module.exports = {
 
 	symbol: {
 		...SymbolModels, // must be before Network to promote Address from Network
+
 		...SymbolKeyPair,
 		...SymbolNetwork,
 		...SymbolTransactionFactory,
@@ -50,3 +52,5 @@ module.exports = {
 		uint8ToHex
 	}
 };
+
+export default sdk;

--- a/sdk/javascript/src/nem/KeyPair.js
+++ b/sdk/javascript/src/nem/KeyPair.js
@@ -1,13 +1,13 @@
-const { PrivateKey, PublicKey, Signature } = require('../CryptoTypes');
-const ed25519 = require('../impl/ed25519');
-const { deepCompare } = require('../utils/arrayHelpers');
+import { PrivateKey, PublicKey, Signature } from '../CryptoTypes.js';
+import ed25519 from '../impl/ed25519.js';
+import { deepCompare } from '../utils/arrayHelpers.js';
 
 const HASH_MODE = 'Keccak';
 
 /**
  * Represents an ED25519 private and public key.
  */
-class KeyPair {
+export class KeyPair {
 	/**
 	 * Creates a key pair from a private key.
 	 * @param {PrivateKey} privateKey Private key.
@@ -49,7 +49,7 @@ class KeyPair {
 /**
  * Verifies signatures signed by a single key pair.
  */
-class Verifier {
+export class Verifier {
 	/**
 	 * Creates a verifier from a public key.
 	 * @param {PublicKey} publicKey Public key.
@@ -71,5 +71,3 @@ class Verifier {
 		return ed25519.verify(HASH_MODE, message, signature.bytes, this.publicKey.bytes);
 	}
 }
-
-module.exports = { KeyPair, Verifier };

--- a/sdk/javascript/src/nem/MessageEncoder.js
+++ b/sdk/javascript/src/nem/MessageEncoder.js
@@ -1,8 +1,8 @@
-const { deriveSharedKey, deriveSharedKeyDeprecated } = require('./SharedKey');
-const { MessageType, Message } = require('./models');
-const {
+import { deriveSharedKey, deriveSharedKeyDeprecated } from './SharedKey.js'; // eslint-disable-line import/no-deprecated
+import { MessageType, Message } from './models.js';
+import {
 	concatArrays, decodeAesGcm, encodeAesGcm, encodeAesCbc, decodeAesCbc
-} = require('../impl/CipherHelpers');
+} from '../impl/CipherHelpers.js';
 
 const filterExceptions = (statement, exceptions) => {
 	try {
@@ -19,7 +19,7 @@ const filterExceptions = (statement, exceptions) => {
 /**
  * Encrypts and encodes messages between two parties.
  */
-class MessageEncoder {
+export default class MessageEncoder {
 	/**
 	 * Creates message encoder around key pair.
 	 * @param {KeyPair} keyPair Key pair.
@@ -48,6 +48,7 @@ class MessageEncoder {
 			return [true, message];
 
 		[result, message] = filterExceptions(
+			// eslint-disable-next-line import/no-deprecated
 			() => decodeAesCbc(deriveSharedKeyDeprecated, this.keyPair, recipientPublicKey, encodedMessage.message),
 			[
 				'digital envelope routines:EVP_DecryptFinal_ex:bad decrypt',
@@ -69,6 +70,7 @@ class MessageEncoder {
 	 * @returns {Uint8Array} Encrypted and encoded message.
 	 */
 	encodeDeprecated(recipientPublicKey, message) {
+		// eslint-disable-next-line import/no-deprecated
 		const encoded = encodeAesCbc(deriveSharedKeyDeprecated, this.keyPair, recipientPublicKey, message);
 
 		const encodedMessage = new Message();
@@ -92,5 +94,3 @@ class MessageEncoder {
 		return encodedMessage;
 	}
 }
-
-module.exports = { MessageEncoder };

--- a/sdk/javascript/src/nem/Network.js
+++ b/sdk/javascript/src/nem/Network.js
@@ -1,14 +1,13 @@
-const { ByteArray } = require('../ByteArray');
-const BasicNetwork = require('../Network').Network;
-const BasicNetworkTimestamp = require('../NetworkTimestamp').NetworkTimestamp;
-const { NetworkTimestampDatetimeConverter } = require('../NetworkTimestamp');
-const base32 = require('../utils/base32');
-const { keccak_256 } = require('@noble/hashes/sha3');
+import ByteArray from '../ByteArray.js';
+import { Network as BasicNetwork } from '../Network.js';
+import { NetworkTimestamp as BasicNetworkTimestamp, NetworkTimestampDatetimeConverter } from '../NetworkTimestamp.js';
+import base32 from '../utils/base32.js';
+import { keccak_256 } from '@noble/hashes/sha3';
 
 /**
  * Represents a NEM network timestamp with millisecond resolution.
  */
-class NetworkTimestamp extends BasicNetworkTimestamp {
+export class NetworkTimestamp extends BasicNetworkTimestamp {
 	/**
 	 * Adds a specified number of seconds to this timestamp.
 	 * @override
@@ -23,7 +22,7 @@ class NetworkTimestamp extends BasicNetworkTimestamp {
 /**
  * Represents a NEM address.
  */
-class Address extends ByteArray {
+export class Address extends ByteArray {
 	static SIZE = 25;
 
 	static ENCODED_SIZE = 40;
@@ -54,7 +53,7 @@ class Address extends ByteArray {
 /**
  * Represents a NEM network.
  */
-class Network extends BasicNetwork {
+export class Network extends BasicNetwork {
 	/**
 	 * Creates a new network with the specified name, identifier byte and generation hash seed.
 	 * @param {string} name Network name.
@@ -77,5 +76,3 @@ class Network extends BasicNetwork {
 Network.MAINNET = new Network('mainnet', 0x68, new Date(Date.UTC(2015, 2, 29, 0, 6, 25)));
 Network.TESTNET = new Network('testnet', 0x98, new Date(Date.UTC(2015, 2, 29, 0, 6, 25)));
 Network.NETWORKS = [Network.MAINNET, Network.TESTNET];
-
-module.exports = { Address, Network, NetworkTimestamp };

--- a/sdk/javascript/src/nem/SharedKey.js
+++ b/sdk/javascript/src/nem/SharedKey.js
@@ -1,6 +1,6 @@
-const { SharedKey256 } = require('../CryptoTypes');
-const { deriveSharedSecretFactory, deriveSharedKeyFactory } = require('../SharedKey');
-const { keccak_256, keccak_512 } = require('@noble/hashes/sha3');
+import { SharedKey256 } from '../CryptoTypes.js';
+import { deriveSharedSecretFactory, deriveSharedKeyFactory } from '../SharedKey.js';
+import { keccak_256, keccak_512 } from '@noble/hashes/sha3';
 
 const crypto_hash = (out, m, n) => {
 	const hashBuilder = keccak_512.create();
@@ -21,7 +21,7 @@ const deriveSharedKeyImpl = deriveSharedKeyFactory('nem-nis1', crypto_hash);
  * @param {PublicKey} otherPublicKey Other party's public key.
  * @returns {SharedKey256} Shared encryption key.
  */
-const deriveSharedKey = (keyPair, otherPublicKey) => {
+export const deriveSharedKey = (keyPair, otherPublicKey) => {
 	const reversedPrivateKeyBytes = new Uint8Array([...keyPair.privateKey.bytes]);
 	reversedPrivateKeyBytes.reverse();
 
@@ -36,7 +36,7 @@ const deriveSharedKey = (keyPair, otherPublicKey) => {
  * @param {Uint8Array} salt Random salt. Should be unique per every use.
  * @returns {SharedKey256} Shared encryption key.
  */
-const deriveSharedKeyDeprecated = (keyPair, otherPublicKey, salt) => {
+export const deriveSharedKeyDeprecated = (keyPair, otherPublicKey, salt) => {
 	if (SharedKey256.SIZE !== salt.length)
 		throw Error('invalid salt');
 
@@ -50,5 +50,3 @@ const deriveSharedKeyDeprecated = (keyPair, otherPublicKey, salt) => {
 
 	return new SharedKey256(keccak_256(sharedKeyBytes));
 };
-
-module.exports = { deriveSharedKey, deriveSharedKeyDeprecated };

--- a/sdk/javascript/src/nem/TransactionFactory.js
+++ b/sdk/javascript/src/nem/TransactionFactory.js
@@ -1,13 +1,13 @@
-const { Address } = require('./Network');
-const nc = require('./models');
-const { Hash256, PublicKey } = require('../CryptoTypes');
-const { RuleBasedTransactionFactory } = require('../RuleBasedTransactionFactory');
-const { uint8ToHex } = require('../utils/converter');
+import { Address } from './Network.js';
+import * as nc from './models.js';
+import { Hash256, PublicKey } from '../CryptoTypes.js';
+import RuleBasedTransactionFactory from '../RuleBasedTransactionFactory.js';
+import { uint8ToHex } from '../utils/converter.js';
 
 /**
  * Factory for creating NEM transactions.
  */
-class TransactionFactory {
+export default class TransactionFactory {
 	/**
 	 * Creates a factory for the specified network.
 	 * @param {Network} network NEM network.
@@ -112,5 +112,3 @@ class TransactionFactory {
 		return factory;
 	}
 }
-
-module.exports = { TransactionFactory };

--- a/sdk/javascript/src/nem/models.js
+++ b/sdk/javascript/src/nem/models.js
@@ -1,13 +1,14 @@
 /* eslint-disable max-len, object-property-newline, no-underscore-dangle, no-use-before-define */
 
-const { BaseValue } = require('../BaseValue');
-const { ByteArray } = require('../ByteArray');
-const { BufferView } = require('../utils/BufferView');
-const { Writer } = require('../utils/Writer');
-const arrayHelpers = require('../utils/arrayHelpers');
-const converter = require('../utils/converter');
+import BaseValue from '../BaseValue.js';
+import ByteArray from '../ByteArray.js';
+import BufferView from '../utils/BufferView.js';
+import Writer from '../utils/Writer.js';
+import * as arrayHelpers from '../utils/arrayHelpers.js';
+import * as converter from '../utils/converter.js';
+import { ripemdKeccak256 } from '../utils/transforms.js';
 
-class Amount extends BaseValue {
+export class Amount extends BaseValue {
 	static SIZE = 8;
 
 	constructor(amount = 0n) {
@@ -29,7 +30,7 @@ class Amount extends BaseValue {
 	}
 }
 
-class Height extends BaseValue {
+export class Height extends BaseValue {
 	static SIZE = 8;
 
 	constructor(height = 0n) {
@@ -51,7 +52,7 @@ class Height extends BaseValue {
 	}
 }
 
-class Timestamp extends BaseValue {
+export class Timestamp extends BaseValue {
 	static SIZE = 4;
 
 	constructor(timestamp = 0) {
@@ -73,7 +74,7 @@ class Timestamp extends BaseValue {
 	}
 }
 
-class Address extends ByteArray {
+export class Address extends ByteArray {
 	static SIZE = 40;
 
 	constructor(address = new Uint8Array(40)) {
@@ -94,7 +95,7 @@ class Address extends ByteArray {
 	}
 }
 
-class Hash256 extends ByteArray {
+export class Hash256 extends ByteArray {
 	static SIZE = 32;
 
 	constructor(hash256 = new Uint8Array(32)) {
@@ -115,7 +116,7 @@ class Hash256 extends ByteArray {
 	}
 }
 
-class PublicKey extends ByteArray {
+export class PublicKey extends ByteArray {
 	static SIZE = 32;
 
 	constructor(publicKey = new Uint8Array(32)) {
@@ -136,7 +137,7 @@ class PublicKey extends ByteArray {
 	}
 }
 
-class Signature extends ByteArray {
+export class Signature extends ByteArray {
 	static SIZE = 64;
 
 	constructor(signature = new Uint8Array(64)) {
@@ -157,7 +158,7 @@ class Signature extends ByteArray {
 	}
 }
 
-class NetworkType {
+export class NetworkType {
 	static MAINNET = new NetworkType(104);
 
 	static TESTNET = new NetworkType(152);
@@ -208,7 +209,7 @@ class NetworkType {
 	}
 }
 
-class TransactionType {
+export class TransactionType {
 	static TRANSFER = new TransactionType(257);
 
 	static ACCOUNT_KEY_LINK = new TransactionType(2049);
@@ -272,7 +273,7 @@ class TransactionType {
 	}
 }
 
-class Transaction {
+export class Transaction {
 	static TYPE_HINTS = {
 		type: 'enum:TransactionType',
 		network: 'enum:NetworkType',
@@ -454,7 +455,7 @@ class Transaction {
 	}
 }
 
-class NonVerifiableTransaction {
+export class NonVerifiableTransaction {
 	static TYPE_HINTS = {
 		type: 'enum:TransactionType',
 		network: 'enum:NetworkType',
@@ -613,7 +614,7 @@ class NonVerifiableTransaction {
 	}
 }
 
-class LinkAction {
+export class LinkAction {
 	static LINK = new LinkAction(1);
 
 	static UNLINK = new LinkAction(2);
@@ -664,7 +665,7 @@ class LinkAction {
 	}
 }
 
-class AccountKeyLinkTransaction {
+export class AccountKeyLinkTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.ACCOUNT_KEY_LINK;
@@ -889,7 +890,7 @@ class AccountKeyLinkTransaction {
 	}
 }
 
-class NonVerifiableAccountKeyLinkTransaction {
+export class NonVerifiableAccountKeyLinkTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.ACCOUNT_KEY_LINK;
@@ -1091,7 +1092,7 @@ class NonVerifiableAccountKeyLinkTransaction {
 	}
 }
 
-class NamespaceId {
+export class NamespaceId {
 	static TYPE_HINTS = {
 		name: 'bytes_array'
 	};
@@ -1145,7 +1146,7 @@ class NamespaceId {
 	}
 }
 
-class MosaicId {
+export class MosaicId {
 	static TYPE_HINTS = {
 		namespaceId: 'struct:NamespaceId',
 		name: 'bytes_array'
@@ -1216,7 +1217,7 @@ class MosaicId {
 	}
 }
 
-class Mosaic {
+export class Mosaic {
 	static TYPE_HINTS = {
 		mosaicId: 'struct:MosaicId',
 		amount: 'pod:Amount'
@@ -1288,7 +1289,7 @@ class Mosaic {
 	}
 }
 
-class SizePrefixedMosaic {
+export class SizePrefixedMosaic {
 	static TYPE_HINTS = {
 		mosaic: 'struct:Mosaic'
 	};
@@ -1344,7 +1345,7 @@ class SizePrefixedMosaic {
 	}
 }
 
-class MosaicTransferFeeType {
+export class MosaicTransferFeeType {
 	static ABSOLUTE = new MosaicTransferFeeType(1);
 
 	static PERCENTILE = new MosaicTransferFeeType(2);
@@ -1395,7 +1396,7 @@ class MosaicTransferFeeType {
 	}
 }
 
-class MosaicLevy {
+export class MosaicLevy {
 	static TYPE_HINTS = {
 		transferFeeType: 'enum:MosaicTransferFeeType',
 		recipientAddress: 'pod:Address',
@@ -1506,7 +1507,7 @@ class MosaicLevy {
 	}
 }
 
-class MosaicProperty {
+export class MosaicProperty {
 	static TYPE_HINTS = {
 		name: 'bytes_array',
 		value: 'bytes_array'
@@ -1580,7 +1581,7 @@ class MosaicProperty {
 	}
 }
 
-class SizePrefixedMosaicProperty {
+export class SizePrefixedMosaicProperty {
 	static TYPE_HINTS = {
 		property: 'struct:MosaicProperty'
 	};
@@ -1636,7 +1637,7 @@ class SizePrefixedMosaicProperty {
 	}
 }
 
-class MosaicDefinition {
+export class MosaicDefinition {
 	static TYPE_HINTS = {
 		ownerPublicKey: 'pod:PublicKey',
 		id: 'struct:MosaicId',
@@ -1790,7 +1791,7 @@ class MosaicDefinition {
 	}
 }
 
-class MosaicDefinitionTransaction {
+export class MosaicDefinitionTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MOSAIC_DEFINITION;
@@ -2037,7 +2038,7 @@ class MosaicDefinitionTransaction {
 	}
 }
 
-class NonVerifiableMosaicDefinitionTransaction {
+export class NonVerifiableMosaicDefinitionTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MOSAIC_DEFINITION;
@@ -2261,7 +2262,7 @@ class NonVerifiableMosaicDefinitionTransaction {
 	}
 }
 
-class MosaicSupplyChangeAction {
+export class MosaicSupplyChangeAction {
 	static INCREASE = new MosaicSupplyChangeAction(1);
 
 	static DECREASE = new MosaicSupplyChangeAction(2);
@@ -2312,7 +2313,7 @@ class MosaicSupplyChangeAction {
 	}
 }
 
-class MosaicSupplyChangeTransaction {
+export class MosaicSupplyChangeTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MOSAIC_SUPPLY_CHANGE;
@@ -2552,7 +2553,7 @@ class MosaicSupplyChangeTransaction {
 	}
 }
 
-class NonVerifiableMosaicSupplyChangeTransaction {
+export class NonVerifiableMosaicSupplyChangeTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MOSAIC_SUPPLY_CHANGE;
@@ -2769,7 +2770,7 @@ class NonVerifiableMosaicSupplyChangeTransaction {
 	}
 }
 
-class MultisigAccountModificationType {
+export class MultisigAccountModificationType {
 	static ADD_COSIGNATORY = new MultisigAccountModificationType(1);
 
 	static DELETE_COSIGNATORY = new MultisigAccountModificationType(2);
@@ -2820,7 +2821,7 @@ class MultisigAccountModificationType {
 	}
 }
 
-class MultisigAccountModification {
+export class MultisigAccountModification {
 	static TYPE_HINTS = {
 		modificationType: 'enum:MultisigAccountModificationType',
 		cosignatoryPublicKey: 'pod:PublicKey'
@@ -2833,8 +2834,6 @@ class MultisigAccountModification {
 	}
 
 	comparer() {
-		const { ripemdKeccak256 } = require('../utils/transforms'); // eslint-disable-line global-require
-
 		return [
 			this.modificationType,
 			ripemdKeccak256(this.cosignatoryPublicKey.bytes)
@@ -2902,7 +2901,7 @@ class MultisigAccountModification {
 	}
 }
 
-class SizePrefixedMultisigAccountModification {
+export class SizePrefixedMultisigAccountModification {
 	static TYPE_HINTS = {
 		modification: 'struct:MultisigAccountModification'
 	};
@@ -2958,7 +2957,7 @@ class SizePrefixedMultisigAccountModification {
 	}
 }
 
-class MultisigAccountModificationTransactionV1 {
+export class MultisigAccountModificationTransactionV1 {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MULTISIG_ACCOUNT_MODIFICATION;
@@ -3168,7 +3167,7 @@ class MultisigAccountModificationTransactionV1 {
 	}
 }
 
-class NonVerifiableMultisigAccountModificationTransactionV1 {
+export class NonVerifiableMultisigAccountModificationTransactionV1 {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MULTISIG_ACCOUNT_MODIFICATION;
@@ -3355,7 +3354,7 @@ class NonVerifiableMultisigAccountModificationTransactionV1 {
 	}
 }
 
-class MultisigAccountModificationTransaction {
+export class MultisigAccountModificationTransaction {
 	static TRANSACTION_VERSION = 2;
 
 	static TRANSACTION_TYPE = TransactionType.MULTISIG_ACCOUNT_MODIFICATION;
@@ -3587,7 +3586,7 @@ class MultisigAccountModificationTransaction {
 	}
 }
 
-class NonVerifiableMultisigAccountModificationTransaction {
+export class NonVerifiableMultisigAccountModificationTransaction {
 	static TRANSACTION_VERSION = 2;
 
 	static TRANSACTION_TYPE = TransactionType.MULTISIG_ACCOUNT_MODIFICATION;
@@ -3796,7 +3795,7 @@ class NonVerifiableMultisigAccountModificationTransaction {
 	}
 }
 
-class Cosignature {
+export class Cosignature {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MULTISIG_COSIGNATURE;
@@ -4035,7 +4034,7 @@ class Cosignature {
 	}
 }
 
-class SizePrefixedCosignature {
+export class SizePrefixedCosignature {
 	static TYPE_HINTS = {
 		cosignature: 'struct:Cosignature'
 	};
@@ -4091,7 +4090,7 @@ class SizePrefixedCosignature {
 	}
 }
 
-class MultisigTransaction {
+export class MultisigTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MULTISIG_TRANSACTION;
@@ -4319,7 +4318,7 @@ class MultisigTransaction {
 	}
 }
 
-class NamespaceRegistrationTransaction {
+export class NamespaceRegistrationTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.NAMESPACE_REGISTRATION;
@@ -4593,7 +4592,7 @@ class NamespaceRegistrationTransaction {
 	}
 }
 
-class NonVerifiableNamespaceRegistrationTransaction {
+export class NonVerifiableNamespaceRegistrationTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.NAMESPACE_REGISTRATION;
@@ -4844,7 +4843,7 @@ class NonVerifiableNamespaceRegistrationTransaction {
 	}
 }
 
-class MessageType {
+export class MessageType {
 	static PLAIN = new MessageType(1);
 
 	static ENCRYPTED = new MessageType(2);
@@ -4895,7 +4894,7 @@ class MessageType {
 	}
 }
 
-class Message {
+export class Message {
 	static TYPE_HINTS = {
 		messageType: 'enum:MessageType',
 		message: 'bytes_array'
@@ -4965,7 +4964,7 @@ class Message {
 	}
 }
 
-class TransferTransactionV1 {
+export class TransferTransactionV1 {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.TRANSFER;
@@ -5225,7 +5224,7 @@ class TransferTransactionV1 {
 	}
 }
 
-class NonVerifiableTransferTransactionV1 {
+export class NonVerifiableTransferTransactionV1 {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.TRANSFER;
@@ -5462,7 +5461,7 @@ class NonVerifiableTransferTransactionV1 {
 	}
 }
 
-class TransferTransaction {
+export class TransferTransaction {
 	static TRANSACTION_VERSION = 2;
 
 	static TRANSACTION_TYPE = TransactionType.TRANSFER;
@@ -5742,7 +5741,7 @@ class TransferTransaction {
 	}
 }
 
-class NonVerifiableTransferTransaction {
+export class NonVerifiableTransferTransaction {
 	static TRANSACTION_VERSION = 2;
 
 	static TRANSACTION_TYPE = TransactionType.TRANSFER;
@@ -5999,7 +5998,7 @@ class NonVerifiableTransferTransaction {
 	}
 }
 
-class TransactionFactory {
+export class TransactionFactory {
 	static toKey(values) {
 		if (1 === values.length)
 			return values[0];
@@ -6049,7 +6048,7 @@ class TransactionFactory {
 	}
 }
 
-class NonVerifiableTransactionFactory {
+export class NonVerifiableTransactionFactory {
 	static toKey(values) {
 		if (1 === values.length)
 			return values[0];
@@ -6094,16 +6093,3 @@ class NonVerifiableTransactionFactory {
 		return new mapping[entityName]();
 	}
 }
-
-module.exports = {
-	Amount, Height, Timestamp, Address, Hash256, PublicKey, Signature, NetworkType, TransactionType, Transaction, NonVerifiableTransaction,
-	LinkAction, AccountKeyLinkTransaction, NonVerifiableAccountKeyLinkTransaction, NamespaceId, MosaicId, Mosaic, SizePrefixedMosaic,
-	MosaicTransferFeeType, MosaicLevy, MosaicProperty, SizePrefixedMosaicProperty, MosaicDefinition, MosaicDefinitionTransaction,
-	NonVerifiableMosaicDefinitionTransaction, MosaicSupplyChangeAction, MosaicSupplyChangeTransaction,
-	NonVerifiableMosaicSupplyChangeTransaction, MultisigAccountModificationType, MultisigAccountModification,
-	SizePrefixedMultisigAccountModification, MultisigAccountModificationTransactionV1, NonVerifiableMultisigAccountModificationTransactionV1,
-	MultisigAccountModificationTransaction, NonVerifiableMultisigAccountModificationTransaction, Cosignature, SizePrefixedCosignature,
-	MultisigTransaction, NamespaceRegistrationTransaction, NonVerifiableNamespaceRegistrationTransaction, MessageType, Message,
-	TransferTransactionV1, NonVerifiableTransferTransactionV1, TransferTransaction, NonVerifiableTransferTransaction, TransactionFactory,
-	NonVerifiableTransactionFactory
-};

--- a/sdk/javascript/src/symbol/KeyPair.js
+++ b/sdk/javascript/src/symbol/KeyPair.js
@@ -1,13 +1,13 @@
-const { PrivateKey, PublicKey, Signature } = require('../CryptoTypes');
-const ed25519 = require('../impl/ed25519');
-const { deepCompare } = require('../utils/arrayHelpers');
+import { PrivateKey, PublicKey, Signature } from '../CryptoTypes.js';
+import ed25519 from '../impl/ed25519.js';
+import { deepCompare } from '../utils/arrayHelpers.js';
 
 const HASH_MODE = 'Sha2_512';
 
 /**
  * Represents an ED25519 private and public key.
  */
-class KeyPair {
+export class KeyPair {
 	/**
 	 * Creates a key pair from a private key.
 	 * @param {PrivateKey} privateKey Private key.
@@ -46,7 +46,7 @@ class KeyPair {
 /**
  * Verifies signatures signed by a single key pair.
  */
-class Verifier {
+export class Verifier {
 	/**
 	 * Creates a verifier from a public key.
 	 * @param {PublicKey} publicKey Public key.
@@ -68,5 +68,3 @@ class Verifier {
 		return ed25519.verify(HASH_MODE, message, signature.bytes, this.publicKey.bytes);
 	}
 }
-
-module.exports = { KeyPair, Verifier };

--- a/sdk/javascript/src/symbol/MessageEncoder.js
+++ b/sdk/javascript/src/symbol/MessageEncoder.js
@@ -1,8 +1,8 @@
-const { KeyPair } = require('./KeyPair');
-const { deriveSharedKey } = require('./SharedKey');
-const { PrivateKey, PublicKey } = require('../CryptoTypes');
-const { concatArrays, decodeAesGcm, encodeAesGcm } = require('../impl/CipherHelpers');
-const { deepCompare } = require('../utils/arrayHelpers');
+import { KeyPair } from './KeyPair.js';
+import { deriveSharedKey } from './SharedKey.js';
+import { PrivateKey, PublicKey } from '../CryptoTypes.js';
+import { concatArrays, decodeAesGcm, encodeAesGcm } from '../impl/CipherHelpers.js';
+import { deepCompare } from '../utils/arrayHelpers.js';
 
 const DELEGATION_MARKER = Uint8Array.from(Buffer.from('FE2A8061577301E2', 'hex'));
 
@@ -21,7 +21,7 @@ const filterExceptions = (statement, exceptions) => {
 /**
  * Encrypts and encodes messages between two parties.
  */
-class MessageEncoder {
+export default class MessageEncoder {
 	/**
 	 * Creates message encoder around key pair.
 	 * @param {KeyPair} keyPair Key pair.
@@ -95,5 +95,3 @@ class MessageEncoder {
 		return concatArrays(DELEGATION_MARKER, ephemeralKeyPair.publicKey.bytes, tag, initializationVector, cipherText);
 	}
 }
-
-module.exports = { MessageEncoder };

--- a/sdk/javascript/src/symbol/Network.js
+++ b/sdk/javascript/src/symbol/Network.js
@@ -1,15 +1,14 @@
-const { ByteArray } = require('../ByteArray');
-const { Hash256 } = require('../CryptoTypes');
-const BasicNetwork = require('../Network').Network;
-const BasicNetworkTimestamp = require('../NetworkTimestamp').NetworkTimestamp;
-const { NetworkTimestampDatetimeConverter } = require('../NetworkTimestamp');
-const base32 = require('../utils/base32');
-const { sha3_256 } = require('@noble/hashes/sha3');
+import ByteArray from '../ByteArray.js';
+import { Hash256 } from '../CryptoTypes.js';
+import { Network as BasicNetwork } from '../Network.js';
+import { NetworkTimestamp as BasicNetworkTimestamp, NetworkTimestampDatetimeConverter } from '../NetworkTimestamp.js';
+import base32 from '../utils/base32.js';
+import { sha3_256 } from '@noble/hashes/sha3';
 
 /**
  * Represents a symbol network timestamp with millisecond resolution.
  */
-class NetworkTimestamp extends BasicNetworkTimestamp {
+export class NetworkTimestamp extends BasicNetworkTimestamp {
 	/**
 	 * Adds a specified number of milliseconds to this timestamp.
 	 * @param {number} count Number of milliseconds to add.
@@ -33,7 +32,7 @@ class NetworkTimestamp extends BasicNetworkTimestamp {
 /**
  * Represents a Symbol address.
  */
-class Address extends ByteArray {
+export class Address extends ByteArray {
 	static SIZE = 24;
 
 	static ENCODED_SIZE = 39;
@@ -64,7 +63,7 @@ class Address extends ByteArray {
 /**
  * Represents a Symbol network.
  */
-class Network extends BasicNetwork {
+export class Network extends BasicNetwork {
 	/**
 	 * Creates a new network with the specified name, identifier byte and generation hash seed.
 	 * @param {string} name Network name.
@@ -99,5 +98,3 @@ Network.TESTNET = new Network(
 	new Hash256('7FCCD304802016BEBBCD342A332F91FF1F3BB5E902988B352697BE245F48E836')
 );
 Network.NETWORKS = [Network.MAINNET, Network.TESTNET];
-
-module.exports = { Address, Network, NetworkTimestamp };

--- a/sdk/javascript/src/symbol/SharedKey.js
+++ b/sdk/javascript/src/symbol/SharedKey.js
@@ -1,5 +1,5 @@
-const { deriveSharedKeyFactory } = require('../SharedKey');
-const tweetnacl = require('tweetnacl');
+import { deriveSharedKeyFactory } from '../SharedKey.js';
+import tweetnacl from 'tweetnacl';
 
 const { crypto_hash } = tweetnacl.lowlevel;
 const deriveSharedKeyImpl = deriveSharedKeyFactory('catapult', crypto_hash);
@@ -10,6 +10,5 @@ const deriveSharedKeyImpl = deriveSharedKeyFactory('catapult', crypto_hash);
  * @param {PublicKey} otherPublicKey Other party's public key.
  * @returns {SharedKey256} Shared encryption key.
  */
-const deriveSharedKey = (keyPair, otherPublicKey) => deriveSharedKeyImpl(keyPair.privateKey.bytes, otherPublicKey);
-
-module.exports = { deriveSharedKey };
+export const deriveSharedKey = (keyPair, otherPublicKey) => // eslint-disable-line import/prefer-default-export
+	deriveSharedKeyImpl(keyPair.privateKey.bytes, otherPublicKey);

--- a/sdk/javascript/src/symbol/TransactionFactory.js
+++ b/sdk/javascript/src/symbol/TransactionFactory.js
@@ -1,14 +1,14 @@
-const { Address } = require('./Network');
-const { generateNamespaceId, generateMosaicId } = require('./idGenerator');
-const sc = require('./models');
-const { Hash256, PublicKey } = require('../CryptoTypes');
-const { RuleBasedTransactionFactory } = require('../RuleBasedTransactionFactory');
-const { uint8ToHex } = require('../utils/converter');
+import { Address } from './Network.js';
+import { generateNamespaceId, generateMosaicId } from './idGenerator.js';
+import * as sc from './models.js';
+import { Hash256, PublicKey } from '../CryptoTypes.js';
+import RuleBasedTransactionFactory from '../RuleBasedTransactionFactory.js';
+import { uint8ToHex } from '../utils/converter.js';
 
 /**
  * Factory for creating Symbol transactions.
  */
-class TransactionFactory {
+export default class TransactionFactory {
 	/**
 	 * Creates a factory for the specified network.
 	 * @param {Network} network Symbol network.
@@ -114,5 +114,3 @@ class TransactionFactory {
 		return factory;
 	}
 }
-
-module.exports = { TransactionFactory };

--- a/sdk/javascript/src/symbol/VotingKeysGenerator.js
+++ b/sdk/javascript/src/symbol/VotingKeysGenerator.js
@@ -1,5 +1,5 @@
-const { KeyPair } = require('./KeyPair');
-const { PrivateKey } = require('../CryptoTypes');
+import { KeyPair } from './KeyPair.js';
+import { PrivateKey } from '../CryptoTypes.js';
 
 const setBuffer = (destination, offset, source) => {
 	source.forEach((byte, i) => { destination.setUint8(offset + i, source[i]); });
@@ -8,7 +8,7 @@ const setBuffer = (destination, offset, source) => {
 /**
  * Generates symbol voting keys.
  */
-class VotingKeysGenerator {
+export default class VotingKeysGenerator {
 	/**
 	 * Creates a generator around a voting root key pair.
 	 * @param {KeyPair} rootKeyPair Voting root key pair.
@@ -61,5 +61,3 @@ class VotingKeysGenerator {
 		return new Uint8Array(buffer);
 	}
 }
-
-module.exports = { VotingKeysGenerator };

--- a/sdk/javascript/src/symbol/idGenerator.js
+++ b/sdk/javascript/src/symbol/idGenerator.js
@@ -1,4 +1,4 @@
-const { sha3_256 } = require('@noble/hashes/sha3');
+import { sha3_256 } from '@noble/hashes/sha3';
 
 const NAMESPACE_FLAG = 1n << 63n;
 
@@ -23,7 +23,7 @@ const digestToBigInt = digest => {
  * @param {number} nonce Nonce.
  * @returns {BigInt} Computed mosaic id.
  */
-const generateMosaicId = (ownerAddress, nonce) => {
+export const generateMosaicId = (ownerAddress, nonce) => {
 	const hasher = sha3_256.create();
 	hasher.update(uint32ToBytes(nonce));
 	hasher.update(ownerAddress.bytes);
@@ -42,7 +42,7 @@ const generateMosaicId = (ownerAddress, nonce) => {
  * @param {BigInt} parentNamespaceId Parent namespace id.
  * @returns {BigInt} Computed namespace id.
  */
-const generateNamespaceId = (name, parentNamespaceId = 0n) => {
+export const generateNamespaceId = (name, parentNamespaceId = 0n) => {
 	const hasher = sha3_256.create();
 	hasher.update(uint32ToBytes(Number(parentNamespaceId & 0xFFFFFFFFn)));
 	hasher.update(uint32ToBytes(Number((parentNamespaceId >> 32n) & 0xFFFFFFFFn)));
@@ -58,7 +58,7 @@ const generateNamespaceId = (name, parentNamespaceId = 0n) => {
  * @param {string} name Namespace name to check.
  * @returns {boolean} true if the specified name is valid.
  */
-const isValidNamespaceName = name => {
+export const isValidNamespaceName = name => {
 	const isAlphanum = character => ('a' <= character && 'z' >= character) || ('0' <= character && '9' >= character);
 	if (!name || !isAlphanum(name[0]))
 		return false;
@@ -77,7 +77,7 @@ const isValidNamespaceName = name => {
  * @param {string} fullyQualifiedName Fully qualified namespace name.
  * @returns {array<BigInt>} Computed namespace path.
  */
-const generateNamespacePath = fullyQualifiedName => {
+export const generateNamespacePath = fullyQualifiedName => {
 	const path = [];
 	let parentNamespaceId = 0n;
 	fullyQualifiedName.split('.').forEach(name => {
@@ -96,11 +96,7 @@ const generateNamespacePath = fullyQualifiedName => {
  * @param {string} fullyQualifiedName Fully qualified mosaic name.
  * @returns {BigInt} Computed mosaic id.
  */
-const generateMosaicAliasId = fullyQualifiedName => {
+export const generateMosaicAliasId = fullyQualifiedName => {
 	const path = generateNamespacePath(fullyQualifiedName);
 	return path[path.length - 1];
-};
-
-module.exports = {
-	generateMosaicId, generateNamespaceId, isValidNamespaceName, generateNamespacePath, generateMosaicAliasId
 };

--- a/sdk/javascript/src/symbol/merkle.js
+++ b/sdk/javascript/src/symbol/merkle.js
@@ -1,14 +1,14 @@
-const { Hash256 } = require('../CryptoTypes');
-const { deepCompare } = require('../utils/arrayHelpers');
-const { uint8ToHex } = require('../utils/converter');
-const { sha3_256 } = require('@noble/hashes/sha3');
+import { Hash256 } from '../CryptoTypes.js';
+import { deepCompare } from '../utils/arrayHelpers.js';
+import { uint8ToHex } from '../utils/converter.js';
+import { sha3_256 } from '@noble/hashes/sha3';
 
 // region MerkleHashBuilder
 
 /**
  * Builder for creating a merkle hash.
  */
-class MerkleHashBuilder {
+export class MerkleHashBuilder {
 	/**
 	 * Creates a merkle hash builder.
 	 */
@@ -69,7 +69,7 @@ class MerkleHashBuilder {
  * @param {Hash256} rootHash Root hash of the merkle tree.
  * @returns {boolean} true if leaf hash is connected to root hash; false otherwise.
  */
-const proveMerkle = (leafHash, merklePath, rootHash) => {
+export const proveMerkle = (leafHash, merklePath, rootHash) => {
 	const computedRootHash = merklePath.reduce((workingHash, merklePart) => {
 		const hasher = sha3_256.create();
 		if (merklePart.isLeft) {
@@ -223,7 +223,7 @@ const deserializeBranch = reader => {
 	return new BranchNode(path, links);
 };
 
-const deserializePatriciaTreeNodes = buffer => {
+export const deserializePatriciaTreeNodes = buffer => {
 	const reader = new BufferReader(buffer.buffer);
 	const nodes = [];
 	while (!reader.eof) {
@@ -253,7 +253,7 @@ const deserializePatriciaTreeNodes = buffer => {
 /**
  * Possible results of a patricia merkle proof.
  */
-class PatriciaMerkleProofResult {
+export class PatriciaMerkleProofResult {
 	/// Proof is valid (positive).
 	static VALID_POSITIVE = 0x0001;
 
@@ -301,7 +301,7 @@ const findLinkIndex = (branchNode, targetLinkHash) => (
  * @param {Hash256} subcacheMerkleRoots Sub cache merkle roots corresponding to the state hash.
  * @returns {numeric} Proof result code.
  */
-const provePatriciaMerkle = (encodedKey, valueToTest, merklePath, stateHash, subcacheMerkleRoots) => {
+export const provePatriciaMerkle = (encodedKey, valueToTest, merklePath, stateHash, subcacheMerkleRoots) => {
 	if (!checkStateHash(stateHash, subcacheMerkleRoots))
 		return PatriciaMerkleProofResult.STATE_HASH_DOES_NOT_MATCH_ROOTS;
 
@@ -349,7 +349,3 @@ const provePatriciaMerkle = (encodedKey, valueToTest, merklePath, stateHash, sub
 };
 
 // endregion
-
-module.exports = {
-	MerkleHashBuilder, PatriciaMerkleProofResult, deserializePatriciaTreeNodes, proveMerkle, provePatriciaMerkle
-};

--- a/sdk/javascript/src/symbol/metadata.js
+++ b/sdk/javascript/src/symbol/metadata.js
@@ -4,7 +4,7 @@
  * @param {Uint8Array} newValue New metadata value.
  * @returns {Uint8Array} Metadata payload for updating old value to new value.
  */
-const metadataUpdateValue = (oldValue, newValue) => {
+export const metadataUpdateValue = (oldValue, newValue) => { // eslint-disable-line import/prefer-default-export
 	if (!oldValue)
 		return newValue;
 
@@ -23,5 +23,3 @@ const metadataUpdateValue = (oldValue, newValue) => {
 
 	return result;
 };
-
-module.exports = { metadataUpdateValue };

--- a/sdk/javascript/src/symbol/models.js
+++ b/sdk/javascript/src/symbol/models.js
@@ -1,13 +1,13 @@
 /* eslint-disable max-len, object-property-newline, no-underscore-dangle, no-use-before-define */
 
-const { BaseValue } = require('../BaseValue');
-const { ByteArray } = require('../ByteArray');
-const { BufferView } = require('../utils/BufferView');
-const { Writer } = require('../utils/Writer');
-const arrayHelpers = require('../utils/arrayHelpers');
-const converter = require('../utils/converter');
+import BaseValue from '../BaseValue.js';
+import ByteArray from '../ByteArray.js';
+import BufferView from '../utils/BufferView.js';
+import Writer from '../utils/Writer.js';
+import * as arrayHelpers from '../utils/arrayHelpers.js';
+import * as converter from '../utils/converter.js';
 
-class Amount extends BaseValue {
+export class Amount extends BaseValue {
 	static SIZE = 8;
 
 	constructor(amount = 0n) {
@@ -29,7 +29,7 @@ class Amount extends BaseValue {
 	}
 }
 
-class BlockDuration extends BaseValue {
+export class BlockDuration extends BaseValue {
 	static SIZE = 8;
 
 	constructor(blockDuration = 0n) {
@@ -51,7 +51,7 @@ class BlockDuration extends BaseValue {
 	}
 }
 
-class BlockFeeMultiplier extends BaseValue {
+export class BlockFeeMultiplier extends BaseValue {
 	static SIZE = 4;
 
 	constructor(blockFeeMultiplier = 0) {
@@ -73,7 +73,7 @@ class BlockFeeMultiplier extends BaseValue {
 	}
 }
 
-class Difficulty extends BaseValue {
+export class Difficulty extends BaseValue {
 	static SIZE = 8;
 
 	constructor(difficulty = 0n) {
@@ -95,7 +95,7 @@ class Difficulty extends BaseValue {
 	}
 }
 
-class FinalizationEpoch extends BaseValue {
+export class FinalizationEpoch extends BaseValue {
 	static SIZE = 4;
 
 	constructor(finalizationEpoch = 0) {
@@ -117,7 +117,7 @@ class FinalizationEpoch extends BaseValue {
 	}
 }
 
-class FinalizationPoint extends BaseValue {
+export class FinalizationPoint extends BaseValue {
 	static SIZE = 4;
 
 	constructor(finalizationPoint = 0) {
@@ -139,7 +139,7 @@ class FinalizationPoint extends BaseValue {
 	}
 }
 
-class Height extends BaseValue {
+export class Height extends BaseValue {
 	static SIZE = 8;
 
 	constructor(height = 0n) {
@@ -161,7 +161,7 @@ class Height extends BaseValue {
 	}
 }
 
-class Importance extends BaseValue {
+export class Importance extends BaseValue {
 	static SIZE = 8;
 
 	constructor(importance = 0n) {
@@ -183,7 +183,7 @@ class Importance extends BaseValue {
 	}
 }
 
-class ImportanceHeight extends BaseValue {
+export class ImportanceHeight extends BaseValue {
 	static SIZE = 8;
 
 	constructor(importanceHeight = 0n) {
@@ -205,7 +205,7 @@ class ImportanceHeight extends BaseValue {
 	}
 }
 
-class UnresolvedMosaicId extends BaseValue {
+export class UnresolvedMosaicId extends BaseValue {
 	static SIZE = 8;
 
 	constructor(unresolvedMosaicId = 0n) {
@@ -227,7 +227,7 @@ class UnresolvedMosaicId extends BaseValue {
 	}
 }
 
-class MosaicId extends BaseValue {
+export class MosaicId extends BaseValue {
 	static SIZE = 8;
 
 	constructor(mosaicId = 0n) {
@@ -249,7 +249,7 @@ class MosaicId extends BaseValue {
 	}
 }
 
-class Timestamp extends BaseValue {
+export class Timestamp extends BaseValue {
 	static SIZE = 8;
 
 	constructor(timestamp = 0n) {
@@ -271,7 +271,7 @@ class Timestamp extends BaseValue {
 	}
 }
 
-class UnresolvedAddress extends ByteArray {
+export class UnresolvedAddress extends ByteArray {
 	static SIZE = 24;
 
 	constructor(unresolvedAddress = new Uint8Array(24)) {
@@ -292,7 +292,7 @@ class UnresolvedAddress extends ByteArray {
 	}
 }
 
-class Address extends ByteArray {
+export class Address extends ByteArray {
 	static SIZE = 24;
 
 	constructor(address = new Uint8Array(24)) {
@@ -313,7 +313,7 @@ class Address extends ByteArray {
 	}
 }
 
-class Hash256 extends ByteArray {
+export class Hash256 extends ByteArray {
 	static SIZE = 32;
 
 	constructor(hash256 = new Uint8Array(32)) {
@@ -334,7 +334,7 @@ class Hash256 extends ByteArray {
 	}
 }
 
-class Hash512 extends ByteArray {
+export class Hash512 extends ByteArray {
 	static SIZE = 64;
 
 	constructor(hash512 = new Uint8Array(64)) {
@@ -355,7 +355,7 @@ class Hash512 extends ByteArray {
 	}
 }
 
-class PublicKey extends ByteArray {
+export class PublicKey extends ByteArray {
 	static SIZE = 32;
 
 	constructor(publicKey = new Uint8Array(32)) {
@@ -376,7 +376,7 @@ class PublicKey extends ByteArray {
 	}
 }
 
-class VotingPublicKey extends ByteArray {
+export class VotingPublicKey extends ByteArray {
 	static SIZE = 32;
 
 	constructor(votingPublicKey = new Uint8Array(32)) {
@@ -397,7 +397,7 @@ class VotingPublicKey extends ByteArray {
 	}
 }
 
-class Signature extends ByteArray {
+export class Signature extends ByteArray {
 	static SIZE = 64;
 
 	constructor(signature = new Uint8Array(64)) {
@@ -418,7 +418,7 @@ class Signature extends ByteArray {
 	}
 }
 
-class Mosaic {
+export class Mosaic {
 	static TYPE_HINTS = {
 		mosaicId: 'pod:MosaicId',
 		amount: 'pod:Amount'
@@ -484,7 +484,7 @@ class Mosaic {
 	}
 }
 
-class UnresolvedMosaic {
+export class UnresolvedMosaic {
 	static TYPE_HINTS = {
 		mosaicId: 'pod:UnresolvedMosaicId',
 		amount: 'pod:Amount'
@@ -550,7 +550,7 @@ class UnresolvedMosaic {
 	}
 }
 
-class LinkAction {
+export class LinkAction {
 	static UNLINK = new LinkAction(0);
 
 	static LINK = new LinkAction(1);
@@ -601,7 +601,7 @@ class LinkAction {
 	}
 }
 
-class NetworkType {
+export class NetworkType {
 	static MAINNET = new NetworkType(104);
 
 	static TESTNET = new NetworkType(152);
@@ -652,7 +652,7 @@ class NetworkType {
 	}
 }
 
-class TransactionType {
+export class TransactionType {
 	static ACCOUNT_KEY_LINK = new TransactionType(16716);
 
 	static NODE_KEY_LINK = new TransactionType(16972);
@@ -754,7 +754,7 @@ class TransactionType {
 	}
 }
 
-class Transaction {
+export class Transaction {
 	static TYPE_HINTS = {
 		signature: 'pod:Signature',
 		signerPublicKey: 'pod:PublicKey',
@@ -918,7 +918,7 @@ class Transaction {
 	}
 }
 
-class EmbeddedTransaction {
+export class EmbeddedTransaction {
 	static TYPE_HINTS = {
 		signerPublicKey: 'pod:PublicKey',
 		network: 'enum:NetworkType',
@@ -1034,7 +1034,7 @@ class EmbeddedTransaction {
 	}
 }
 
-class AccountKeyLinkTransaction {
+export class AccountKeyLinkTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.ACCOUNT_KEY_LINK;
@@ -1234,7 +1234,7 @@ class AccountKeyLinkTransaction {
 	}
 }
 
-class EmbeddedAccountKeyLinkTransaction {
+export class EmbeddedAccountKeyLinkTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.ACCOUNT_KEY_LINK;
@@ -1386,7 +1386,7 @@ class EmbeddedAccountKeyLinkTransaction {
 	}
 }
 
-class NodeKeyLinkTransaction {
+export class NodeKeyLinkTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.NODE_KEY_LINK;
@@ -1586,7 +1586,7 @@ class NodeKeyLinkTransaction {
 	}
 }
 
-class EmbeddedNodeKeyLinkTransaction {
+export class EmbeddedNodeKeyLinkTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.NODE_KEY_LINK;
@@ -1738,7 +1738,7 @@ class EmbeddedNodeKeyLinkTransaction {
 	}
 }
 
-class Cosignature {
+export class Cosignature {
 	static TYPE_HINTS = {
 		signerPublicKey: 'pod:PublicKey',
 		signature: 'pod:Signature'
@@ -1819,7 +1819,7 @@ class Cosignature {
 	}
 }
 
-class DetachedCosignature {
+export class DetachedCosignature {
 	static TYPE_HINTS = {
 		signerPublicKey: 'pod:PublicKey',
 		signature: 'pod:Signature',
@@ -1916,7 +1916,7 @@ class DetachedCosignature {
 	}
 }
 
-class AggregateCompleteTransaction {
+export class AggregateCompleteTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.AGGREGATE_COMPLETE;
@@ -2143,7 +2143,7 @@ class AggregateCompleteTransaction {
 	}
 }
 
-class AggregateBondedTransaction {
+export class AggregateBondedTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.AGGREGATE_BONDED;
@@ -2370,7 +2370,7 @@ class AggregateBondedTransaction {
 	}
 }
 
-class VotingKeyLinkTransaction {
+export class VotingKeyLinkTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.VOTING_KEY_LINK;
@@ -2602,7 +2602,7 @@ class VotingKeyLinkTransaction {
 	}
 }
 
-class EmbeddedVotingKeyLinkTransaction {
+export class EmbeddedVotingKeyLinkTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.VOTING_KEY_LINK;
@@ -2786,7 +2786,7 @@ class EmbeddedVotingKeyLinkTransaction {
 	}
 }
 
-class VrfKeyLinkTransaction {
+export class VrfKeyLinkTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.VRF_KEY_LINK;
@@ -2986,7 +2986,7 @@ class VrfKeyLinkTransaction {
 	}
 }
 
-class EmbeddedVrfKeyLinkTransaction {
+export class EmbeddedVrfKeyLinkTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.VRF_KEY_LINK;
@@ -3138,7 +3138,7 @@ class EmbeddedVrfKeyLinkTransaction {
 	}
 }
 
-class HashLockTransaction {
+export class HashLockTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.HASH_LOCK;
@@ -3355,7 +3355,7 @@ class HashLockTransaction {
 	}
 }
 
-class EmbeddedHashLockTransaction {
+export class EmbeddedHashLockTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.HASH_LOCK;
@@ -3524,7 +3524,7 @@ class EmbeddedHashLockTransaction {
 	}
 }
 
-class LockHashAlgorithm {
+export class LockHashAlgorithm {
 	static SHA3_256 = new LockHashAlgorithm(0);
 
 	static HASH_160 = new LockHashAlgorithm(1);
@@ -3577,7 +3577,7 @@ class LockHashAlgorithm {
 	}
 }
 
-class SecretLockTransaction {
+export class SecretLockTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.SECRET_LOCK;
@@ -3826,7 +3826,7 @@ class SecretLockTransaction {
 	}
 }
 
-class EmbeddedSecretLockTransaction {
+export class EmbeddedSecretLockTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.SECRET_LOCK;
@@ -4027,7 +4027,7 @@ class EmbeddedSecretLockTransaction {
 	}
 }
 
-class SecretProofTransaction {
+export class SecretProofTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.SECRET_PROOF;
@@ -4263,7 +4263,7 @@ class SecretProofTransaction {
 	}
 }
 
-class EmbeddedSecretProofTransaction {
+export class EmbeddedSecretProofTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.SECRET_PROOF;
@@ -4451,7 +4451,7 @@ class EmbeddedSecretProofTransaction {
 	}
 }
 
-class AccountMetadataTransaction {
+export class AccountMetadataTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.ACCOUNT_METADATA;
@@ -4685,7 +4685,7 @@ class AccountMetadataTransaction {
 	}
 }
 
-class EmbeddedAccountMetadataTransaction {
+export class EmbeddedAccountMetadataTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.ACCOUNT_METADATA;
@@ -4871,7 +4871,7 @@ class EmbeddedAccountMetadataTransaction {
 	}
 }
 
-class MosaicMetadataTransaction {
+export class MosaicMetadataTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MOSAIC_METADATA;
@@ -5121,7 +5121,7 @@ class MosaicMetadataTransaction {
 	}
 }
 
-class EmbeddedMosaicMetadataTransaction {
+export class EmbeddedMosaicMetadataTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MOSAIC_METADATA;
@@ -5323,7 +5323,7 @@ class EmbeddedMosaicMetadataTransaction {
 	}
 }
 
-class NamespaceId extends BaseValue {
+export class NamespaceId extends BaseValue {
 	static SIZE = 8;
 
 	constructor(namespaceId = 0n) {
@@ -5345,7 +5345,7 @@ class NamespaceId extends BaseValue {
 	}
 }
 
-class NamespaceRegistrationType {
+export class NamespaceRegistrationType {
 	static ROOT = new NamespaceRegistrationType(0);
 
 	static CHILD = new NamespaceRegistrationType(1);
@@ -5396,7 +5396,7 @@ class NamespaceRegistrationType {
 	}
 }
 
-class AliasAction {
+export class AliasAction {
 	static UNLINK = new AliasAction(0);
 
 	static LINK = new AliasAction(1);
@@ -5447,7 +5447,7 @@ class AliasAction {
 	}
 }
 
-class NamespaceMetadataTransaction {
+export class NamespaceMetadataTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.NAMESPACE_METADATA;
@@ -5697,7 +5697,7 @@ class NamespaceMetadataTransaction {
 	}
 }
 
-class EmbeddedNamespaceMetadataTransaction {
+export class EmbeddedNamespaceMetadataTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.NAMESPACE_METADATA;
@@ -5899,7 +5899,7 @@ class EmbeddedNamespaceMetadataTransaction {
 	}
 }
 
-class MosaicNonce extends BaseValue {
+export class MosaicNonce extends BaseValue {
 	static SIZE = 4;
 
 	constructor(mosaicNonce = 0) {
@@ -5921,7 +5921,7 @@ class MosaicNonce extends BaseValue {
 	}
 }
 
-class MosaicFlags {
+export class MosaicFlags {
 	static NONE = new MosaicFlags(0);
 
 	static SUPPLY_MUTABLE = new MosaicFlags(1);
@@ -5976,7 +5976,7 @@ class MosaicFlags {
 	}
 }
 
-class MosaicSupplyChangeAction {
+export class MosaicSupplyChangeAction {
 	static DECREASE = new MosaicSupplyChangeAction(0);
 
 	static INCREASE = new MosaicSupplyChangeAction(1);
@@ -6027,7 +6027,7 @@ class MosaicSupplyChangeAction {
 	}
 }
 
-class MosaicDefinitionTransaction {
+export class MosaicDefinitionTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MOSAIC_DEFINITION;
@@ -6274,7 +6274,7 @@ class MosaicDefinitionTransaction {
 	}
 }
 
-class EmbeddedMosaicDefinitionTransaction {
+export class EmbeddedMosaicDefinitionTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MOSAIC_DEFINITION;
@@ -6473,7 +6473,7 @@ class EmbeddedMosaicDefinitionTransaction {
 	}
 }
 
-class MosaicSupplyChangeTransaction {
+export class MosaicSupplyChangeTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MOSAIC_SUPPLY_CHANGE;
@@ -6689,7 +6689,7 @@ class MosaicSupplyChangeTransaction {
 	}
 }
 
-class EmbeddedMosaicSupplyChangeTransaction {
+export class EmbeddedMosaicSupplyChangeTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MOSAIC_SUPPLY_CHANGE;
@@ -6857,7 +6857,7 @@ class EmbeddedMosaicSupplyChangeTransaction {
 	}
 }
 
-class MosaicSupplyRevocationTransaction {
+export class MosaicSupplyRevocationTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MOSAIC_SUPPLY_REVOCATION;
@@ -7058,7 +7058,7 @@ class MosaicSupplyRevocationTransaction {
 	}
 }
 
-class EmbeddedMosaicSupplyRevocationTransaction {
+export class EmbeddedMosaicSupplyRevocationTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MOSAIC_SUPPLY_REVOCATION;
@@ -7211,7 +7211,7 @@ class EmbeddedMosaicSupplyRevocationTransaction {
 	}
 }
 
-class MultisigAccountModificationTransaction {
+export class MultisigAccountModificationTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MULTISIG_ACCOUNT_MODIFICATION;
@@ -7456,7 +7456,7 @@ class MultisigAccountModificationTransaction {
 	}
 }
 
-class EmbeddedMultisigAccountModificationTransaction {
+export class EmbeddedMultisigAccountModificationTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MULTISIG_ACCOUNT_MODIFICATION;
@@ -7653,7 +7653,7 @@ class EmbeddedMultisigAccountModificationTransaction {
 	}
 }
 
-class AddressAliasTransaction {
+export class AddressAliasTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.ADDRESS_ALIAS;
@@ -7869,7 +7869,7 @@ class AddressAliasTransaction {
 	}
 }
 
-class EmbeddedAddressAliasTransaction {
+export class EmbeddedAddressAliasTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.ADDRESS_ALIAS;
@@ -8037,7 +8037,7 @@ class EmbeddedAddressAliasTransaction {
 	}
 }
 
-class MosaicAliasTransaction {
+export class MosaicAliasTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MOSAIC_ALIAS;
@@ -8253,7 +8253,7 @@ class MosaicAliasTransaction {
 	}
 }
 
-class EmbeddedMosaicAliasTransaction {
+export class EmbeddedMosaicAliasTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MOSAIC_ALIAS;
@@ -8421,7 +8421,7 @@ class EmbeddedMosaicAliasTransaction {
 	}
 }
 
-class NamespaceRegistrationTransaction {
+export class NamespaceRegistrationTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.NAMESPACE_REGISTRATION;
@@ -8694,7 +8694,7 @@ class NamespaceRegistrationTransaction {
 	}
 }
 
-class EmbeddedNamespaceRegistrationTransaction {
+export class EmbeddedNamespaceRegistrationTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.NAMESPACE_REGISTRATION;
@@ -8919,7 +8919,7 @@ class EmbeddedNamespaceRegistrationTransaction {
 	}
 }
 
-class AccountRestrictionFlags {
+export class AccountRestrictionFlags {
 	static ADDRESS = new AccountRestrictionFlags(1);
 
 	static MOSAIC_ID = new AccountRestrictionFlags(2);
@@ -8974,7 +8974,7 @@ class AccountRestrictionFlags {
 	}
 }
 
-class AccountAddressRestrictionTransaction {
+export class AccountAddressRestrictionTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.ACCOUNT_ADDRESS_RESTRICTION;
@@ -9205,7 +9205,7 @@ class AccountAddressRestrictionTransaction {
 	}
 }
 
-class EmbeddedAccountAddressRestrictionTransaction {
+export class EmbeddedAccountAddressRestrictionTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.ACCOUNT_ADDRESS_RESTRICTION;
@@ -9388,7 +9388,7 @@ class EmbeddedAccountAddressRestrictionTransaction {
 	}
 }
 
-class AccountMosaicRestrictionTransaction {
+export class AccountMosaicRestrictionTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.ACCOUNT_MOSAIC_RESTRICTION;
@@ -9619,7 +9619,7 @@ class AccountMosaicRestrictionTransaction {
 	}
 }
 
-class EmbeddedAccountMosaicRestrictionTransaction {
+export class EmbeddedAccountMosaicRestrictionTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.ACCOUNT_MOSAIC_RESTRICTION;
@@ -9802,7 +9802,7 @@ class EmbeddedAccountMosaicRestrictionTransaction {
 	}
 }
 
-class AccountOperationRestrictionTransaction {
+export class AccountOperationRestrictionTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.ACCOUNT_OPERATION_RESTRICTION;
@@ -10033,7 +10033,7 @@ class AccountOperationRestrictionTransaction {
 	}
 }
 
-class EmbeddedAccountOperationRestrictionTransaction {
+export class EmbeddedAccountOperationRestrictionTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.ACCOUNT_OPERATION_RESTRICTION;
@@ -10216,7 +10216,7 @@ class EmbeddedAccountOperationRestrictionTransaction {
 	}
 }
 
-class MosaicAddressRestrictionTransaction {
+export class MosaicAddressRestrictionTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MOSAIC_ADDRESS_RESTRICTION;
@@ -10461,7 +10461,7 @@ class MosaicAddressRestrictionTransaction {
 	}
 }
 
-class EmbeddedMosaicAddressRestrictionTransaction {
+export class EmbeddedMosaicAddressRestrictionTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MOSAIC_ADDRESS_RESTRICTION;
@@ -10658,7 +10658,7 @@ class EmbeddedMosaicAddressRestrictionTransaction {
 	}
 }
 
-class MosaicRestrictionKey extends BaseValue {
+export class MosaicRestrictionKey extends BaseValue {
 	static SIZE = 8;
 
 	constructor(mosaicRestrictionKey = 0n) {
@@ -10680,7 +10680,7 @@ class MosaicRestrictionKey extends BaseValue {
 	}
 }
 
-class MosaicRestrictionType {
+export class MosaicRestrictionType {
 	static NONE = new MosaicRestrictionType(0);
 
 	static EQ = new MosaicRestrictionType(1);
@@ -10741,7 +10741,7 @@ class MosaicRestrictionType {
 	}
 }
 
-class MosaicGlobalRestrictionTransaction {
+export class MosaicGlobalRestrictionTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MOSAIC_GLOBAL_RESTRICTION;
@@ -11018,7 +11018,7 @@ class MosaicGlobalRestrictionTransaction {
 	}
 }
 
-class EmbeddedMosaicGlobalRestrictionTransaction {
+export class EmbeddedMosaicGlobalRestrictionTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.MOSAIC_GLOBAL_RESTRICTION;
@@ -11247,7 +11247,7 @@ class EmbeddedMosaicGlobalRestrictionTransaction {
 	}
 }
 
-class TransferTransaction {
+export class TransferTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.TRANSFER;
@@ -11489,7 +11489,7 @@ class TransferTransaction {
 	}
 }
 
-class EmbeddedTransferTransaction {
+export class EmbeddedTransferTransaction {
 	static TRANSACTION_VERSION = 1;
 
 	static TRANSACTION_TYPE = TransactionType.TRANSFER;
@@ -11683,7 +11683,7 @@ class EmbeddedTransferTransaction {
 	}
 }
 
-class TransactionFactory {
+export class TransactionFactory {
 	static toKey(values) {
 		if (1 === values.length)
 			return values[0];
@@ -11763,7 +11763,7 @@ class TransactionFactory {
 	}
 }
 
-class EmbeddedTransactionFactory {
+export class EmbeddedTransactionFactory {
 	static toKey(values) {
 		if (1 === values.length)
 			return values[0];
@@ -11838,24 +11838,3 @@ class EmbeddedTransactionFactory {
 		return new mapping[entityName]();
 	}
 }
-
-module.exports = {
-	Amount, BlockDuration, BlockFeeMultiplier, Difficulty, FinalizationEpoch, FinalizationPoint, Height, Importance, ImportanceHeight,
-	UnresolvedMosaicId, MosaicId, Timestamp, UnresolvedAddress, Address, Hash256, Hash512, PublicKey, VotingPublicKey, Signature, Mosaic,
-	UnresolvedMosaic, LinkAction, NetworkType, TransactionType, Transaction, EmbeddedTransaction, AccountKeyLinkTransaction,
-	EmbeddedAccountKeyLinkTransaction, NodeKeyLinkTransaction, EmbeddedNodeKeyLinkTransaction, Cosignature, DetachedCosignature,
-	AggregateCompleteTransaction, AggregateBondedTransaction, VotingKeyLinkTransaction, EmbeddedVotingKeyLinkTransaction, VrfKeyLinkTransaction,
-	EmbeddedVrfKeyLinkTransaction, HashLockTransaction, EmbeddedHashLockTransaction, LockHashAlgorithm, SecretLockTransaction,
-	EmbeddedSecretLockTransaction, SecretProofTransaction, EmbeddedSecretProofTransaction, AccountMetadataTransaction,
-	EmbeddedAccountMetadataTransaction, MosaicMetadataTransaction, EmbeddedMosaicMetadataTransaction, NamespaceId, NamespaceRegistrationType,
-	AliasAction, NamespaceMetadataTransaction, EmbeddedNamespaceMetadataTransaction, MosaicNonce, MosaicFlags, MosaicSupplyChangeAction,
-	MosaicDefinitionTransaction, EmbeddedMosaicDefinitionTransaction, MosaicSupplyChangeTransaction, EmbeddedMosaicSupplyChangeTransaction,
-	MosaicSupplyRevocationTransaction, EmbeddedMosaicSupplyRevocationTransaction, MultisigAccountModificationTransaction,
-	EmbeddedMultisigAccountModificationTransaction, AddressAliasTransaction, EmbeddedAddressAliasTransaction, MosaicAliasTransaction,
-	EmbeddedMosaicAliasTransaction, NamespaceRegistrationTransaction, EmbeddedNamespaceRegistrationTransaction, AccountRestrictionFlags,
-	AccountAddressRestrictionTransaction, EmbeddedAccountAddressRestrictionTransaction, AccountMosaicRestrictionTransaction,
-	EmbeddedAccountMosaicRestrictionTransaction, AccountOperationRestrictionTransaction, EmbeddedAccountOperationRestrictionTransaction,
-	MosaicAddressRestrictionTransaction, EmbeddedMosaicAddressRestrictionTransaction, MosaicRestrictionKey, MosaicRestrictionType,
-	MosaicGlobalRestrictionTransaction, EmbeddedMosaicGlobalRestrictionTransaction, TransferTransaction, EmbeddedTransferTransaction,
-	TransactionFactory, EmbeddedTransactionFactory
-};

--- a/sdk/javascript/src/utils/BufferView.js
+++ b/sdk/javascript/src/utils/BufferView.js
@@ -1,7 +1,7 @@
 /**
  * Buffer view.
  */
-class BufferView {
+export default class BufferView {
 	/**
 	 * Creates buffer view around buffer.
 	 * @param {Uint8Array} buffer Initial buffer view.
@@ -38,5 +38,3 @@ class BufferView {
 		this.buffer = this.window(size);
 	}
 }
-
-module.exports = { BufferView };

--- a/sdk/javascript/src/utils/Writer.js
+++ b/sdk/javascript/src/utils/Writer.js
@@ -1,7 +1,7 @@
 /**
  * Position tracking writer.
  */
-class Writer {
+export default class Writer {
 	/**
 	 * Creates a writer with specified size.
 	 * @param {number} size Allocated buffer size.
@@ -20,5 +20,3 @@ class Writer {
 		this.offset += buffer.length;
 	}
 }
-
-module.exports = { Writer };

--- a/sdk/javascript/src/utils/base32.js
+++ b/sdk/javascript/src/utils/base32.js
@@ -1,4 +1,4 @@
-const charMapping = require('./charMapping');
+import charMapping from './charMapping.js';
 
 const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
 const DECODED_BLOCK_SIZE = 5;
@@ -84,4 +84,4 @@ const base32 = {
 	}
 };
 
-module.exports = base32;
+export default base32;

--- a/sdk/javascript/src/utils/charMapping.js
+++ b/sdk/javascript/src/utils/charMapping.js
@@ -34,4 +34,4 @@ const charMapping = {
 	}
 };
 
-module.exports = charMapping;
+export default charMapping;

--- a/sdk/javascript/src/utils/converter.js
+++ b/sdk/javascript/src/utils/converter.js
@@ -1,4 +1,4 @@
-const charMapping = require('./charMapping');
+import charMapping from './charMapping.js';
 
 const CHAR_TO_NIBBLE_MAP = (() => {
 	const builder = charMapping.createBuilder();
@@ -39,140 +39,143 @@ const tryParseByte = (char1, char2) => {
 		: (nibble1 << 4) | nibble2;
 };
 
-const converter = {
-	/**
-	 * Decodes two hex characters into a byte.
-	 * @param {string} char1 First hex digit.
-	 * @param {string} char2 Second hex digit.
-	 * @returns {numeric} Decoded byte.
-	 */
-	toByte: (char1, char2) => {
-		const byte = tryParseByte(char1, char2);
-		if (undefined === byte)
-			throw Error(`unrecognized hex char '${char1}${char2}'`);
+/**
+ * Decodes two hex characters into a byte.
+ * @param {string} char1 First hex digit.
+ * @param {string} char2 Second hex digit.
+ * @returns {numeric} Decoded byte.
+ */
+export const toByte = (char1, char2) => {
+	const byte = tryParseByte(char1, char2);
+	if (undefined === byte)
+		throw Error(`unrecognized hex char '${char1}${char2}'`);
 
-		return byte;
-	},
-
-	/**
-	 * Determines whether or not a string is a hex string.
-	 * @param {string} input String to test.
-	 * @returns {boolean} true if the input is a hex string, false otherwise.
-	 */
-	isHexString: input => {
-		if (0 !== input.length % 2)
-			return false;
-
-		for (let i = 0; i < input.length; i += 2) {
-			if (undefined === tryParseByte(input[i], input[i + 1]))
-				return false;
-		}
-
-		return true;
-	},
-
-	/**
-	 * Converts a hex string to a uint8 array.
-	 * @param {string} input A hex encoded string.
-	 * @returns {Uint8Array} A uint8 array corresponding to the input.
-	 */
-	hexToUint8: input => {
-		if (0 !== input.length % 2)
-			throw Error(`hex string has unexpected size '${input.length}'`);
-
-		const output = new Uint8Array(input.length / 2);
-		for (let i = 0; i < input.length; i += 2)
-			output[i / 2] = converter.toByte(input[i], input[i + 1]);
-
-		return output;
-	},
-
-	/**
-	 * Converts a uint8 array to a hex string.
-	 * @param {Uint8Array} input A uint8 array.
-	 * @returns {string} A hex encoded string corresponding to the input.
-	 */
-	uint8ToHex: input => {
-		let s = '';
-		input.forEach(byte => {
-			s += NIBBLE_TO_CHAR_MAP[byte >> 4];
-			s += NIBBLE_TO_CHAR_MAP[byte & 0x0F];
-		});
-
-		return s;
-	},
-
-	/**
-	 * Tries to parse a string representing an unsigned integer.
-	 * @param {string} str String to parse.
-	 * @returns {numeric} Number represented by the input or undefined.
-	 */
-	tryParseUint: str => {
-		if ('0' === str)
-			return 0;
-
-		let value = 0;
-		for (let i = 0; i < str.length; ++i) {
-			const char = str[i];
-			const digit = CHAR_TO_DIGIT_MAP[char];
-			if (undefined === digit || (0 === value && 0 === digit))
-				return undefined;
-
-			value *= 10;
-			value += digit;
-
-			if (value > Number.MAX_SAFE_INTEGER)
-				return undefined;
-		}
-
-		return value;
-	},
-
-	/**
-	 * Converts aligned bytes to little-endian number.
-	 * @param {Uint8Array} input A uint8 array.
-	 * @param {numeric} size Number of bytes.
-	 * @param {boolean} isSigned Should number be treated as signed.
-	 * @returns {numeric|BigInt} Value corresponding to the input.
-	 */
-	bytesToInt: (input, size, isSigned = false) => {
-		const DataType = SIGNEDNESS_AND_SIZE_TO_ARRAY_TYPE_MAPPING[isSigned][size];
-		return new DataType(input.buffer, input.byteOffset, 1)[0];
-	},
-
-	/**
-	 * Converts bytes to little-endian number.
-	 * @param {Uint8Array} input A uint8 array.
-	 * @param {numeric} size Number of bytes.
-	 * @param {boolean} isSigned Should number be treated as signed.
-	 * @returns {numeric|BigInt} Value corresponding to the input.
-	 */
-	bytesToIntUnaligned: (input, size, isSigned = false) => {
-		const view = new DataView(input.buffer, input.byteOffset);
-		const mapping = {
-			false: {
-				1: view.getUint8,
-				2: view.getUint16,
-				4: view.getUint32,
-				8: view.getBigUint64
-			},
-			true: {
-				1: view.getInt8,
-				2: view.getInt16,
-				4: view.getInt32,
-				8: view.getBigInt64
-			}
-		};
-
-		const reader = mapping[isSigned][size];
-		return reader.call(view, 0, true);
-	},
-
-	intToBytes: (value, byteSize, isSigned = false) => {
-		const DataType = SIGNEDNESS_AND_SIZE_TO_ARRAY_TYPE_MAPPING[isSigned][byteSize];
-		const typedBuffer = new DataType([value]);
-		return new Uint8Array(typedBuffer.buffer);
-	}
+	return byte;
 };
 
-module.exports = converter;
+/**
+ * Determines whether or not a string is a hex string.
+ * @param {string} input String to test.
+ * @returns {boolean} true if the input is a hex string, false otherwise.
+ */
+export const isHexString = input => {
+	if (0 !== input.length % 2)
+		return false;
+
+	for (let i = 0; i < input.length; i += 2) {
+		if (undefined === tryParseByte(input[i], input[i + 1]))
+			return false;
+	}
+
+	return true;
+};
+
+/**
+ * Converts a hex string to a uint8 array.
+ * @param {string} input A hex encoded string.
+ * @returns {Uint8Array} A uint8 array corresponding to the input.
+ */
+export const hexToUint8 = input => {
+	if (0 !== input.length % 2)
+		throw Error(`hex string has unexpected size '${input.length}'`);
+
+	const output = new Uint8Array(input.length / 2);
+	for (let i = 0; i < input.length; i += 2)
+		output[i / 2] = toByte(input[i], input[i + 1]);
+
+	return output;
+};
+
+/**
+ * Converts a uint8 array to a hex string.
+ * @param {Uint8Array} input A uint8 array.
+ * @returns {string} A hex encoded string corresponding to the input.
+ */
+export const uint8ToHex = input => {
+	let s = '';
+	input.forEach(byte => {
+		s += NIBBLE_TO_CHAR_MAP[byte >> 4];
+		s += NIBBLE_TO_CHAR_MAP[byte & 0x0F];
+	});
+
+	return s;
+};
+
+/**
+ * Tries to parse a string representing an unsigned integer.
+ * @param {string} str String to parse.
+ * @returns {numeric} Number represented by the input or undefined.
+ */
+export const tryParseUint = str => {
+	if ('0' === str)
+		return 0;
+
+	let value = 0;
+	for (let i = 0; i < str.length; ++i) {
+		const char = str[i];
+		const digit = CHAR_TO_DIGIT_MAP[char];
+		if (undefined === digit || (0 === value && 0 === digit))
+			return undefined;
+
+		value *= 10;
+		value += digit;
+
+		if (value > Number.MAX_SAFE_INTEGER)
+			return undefined;
+	}
+
+	return value;
+};
+
+/**
+ * Converts aligned bytes to little-endian number.
+ * @param {Uint8Array} input A uint8 array.
+ * @param {numeric} size Number of bytes.
+ * @param {boolean} isSigned Should number be treated as signed.
+ * @returns {numeric|BigInt} Value corresponding to the input.
+ */
+export const bytesToInt = (input, size, isSigned = false) => {
+	const DataType = SIGNEDNESS_AND_SIZE_TO_ARRAY_TYPE_MAPPING[isSigned][size];
+	return new DataType(input.buffer, input.byteOffset, 1)[0];
+};
+
+/**
+ * Converts bytes to little-endian number.
+ * @param {Uint8Array} input A uint8 array.
+ * @param {numeric} size Number of bytes.
+ * @param {boolean} isSigned Should number be treated as signed.
+ * @returns {numeric|BigInt} Value corresponding to the input.
+ */
+export const bytesToIntUnaligned = (input, size, isSigned = false) => {
+	const view = new DataView(input.buffer, input.byteOffset);
+	const mapping = {
+		false: {
+			1: view.getUint8,
+			2: view.getUint16,
+			4: view.getUint32,
+			8: view.getBigUint64
+		},
+		true: {
+			1: view.getInt8,
+			2: view.getInt16,
+			4: view.getInt32,
+			8: view.getBigInt64
+		}
+	};
+
+	const reader = mapping[isSigned][size];
+	return reader.call(view, 0, true);
+};
+
+/**
+ * Converts an integer to bytes.
+ * @param {numeric} value Integer value.
+ * @param {numeric} byteSize Number of output bytes.
+ * @param {numeric} isSigned \c true if the value is signed.
+ * @returns {Uint8Array} Byte representation of the integer.
+ */
+export const intToBytes = (value, byteSize, isSigned = false) => {
+	const DataType = SIGNEDNESS_AND_SIZE_TO_ARRAY_TYPE_MAPPING[isSigned][byteSize];
+	const typedBuffer = new DataType([value]);
+	return new Uint8Array(typedBuffer.buffer);
+};

--- a/sdk/javascript/src/utils/transforms.js
+++ b/sdk/javascript/src/utils/transforms.js
@@ -1,16 +1,12 @@
-const { keccak_256 } = require('@noble/hashes/sha3');
-const Ripemd160 = require('ripemd160');
+import { keccak_256 } from '@noble/hashes/sha3';
+import Ripemd160 from 'ripemd160';
 
 /**
  * Hashes payload with keccak 256 and then hashes the result with ripemd160.
  * @param {Uint8Array} payload Input buffer to hash.
  * @returns {Uint8Array} Hash result.
  */
-const ripemdKeccak256 = payload => {
+export const ripemdKeccak256 = payload => { // eslint-disable-line import/prefer-default-export
 	const partOneHash = keccak_256.create().update(payload).digest();
 	return new Uint8Array(new Ripemd160().update(Buffer.from(partOneHash)).digest());
-};
-
-module.exports = {
-	ripemdKeccak256
 };

--- a/sdk/javascript/test/BaseValue_spec.js
+++ b/sdk/javascript/test/BaseValue_spec.js
@@ -1,5 +1,5 @@
-const { BaseValue } = require('../src/BaseValue');
-const { expect } = require('chai');
+import BaseValue from '../src/BaseValue.js';
+import { expect } from 'chai';
 
 describe('BaseValue', () => {
 	const canCreateBaseValueFactory = isSigned => (rawValue, size, expectedValue) => {

--- a/sdk/javascript/test/Bip32_spec.js
+++ b/sdk/javascript/test/Bip32_spec.js
@@ -1,7 +1,7 @@
-const { Bip32 } = require('../src/Bip32');
-const { PrivateKey } = require('../src/CryptoTypes');
-const { hexToUint8 } = require('../src/utils/converter');
-const { expect } = require('chai');
+import Bip32 from '../src/Bip32.js';
+import { PrivateKey } from '../src/CryptoTypes.js';
+import { hexToUint8 } from '../src/utils/converter.js';
+import { expect } from 'chai';
 
 const DETERIMINISTIC_SEED = hexToUint8('000102030405060708090A0B0C0D0E0F');
 const DETERIMINISTIC_MNEMONIC = 'cat swing flag economy stadium alone churn speed unique patch report train';

--- a/sdk/javascript/test/ByteArray_spec.js
+++ b/sdk/javascript/test/ByteArray_spec.js
@@ -1,7 +1,7 @@
-const { ByteArray } = require('../src/ByteArray');
-const converter = require('../src/utils/converter');
-const { expect } = require('chai');
-const crypto = require('crypto');
+import ByteArray from '../src/ByteArray.js';
+import { uint8ToHex } from '../src/utils/converter.js';
+import { expect } from 'chai';
+import crypto from 'crypto';
 
 describe('ByteArray', () => {
 	const FIXED_SIZE = 24;
@@ -39,7 +39,7 @@ describe('ByteArray', () => {
 	it('cannot create byte array with incorrect number of hex characters', () => {
 		[0, FIXED_SIZE - 1, FIXED_SIZE + 1].forEach(size => {
 			expect(() => {
-				new ByteArray(FIXED_SIZE, converter.uint8ToHex(crypto.randomBytes(size))); // eslint-disable-line no-new
+				new ByteArray(FIXED_SIZE, uint8ToHex(crypto.randomBytes(size))); // eslint-disable-line no-new
 			}).to.throw('bytes was size');
 		});
 	});

--- a/sdk/javascript/test/Cipher_spec.js
+++ b/sdk/javascript/test/Cipher_spec.js
@@ -1,8 +1,8 @@
-const { AesCbcCipher, AesGcmCipher } = require('../src/Cipher');
-const { SharedKey256 } = require('../src/CryptoTypes');
-const { hexToUint8 } = require('../src/utils/converter');
-const { expect } = require('chai');
-const crypto = require('crypto');
+import { AesCbcCipher, AesGcmCipher } from '../src/Cipher.js';
+import { SharedKey256 } from '../src/CryptoTypes.js';
+import { hexToUint8 } from '../src/utils/converter.js';
+import { expect } from 'chai';
+import crypto from 'crypto';
 
 describe('Cipher', () => {
 	// region runBasicCipherTests

--- a/sdk/javascript/test/CryptoTypes_spec.js
+++ b/sdk/javascript/test/CryptoTypes_spec.js
@@ -1,8 +1,8 @@
-const {
+import {
 	Hash256, PrivateKey, PublicKey, SharedKey256, Signature
-} = require('../src/CryptoTypes');
-const { expect } = require('chai');
-const crypto = require('crypto');
+} from '../src/CryptoTypes.js';
+import { expect } from 'chai';
+import crypto from 'crypto';
 
 describe('CryptoTypes', () => {
 	// region test utils

--- a/sdk/javascript/test/NetworkTimestamp_spec.js
+++ b/sdk/javascript/test/NetworkTimestamp_spec.js
@@ -1,5 +1,5 @@
-const { NetworkTimestamp, NetworkTimestampDatetimeConverter } = require('../src/NetworkTimestamp');
-const { expect } = require('chai');
+import { NetworkTimestamp, NetworkTimestampDatetimeConverter } from '../src/NetworkTimestamp.js';
+import { expect } from 'chai';
 
 describe('NetworkTimestamp', () => {
 	const runTestCases = wrapInt => {

--- a/sdk/javascript/test/Network_spec.js
+++ b/sdk/javascript/test/Network_spec.js
@@ -1,6 +1,6 @@
-const { Network, NetworkLocator } = require('../src/Network');
-const { NetworkTimestamp, NetworkTimestampDatetimeConverter } = require('../src/NetworkTimestamp');
-const { expect } = require('chai');
+import { Network, NetworkLocator } from '../src/Network.js';
+import { NetworkTimestamp, NetworkTimestampDatetimeConverter } from '../src/NetworkTimestamp.js';
+import { expect } from 'chai';
 
 describe('Network', () => {
 	it('can convert network time to datetime', () => {

--- a/sdk/javascript/test/RuleBasedTransactionFactory_spec.js
+++ b/sdk/javascript/test/RuleBasedTransactionFactory_spec.js
@@ -1,8 +1,8 @@
-const { BaseValue } = require('../src/BaseValue');
-const { ByteArray } = require('../src/ByteArray');
-const { Hash256, PublicKey } = require('../src/CryptoTypes');
-const { RuleBasedTransactionFactory } = require('../src/RuleBasedTransactionFactory');
-const { expect } = require('chai');
+import BaseValue from '../src/BaseValue.js';
+import ByteArray from '../src/ByteArray.js';
+import { Hash256, PublicKey } from '../src/CryptoTypes.js';
+import RuleBasedTransactionFactory from '../src/RuleBasedTransactionFactory.js';
+import { expect } from 'chai';
 
 describe('RuleBasedTransactionFactory', () => {
 	// region Module

--- a/sdk/javascript/test/TransactionDescriptorProcessor_spec.js
+++ b/sdk/javascript/test/TransactionDescriptorProcessor_spec.js
@@ -1,6 +1,6 @@
-const { PublicKey } = require('../src/CryptoTypes');
-const { TransactionDescriptorProcessor } = require('../src/TransactionDescriptorProcessor');
-const { expect } = require('chai');
+import { PublicKey } from '../src/CryptoTypes.js';
+import TransactionDescriptorProcessor from '../src/TransactionDescriptorProcessor.js';
+import { expect } from 'chai';
 
 describe('TransactionDescriptorProcessor', () => {
 	// region test utils

--- a/sdk/javascript/test/facade/NemFacade_spec.js
+++ b/sdk/javascript/test/facade/NemFacade_spec.js
@@ -1,11 +1,11 @@
-const { Bip32 } = require('../../src/Bip32');
-const {
+import Bip32 from '../../src/Bip32.js';
+import {
 	Hash256, PrivateKey, PublicKey, Signature
-} = require('../../src/CryptoTypes');
-const { NemFacade } = require('../../src/facade/NemFacade');
-const { Network } = require('../../src/nem/Network');
-const { expect } = require('chai');
-const crypto = require('crypto');
+} from '../../src/CryptoTypes.js';
+import NemFacade from '../../src/facade/NemFacade.js';
+import { Network } from '../../src/nem/Network.js';
+import { expect } from 'chai';
+import crypto from 'crypto';
 
 describe('NEM Facade', () => {
 	// region constants

--- a/sdk/javascript/test/facade/SymbolFacade_spec.js
+++ b/sdk/javascript/test/facade/SymbolFacade_spec.js
@@ -1,12 +1,12 @@
-const { Bip32 } = require('../../src/Bip32');
-const {
+import Bip32 from '../../src/Bip32.js';
+import {
 	Hash256, PrivateKey, PublicKey, Signature
-} = require('../../src/CryptoTypes');
-const { SymbolFacade } = require('../../src/facade/SymbolFacade');
-const { Network } = require('../../src/symbol/Network');
-const sc = require('../../src/symbol/models');
-const { expect } = require('chai');
-const crypto = require('crypto');
+} from '../../src/CryptoTypes.js';
+import SymbolFacade from '../../src/facade/SymbolFacade.js';
+import { Network } from '../../src/symbol/Network.js';
+import * as sc from '../../src/symbol/models.js';
+import { expect } from 'chai';
+import crypto from 'crypto';
 
 describe('Symbol Facade', () => {
 	// region real transactions

--- a/sdk/javascript/test/nem/KeyPair_spec.js
+++ b/sdk/javascript/test/nem/KeyPair_spec.js
@@ -1,6 +1,6 @@
-const { PrivateKey, PublicKey } = require('../../src/CryptoTypes');
-const { KeyPair, Verifier } = require('../../src/nem/KeyPair');
-const { runBasicKeyPairTests } = require('../test/keyPairTests');
+import { PrivateKey, PublicKey } from '../../src/CryptoTypes.js';
+import { KeyPair, Verifier } from '../../src/nem/KeyPair.js';
+import { runBasicKeyPairTests } from '../test/keyPairTests.js';
 
 describe('KeyPair (NEM)', () => {
 	runBasicKeyPairTests({

--- a/sdk/javascript/test/nem/MessageEncoder_spec.js
+++ b/sdk/javascript/test/nem/MessageEncoder_spec.js
@@ -1,9 +1,9 @@
-const { PrivateKey, PublicKey } = require('../../src/CryptoTypes');
-const { KeyPair } = require('../../src/nem/KeyPair');
-const { MessageEncoder } = require('../../src/nem/MessageEncoder');
-const { MessageType, Message } = require('../../src/nem/models');
-const { runBasicMessageEncoderTests } = require('../test/messageEncoderTests');
-const { expect } = require('chai');
+import { PrivateKey, PublicKey } from '../../src/CryptoTypes.js';
+import { KeyPair } from '../../src/nem/KeyPair.js';
+import MessageEncoder from '../../src/nem/MessageEncoder.js';
+import { MessageType, Message } from '../../src/nem/models.js';
+import { runBasicMessageEncoderTests } from '../test/messageEncoderTests.js';
+import { expect } from 'chai';
 
 describe('MessageEncoder (NEM)', () => {
 	runBasicMessageEncoderTests({

--- a/sdk/javascript/test/nem/Network_spec.js
+++ b/sdk/javascript/test/nem/Network_spec.js
@@ -1,9 +1,9 @@
-const { PublicKey } = require('../../src/CryptoTypes');
-const { Address, Network, NetworkTimestamp } = require('../../src/nem/Network');
-const { hexToUint8 } = require('../../src/utils/converter');
-const { runBasicAddressTests } = require('../test/addressTests');
-const { runBasicNetworkTests } = require('../test/networkTests');
-const { expect } = require('chai');
+import { PublicKey } from '../../src/CryptoTypes.js';
+import { Address, Network, NetworkTimestamp } from '../../src/nem/Network.js';
+import { hexToUint8 } from '../../src/utils/converter.js';
+import { runBasicAddressTests } from '../test/addressTests.js';
+import { runBasicNetworkTests } from '../test/networkTests.js';
+import { expect } from 'chai';
 
 describe('NetworkTimestamp (NEM)', () => {
 	const runTestCases = (wrapInt, postfix) => {

--- a/sdk/javascript/test/nem/SharedKey_spec.js
+++ b/sdk/javascript/test/nem/SharedKey_spec.js
@@ -1,9 +1,9 @@
-const { PrivateKey } = require('../../src/CryptoTypes');
-const { NemFacade } = require('../../src/facade/NemFacade');
-const { KeyPair } = require('../../src/nem/KeyPair');
-const { deriveSharedKeyDeprecated } = require('../../src/nem/SharedKey');
-const { runBasicSharedKeyTests } = require('../test/sharedKeyTests');
-const { expect } = require('chai');
+import { PrivateKey } from '../../src/CryptoTypes.js';
+import NemFacade from '../../src/facade/NemFacade.js';
+import { KeyPair } from '../../src/nem/KeyPair.js';
+import { deriveSharedKeyDeprecated } from '../../src/nem/SharedKey.js'; // eslint-disable-line import/no-deprecated
+import runBasicSharedKeyTests from '../test/sharedKeyTests.js';
+import { expect } from 'chai';
 
 describe('SharedKey (NEM)', () => {
 	runBasicSharedKeyTests({
@@ -16,6 +16,7 @@ describe('SharedKey (NEM) (deprecated)', () => {
 	const deterministicSalt = new TextEncoder('utf-8').encode('1234567890ABCDEF1234567890ABCDEF');
 	runBasicSharedKeyTests({
 		KeyPair,
+		// eslint-disable-next-line import/no-deprecated
 		deriveSharedKey: (keyPair, publicKey) => deriveSharedKeyDeprecated(keyPair, publicKey, deterministicSalt)
 	});
 
@@ -25,8 +26,11 @@ describe('SharedKey (NEM) (deprecated)', () => {
 		const otherPublicKey = new KeyPair(PrivateKey.random()).publicKey;
 
 		// Act:
+		// eslint-disable-next-line import/no-deprecated
 		expect(() => deriveSharedKeyDeprecated(keyPair, otherPublicKey, new Uint8Array(31))).to.throw('invalid salt');
+		// eslint-disable-next-line import/no-deprecated
 		expect(() => deriveSharedKeyDeprecated(keyPair, otherPublicKey, deterministicSalt.subarray(0, 31))).to.throw('invalid salt');
+		// eslint-disable-next-line import/no-deprecated
 		expect(() => deriveSharedKeyDeprecated(keyPair, otherPublicKey, new Uint8Array(33))).to.throw('invalid salt');
 	});
 });

--- a/sdk/javascript/test/nem/TransactionFactory_spec.js
+++ b/sdk/javascript/test/nem/TransactionFactory_spec.js
@@ -1,11 +1,11 @@
-const { PublicKey, Signature } = require('../../src/CryptoTypes');
-const { Address, Network } = require('../../src/nem/Network');
-const { TransactionFactory } = require('../../src/nem/TransactionFactory');
-const nc = require('../../src/nem/models');
-const { uint8ToHex } = require('../../src/utils/converter');
-const { runBasicTransactionFactoryTests } = require('../test/basicTransactionFactoryTests');
-const { expect } = require('chai');
-const crypto = require('crypto');
+import { PublicKey, Signature } from '../../src/CryptoTypes.js';
+import { Address, Network } from '../../src/nem/Network.js';
+import TransactionFactory from '../../src/nem/TransactionFactory.js';
+import * as nc from '../../src/nem/models.js';
+import { uint8ToHex } from '../../src/utils/converter.js';
+import { runBasicTransactionFactoryTests } from '../test/basicTransactionFactoryTests.js';
+import { expect } from 'chai';
+import crypto from 'crypto';
 
 describe('transaction factory (NEM)', () => {
 	const TEST_SIGNER_PUBLIC_KEY = new PublicKey(crypto.randomBytes(PublicKey.SIZE));

--- a/sdk/javascript/test/symbol/KeyPair_spec.js
+++ b/sdk/javascript/test/symbol/KeyPair_spec.js
@@ -1,6 +1,6 @@
-const { PrivateKey, PublicKey } = require('../../src/CryptoTypes');
-const { KeyPair, Verifier } = require('../../src/symbol/KeyPair');
-const { runBasicKeyPairTests } = require('../test/keyPairTests');
+import { PrivateKey, PublicKey } from '../../src/CryptoTypes.js';
+import { KeyPair, Verifier } from '../../src/symbol/KeyPair.js';
+import { runBasicKeyPairTests } from '../test/keyPairTests.js';
 
 describe('KeyPair (Symbol)', () => {
 	runBasicKeyPairTests({

--- a/sdk/javascript/test/symbol/MessageEncoder_spec.js
+++ b/sdk/javascript/test/symbol/MessageEncoder_spec.js
@@ -1,9 +1,9 @@
-const { PrivateKey, PublicKey } = require('../../src/CryptoTypes');
-const { concatArrays } = require('../../src/impl/CipherHelpers');
-const { KeyPair } = require('../../src/symbol/KeyPair');
-const { MessageEncoder } = require('../../src/symbol/MessageEncoder');
-const { runBasicMessageEncoderTests, runMessageEncoderDecodeFailureTests } = require('../test/messageEncoderTests');
-const { expect } = require('chai');
+import { PrivateKey, PublicKey } from '../../src/CryptoTypes.js';
+import { concatArrays } from '../../src/impl/CipherHelpers.js';
+import { KeyPair } from '../../src/symbol/KeyPair.js';
+import MessageEncoder from '../../src/symbol/MessageEncoder.js';
+import { runBasicMessageEncoderTests, runMessageEncoderDecodeFailureTests } from '../test/messageEncoderTests.js';
+import { expect } from 'chai';
 
 describe('MessageEncoder (Symbol)', () => {
 	runBasicMessageEncoderTests({

--- a/sdk/javascript/test/symbol/Network_spec.js
+++ b/sdk/javascript/test/symbol/Network_spec.js
@@ -1,9 +1,9 @@
-const { Hash256, PublicKey } = require('../../src/CryptoTypes');
-const { Address, Network, NetworkTimestamp } = require('../../src/symbol/Network');
-const { hexToUint8 } = require('../../src/utils/converter');
-const { runBasicAddressTests } = require('../test/addressTests');
-const { runBasicNetworkTests } = require('../test/networkTests');
-const { expect } = require('chai');
+import { Hash256, PublicKey } from '../../src/CryptoTypes.js';
+import { Address, Network, NetworkTimestamp } from '../../src/symbol/Network.js';
+import { hexToUint8 } from '../../src/utils/converter.js';
+import { runBasicAddressTests } from '../test/addressTests.js';
+import { runBasicNetworkTests } from '../test/networkTests.js';
+import { expect } from 'chai';
 
 const MAINNET_GENERATION_HASH_SEED = new Hash256('57F7DA205008026C776CB6AED843393F04CD458E0AA2D9F1D5F31A402072B2D6');
 const TESTNET_GENERATION_HASH_SEED = new Hash256('7FCCD304802016BEBBCD342A332F91FF1F3BB5E902988B352697BE245F48E836');

--- a/sdk/javascript/test/symbol/SharedKey_spec.js
+++ b/sdk/javascript/test/symbol/SharedKey_spec.js
@@ -1,6 +1,6 @@
-const { SymbolFacade } = require('../../src/facade/SymbolFacade');
-const { KeyPair } = require('../../src/symbol/KeyPair');
-const { runBasicSharedKeyTests } = require('../test/sharedKeyTests');
+import SymbolFacade from '../../src/facade/SymbolFacade.js';
+import { KeyPair } from '../../src/symbol/KeyPair.js';
+import runBasicSharedKeyTests from '../test/sharedKeyTests.js';
 
 describe('SharedKey (Symbol)', () => {
 	runBasicSharedKeyTests({

--- a/sdk/javascript/test/symbol/TransactionFactory_spec.js
+++ b/sdk/javascript/test/symbol/TransactionFactory_spec.js
@@ -1,12 +1,12 @@
-const { Hash256, PublicKey } = require('../../src/CryptoTypes');
-const { Address, Network } = require('../../src/symbol/Network');
-const { TransactionFactory } = require('../../src/symbol/TransactionFactory');
-const { generateMosaicId, generateNamespaceId } = require('../../src/symbol/idGenerator');
-const sc = require('../../src/symbol/models');
-const { uint8ToHex } = require('../../src/utils/converter');
-const { runBasicTransactionFactoryTests } = require('../test/basicTransactionFactoryTests');
-const { expect } = require('chai');
-const crypto = require('crypto');
+import { Hash256, PublicKey } from '../../src/CryptoTypes.js';
+import { Address, Network } from '../../src/symbol/Network.js';
+import TransactionFactory from '../../src/symbol/TransactionFactory.js';
+import { generateMosaicId, generateNamespaceId } from '../../src/symbol/idGenerator.js';
+import * as sc from '../../src/symbol/models.js';
+import { uint8ToHex } from '../../src/utils/converter.js';
+import { runBasicTransactionFactoryTests } from '../test/basicTransactionFactoryTests.js';
+import { expect } from 'chai';
+import crypto from 'crypto';
 
 describe('transaction factory (Symbol)', () => {
 	const TEST_SIGNER_PUBLIC_KEY = new PublicKey(crypto.randomBytes(PublicKey.SIZE));

--- a/sdk/javascript/test/symbol/VotingKeysGenerator_spec.js
+++ b/sdk/javascript/test/symbol/VotingKeysGenerator_spec.js
@@ -1,7 +1,7 @@
-const { PrivateKey, PublicKey, Signature } = require('../../src/CryptoTypes');
-const { KeyPair, Verifier } = require('../../src/symbol/KeyPair');
-const { VotingKeysGenerator } = require('../../src/symbol/VotingKeysGenerator');
-const { expect } = require('chai');
+import { PrivateKey, PublicKey, Signature } from '../../src/CryptoTypes.js';
+import { KeyPair, Verifier } from '../../src/symbol/KeyPair.js';
+import VotingKeysGenerator from '../../src/symbol/VotingKeysGenerator.js';
+import { expect } from 'chai';
 
 describe('VotingKeysGenerator', () => {
 	it('can generate header', () => {

--- a/sdk/javascript/test/symbol/idGenerator_spec.js
+++ b/sdk/javascript/test/symbol/idGenerator_spec.js
@@ -1,9 +1,9 @@
-const { Address } = require('../../src/symbol/Network');
-const {
+import { Address } from '../../src/symbol/Network.js';
+import {
 	generateMosaicId, generateNamespaceId, generateMosaicAliasId, isValidNamespaceName, generateNamespacePath
-} = require('../../src/symbol/idGenerator');
-const { expect } = require('chai');
-const crypto = require('crypto');
+} from '../../src/symbol/idGenerator.js';
+import { expect } from 'chai';
+import crypto from 'crypto';
 
 const TEST_VECTORS = {
 	uppercase: ['CAT.token', 'CAT.TOKEN', 'cat.TOKEN', 'cAt.ToKeN', 'CaT.tOkEn'],

--- a/sdk/javascript/test/symbol/merkle_spec.js
+++ b/sdk/javascript/test/symbol/merkle_spec.js
@@ -1,10 +1,10 @@
-const { Hash256 } = require('../../src/CryptoTypes');
-const {
+import { Hash256 } from '../../src/CryptoTypes.js';
+import {
 	MerkleHashBuilder, PatriciaMerkleProofResult, deserializePatriciaTreeNodes, proveMerkle, provePatriciaMerkle
-} = require('../../src/symbol/merkle');
-const { hexToUint8 } = require('../../src/utils/converter');
-const { expect } = require('chai');
-const crypto = require('crypto');
+} from '../../src/symbol/merkle.js';
+import { hexToUint8 } from '../../src/utils/converter.js';
+import { expect } from 'chai';
+import crypto from 'crypto';
 
 describe('merkle', () => {
 	// region MerkleHashBuilder

--- a/sdk/javascript/test/symbol/metadata_spec.js
+++ b/sdk/javascript/test/symbol/metadata_spec.js
@@ -1,5 +1,5 @@
-const { metadataUpdateValue } = require('../../src/symbol/metadata');
-const { expect } = require('chai');
+import { metadataUpdateValue } from '../../src/symbol/metadata.js';
+import { expect } from 'chai';
 
 describe('metadata', () => {
 	describe('metadataUpdateValue', () => {

--- a/sdk/javascript/test/test/addressTests.js
+++ b/sdk/javascript/test/test/addressTests.js
@@ -1,6 +1,6 @@
-const { expect } = require('chai');
+import { expect } from 'chai';
 
-const runBasicAddressTests = testDescriptor => {
+export const runBasicAddressTests = testDescriptor => { // eslint-disable-line import/prefer-default-export
 	it('has correct size', () => {
 		expect(testDescriptor.Address.SIZE).to.equal(testDescriptor.decodedAddress.length);
 	});
@@ -35,5 +35,3 @@ const runBasicAddressTests = testDescriptor => {
 		expect(address.toString()).to.equal(testDescriptor.encodedAddress);
 	});
 };
-
-module.exports = { runBasicAddressTests };

--- a/sdk/javascript/test/test/basicTransactionFactoryTests.js
+++ b/sdk/javascript/test/test/basicTransactionFactoryTests.js
@@ -1,8 +1,11 @@
-const { PublicKey, Signature } = require('../../src/CryptoTypes');
-const { expect } = require('chai');
-const crypto = require('crypto');
+import { PublicKey, Signature } from '../../src/CryptoTypes.js';
+import { expect } from 'chai';
+import crypto from 'crypto';
 
-const runBasicTransactionFactoryTests = (testDescriptor, includeAttachSignatureTests = true) => {
+export const runBasicTransactionFactoryTests = ( // eslint-disable-line import/prefer-default-export
+	testDescriptor,
+	includeAttachSignatureTests = true
+) => {
 	const TEST_SIGNER_PUBLIC_KEY = new PublicKey(crypto.randomBytes(PublicKey.SIZE));
 
 	// region create
@@ -66,5 +69,3 @@ const runBasicTransactionFactoryTests = (testDescriptor, includeAttachSignatureT
 		// endregion
 	}
 };
-
-module.exports = { runBasicTransactionFactoryTests };

--- a/sdk/javascript/test/test/keyPairTests.js
+++ b/sdk/javascript/test/test/keyPairTests.js
@@ -1,9 +1,9 @@
-const { PrivateKey, PublicKey, Signature } = require('../../src/CryptoTypes');
-const { hexToUint8 } = require('../../src/utils/converter');
-const { expect } = require('chai');
-const crypto = require('crypto');
+import { PrivateKey, PublicKey, Signature } from '../../src/CryptoTypes.js';
+import { hexToUint8 } from '../../src/utils/converter.js';
+import { expect } from 'chai';
+import crypto from 'crypto';
 
-const runBasicKeyPairTests = testDescriptor => {
+export const runBasicKeyPairTests = testDescriptor => { // eslint-disable-line import/prefer-default-export
 	// region create
 
 	it('can create key pair from private key', () => {
@@ -200,5 +200,3 @@ const runBasicKeyPairTests = testDescriptor => {
 
 	// endregion
 };
-
-module.exports = { runBasicKeyPairTests };

--- a/sdk/javascript/test/test/messageEncoderTests.js
+++ b/sdk/javascript/test/test/messageEncoderTests.js
@@ -1,5 +1,5 @@
-const { PrivateKey } = require('../../src/CryptoTypes');
-const { expect } = require('chai');
+import { PrivateKey } from '../../src/CryptoTypes.js';
+import { expect } from 'chai';
 
 const runMessageEncoderDecodeSuccessTests = testDescriptor => {
 	const testSuffix = testDescriptor.name ? ` (${testDescriptor.name})` : '';
@@ -36,7 +36,7 @@ const runMessageEncoderDecodeSuccessTests = testDescriptor => {
 	});
 };
 
-const runMessageEncoderDecodeFailureTests = testDescriptor => {
+export const runMessageEncoderDecodeFailureTests = testDescriptor => {
 	const testSuffix = testDescriptor.name ? ` (${testDescriptor.name})` : '';
 
 	const runDecodeFailureTest = message => {
@@ -64,9 +64,7 @@ const runMessageEncoderDecodeFailureTests = testDescriptor => {
 	});
 };
 
-const runBasicMessageEncoderTests = testDescriptor => {
+export const runBasicMessageEncoderTests = testDescriptor => {
 	runMessageEncoderDecodeSuccessTests(testDescriptor);
 	runMessageEncoderDecodeFailureTests(testDescriptor);
 };
-
-module.exports = { runBasicMessageEncoderTests, runMessageEncoderDecodeFailureTests };

--- a/sdk/javascript/test/test/networkTests.js
+++ b/sdk/javascript/test/test/networkTests.js
@@ -1,7 +1,7 @@
-const { NetworkTimestamp } = require('../../src/NetworkTimestamp');
-const { expect } = require('chai');
+import { NetworkTimestamp } from '../../src/NetworkTimestamp.js';
+import { expect } from 'chai';
 
-const runBasicNetworkTests = testDescriptor => {
+export const runBasicNetworkTests = testDescriptor => { // eslint-disable-line import/prefer-default-export
 	const getTimeUnits = value => value * testDescriptor.timeUnitMultiplier;
 
 	// region publicKeyToAddress
@@ -156,5 +156,3 @@ const runBasicNetworkTests = testDescriptor => {
 
 	// endregion
 };
-
-module.exports = { runBasicNetworkTests };

--- a/sdk/javascript/test/test/sharedKeyTests.js
+++ b/sdk/javascript/test/test/sharedKeyTests.js
@@ -1,7 +1,7 @@
-const { PrivateKey, PublicKey } = require('../../src/CryptoTypes');
-const { expect } = require('chai');
+import { PrivateKey, PublicKey } from '../../src/CryptoTypes.js';
+import { expect } from 'chai';
 
-const runBasicSharedKeyTests = testDescriptor => {
+export default testDescriptor => {
 	// region mutual shared
 
 	const assertDerivedSharedResult = (mutate, assertion) => {
@@ -92,5 +92,3 @@ const runBasicSharedKeyTests = testDescriptor => {
 
 	// endregion
 };
-
-module.exports = { runBasicSharedKeyTests };

--- a/sdk/javascript/test/utils/BufferView_spec.js
+++ b/sdk/javascript/test/utils/BufferView_spec.js
@@ -1,5 +1,5 @@
-const { BufferView } = require('../../src/utils/BufferView');
-const { expect } = require('chai');
+import BufferView from '../../src/utils/BufferView.js';
+import { expect } from 'chai';
 
 describe('BufferView', () => {
 	// region constructor

--- a/sdk/javascript/test/utils/Writer_spec.js
+++ b/sdk/javascript/test/utils/Writer_spec.js
@@ -1,5 +1,5 @@
-const { Writer } = require('../../src/utils/Writer');
-const { expect } = require('chai');
+import Writer from '../../src/utils/Writer.js';
+import { expect } from 'chai';
 
 describe('Writer', () => {
 	describe('can consturct', () => {

--- a/sdk/javascript/test/utils/arrayHelpers_spec.js
+++ b/sdk/javascript/test/utils/arrayHelpers_spec.js
@@ -1,5 +1,5 @@
-const arrayHelpers = require('../../src/utils/arrayHelpers');
-const { expect } = require('chai');
+import * as arrayHelpers from '../../src/utils/arrayHelpers.js';
+import { expect } from 'chai';
 
 describe('arrayHelpers', () => {
 	// region helpers

--- a/sdk/javascript/test/utils/base32_spec.js
+++ b/sdk/javascript/test/utils/base32_spec.js
@@ -1,6 +1,6 @@
-const base32 = require('../../src/utils/base32');
-const convert = require('../../src/utils/converter');
-const { expect } = require('chai');
+import base32 from '../../src/utils/base32.js';
+import { hexToUint8, uint8ToHex } from '../../src/utils/converter.js';
+import { expect } from 'chai';
 
 describe('base32', () => {
 	const testVectors = [
@@ -23,7 +23,7 @@ describe('base32', () => {
 		it('can convert test vectors', () => {
 			// Arrange:
 			testVectors.forEach(sample => {
-				const input = convert.hexToUint8(sample.decoded);
+				const input = hexToUint8(sample.decoded);
 
 				// Act:
 				const encoded = base32.encode(input);
@@ -75,7 +75,7 @@ describe('base32', () => {
 			const decoded = base32.decode('');
 
 			// Assert:
-			expect(convert.uint8ToHex(decoded)).to.equal('');
+			expect(uint8ToHex(decoded)).to.equal('');
 		});
 
 		it('can convert test vectors', () => {
@@ -85,7 +85,7 @@ describe('base32', () => {
 				const decoded = base32.decode(sample.encoded);
 
 				// Assert:
-				expect(convert.uint8ToHex(decoded), `input ${sample.encoded}`).to.equal(sample.decoded);
+				expect(uint8ToHex(decoded), `input ${sample.encoded}`).to.equal(sample.decoded);
 			});
 		});
 
@@ -94,7 +94,7 @@ describe('base32', () => {
 			const decoded = base32.decode('ABCDEFGHIJKLMNOPQRSTUVWXYZ234567');
 
 			// Assert:
-			expect(convert.uint8ToHex(decoded)).to.equal('00443214C74254B635CF84653A56D7C675BE77DF');
+			expect(uint8ToHex(decoded)).to.equal('00443214C74254B635CF84653A56D7C675BE77DF');
 		});
 
 		it('throws if input size is not a multiple of block size', () => {
@@ -141,11 +141,11 @@ describe('base32', () => {
 			const inputs = ['8A4E7DF5B61CC0F97ED572A95F6ACA', '2D96E4ABB65F0AD3C29FEA48C132CE'];
 			inputs.forEach(input => {
 				// Act:
-				const encoded = base32.encode(convert.hexToUint8(input));
+				const encoded = base32.encode(hexToUint8(input));
 				const result = base32.decode(encoded);
 
 				// Assert:
-				expect(convert.uint8ToHex(result), `input ${input}`).to.equal(input);
+				expect(uint8ToHex(result), `input ${input}`).to.equal(input);
 			});
 		});
 	});

--- a/sdk/javascript/test/utils/charMapping_spec.js
+++ b/sdk/javascript/test/utils/charMapping_spec.js
@@ -1,5 +1,5 @@
-const charMapping = require('../../src/utils/charMapping');
-const { expect } = require('chai');
+import charMapping from '../../src/utils/charMapping.js';
+import { expect } from 'chai';
 
 describe('char mapping', () => {
 	describe('builder', () => {

--- a/sdk/javascript/test/utils/converter_spec.js
+++ b/sdk/javascript/test/utils/converter_spec.js
@@ -1,5 +1,5 @@
-const converter = require('../../src/utils/converter');
-const { expect } = require('chai');
+import * as converter from '../../src/utils/converter.js';
+import { expect } from 'chai';
 
 describe('converter', () => {
 	describe('toByte', () => {

--- a/sdk/javascript/test/utils/transforms_spec.js
+++ b/sdk/javascript/test/utils/transforms_spec.js
@@ -1,6 +1,6 @@
-const { hexToUint8 } = require('../../src/utils/converter');
-const { ripemdKeccak256 } = require('../../src/utils/transforms');
-const { expect } = require('chai');
+import { hexToUint8 } from '../../src/utils/converter.js';
+import { ripemdKeccak256 } from '../../src/utils/transforms.js';
+import { expect } from 'chai';
 
 describe('transforms', () => {
 	it('can transform with ripemd keccak 256', () => {

--- a/sdk/javascript/vectors/all.js
+++ b/sdk/javascript/vectors/all.js
@@ -1,16 +1,20 @@
-const { Bip32 } = require('../src/Bip32');
-const { AesCbcCipher, AesGcmCipher } = require('../src/Cipher');
-const {
+import Bip32 from '../src/Bip32.js';
+import { AesCbcCipher, AesGcmCipher } from '../src/Cipher.js';
+import {
 	PrivateKey, PublicKey, SharedKey256, Signature
-} = require('../src/CryptoTypes');
-const { NetworkLocator } = require('../src/Network');
-const { deriveSharedKeyDeprecated } = require('../src/nem/SharedKey');
-const { VotingKeysGenerator } = require('../src/symbol/VotingKeysGenerator');
-const { generateMosaicId } = require('../src/symbol/idGenerator');
-const { hexToUint8 } = require('../src/utils/converter');
-const yargs = require('yargs');
-const fs = require('fs');
-const path = require('path');
+} from '../src/CryptoTypes.js';
+import { NetworkLocator } from '../src/Network.js';
+import NemFacade from '../src/facade/NemFacade.js';
+import SymbolFacade from '../src/facade/SymbolFacade.js';
+import { Network as NemNetwork } from '../src/nem/Network.js';
+import { deriveSharedKeyDeprecated } from '../src/nem/SharedKey.js'; // eslint-disable-line import/no-deprecated
+import { Network as SymbolNetwork } from '../src/symbol/Network.js';
+import VotingKeysGenerator from '../src/symbol/VotingKeysGenerator.js';
+import { generateMosaicId } from '../src/symbol/idGenerator.js';
+import { hexToUint8 } from '../src/utils/converter.js';
+import yargs from 'yargs';
+import fs from 'fs';
+import path from 'path';
 
 (() => {
 	// region VectorsTestSuite, KeyConversionTester, AddressConversionTester
@@ -134,7 +138,7 @@ const path = require('path');
 			const salt = hexToUint8(testVector.salt);
 
 			// Act:
-			const sharedKey = deriveSharedKeyDeprecated(keyPair, otherPublicKey, salt);
+			const sharedKey = deriveSharedKeyDeprecated(keyPair, otherPublicKey, salt); // eslint-disable-line import/no-deprecated
 
 			// Assert:
 			return [[new SharedKey256(testVector.sharedKey), sharedKey]];
@@ -171,7 +175,7 @@ const path = require('path');
 			const otherPublicKey = new PublicKey(testVector.otherPublicKey);
 			const keyPair = new this.classLocator.Facade.KeyPair(new PrivateKey(testVector.privateKey));
 			const salt = hexToUint8(testVector.salt);
-			const sharedKey = deriveSharedKeyDeprecated(keyPair, otherPublicKey, salt);
+			const sharedKey = deriveSharedKeyDeprecated(keyPair, otherPublicKey, salt); // eslint-disable-line import/no-deprecated
 
 			const iv = hexToUint8(testVector.iv);
 			const cipherText = hexToUint8(testVector.cipherText);
@@ -384,17 +388,9 @@ const path = require('path');
 
 	// endregion
 
-	const loadClassLocator = blockchain => {
-		if ('symbol' === blockchain) {
-			const { SymbolFacade } = require('../src/facade/SymbolFacade'); // eslint-disable-line global-require
-			const { Network } = require('../src/symbol/Network'); // eslint-disable-line global-require
-			return { Facade: SymbolFacade, Network };
-		}
-
-		const { NemFacade } = require('../src/facade/NemFacade'); // eslint-disable-line global-require
-		const { Network } = require('../src/nem/Network'); // eslint-disable-line global-require
-		return { Facade: NemFacade, Network };
-	};
+	const loadClassLocator = blockchain => ('symbol' === blockchain
+		? { Facade: SymbolFacade, Network: SymbolNetwork }
+		: { Facade: NemFacade, Network: NemNetwork });
 
 	const loadTestSuites = blockchain => {
 		const classLocator = loadClassLocator(blockchain);

--- a/sdk/javascript/vectors/catbuffer.js
+++ b/sdk/javascript/vectors/catbuffer.js
@@ -1,12 +1,14 @@
-const { NemFacade } = require('../src/facade/NemFacade');
-const { SymbolFacade } = require('../src/facade/SymbolFacade');
-const nc = require('../src/nem/models');
-const sc = require('../src/symbol/models');
-const converter = require('../src/utils/converter');
-const { expect } = require('chai');
-const JSONBigInt = require('json-bigint')({ alwaysParseAsBig: true, useNativeBigInt: true });
-const fs = require('fs');
-const path = require('path');
+import NemFacade from '../src/facade/NemFacade.js';
+import SymbolFacade from '../src/facade/SymbolFacade.js';
+import * as nc from '../src/nem/models.js';
+import * as sc from '../src/symbol/models.js';
+import * as converter from '../src/utils/converter.js';
+import { expect } from 'chai';
+import JSONBigIntLib from 'json-bigint';
+import fs from 'fs';
+import path from 'path';
+
+const JSONBigInt = JSONBigIntLib({ alwaysParseAsBig: true, useNativeBigInt: true });
 
 describe('catbuffer vectors', () => {
 	// region common test utils


### PR DESCRIPTION
we want to cross compile sdk for node and browser. this will be simpler with ES6 modules in node. 

currently, we've been using CommonJS  imports, which is node's default.