### PR TITLE
[jenkins] fix: catapult client private build tag name

### DIFF
--- a/jenkins/catapult/jenkins/catapult-client-release-build.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-release-build.groovy
@@ -171,7 +171,7 @@ String resolveImageLabel() {
 
 	friendlyBranchName = friendlyBranchName.replaceAll('/', '-')
 	architecture = resolveArchitectureLabel()
-	gitHash = "${env.GIT_COMMIT}".substring(8)
+	git_hash = "${env.GIT_COMMIT}".substring(0, 8)
 	return "${COMPILER_CONFIGURATION}-${friendlyBranchName}${architecture}-${gitHash}"
 }
 

--- a/jenkins/catapult/jenkins/catapult-client-release-build.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-release-build.groovy
@@ -171,7 +171,7 @@ String resolveImageLabel() {
 
 	friendlyBranchName = friendlyBranchName.replaceAll('/', '-')
 	architecture = resolveArchitectureLabel()
-	git_hash = "${env.GIT_COMMIT}".substring(0, 8)
+	gitHash = "${env.GIT_COMMIT}".substring(0, 8)
 	return "${COMPILER_CONFIGURATION}-${friendlyBranchName}${architecture}-${gitHash}"
 }
 


### PR DESCRIPTION
## What's the issue?
private build of the catapult client tag has invalid git hash
This is a regression in https://github.com/symbol/symbol/commit/69b0753aaa7c8e8370794cc056760f4d4233bd0e

## How have you changed the behavior?
change the tag name to use the first 8 chars of the git hash

## How was this change tested?
Ran the jenkins build