### PR TITLE
[catapult/client] build: fail on lint and individually disable gcc 12 warnings

### DIFF
--- a/client/catapult/CMakeGlobalSettings.cmake
+++ b/client/catapult/CMakeGlobalSettings.cmake
@@ -123,11 +123,6 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 	# -Wstrict-aliasing=1 perform most paranoid strict aliasing checks
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wformat-security -Werror -Wstrict-aliasing=1")
 
-	# disable warning as error for gcc 12 until 12.2 is release
-	if("${CMAKE_CXX_COMPILER_VERSION}" MATCHES "^12.")
-		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-error=stringop-overread -Wno-error=array-bounds")
-	endif()
-
 	# - Wno-maybe-uninitialized: false positives where gcc isn't sure if an uninitialized variable is used or not
 	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -Wno-maybe-uninitialized -g1 -fno-omit-frame-pointer")
 	set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -Wno-maybe-uninitialized")

--- a/client/catapult/plugins/txes/restriction_mosaic/tests/state/RestrictionValueMapTests.cpp
+++ b/client/catapult/plugins/txes/restriction_mosaic/tests/state/RestrictionValueMapTests.cpp
@@ -142,14 +142,17 @@ namespace catapult { namespace state {
 	TEST(TEST_CLASS, CanRemoveValueNotInMap) {
 		// Arrange:
 		RestrictionValueMap<uint64_t> map;
+		map.set(111, 444);
+		map.set(321, 987);
 
 		// Act:
-		map.remove(111);
+		map.remove(222);
 
 		// Assert:
-		EXPECT_EQ(0u, map.size());
-		AssertCannotGetValue(map, 111);
-		EXPECT_EQ(std::set<uint64_t>(), map.keys());
+		EXPECT_EQ(2u, map.size());
+		AssertCanGetValue(map, 111, 444);
+		AssertCanGetValue(map, 321, 987);
+		EXPECT_EQ(std::set<uint64_t>({ 111, 321 }), map.keys());
 	}
 
 	TEST(TEST_CLASS, CanRemoveSingleValue) {

--- a/client/catapult/src/catapult/model/EntityRange.h
+++ b/client/catapult/src/catapult/model/EntityRange.h
@@ -392,6 +392,9 @@ namespace catapult { namespace model {
 
 		/// Creates an entity range around \a numElements fixed size elements pointed to by \a pData.
 		static Range CopyFixed(const uint8_t* pData, size_t numElements) {
+			if (0 == numElements)
+				return Range();
+
 			uint8_t* pRangeData;
 			auto range = PrepareFixed(numElements, &pRangeData);
 			utils::memcpy_cond(pRangeData, pData, range.totalSize());

--- a/client/catapult/tests/catapult/model/TransactionTests.cpp
+++ b/client/catapult/tests/catapult/model/TransactionTests.cpp
@@ -118,7 +118,17 @@ namespace catapult { namespace model {
 		// Arrange:
 		std::vector<uint8_t> buffer(sizeof(SizePrefixedEntity));
 		auto* pTransaction = reinterpret_cast<Transaction*>(&buffer[0]);
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds" // Transaction[0] is partly outside array bounds
+#endif
+
 		pTransaction->Size = sizeof(SizePrefixedEntity);
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 		// Act:
 		EXPECT_FALSE(IsSizeValid(*pTransaction));

--- a/client/catapult/tests/catapult/model/VerifiableEntityTests.cpp
+++ b/client/catapult/tests/catapult/model/VerifiableEntityTests.cpp
@@ -165,7 +165,17 @@ namespace catapult { namespace model {
 		// Arrange:
 		std::vector<uint8_t> buffer(sizeof(SizePrefixedEntity));
 		auto* pEntity = reinterpret_cast<VerifiableEntity*>(&buffer[0]);
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds" // VerifiableEntity[0] is partly outside array bounds
+#endif
+
 		pEntity->Size = sizeof(SizePrefixedEntity);
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 		// Act:
 		EXPECT_FALSE(IsSizeValid(*pEntity));

--- a/jenkins/catapult/runDockerTestsInnerLint.py
+++ b/jenkins/catapult/runDockerTestsInnerLint.py
@@ -14,8 +14,8 @@ def print_linter_status(name, return_code):
 	print(f'{name} {return_code_description}')
 
 
-def find_files_with_extension(environment_manager, extension):
-	return list(environment_manager.find_glob(Path('.').resolve(), '*' + extension, recursive=True))
+def find_files_with_extension(environment_manager, directory, extension):
+	return list(environment_manager.find_glob(directory, f'*{extension}', recursive=True))
 
 
 def run_cpp_linters(process_manager, dest_dir):
@@ -42,7 +42,7 @@ class LinterRunner:
 		self.output_filepath = Path(self.dest_dir) / f'{self.scope}.log'
 
 	def run(self, args):
-		linter_result = self.process_manager.dispatch_subprocess(args, handle_error=False, redirect_filename=self.output_filepath)
+		linter_result = self.process_manager.dispatch_subprocess(args, redirect_filename=self.output_filepath)
 		print_linter_status(self.scope, linter_result)
 
 	def fixup(self, modifier):
@@ -100,6 +100,8 @@ def main():
 	parser.add_argument('--dry-run', help='outputs desired commands without running them', action='store_true')
 	args = parser.parse_args()
 
+	source_dir = Path('.').resolve()
+
 	process_manager = ProcessManager(args.dry_run)
 	environment_manager = EnvironmentManager(args.dry_run)
 	environment_manager.set_env_var('HOME', '/tmp')
@@ -110,8 +112,8 @@ def main():
 	environment_manager.chdir(script_path)
 
 	linter_runner = LinterRunner(process_manager, args.out_dir, args.dry_run)
-	run_shell_linters(linter_runner, find_files_with_extension(environment_manager, '.sh'))
-	run_python_linters(linter_runner, find_files_with_extension(environment_manager, '.py'), str(script_path))
+	run_shell_linters(linter_runner, find_files_with_extension(environment_manager, source_dir, '.sh'))
+	run_python_linters(linter_runner, find_files_with_extension(environment_manager, source_dir, '.py'), str(script_path))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
problem: lint failures don't fail build
solution: fail build on lint failure

problem: gcc 12 stringop-overread and array-bounds warnings are disabled
solution: enable those warnings and fix / disable individually 