### PR TITLE
[jenkins] fix: update catapult client jobs

### DIFF
--- a/jenkins/catapult/jenkins/catapult-client-build-base-image-all.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-base-image-all.groovy
@@ -147,29 +147,29 @@ pipeline {
 				}
 			}
 		}
-		post {
-			success {
-				script {
-					if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
-						helper.sendDiscordNotification(
+	}
+	post {
+		success {
+			script {
+				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
+					helper.sendDiscordNotification(
 							':confetti2: Catapult Client All Image Job Successfully completed',
 							'Not much to see here, all is good',
 							env.BUILD_URL,
 							currentBuild.currentResult
-						)
-					}
+					)
 				}
 			}
-			unsuccessful {
-				script {
-					if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
-						helper.sendDiscordNotification(
+		}
+		unsuccessful {
+			script {
+				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
+					helper.sendDiscordNotification(
 							":confused_dog: Catapult Client All Image Job Failed for ${currentBuild.fullDisplayName}",
 							"At least an image job failed for Build#${env.BUILD_NUMBER} with a result of ${currentBuild.currentResult}.",
 							env.BUILD_URL,
 							currentBuild.currentResult
-						)
-					}
+					)
 				}
 			}
 		}

--- a/jenkins/catapult/jenkins/catapult-client-build-base-image-all.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-base-image-all.groovy
@@ -15,7 +15,7 @@ pipeline {
 		// second of the month
 		cron('H 0 2 * *')
 	}
-	
+
 	stages {
 		stage('print env') {
 			steps {
@@ -171,7 +171,7 @@ void dispatchBuildBaseImageJob(String compilerConfiguration, String operatingSys
 		string(name: 'SHOULD_BUILD_CONAN_LAYER', value: "${shouldBuildConanLayer}"),
 		string(name: 'MANUAL_GIT_BRANCH', value: "${params.MANUAL_GIT_BRANCH}"),
 		booleanParam(
-			name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS', 
+			name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS',
 			value: "${!env.SHOULD_PUBLISH_FAIL_JOB_STATUS || env.SHOULD_PUBLISH_FAIL_JOB_STATUS.toBoolean()}"
 		)
 	]
@@ -183,7 +183,7 @@ void dispatchPrepareBaseImageJob(String imageType, String operatingSystem) {
 		string(name: 'OPERATING_SYSTEM', value: "${operatingSystem}"),
 		string(name: 'MANUAL_GIT_BRANCH', value: "${params.MANUAL_GIT_BRANCH}"),
 		booleanParam(
-			name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS', 
+			name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS',
 			value: "${!env.SHOULD_PUBLISH_FAIL_JOB_STATUS || env.SHOULD_PUBLISH_FAIL_JOB_STATUS.toBoolean()}"
 		)
 	]

--- a/jenkins/catapult/jenkins/catapult-client-build-base-image-all.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-base-image-all.groovy
@@ -153,10 +153,10 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
-							':confetti_ball: Catapult Client All Image Job Successfully completed',
-							'Not much to see here, all is good',
-							env.BUILD_URL,
-							currentBuild.currentResult
+						':confetti_ball: Catapult Client All Image Job Successfully completed',
+						'Not much to see here, all is good',
+						env.BUILD_URL,
+						currentBuild.currentResult
 					)
 				}
 			}
@@ -165,10 +165,10 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
-							":confused: Catapult Client All Image Job Failed for ${currentBuild.fullDisplayName}",
-							"At least an image job failed for Build#${env.BUILD_NUMBER} with a result of ${currentBuild.currentResult}.",
-							env.BUILD_URL,
-							currentBuild.currentResult
+						":confused: Catapult Client All Image Job Failed for ${currentBuild.fullDisplayName}",
+						"At least an image job failed for Build#${env.BUILD_NUMBER} with a result of ${currentBuild.currentResult}.",
+						env.BUILD_URL,
+						currentBuild.currentResult
 					)
 				}
 			}

--- a/jenkins/catapult/jenkins/catapult-client-build-base-image-all.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-base-image-all.groovy
@@ -153,7 +153,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
-							':confetti2: Catapult Client All Image Job Successfully completed',
+							':confetti_ball: Catapult Client All Image Job Successfully completed',
 							'Not much to see here, all is good',
 							env.BUILD_URL,
 							currentBuild.currentResult
@@ -165,7 +165,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
-							":confused_dog: Catapult Client All Image Job Failed for ${currentBuild.fullDisplayName}",
+							":confused: Catapult Client All Image Job Failed for ${currentBuild.fullDisplayName}",
 							"At least an image job failed for Build#${env.BUILD_NUMBER} with a result of ${currentBuild.currentResult}.",
 							env.BUILD_URL,
 							currentBuild.currentResult

--- a/jenkins/catapult/jenkins/catapult-client-build-base-image-all.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-base-image-all.groovy
@@ -3,7 +3,7 @@ pipeline {
 
 	parameters {
 		gitParameter branchFilter: 'origin/(.*)', defaultValue: 'dev', name: 'MANUAL_GIT_BRANCH', type: 'PT_BRANCH'
-		booleanParam name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS', description: 'true to publish job status if failed', defaultValue: true
+		booleanParam name: 'SHOULD_PUBLISH_JOB_STATUS', description: 'true to publish job status', defaultValue: true
 	}
 
 	options {
@@ -148,11 +148,23 @@ pipeline {
 			}
 		}
 		post {
+			success {
+				script {
+					if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
+						helper.sendDiscordNotification(
+							':confetti2: Catapult Client All Image Job Successfully completed',
+							'Not much to see here, all is good',
+							env.BUILD_URL,
+							currentBuild.currentResult
+						)
+					}
+				}
+			}
 			unsuccessful {
 				script {
-					if (env.SHOULD_PUBLISH_FAIL_JOB_STATUS?.toBoolean()) {
+					if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 						helper.sendDiscordNotification(
-							"Catapult Client All Image Job Failed for ${currentBuild.fullDisplayName}",
+							":confused_dog: Catapult Client All Image Job Failed for ${currentBuild.fullDisplayName}",
 							"At least an image job failed for Build#${env.BUILD_NUMBER} with a result of ${currentBuild.currentResult}.",
 							env.BUILD_URL,
 							currentBuild.currentResult
@@ -172,7 +184,7 @@ void dispatchBuildBaseImageJob(String compilerConfiguration, String operatingSys
 		string(name: 'MANUAL_GIT_BRANCH', value: "${params.MANUAL_GIT_BRANCH}"),
 		booleanParam(
 			name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS',
-			value: "${!env.SHOULD_PUBLISH_FAIL_JOB_STATUS || env.SHOULD_PUBLISH_FAIL_JOB_STATUS.toBoolean()}"
+			value: "${!env.SHOULD_PUBLISH_JOB_STATUS || env.SHOULD_PUBLISH_JOB_STATUS.toBoolean()}"
 		)
 	]
 }
@@ -184,7 +196,7 @@ void dispatchPrepareBaseImageJob(String imageType, String operatingSystem) {
 		string(name: 'MANUAL_GIT_BRANCH', value: "${params.MANUAL_GIT_BRANCH}"),
 		booleanParam(
 			name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS',
-			value: "${!env.SHOULD_PUBLISH_FAIL_JOB_STATUS || env.SHOULD_PUBLISH_FAIL_JOB_STATUS.toBoolean()}"
+			value: "${!env.SHOULD_PUBLISH_JOB_STATUS || env.SHOULD_PUBLISH_JOB_STATUS.toBoolean()}"
 		)
 	]
 }

--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project-daily.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project-daily.groovy
@@ -108,7 +108,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
-						":shrekscream: Catapult Client Daily Job Failed for ${currentBuild.fullDisplayName}",
+						":scream_cat: Catapult Client Daily Job Failed for ${currentBuild.fullDisplayName}",
 						"At least one daily job failed for Build#${env.BUILD_NUMBER} with a result of ${currentBuild.currentResult}.",
 						env.BUILD_URL,
 						currentBuild.currentResult

--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project-daily.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project-daily.groovy
@@ -96,10 +96,10 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
-							':tada: Catapult Client Daily Job Successfully completed',
-							'All is good with the client',
-							env.BUILD_URL,
-							currentBuild.currentResult
+						':tada: Catapult Client Daily Job Successfully completed',
+						'All is good with the client',
+						env.BUILD_URL,
+						currentBuild.currentResult
 					)
 				}
 			}

--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project-daily.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project-daily.groovy
@@ -114,7 +114,7 @@ void dispatchBuildJob(String compilerConfiguration, String buildConfiguration, S
 		string(name: 'OPERATING_SYSTEM', value: "${operatingSystem}"),
 		string(name: 'MANUAL_GIT_BRANCH', value: "${params.MANUAL_GIT_BRANCH}"),
 		booleanParam(
-			name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS', 
+			name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS',
 			value: "${!env.SHOULD_PUBLISH_FAIL_JOB_STATUS || env.SHOULD_PUBLISH_FAIL_JOB_STATUS.toBoolean()}"
 		)
 	]

--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project-daily.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project-daily.groovy
@@ -3,7 +3,7 @@ pipeline {
 
 	parameters {
 		gitParameter branchFilter: 'origin/(.*)', defaultValue: 'dev', name: 'MANUAL_GIT_BRANCH', type: 'PT_BRANCH'
-		booleanParam name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS', description: 'true to publish job status if failed', defaultValue: true
+		booleanParam name: 'SHOULD_PUBLISH_JOB_STATUS', description: 'true to publish job status', defaultValue: true
 	}
 
 	options {
@@ -92,11 +92,23 @@ pipeline {
 		}
 	}
 	post {
+		success {
+			script {
+				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
+					helper.sendDiscordNotification(
+							':tada: Catapult Client Daily Job Successfully completed',
+							'All is good with the client',
+							env.BUILD_URL,
+							currentBuild.currentResult
+					)
+				}
+			}
+		}
 		unsuccessful {
 			script {
-				if (env.SHOULD_PUBLISH_FAIL_JOB_STATUS?.toBoolean()) {
+				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
-						"Catapult Client Daily Job Failed for ${currentBuild.fullDisplayName}",
+						":shrekscream: Catapult Client Daily Job Failed for ${currentBuild.fullDisplayName}",
 						"At least one daily job failed for Build#${env.BUILD_NUMBER} with a result of ${currentBuild.currentResult}.",
 						env.BUILD_URL,
 						currentBuild.currentResult
@@ -115,7 +127,7 @@ void dispatchBuildJob(String compilerConfiguration, String buildConfiguration, S
 		string(name: 'MANUAL_GIT_BRANCH', value: "${params.MANUAL_GIT_BRANCH}"),
 		booleanParam(
 			name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS',
-			value: "${!env.SHOULD_PUBLISH_FAIL_JOB_STATUS || env.SHOULD_PUBLISH_FAIL_JOB_STATUS.toBoolean()}"
+			value: "${!env.SHOULD_PUBLISH_JOB_STATUS || env.SHOULD_PUBLISH_JOB_STATUS.toBoolean()}"
 		)
 	]
 }

--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project-weekly.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project-weekly.groovy
@@ -94,10 +94,10 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
-							':partying_face: Catapult Client Weekly Job Successfully completed',
-							'All is good with the client',
-							env.BUILD_URL,
-							currentBuild.currentResult
+						':partying_face: Catapult Client Weekly Job Successfully completed',
+						'All is good with the client',
+						env.BUILD_URL,
+						currentBuild.currentResult
 					)
 				}
 			}
@@ -106,10 +106,10 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
-							":face_with_monocle: Catapult Client Weekly Job Failed for ${currentBuild.fullDisplayName}",
-							"At least one job failed for Build#${env.BUILD_NUMBER} with a result of ${currentBuild.currentResult}.",
-							env.BUILD_URL,
-							currentBuild.currentResult
+						":face_with_monocle: Catapult Client Weekly Job Failed for ${currentBuild.fullDisplayName}",
+						"At least one job failed for Build#${env.BUILD_NUMBER} with a result of ${currentBuild.currentResult}.",
+						env.BUILD_URL,
+						currentBuild.currentResult
 					)
 				}
 			}

--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project-weekly.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project-weekly.groovy
@@ -3,7 +3,7 @@ pipeline {
 
 	parameters {
 		gitParameter branchFilter: 'origin/(.*)', defaultValue: 'dev', name: 'MANUAL_GIT_BRANCH', type: 'PT_BRANCH'
-		booleanParam name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS', description: 'true to publish job status if failed', defaultValue: true
+		booleanParam name: 'SHOULD_PUBLISH_JOB_STATUS', description: 'true to publish job status', defaultValue: true
 	}
 
 	options {
@@ -89,11 +89,23 @@ pipeline {
 			}
 		}
 		post {
+			success {
+				script {
+					if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
+						helper.sendDiscordNotification(
+								':dancingBlahaj: Catapult Client Weekly Job Successfully completed',
+								'All is good with the client',
+								env.BUILD_URL,
+								currentBuild.currentResult
+						)
+					}
+				}
+			}
 			unsuccessful {
 				script {
-					if (env.SHOULD_PUBLISH_FAIL_JOB_STATUS?.toBoolean()) {
+					if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 						helper.sendDiscordNotification(
-							"Catapult Weekly Job Failed for ${currentBuild.fullDisplayName}",
+							":shrekscream: Catapult Client Weekly Job Failed for ${currentBuild.fullDisplayName}",
 							"At least one job failed for Build#${env.BUILD_NUMBER} with a result of ${currentBuild.currentResult}.",
 							env.BUILD_URL,
 							currentBuild.currentResult
@@ -113,7 +125,7 @@ void dispatchBuildJob(String compilerConfiguration, String buildConfiguration, S
 		string(name: 'MANUAL_GIT_BRANCH', value: "${params.MANUAL_GIT_BRANCH}"),
 		booleanParam(
 			name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS',
-			value: "${!env.SHOULD_PUBLISH_FAIL_JOB_STATUS || env.SHOULD_PUBLISH_FAIL_JOB_STATUS.toBoolean()}"
+			value: "${!env.SHOULD_PUBLISH_JOB_STATUS || env.SHOULD_PUBLISH_JOB_STATUS.toBoolean()}"
 		)
 	]
 }

--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project-weekly.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project-weekly.groovy
@@ -112,7 +112,7 @@ void dispatchBuildJob(String compilerConfiguration, String buildConfiguration, S
 		string(name: 'OPERATING_SYSTEM', value: "${operatingSystem}"),
 		string(name: 'MANUAL_GIT_BRANCH', value: "${params.MANUAL_GIT_BRANCH}"),
 		booleanParam(
-			name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS', 
+			name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS',
 			value: "${!env.SHOULD_PUBLISH_FAIL_JOB_STATUS || env.SHOULD_PUBLISH_FAIL_JOB_STATUS.toBoolean()}"
 		)
 	]

--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project-weekly.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project-weekly.groovy
@@ -88,29 +88,29 @@ pipeline {
 				}
 			}
 		}
-		post {
-			success {
-				script {
-					if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
-						helper.sendDiscordNotification(
-								':dancingBlahaj: Catapult Client Weekly Job Successfully completed',
-								'All is good with the client',
-								env.BUILD_URL,
-								currentBuild.currentResult
-						)
-					}
+	}
+	post {
+		success {
+			script {
+				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
+					helper.sendDiscordNotification(
+							':dancingBlahaj: Catapult Client Weekly Job Successfully completed',
+							'All is good with the client',
+							env.BUILD_URL,
+							currentBuild.currentResult
+					)
 				}
 			}
-			unsuccessful {
-				script {
-					if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
-						helper.sendDiscordNotification(
+		}
+		unsuccessful {
+			script {
+				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
+					helper.sendDiscordNotification(
 							":shrekscream: Catapult Client Weekly Job Failed for ${currentBuild.fullDisplayName}",
 							"At least one job failed for Build#${env.BUILD_NUMBER} with a result of ${currentBuild.currentResult}.",
 							env.BUILD_URL,
 							currentBuild.currentResult
-						)
-					}
+					)
 				}
 			}
 		}

--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project-weekly.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project-weekly.groovy
@@ -94,7 +94,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
-							':dancingBlahaj: Catapult Client Weekly Job Successfully completed',
+							':partying_face: Catapult Client Weekly Job Successfully completed',
 							'All is good with the client',
 							env.BUILD_URL,
 							currentBuild.currentResult
@@ -106,7 +106,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
-							":shrekscream: Catapult Client Weekly Job Failed for ${currentBuild.fullDisplayName}",
+							":face_with_monocle: Catapult Client Weekly Job Failed for ${currentBuild.fullDisplayName}",
 							"At least one job failed for Build#${env.BUILD_NUMBER} with a result of ${currentBuild.currentResult}.",
 							env.BUILD_URL,
 							currentBuild.currentResult

--- a/jenkins/catapult/jenkins/catapult-client-build-compiler-image-all.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-compiler-image-all.groovy
@@ -96,10 +96,10 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
-							':confetti_ball: Compiler Image All Job Successfully completed',
-							'Not much to see here, all is good',
-							env.BUILD_URL,
-							currentBuild.currentResult
+						':confetti_ball: Compiler Image All Job Successfully completed',
+						'Not much to see here, all is good',
+						env.BUILD_URL,
+						currentBuild.currentResult
 					)
 				}
 			}

--- a/jenkins/catapult/jenkins/catapult-client-build-compiler-image-all.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-compiler-image-all.groovy
@@ -15,7 +15,7 @@ pipeline {
 		// first of the month
 		cron('H 0 1 * *')
 	}
-	
+
 	stages {
 		stage('print env') {
 			steps {
@@ -111,7 +111,7 @@ void dispatchBuildCompilerImageJob(String compilerConfiguration, String operatin
 		string(name: 'OPERATING_SYSTEM', value: "${operatingSystem}"),
 		string(name: 'MANUAL_GIT_BRANCH', value: "${params.MANUAL_GIT_BRANCH}"),
 		booleanParam(
-			name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS', 
+			name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS',
 			value: "${!env.SHOULD_PUBLISH_FAIL_JOB_STATUS || env.SHOULD_PUBLISH_FAIL_JOB_STATUS.toBoolean()}"
 		)
 	]

--- a/jenkins/catapult/jenkins/catapult-client-build-compiler-image-all.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-compiler-image-all.groovy
@@ -1,0 +1,118 @@
+pipeline {
+	agent 'ubuntu-agent'
+
+	parameters {
+		gitParameter branchFilter: 'origin/(.*)', defaultValue: 'dev', name: 'MANUAL_GIT_BRANCH', type: 'PT_BRANCH'
+		booleanParam name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS', description: 'true to publish job status if failed', defaultValue: true
+	}
+
+	options {
+		ansiColor('css')
+		timestamps()
+	}
+
+	triggers {
+		// first of the month
+		cron('H 0 1 * *')
+	}
+	
+	stages {
+		stage('print env') {
+			steps {
+				echo """
+							env.GIT_BRANCH: ${env.GIT_BRANCH}
+						 MANUAL_GIT_BRANCH: ${MANUAL_GIT_BRANCH}
+				"""
+			}
+		}
+
+		stage('build compiler images') {
+			parallel {
+				stage('gcc prior') {
+					steps {
+						script {
+							dispatchBuildCompilerImageJob('gcc-prior', 'ubuntu')
+						}
+					}
+				}
+				stage('gcc latest') {
+					steps {
+						script {
+							dispatchBuildCompilerImageJob('gcc-latest', 'ubuntu')
+						}
+					}
+				}
+				stage('gcc [debian]') {
+					steps {
+						script {
+							dispatchBuildCompilerImageJob('gcc-debian', 'debian')
+						}
+					}
+				}
+				stage('gcc [fedora]') {
+					steps {
+						script {
+							dispatchBuildCompilerImageJob('gcc-latest', 'fedora')
+						}
+					}
+				}
+
+				stage('clang prior') {
+					steps {
+						script {
+							dispatchBuildCompilerImageJob('clang-prior', 'ubuntu')
+						}
+					}
+				}
+				stage('clang latest') {
+					steps {
+						script {
+							dispatchBuildCompilerImageJob('clang-latest', 'ubuntu')
+						}
+					}
+				}
+
+				stage('msvc latest') {
+					steps {
+						script {
+							dispatchBuildCompilerImageJob('msvc-latest', 'windows')
+						}
+					}
+				}
+				stage('msvc prior') {
+					steps {
+						script {
+							dispatchBuildCompilerImageJob('msvc-prior', 'windows')
+						}
+					}
+				}
+			}
+		}
+	}
+	post {
+		unsuccessful {
+			script {
+				if (env.SHOULD_PUBLISH_FAIL_JOB_STATUS?.toBoolean()) {
+					helper.sendDiscordNotification(
+						"Compiler Image All Job Failed for ${currentBuild.fullDisplayName}",
+						"At least one job failed for Build#${env.BUILD_NUMBER} which has a result of ${currentBuild.currentResult}.",
+						env.BUILD_URL,
+						currentBuild.currentResult
+					)
+				}
+			}
+		}
+	}
+}
+
+void dispatchBuildCompilerImageJob(String compilerConfiguration, String operatingSystem) {
+	build job: 'Symbol/server-pipelines/catapult-client-build-compiler-image', parameters: [
+		string(name: 'COMPILER_CONFIGURATION', value: "${compilerConfiguration}"),
+		string(name: 'OPERATING_SYSTEM', value: "${operatingSystem}"),
+		string(name: 'MANUAL_GIT_BRANCH', value: "${params.MANUAL_GIT_BRANCH}"),
+		booleanParam(
+			name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS', 
+			value: "${!env.SHOULD_PUBLISH_FAIL_JOB_STATUS || env.SHOULD_PUBLISH_FAIL_JOB_STATUS.toBoolean()}"
+		)
+	]
+}

--- a/jenkins/catapult/jenkins/catapult-client-build-compiler-image-all.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-compiler-image-all.groovy
@@ -96,7 +96,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
-							':confetti2: Compiler Image All Job Successfully completed',
+							':confetti_ball: Compiler Image All Job Successfully completed',
 							'Not much to see here, all is good',
 							env.BUILD_URL,
 							currentBuild.currentResult
@@ -108,7 +108,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
-						":confused_dog: Compiler Image All Job Failed for ${currentBuild.fullDisplayName}",
+						":worried: Compiler Image All Job Failed for ${currentBuild.fullDisplayName}",
 						"At least one job failed for Build#${env.BUILD_NUMBER} which has a result of ${currentBuild.currentResult}.",
 						env.BUILD_URL,
 						currentBuild.currentResult

--- a/jenkins/catapult/jenkins/catapult-client-prepare-base-image.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-prepare-base-image.groovy
@@ -9,6 +9,7 @@ pipeline {
 			description: 'image type'
 
 		booleanParam name: 'SANITIZER_BUILD', description: 'true to build sanitizer', defaultValue: false
+		booleanParam name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS', description: 'true to publish job status if failed', defaultValue: false
 	}
 
 	agent {
@@ -41,43 +42,65 @@ pipeline {
 		stage('prepare Dockerfile') {
 			steps {
 				script {
-					properties = readProperties(file: './jenkins/catapult/versions.properties')
-					version = properties[params.OPERATING_SYSTEM]
+					helper.runStepAndRecordFailure {
+						properties = readProperties(file: './jenkins/catapult/versions.properties')
+						version = properties[params.OPERATING_SYSTEM]
 
-					sanitizer = SANITIZER_BUILD.toBoolean() ? 'Sanitizer' : ''
-					filename = "${params.OPERATING_SYSTEM.capitalize()}${params.IMAGE_TYPE.capitalize()}${sanitizer}"
-					dockerfileTemplate = "./jenkins/catapult/templates/${filename}BaseImage.Dockerfile"
-					dockerfileContents = readFile(file: dockerfileTemplate)
-					baseImage = 'windows' == "${OPERATING_SYSTEM}"
-							? "mcr.microsoft.com/windows/servercore:ltsc${version}"
-							: "${params.OPERATING_SYSTEM}:${version}"
-					dockerfileContents = dockerfileContents.replaceAll('\\{\\{BASE_IMAGE\\}\\}', "${baseImage}")
+						sanitizer = SANITIZER_BUILD.toBoolean() ? 'Sanitizer' : ''
+						filename = "${params.OPERATING_SYSTEM.capitalize()}${params.IMAGE_TYPE.capitalize()}${sanitizer}"
+						dockerfileTemplate = "./jenkins/catapult/templates/${filename}BaseImage.Dockerfile"
+						dockerfileContents = readFile(file: dockerfileTemplate)
+						baseImage = 'windows' == "${OPERATING_SYSTEM}"
+								? "mcr.microsoft.com/windows/servercore:ltsc${version}"
+								: "${params.OPERATING_SYSTEM}:${version}"
+						dockerfileContents = dockerfileContents.replaceAll('\\{\\{BASE_IMAGE\\}\\}', "${baseImage}")
 
-					writeFile(file: 'Dockerfile', text: dockerfileContents)
+						writeFile(file: 'Dockerfile', text: dockerfileContents)
+					}
 				}
 			}
 		}
 		stage('print Dockerfile') {
 			steps {
-				sh '''
-					echo '*** Dockerfile ***'
-					cat Dockerfile
-				'''
+				helper.runStepAndRecordFailure {
+					sh '''
+						echo '*** Dockerfile ***'
+						cat Dockerfile
+					'''
+				}
 			}
 		}
 
 		stage('build image') {
 			steps {
 				script {
-					dockerImageName = "symbolplatform/symbol-server-${params.IMAGE_TYPE}-base:${params.OPERATING_SYSTEM}"
-					if (SANITIZER_BUILD.toBoolean()) {
-						dockerImageName += '-sanitizer'
+					helper.runStepAndRecordFailure {
+						dockerImageName = "symbolplatform/symbol-server-${params.IMAGE_TYPE}-base:${params.OPERATING_SYSTEM}"
+						if (SANITIZER_BUILD.toBoolean()) {
+							dockerImageName += '-sanitizer'
+						}
+
+						echo "Docker image name: ${dockerImageName}"
+						dockerImage = docker.build(dockerImageName)
+						docker.withRegistry(DOCKER_URL, DOCKER_CREDENTIALS_ID) {
+							dockerImage.push()
+						}
 					}
-					echo "Docker image name: ${dockerImageName}"
-					dockerImage = docker.build(dockerImageName)
-					docker.withRegistry(DOCKER_URL, DOCKER_CREDENTIALS_ID) {
-						dockerImage.push()
-					}
+				}
+			}
+		}
+	}
+	post {
+		unsuccessful {
+			script {
+				if (env.SHOULD_PUBLISH_FAIL_JOB_STATUS?.toBoolean()) {
+					helper.sendDiscordNotification(
+						"Catapult Client Prepare Base Image Job Failed for ${currentBuild.fullDisplayName}",
+						"Job creating **${env.IMAGE_TYPE}** image on ${env.OPERATING_SYSTEM} has result of ${currentBuild.currentResult}"
+						+ " in stage **${env.FAILED_STAGE_NAME}** with message: **${env.FAILURE_MESSAGE}**.",
+						env.BUILD_URL,
+						currentBuild.currentResult
+					)
 				}
 			}
 		}

--- a/jenkins/catapult/jenkins/catapult-client-prepare-base-image.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-prepare-base-image.groovy
@@ -62,11 +62,13 @@ pipeline {
 		}
 		stage('print Dockerfile') {
 			steps {
-				helper.runStepAndRecordFailure {
-					sh '''
-						echo '*** Dockerfile ***'
-						cat Dockerfile
-					'''
+				script {
+					helper.runStepAndRecordFailure {
+						sh '''
+							echo '*** Dockerfile ***'
+							cat Dockerfile
+						'''
+					}
 				}
 			}
 		}

--- a/jenkins/shared-library/vars/helper.groovy
+++ b/jenkins/shared-library/vars/helper.groovy
@@ -43,3 +43,15 @@ void sendDiscordNotification(String title, String description, String url, Strin
 		discordSend description: description, footer: footer, link: url, result: result, title: title, webhookURL: "${env.WEB_HOOK_URL}"
 	}
 }
+
+void runStepAndRecordFailure(Closure body) {
+	try {
+		body()
+		// groovylint-disable-next-line CatchException
+	} catch (Exception exception) {
+		echo "Stage ${env.STAGE_NAME} failed with exception: ${exception}"
+		env.FAILURE_MESSAGE = exception.message ?: exception
+		env.FAILED_STAGE_NAME = env.STAGE_NAME
+		throw exception
+	}
+}


### PR DESCRIPTION
## What is the current behavior?
Catapult compiler and base image jobs are run manually.

## What's the issue?
Catapult compiler and base image jobs are not run on a regular schedule.

## How have you changed the behavior?
1. enable catapult client image jobs to run monthly
2. add a job that builds all the compiler images
3. add notification for when catapult jobs fails

## How was this change tested?
Tested in Jenkins.