### PR TITLE
[catapult/client]: upgrade openssl from 1.1.1x to 3.0.x

### DIFF
--- a/client/catapult/CMakeGlobalSettings.cmake
+++ b/client/catapult/CMakeGlobalSettings.cmake
@@ -123,11 +123,6 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 	# -Wstrict-aliasing=1 perform most paranoid strict aliasing checks
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wformat-security -Werror -Wstrict-aliasing=1")
 
-	# disable warning as error for gcc 12 until 12.2 is release
-	if("${CMAKE_CXX_COMPILER_VERSION}" MATCHES "^12.")
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=stringop-overread -Wno-error=array-bounds")
-	endif()
-
 	# - Wno-maybe-uninitialized: false positives where gcc isn't sure if an uninitialized variable is used or not
 	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -Wno-maybe-uninitialized -g1 -fno-omit-frame-pointer")
 	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wno-maybe-uninitialized")

--- a/client/catapult/CMakeLists.txt
+++ b/client/catapult/CMakeLists.txt
@@ -51,7 +51,7 @@ endif()
 ### setup openssl
 message("--- locating openssl dependencies ---")
 
-find_package(OpenSSL 1.1.1 EXACT REQUIRED)
+find_package(OpenSSL 3.0.7 EXACT REQUIRED)
 message("OpenSSL   ver: ${OPENSSL_VERSION}")
 message("OpenSSL  root: ${OPENSSL_ROOT_DIR}")
 message("OpenSSL   inc: ${OPENSSL_INCLUDE_DIR}")

--- a/client/catapult/conanfile.txt
+++ b/client/catapult/conanfile.txt
@@ -72,9 +72,9 @@ gtest:build_gmock = False
 gtest:no_main = True
 
 [imports]
-# on windows, copy shared libraries into bin directory
-bin, *.dll -> ./bin
-lib, *.dll -> ./bin
+# on windows, copy shared libraries into deps directory
+bin, *.dll -> ./deps
+lib, *.dll -> ./deps
 
 # on macos, copy shared libraries into deps directory
 lib, *.dylib* -> ./deps

--- a/client/catapult/conanfile.txt
+++ b/client/catapult/conanfile.txt
@@ -1,9 +1,10 @@
 [requires]
 # release dependencies
 boost/1.80.0
+openssl/3.0.7
+
 cppzmq/4.8.1@nemtech/stable
 mongo-cxx-driver/3.6.7@nemtech/stable
-openssl/1.1.1q@nemtech/stable
 rocksdb/7.4.3@nemtech/stable
 
 # test dependencies
@@ -53,9 +54,14 @@ boost:without_timer = True
 boost:without_type_erasure = True
 boost:without_wave = True
 
+# release dependencies - openssl
+openssl:shared = True
+openssl:no_zlib = True
+openssl:no_legacy = False
+openssl:no_module = True
+
 # release dependencies - other
 mongo-cxx-driver:shared = True
-openssl:shared = True
 rocksdb:shared = True
 zeromq:shared = True
 

--- a/client/catapult/plugins/txes/restriction_mosaic/tests/state/RestrictionValueMapTests.cpp
+++ b/client/catapult/plugins/txes/restriction_mosaic/tests/state/RestrictionValueMapTests.cpp
@@ -142,14 +142,17 @@ namespace catapult { namespace state {
 	TEST(TEST_CLASS, CanRemoveValueNotInMap) {
 		// Arrange:
 		RestrictionValueMap<uint64_t> map;
+		map.set(111, 444);
+		map.set(321, 987);
 
 		// Act:
-		map.remove(111);
+		map.remove(222);
 
 		// Assert:
-		EXPECT_EQ(0u, map.size());
-		AssertCannotGetValue(map, 111);
-		EXPECT_EQ(std::set<uint64_t>(), map.keys());
+		EXPECT_EQ(2u, map.size());
+		AssertCanGetValue(map, 111, 444);
+		AssertCanGetValue(map, 321, 987);
+		EXPECT_EQ(std::set<uint64_t>({ 111, 321 }), map.keys());
 	}
 
 	TEST(TEST_CLASS, CanRemoveSingleValue) {

--- a/client/catapult/src/catapult/crypto/OpensslInit.cpp
+++ b/client/catapult/src/catapult/crypto/OpensslInit.cpp
@@ -1,0 +1,46 @@
+/**
+*** Copyright (c) 2016-2019, Jaguar0625, gimre, BloodyRookie, Tech Bureau, Corp.
+*** Copyright (c) 2020-present, Jaguar0625, gimre, BloodyRookie.
+*** All rights reserved.
+***
+*** This file is part of Catapult.
+***
+*** Catapult is free software: you can redistribute it and/or modify
+*** it under the terms of the GNU Lesser General Public License as published by
+*** the Free Software Foundation, either version 3 of the License, or
+*** (at your option) any later version.
+***
+*** Catapult is distributed in the hope that it will be useful,
+*** but WITHOUT ANY WARRANTY; without even the implied warranty of
+*** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*** GNU Lesser General Public License for more details.
+***
+*** You should have received a copy of the GNU Lesser General Public License
+*** along with Catapult. If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#include "OpensslInit.h"
+#include "catapult/exceptions.h"
+#include <openssl/provider.h>
+
+namespace catapult { namespace crypto {
+
+	namespace {
+		struct OpensslContext {
+			std::shared_ptr<OSSL_PROVIDER> pDefaultProvider;
+			std::shared_ptr<OSSL_PROVIDER> pLegacyProvider;
+		};
+	}
+
+	std::shared_ptr<void> SetupOpensslCryptoFunctions() {
+		auto pContext = std::make_shared<OpensslContext>();
+
+		pContext->pDefaultProvider.reset(OSSL_PROVIDER_load(nullptr, "default"), OSSL_PROVIDER_unload);
+		pContext->pLegacyProvider.reset(OSSL_PROVIDER_load(nullptr, "legacy"), OSSL_PROVIDER_unload);
+
+		if (!pContext->pDefaultProvider || !pContext->pLegacyProvider)
+			CATAPULT_THROW_RUNTIME_ERROR("unable to load required OpenSSL crypto providers");
+
+		return pContext;
+	}
+}}

--- a/client/catapult/src/catapult/crypto/OpensslInit.h
+++ b/client/catapult/src/catapult/crypto/OpensslInit.h
@@ -1,0 +1,29 @@
+/**
+*** Copyright (c) 2016-2019, Jaguar0625, gimre, BloodyRookie, Tech Bureau, Corp.
+*** Copyright (c) 2020-present, Jaguar0625, gimre, BloodyRookie.
+*** All rights reserved.
+***
+*** This file is part of Catapult.
+***
+*** Catapult is free software: you can redistribute it and/or modify
+*** it under the terms of the GNU Lesser General Public License as published by
+*** the Free Software Foundation, either version 3 of the License, or
+*** (at your option) any later version.
+***
+*** Catapult is distributed in the hope that it will be useful,
+*** but WITHOUT ANY WARRANTY; without even the implied warranty of
+*** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*** GNU Lesser General Public License for more details.
+***
+*** You should have received a copy of the GNU Lesser General Public License
+*** along with Catapult. If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#pragma once
+#include <memory>
+
+namespace catapult { namespace crypto {
+
+	/// Configures the openssl crypto functions and returns an openssl global context.
+	std::shared_ptr<void> SetupOpensslCryptoFunctions();
+}}

--- a/client/catapult/src/catapult/ionet/PacketSocket.cpp
+++ b/client/catapult/src/catapult/ionet/PacketSocket.cpp
@@ -142,8 +142,16 @@ namespace catapult { namespace ionet {
 			}
 
 		private:
+			static int OpensslErrorGetReason(unsigned long errcode) {
+				if (ERR_SYSTEM_ERROR(errcode))
+					return errcode & ERR_SYSTEM_MASK;
+
+				return errcode & ERR_REASON_MASK;
+			}
+
 			static bool IsProtocolShutdown(const boost::system::error_code& ec) {
-				return boost::asio::error::get_ssl_category() == ec.category() && SSL_R_PROTOCOL_IS_SHUTDOWN == ERR_GET_REASON(ec.value());
+				return boost::asio::error::get_ssl_category() == ec.category()
+						&& SSL_R_PROTOCOL_IS_SHUTDOWN == OpensslErrorGetReason(static_cast<unsigned long>(ec.value()));
 			}
 
 		private:

--- a/client/catapult/src/catapult/model/EntityRange.h
+++ b/client/catapult/src/catapult/model/EntityRange.h
@@ -392,6 +392,9 @@ namespace catapult { namespace model {
 
 		/// Creates an entity range around \a numElements fixed size elements pointed to by \a pData.
 		static Range CopyFixed(const uint8_t* pData, size_t numElements) {
+			if (0 == numElements)
+				return Range();
+
 			uint8_t* pRangeData;
 			auto range = PrepareFixed(numElements, &pRangeData);
 			utils::memcpy_cond(pRangeData, pData, range.totalSize());

--- a/client/catapult/src/catapult/process/ProcessMain.cpp
+++ b/client/catapult/src/catapult/process/ProcessMain.cpp
@@ -25,6 +25,7 @@
 #include "catapult/config/CatapultConfiguration.h"
 #include "catapult/config/CatapultKeys.h"
 #include "catapult/config/ValidateConfiguration.h"
+#include "catapult/crypto/OpensslInit.h"
 #include "catapult/crypto/OpensslMemory.h"
 #include "catapult/io/FileLock.h"
 #include "catapult/thread/ThreadInfo.h"
@@ -119,16 +120,18 @@ namespace catapult { namespace process {
 		thread::SetThreadName(host + " catapult");
 		version::WriteVersionInformation(std::cout);
 
+		// 1. setup OpenSSL
+		auto pOpensslContext = crypto::SetupOpensslCryptoFunctions();
 		crypto::SetupOpensslMemoryFunctions();
 
-		// 1. load and validate the configuration
+		// 2. load and validate the configuration
 		auto config = LoadConfiguration(argc, argv, host);
 		ValidateConfiguration(config);
 
-		// 2. initialize logging
+		// 3. initialize logging
 		auto pLoggingGuard = SetupLogging(host, config.Logging);
 
-		// 3. check instance
+		// 4. check instance
 		std::filesystem::path lockFilePath = config.User.DataDirectory;
 		lockFilePath /= host + ".lock";
 		io::FileLock instanceLock(lockFilePath.generic_string());
@@ -137,10 +140,10 @@ namespace catapult { namespace process {
 			return -3;
 		}
 
-		// 4. platform specific settings
+		// 5. platform specific settings
 		PlatformSettings();
 
-		// 5. run the server
+		// 6. run the server
 		Run(std::move(config), processOptions, createProcessHost);
 		return 0;
 	}

--- a/client/catapult/tests/catapult/model/TransactionTests.cpp
+++ b/client/catapult/tests/catapult/model/TransactionTests.cpp
@@ -118,7 +118,17 @@ namespace catapult { namespace model {
 		// Arrange:
 		std::vector<uint8_t> buffer(sizeof(SizePrefixedEntity));
 		auto* pTransaction = reinterpret_cast<Transaction*>(&buffer[0]);
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds" // Transaction[0] is partly outside array bounds
+#endif
+
 		pTransaction->Size = sizeof(SizePrefixedEntity);
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 		// Act:
 		EXPECT_FALSE(IsSizeValid(*pTransaction));

--- a/client/catapult/tests/catapult/model/VerifiableEntityTests.cpp
+++ b/client/catapult/tests/catapult/model/VerifiableEntityTests.cpp
@@ -165,7 +165,17 @@ namespace catapult { namespace model {
 		// Arrange:
 		std::vector<uint8_t> buffer(sizeof(SizePrefixedEntity));
 		auto* pEntity = reinterpret_cast<VerifiableEntity*>(&buffer[0]);
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds" // VerifiableEntity[0] is partly outside array bounds
+#endif
+
 		pEntity->Size = sizeof(SizePrefixedEntity);
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 		// Act:
 		EXPECT_FALSE(IsSizeValid(*pEntity));

--- a/client/catapult/tests/test/nodeps/CMakeLists.txt
+++ b/client/catapult/tests/test/nodeps/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required(VERSION 3.14)
 
 catapult_library_target(tests.catapult.test.nodeps)
-target_link_libraries(tests.catapult.test.nodeps catapult.utils catapult.version ${GTEST_LIBRARIES} ${CMAKE_DL_LIBS})
+target_link_libraries(tests.catapult.test.nodeps catapult.crypto catapult.utils catapult.version ${GTEST_LIBRARIES} ${CMAKE_DL_LIBS})

--- a/client/catapult/tests/test/nodeps/TestMain.cpp
+++ b/client/catapult/tests/test/nodeps/TestMain.cpp
@@ -19,6 +19,7 @@
 *** along with Catapult. If not, see <http://www.gnu.org/licenses/>.
 **/
 
+#include "catapult/crypto/OpensslInit.h"
 #include "catapult/utils/ConfigurationValueParsers.h"
 #include "catapult/utils/Logging.h"
 #include "catapult/version/version.h"
@@ -97,6 +98,9 @@ int main(int argc, char** argv) {
 
 	std::cout << "Initializing and Running Tests..." << std::endl;
 	::testing::InitGoogleTest(&argc, argv);
+
+	std::cout << "Initializing OpenSSL crypto functions" << std::endl;
+	auto pOpensslContext = catapult::crypto::SetupOpensslCryptoFunctions();
 
 #ifdef CATAPULT_DOCKER_TESTS
 	global_argc = argc;

--- a/client/catapult/tools/tools/ToolMain.cpp
+++ b/client/catapult/tools/tools/ToolMain.cpp
@@ -22,6 +22,7 @@
 #include "ToolMain.h"
 #include "catapult/config/ConfigurationFileLoader.h"
 #include "catapult/config/LoggingConfiguration.h"
+#include "catapult/crypto/OpensslInit.h"
 #include "catapult/thread/ThreadInfo.h"
 #include "catapult/utils/ExceptionLogging.h"
 #include "catapult/version/version.h"
@@ -194,7 +195,11 @@ namespace catapult { namespace tools {
 		auto pLoggingGuard = catapult::tools::SetupLogging(LoadLoggingConfiguration(options.LoggingConfigurationPath));
 		std::cout << std::endl;
 
-		// 5. run the tool
+		// 5. initialize OpenSSL
+		std::cout << "Initializing OpenSSL crypto functions" << std::endl;
+		auto pOpensslContext = crypto::SetupOpensslCryptoFunctions();
+
+		// 6. run the tool
 		return tool.run(options.ToolOptions);
 	}
 }}

--- a/jenkins/catapult/baseImageDockerfileGenerator.py
+++ b/jenkins/catapult/baseImageDockerfileGenerator.py
@@ -135,11 +135,13 @@ class OptionsManager:
 
 	def mongo_c(self):
 		descriptor = self.OptionsDescriptor()
+		descriptor.options += ['-DOPENSSL_ROOT_DIR=/usr/catapult/deps']
 		descriptor.options += get_dependency_flags('mongodb_mongo-c-driver')
 		return self._cmake(descriptor)
 
 	def mongo_cxx(self):
 		descriptor = self.OptionsDescriptor()
+		descriptor.options += ['-DOPENSSL_ROOT_DIR=/usr/catapult/deps']
 		descriptor.options += get_dependency_flags('mongodb_mongo-cxx-driver')
 
 		if self.is_msvc:
@@ -413,15 +415,21 @@ class LinuxSystemGenerator:
 	def add_openssl(options, configure):
 		version = options.versions['openssl_openssl']
 		compiler = 'linux-x86_64-clang' if options.is_clang else 'linux-x86_64'
+		destination = ['--prefix=/usr/catapult/deps', '--openssldir=/usr/catapult/deps', '--libdir=/usr/catapult/deps']
 		print_line([
 			'RUN git clone https://github.com/openssl/openssl.git -b {VERSION}',
 			'cd openssl',
-			'{OPEN_SSL_OPTIONS} perl ./Configure {COMPILER} {OPEN_SSL_CONFIGURE} --prefix=/usr/local --openssldir=/usr/local',
+			'{OPEN_SSL_OPTIONS} perl ./Configure {COMPILER} {OPEN_SSL_CONFIGURE} {OPEN_SSL_DESTINATION}',
 			'make -j 8',
 			'make install',
 			'cd ..',
 			'rm -rf openssl'
-		], OPEN_SSL_OPTIONS=' '.join(options.openssl()), OPEN_SSL_CONFIGURE=' '.join(configure), VERSION=version, COMPILER=compiler)
+		],
+			OPEN_SSL_OPTIONS=' '.join(options.openssl()),
+			OPEN_SSL_CONFIGURE=' '.join(configure),
+			OPEN_SSL_DESTINATION=' '.join(destination),
+			VERSION=version,
+			COMPILER=compiler)
 
 	def generate_phase_deps(self):
 		print(f'FROM {self.options.layer_image_name("boost")}')

--- a/jenkins/catapult/environment.py
+++ b/jenkins/catapult/environment.py
@@ -29,6 +29,14 @@ class EnvironmentManager:
 
 		raise RuntimeError('unable to detect system bin path')
 
+	def get_env_var(self, key):
+		self._print_command('get_env_var', [key])
+
+		if self.dry_run:
+			return
+
+		return os.environ[key]
+
 	def set_env_var(self, key, value):
 		self._print_command('set_env_var', [key, value])
 

--- a/jenkins/catapult/environment.py
+++ b/jenkins/catapult/environment.py
@@ -29,18 +29,6 @@ class EnvironmentManager:
 
 		raise RuntimeError('unable to detect system bin path')
 
-	@property
-	def local_lib_path(self):
-		if self.dry_run:
-			return '<LOCAL_LIB_PATH>'
-
-		for descriptor in [('fedora', '/usr/local/lib64'), ('ubuntu', '/usr/local/lib')]:
-			if Path(descriptor[1]).exists():
-				self._print_command('local_lib_path', ['detected', descriptor[1], 'for', descriptor[0]])
-				return descriptor[1]
-
-		raise RuntimeError('unable to detect local lib path')
-
 	def set_env_var(self, key, value):
 		self._print_command('set_env_var', [key, value])
 

--- a/jenkins/catapult/runDockerBuildInnerBuild.py
+++ b/jenkins/catapult/runDockerBuildInnerBuild.py
@@ -38,8 +38,8 @@ class BuildEnvironment:
 				self.environment_manager.set_env_var('HOME', '/conan')
 		else:
 			if self.environment_manager.is_windows_platform():
-				self.environment_manager.set_env_var('BOOST_ROOT', 'c:/deps/boost')
-				self.environment_manager.set_env_var('GTEST_ROOT', 'c:/deps/google')
+				self.environment_manager.set_env_var('BOOST_ROOT', 'c:/usr/catapult/deps/boost')
+				self.environment_manager.set_env_var('GTEST_ROOT', 'c:/usr/catapult/deps/google')
 			else:
 				self.environment_manager.set_env_var('BOOST_ROOT', '/mybuild')
 				self.environment_manager.set_env_var('GTEST_ROOT', '/usr/local')
@@ -88,13 +88,13 @@ class BuildManager(BasicBuildManager):
 		if self.use_conan:
 			settings.append(('USE_CONAN', 'ON'))
 		else:
-			settings.append(('OPENSSL_ROOT_DIR', '/usr/catapult/deps'))
-
 			if self.environment_manager.is_windows_platform():
 				settings.append((
 					'CMAKE_PREFIX_PATH',
-					';'.join(f'c:/deps/{package}' for package in ['boost', 'facebook', 'google', 'mongodb', 'openssl', 'zeromq'])
+					';'.join(f'c:/usr/catapult/deps/{package}' for package in ['boost', 'facebook', 'google', 'mongodb', 'openssl', 'zeromq'])
 				))
+			else:
+				settings.append(('OPENSSL_ROOT_DIR', '/usr/catapult/deps'))
 
 		if self.sanitizers:
 			settings.append(('USE_SANITIZER', ','.join(self.sanitizers)))
@@ -141,18 +141,17 @@ class BuildManager(BasicBuildManager):
 
 	def copy_dependencies(self, destination):
 		if self.use_conan:
-			if not self.environment_manager.is_windows_platform():
-				self.environment_manager.copy_tree_with_symlinks('./deps', destination)
+			self.environment_manager.copy_tree_with_symlinks('./deps', destination)
 			return
 
 		self.environment_manager.mkdirs(destination)
 		if self.environment_manager.is_windows_platform():
-			self.environment_manager.copy_glob_with_symlinks('c:/deps/boost/lib', '*.dll', destination)
+			self.environment_manager.copy_glob_with_symlinks('c:/usr/catapult/deps/boost/lib', '*.dll', destination)
 			for name in ['facebook', 'mongodb', 'openssl', 'zeromq']:
-				self.environment_manager.copy_glob_with_symlinks(f'c:/deps/{name}/bin', '*.dll', destination)
+				self.environment_manager.copy_glob_with_symlinks(f'c:/usr/catapult/deps/{name}/bin', '*.dll', destination)
 
 			for name in ['engines-3', 'ossl-modules']:
-				self.environment_manager.copy_tree_with_symlinks(f'c:/deps/openssl/lib/{name}', Path(destination) / 'lib' / name)
+				self.environment_manager.copy_tree_with_symlinks(f'c:/usr/catapult/deps/openssl/lib/{name}', Path(destination) / 'openssl/lib' / name)
 
 			return
 
@@ -184,10 +183,8 @@ class BuildManager(BasicBuildManager):
 		deps_output_path = Path(f'{output_path}/deps').resolve()
 		tests_output_path = Path(f'{output_path}/tests').resolve()
 
-		# copy deps into the tests folder for windows
-		dest_path = tests_output_path if EnvironmentManager.is_windows_platform() else deps_output_path
-		self.copy_dependencies(dest_path)
-		self.copy_compiler_deps(dest_path)
+		self.copy_dependencies(deps_output_path)
+		self.copy_compiler_deps(deps_output_path)
 
 		# copy tests
 		if not self.is_release:

--- a/jenkins/catapult/runDockerBuildInnerBuild.py
+++ b/jenkins/catapult/runDockerBuildInnerBuild.py
@@ -88,6 +88,8 @@ class BuildManager(BasicBuildManager):
 		if self.use_conan:
 			settings.append(('USE_CONAN', 'ON'))
 		else:
+			settings.append(('OPENSSL_ROOT_DIR', '/usr/catapult/deps'))
+
 			if self.environment_manager.is_windows_platform():
 				settings.append((
 					'CMAKE_PREFIX_PATH',
@@ -95,10 +97,7 @@ class BuildManager(BasicBuildManager):
 				))
 
 		if self.sanitizers:
-			settings.extend([
-				('USE_SANITIZER', ','.join(self.sanitizers)),
-				('OPENSSL_ROOT_DIR', '/usr/local')
-			])
+			settings.append(('USE_SANITIZER', ','.join(self.sanitizers)))
 
 		if self.is_release:
 			settings.append(('CATAPULT_BUILD_RELEASE', 'ON'))
@@ -152,7 +151,9 @@ class BuildManager(BasicBuildManager):
 			for name in ['facebook', 'mongodb', 'openssl', 'zeromq']:
 				self.environment_manager.copy_glob_with_symlinks(f'c:/deps/{name}/bin', '*.dll', destination)
 
-			self.environment_manager.copy_tree_with_symlinks('c:/deps/openssl/lib/engines-1_1', Path(destination) / 'engines-1_1')
+			for name in ['engines-3', 'ossl-modules']:
+				self.environment_manager.copy_tree_with_symlinks(f'c:/deps/openssl/lib/{name}', Path(destination) / 'lib' / name)
+
 			return
 
 		for name in ['atomic', 'chrono', 'date_time', 'filesystem', 'log', 'log_setup', 'program_options', 'regex', 'thread']:
@@ -162,11 +163,13 @@ class BuildManager(BasicBuildManager):
 			system_bin_path = self.environment_manager.system_bin_path
 			self.environment_manager.copy_glob_with_symlinks(system_bin_path, f'lib{name}.so*', destination)
 
-		local_lib_path = self.environment_manager.local_lib_path
+		openssl_source_directory = Path('/usr/catapult/deps')
+		self.environment_manager.mkdirs(Path(destination), exist_ok=True)
 		for name in ['crypto', 'ssl']:
-			self.environment_manager.copy_glob_with_symlinks(local_lib_path, f'lib{name}*', destination)
+			self.environment_manager.copy_glob_with_symlinks(openssl_source_directory, f'lib{name}.so*', Path(destination))
 
-		self.environment_manager.copy_tree_with_symlinks(f'{local_lib_path}/engines-1.1', Path(destination) / 'engines-1.1')
+		for name in ['engines-3', 'ossl-modules']:
+			self.environment_manager.copy_tree_with_symlinks(openssl_source_directory / name, Path(destination) / name)
 
 	def copy_compiler_deps(self, destination):
 		if not self.compiler.deps:

--- a/jenkins/catapult/runDockerBuildInnerPrepare.py
+++ b/jenkins/catapult/runDockerBuildInnerPrepare.py
@@ -24,7 +24,7 @@ def main():
 		for name in ['seed', 'scripts', 'resources']:
 			environment_manager.copy_tree_with_symlinks(DATA_VOLUME / name, USER_HOME / name)
 
-	bin_folder_names = ['bin'] if EnvironmentManager.is_windows_platform() else ['bin', 'deps', 'lib']
+	bin_folder_names = ['bin', 'deps', 'lib']
 	if is_dev_build:
 		bin_folder_names.append('tests')
 

--- a/jenkins/catapult/runDockerTestsInnerLint.py
+++ b/jenkins/catapult/runDockerTestsInnerLint.py
@@ -14,8 +14,8 @@ def print_linter_status(name, return_code):
 	print(f'{name} {return_code_description}')
 
 
-def find_files_with_extension(environment_manager, extension):
-	return list(environment_manager.find_glob(Path('.').resolve(), '*' + extension, recursive=True))
+def find_files_with_extension(environment_manager, directory, extension):
+	return list(environment_manager.find_glob(directory, f'*{extension}', recursive=True))
 
 
 def run_cpp_linters(process_manager, dest_dir):
@@ -42,7 +42,7 @@ class LinterRunner:
 		self.output_filepath = Path(self.dest_dir) / f'{self.scope}.log'
 
 	def run(self, args):
-		linter_result = self.process_manager.dispatch_subprocess(args, handle_error=False, redirect_filename=self.output_filepath)
+		linter_result = self.process_manager.dispatch_subprocess(args, redirect_filename=self.output_filepath)
 		print_linter_status(self.scope, linter_result)
 
 	def fixup(self, modifier):
@@ -100,6 +100,8 @@ def main():
 	parser.add_argument('--dry-run', help='outputs desired commands without running them', action='store_true')
 	args = parser.parse_args()
 
+	source_dir = Path('.').resolve()
+
 	process_manager = ProcessManager(args.dry_run)
 	environment_manager = EnvironmentManager(args.dry_run)
 	environment_manager.set_env_var('HOME', '/tmp')
@@ -110,8 +112,8 @@ def main():
 	environment_manager.chdir(script_path)
 
 	linter_runner = LinterRunner(process_manager, args.out_dir, args.dry_run)
-	run_shell_linters(linter_runner, find_files_with_extension(environment_manager, '.sh'))
-	run_python_linters(linter_runner, find_files_with_extension(environment_manager, '.py'), str(script_path))
+	run_shell_linters(linter_runner, find_files_with_extension(environment_manager, source_dir, '.sh'))
+	run_python_linters(linter_runner, find_files_with_extension(environment_manager, source_dir, '.py'), str(script_path))
 
 
 if __name__ == '__main__':

--- a/jenkins/catapult/runDockerTestsInnerLint.py
+++ b/jenkins/catapult/runDockerTestsInnerLint.py
@@ -112,7 +112,9 @@ def main():
 	environment_manager.chdir(script_path)
 
 	linter_runner = LinterRunner(process_manager, args.out_dir, args.dry_run)
-	run_shell_linters(linter_runner, find_files_with_extension(environment_manager, source_dir, '.sh'))
+	if not EnvironmentManager.is_windows_platform():
+		run_shell_linters(linter_runner, find_files_with_extension(environment_manager, source_dir, '.sh'))
+
 	run_python_linters(linter_runner, find_files_with_extension(environment_manager, source_dir, '.py'), str(script_path))
 
 

--- a/jenkins/catapult/runDockerTestsInnerTest.py
+++ b/jenkins/catapult/runDockerTestsInnerTest.py
@@ -156,7 +156,11 @@ def main():
 	process_manager.list_dir(args.source_path)
 	process_manager.list_dir(output_path)
 
-	environment_manager.set_env_var('LD_LIBRARY_PATH', f'{output_path}/lib:{output_path}/deps')
+	if EnvironmentManager.is_windows_platform():
+		path = environment_manager.get_env_var('PATH')
+		environment_manager.set_env_var('PATH', f'{path};{output_path}/lib;{output_path}/deps')
+	else:
+		environment_manager.set_env_var('LD_LIBRARY_PATH', f'{output_path}/lib:{output_path}/deps')
 	logs_path = Path(args.out_dir) / 'logs'
 
 	failed_test_suites = []

--- a/jenkins/catapult/templates/RunTestWindows.yaml
+++ b/jenkins/catapult/templates/RunTestWindows.yaml
@@ -11,7 +11,6 @@ services:
     environment:
       - GTESTFILTER={{GTESTFILTER}}
       - STRESSCOUNT={{STRESSCOUNT}}
-      - LD_LIBRARY_PATH=/usr/catapult/lib:/usr/catapult/deps
     working_dir: /catapult-data/workdir
     cap_add:
       - SYS_PTRACE

--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -17,7 +17,7 @@ google_benchmark = v1.7.0
 mongodb_mongo-c-driver = 1.22.0
 mongodb_mongo-cxx-driver = r3.6.7
 
-openssl_openssl = OpenSSL_1_1_1q
+openssl_openssl = openssl-3.0.7
 
 zeromq_libzmq = v4.3.4
 zeromq_cppzmq = v4.8.1

--- a/linters/cpp/exclusions.py
+++ b/linters/cpp/exclusions.py
@@ -105,7 +105,7 @@ CORE_FIRSTINCLUDES = {
 	'src/catapult/version/nix/what_version.cpp': 'catapult/version/version.h',
 
 	# tests
-	'tests/test/nodeps/TestMain.cpp': 'catapult/utils/ConfigurationValueParsers.h',
+	'tests/test/nodeps/TestMain.cpp': 'catapult/crypto/OpensslInit.h',
 
 	'tests/catapult/consumers/BatchSignatureConsumerTests.cpp': 'catapult/consumers/BlockConsumers.h',
 	'tests/catapult/consumers/BlockchainCheckConsumerTests.cpp': 'catapult/consumers/BlockConsumers.h',


### PR DESCRIPTION
problem: client is using openssl version that will be deprecated in 2023
solution: upgrade to latest 3.0.x version