### PR TITLE
[sdk/python]: add repr to BasicArray derived types

### DIFF
--- a/sdk/python/symbolchain/CryptoTypes.py
+++ b/sdk/python/symbolchain/CryptoTypes.py
@@ -12,6 +12,9 @@ class Hash256(ByteArray):
 		"""Creates a hash from bytes or a hex string."""
 		super().__init__(self.SIZE, hash256, Hash256)
 
+	def __repr__(self):
+		return f'Hash256(\'{str(self)}\')'
+
 	@staticmethod
 	def zero():
 		"""Creates a zeroed hash."""
@@ -26,6 +29,9 @@ class PrivateKey(ByteArray):
 	def __init__(self, private_key):
 		"""Creates a private key from bytes or a hex string."""
 		super().__init__(self.SIZE, private_key, PrivateKey)
+
+	def __repr__(self):
+		return f'PrivateKey(\'{str(self)}\')'
 
 	@staticmethod
 	def random():
@@ -42,6 +48,9 @@ class PublicKey(ByteArray):
 		"""Creates a public key from bytes or a hex string."""
 		super().__init__(self.SIZE, public_key.bytes if isinstance(public_key, PublicKey) else public_key, PublicKey)
 
+	def __repr__(self):
+		return f'PublicKey(\'{str(self)}\')'
+
 
 class SharedKey256(ByteArray):
 	"""Represents 256-bit symmetric encryption key."""
@@ -52,6 +61,9 @@ class SharedKey256(ByteArray):
 		"""Creates a key from bytes or a hex string."""
 		super().__init__(self.SIZE, key, SharedKey256)
 
+	def __repr__(self):
+		return f'SharedKey256(\'{str(self)}\')'
+
 
 class Signature(ByteArray):
 	"""Represents a signature."""
@@ -61,6 +73,9 @@ class Signature(ByteArray):
 	def __init__(self, signature):
 		"""Creates a signature from bytes or a hex string."""
 		super().__init__(self.SIZE, signature, Signature)
+
+	def __repr__(self):
+		return f'Signature(\'{str(self)}\')'
 
 	@staticmethod
 	def zero():

--- a/sdk/python/symbolchain/nem/Network.py
+++ b/sdk/python/symbolchain/nem/Network.py
@@ -35,6 +35,9 @@ class Address(ByteArray):
 	def __str__(self):
 		return base64.b32encode(self.bytes).decode('utf8')
 
+	def __repr__(self):
+		return f'Address(\'{str(self)}\')'
+
 
 class Network(BasicNetwork):
 	"""Represents a nem network."""

--- a/sdk/python/symbolchain/symbol/Network.py
+++ b/sdk/python/symbolchain/symbol/Network.py
@@ -40,6 +40,9 @@ class Address(ByteArray):
 	def __str__(self):
 		return base64.b32encode(self.bytes + bytes(0)).decode('utf8')[0:-1]
 
+	def __repr__(self):
+		return f'Address(\'{str(self)}\')'
+
 
 class Network(BasicNetwork):
 	"""Represents a Symbol network."""

--- a/sdk/python/tests/test/BasicAddressTest.py
+++ b/sdk/python/tests/test/BasicAddressTest.py
@@ -52,6 +52,19 @@ class BasicAddressTest:
 		self.assertEqual(test_descriptor.decoded_address, address.bytes)
 		self.assertEqual(test_descriptor.encoded_address, str(address))
 
+	def test_repr_is_supported(self):
+		# Arrange:
+		test_descriptor = self.get_test_descriptor()
+		address = test_descriptor.address_class(test_descriptor.decoded_address)
+
+		# Act:
+		address_repr = repr(address)
+		address_2 = eval(address_repr, {'Address': test_descriptor.address_class})  # pylint: disable=eval-used
+
+		# Assert:
+		self.assertEqual(f'Address(\'{str(address)}\')', address_repr)
+		self.assertEqual(address, address_2)
+
 	@abstractmethod
 	def get_test_descriptor(self):
 		pass

--- a/sdk/python/tests/test_CryptoTypes.py
+++ b/sdk/python/tests/test_CryptoTypes.py
@@ -14,6 +14,9 @@ class CryptoTypesTest(unittest.TestCase):
 	def test_cannot_create_hash256_with_incorrect_number_of_bytes(self):
 		self._assert_cannot_create_byte_array_with_incorrect_number_of_bytes(Hash256, 32)
 
+	def test_hash256_supports_repr(self):
+		self._assert_repr_is_supported(Hash256, 32)
+
 	def test_can_create_zeroed_hash256(self):
 		self._assert_can_create_zeroed_byte_array(Hash256, 32)
 
@@ -26,6 +29,9 @@ class CryptoTypesTest(unittest.TestCase):
 
 	def test_cannot_create_private_key_with_incorrect_number_of_bytes(self):
 		self._assert_cannot_create_byte_array_with_incorrect_number_of_bytes(PrivateKey, 32)
+
+	def test_private_key_supports_repr(self):
+		self._assert_repr_is_supported(PrivateKey, 32)
 
 	def test_can_create_random_private_key(self):
 		# Act:
@@ -44,6 +50,9 @@ class CryptoTypesTest(unittest.TestCase):
 
 	def test_cannot_create_public_key_with_incorrect_number_of_bytes(self):
 		self._assert_cannot_create_byte_array_with_incorrect_number_of_bytes(PublicKey, 32)
+
+	def test_public_key_supports_repr(self):
+		self._assert_repr_is_supported(PublicKey, 32)
 
 	def test_can_create_public_key_from_existing_public_key(self):
 		# Arrange:
@@ -65,6 +74,9 @@ class CryptoTypesTest(unittest.TestCase):
 	def test_cannot_create_shared_key_with_incorrect_number_of_bytes(self):
 		self._assert_cannot_create_byte_array_with_incorrect_number_of_bytes(SharedKey256, 32)
 
+	def test_shared_key_supports_repr(self):
+		self._assert_repr_is_supported(SharedKey256, 32)
+
 	# endregion
 
 	# region Signature
@@ -74,6 +86,9 @@ class CryptoTypesTest(unittest.TestCase):
 
 	def test_cannot_create_signature_with_incorrect_number_of_bytes(self):
 		self._assert_cannot_create_byte_array_with_incorrect_number_of_bytes(Signature, 64)
+
+	def test_signature_supports_repr(self):
+		self._assert_repr_is_supported(Signature, 64)
 
 	def test_can_create_zeroed_signature(self):
 		self._assert_can_create_zeroed_byte_array(Signature, 64)
@@ -111,6 +126,19 @@ class CryptoTypesTest(unittest.TestCase):
 		for size in [0, required_size - 1, required_size + 1]:
 			with self.assertRaises(ValueError):
 				byte_array_class(TestUtils.randbytes(size))
+
+	def _assert_repr_is_supported(self, byte_array_class, size):
+		# Arrange:
+		raw_bytes = TestUtils.randbytes(size)
+		byte_array = byte_array_class(raw_bytes)
+
+		# Act:
+		byte_array_repr = repr(byte_array)
+		byte_array_2 = eval(byte_array_repr)  # pylint: disable=eval-used
+
+		# Assert:
+		self.assertEqual(f'{byte_array_class.__name__}(\'{str(byte_array)}\')', byte_array_repr)
+		self.assertEqual(byte_array, byte_array_2)
 
 	def _assert_can_create_zeroed_byte_array(self, byte_array_class, size):
 		# Act:


### PR DESCRIPTION
 problem: types that can be roundtripped should support repr
solution: add repr to these types