### PR TITLE
[client/catapult] fix: clang latest to 15 plus deps updates

### DIFF
--- a/client/catapult/CMakeLists.txt
+++ b/client/catapult/CMakeLists.txt
@@ -65,7 +65,7 @@ endfunction()
 
 ### setup rocksdb
 message("--- locating rocksdb dependencies ---")
-find_package(RocksDB 7.4.3 EXACT REQUIRED)
+find_package(RocksDB 7.7.3 EXACT REQUIRED)
 
 if(WIN32)
 	set(RocksDB_LIBRARY RocksDB::rocksdb)

--- a/client/catapult/conanfile.txt
+++ b/client/catapult/conanfile.txt
@@ -3,12 +3,12 @@
 boost/1.80.0
 openssl/3.0.7
 
-cppzmq/4.8.1@nemtech/stable
-mongo-cxx-driver/3.6.7@nemtech/stable
-rocksdb/7.4.3@nemtech/stable
+cppzmq/4.9.0@nemtech/stable
+mongo-cxx-driver/3.7.0@nemtech/stable
+rocksdb/7.7.3@nemtech/stable
 
 # test dependencies
-benchmark/1.7.0@nemtech/stable
+benchmark/1.7.1@nemtech/stable
 gtest/1.12.1
 
 [generators]

--- a/client/catapult/conanfile.txt
+++ b/client/catapult/conanfile.txt
@@ -4,7 +4,7 @@ boost/1.80.0
 openssl/3.0.7
 
 cppzmq/4.9.0@nemtech/stable
-mongo-cxx-driver/3.7.0@nemtech/stable
+mongo-cxx-driver/3.6.7@nemtech/stable
 rocksdb/7.7.3@nemtech/stable
 
 # test dependencies

--- a/client/catapult/extensions/mongo/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.14)
 
 message("--- locating mongo dependencies ---")
-find_package(MONGOCXX 3.6.7 EXACT REQUIRED)
-find_package(MONGOC-1.0 1.22.0 EXACT REQUIRED)
+find_package(MONGOCXX 3.7.0 EXACT REQUIRED)
+find_package(MONGOC-1.0 1.22.2 EXACT REQUIRED)
 
 message("mongocxx  ver: ${MONGOCXX_VERSION}")
 message("mongoc    ver: ${MONGOC-1.0_VERSION}")

--- a/client/catapult/extensions/mongo/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.14)
 
 message("--- locating mongo dependencies ---")
-find_package(MONGOCXX 3.7.0 EXACT REQUIRED)
-find_package(MONGOC-1.0 1.23.1 EXACT REQUIRED)
+find_package(MONGOCXX 3.6.7 EXACT REQUIRED)
+find_package(MONGOC-1.0 1.22.0 EXACT REQUIRED)
 
 message("mongocxx  ver: ${MONGOCXX_VERSION}")
 message("mongoc    ver: ${MONGOC-1.0_VERSION}")

--- a/client/catapult/extensions/mongo/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 
 message("--- locating mongo dependencies ---")
 find_package(MONGOCXX 3.7.0 EXACT REQUIRED)
-find_package(MONGOC-1.0 1.22.2 EXACT REQUIRED)
+find_package(MONGOC-1.0 1.23.1 EXACT REQUIRED)
 
 message("mongocxx  ver: ${MONGOCXX_VERSION}")
 message("mongoc    ver: ${MONGOC-1.0_VERSION}")

--- a/client/catapult/extensions/zeromq/CMakeLists.txt
+++ b/client/catapult/extensions/zeromq/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.14)
 
 message("--- locating zeromq dependencies ---")
-find_package(cppzmq 4.8.1 EXACT REQUIRED)
+find_package(cppzmq 4.9.0 EXACT REQUIRED)
 
 message("zeromq    ver: ${ZeroMQ_VERSION}")
 message("zeromq    inc: ${ZeroMQ_INCLUDE_DIR}")

--- a/client/catapult/tests/bench/CMakeLists.txt
+++ b/client/catapult/tests/bench/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 
 # setup benchmark
 message("--- locating bench dependencies ---")
-find_package(benchmark 1.7.0 EXACT REQUIRED)
+find_package(benchmark 1.7.1 EXACT REQUIRED)
 message("bench     ver: ${benchmark_VERSION}")
 
 # add benchmark dependencies

--- a/client/catapult/tests/catapult/consumers/BatchSignatureConsumerTests.cpp
+++ b/client/catapult/tests/catapult/consumers/BatchSignatureConsumerTests.cpp
@@ -106,7 +106,6 @@ namespace catapult { namespace consumers {
 				auto isAlwaysVerifiable = m_alwaysVerifiableIndexes.cend() != m_alwaysVerifiableIndexes.find(m_entityInfos.size());
 				m_entityInfos.push_back(entityInfo);
 
-				auto i = 0u;
 				for (const auto& descriptor : m_descriptors) {
 					m_signatureInputs.push_back(SignatureInput());
 					auto& input = m_signatureInputs.back();
@@ -129,7 +128,6 @@ namespace catapult { namespace consumers {
 
 					const auto& signerPublicKey = input.Signer.publicKey();
 					sub.notify(model::SignatureNotification(signerPublicKey, input.Signature, input.Data, replayProtectionMode));
-					++i;
 				}
 			}
 

--- a/client/catapult/tests/catapult/utils/CatapultExceptionTests.cpp
+++ b/client/catapult/tests/catapult/utils/CatapultExceptionTests.cpp
@@ -117,9 +117,21 @@ namespace catapult {
 		template<typename TException, typename TTraits>
 		void AssertExceptionInformation(const TException& ex, const ExpectedDiagnostics<TTraits>& expected) {
 			// Arrange:
+			std::string endBrace = " >";
+			std::string exceptionFqn = std::string(TTraits::Exception_Fqn);
+
+#if 15 == __clang_major__
+			endBrace = ">";
+			std::string toSearch = "> >";
+			auto pos = exceptionFqn.find(toSearch);
+			if (std::string::npos != pos) {
+				exceptionFqn.replace(pos, toSearch.size(), ">>");
+			}
+#endif
+
 			std::vector<std::string> expectedDiagLines{
 				"Throw in function " + ConvertToExceptionFunctionName(expected.FunctionName),
-				"Dynamic exception type: " STRUCTPREFIX "boost::wrapexcept<" + std::string(TTraits::Exception_Fqn) + " >",
+				"Dynamic exception type: " STRUCTPREFIX "boost::wrapexcept<" + exceptionFqn + endBrace,
 				"std::exception::what: " + expected.What
 			};
 

--- a/client/catapult/tests/catapult/utils/CatapultExceptionTests.cpp
+++ b/client/catapult/tests/catapult/utils/CatapultExceptionTests.cpp
@@ -124,9 +124,8 @@ namespace catapult {
 			endBrace = ">";
 			std::string toSearch = "> >";
 			auto pos = exceptionFqn.find(toSearch);
-			if (std::string::npos != pos) {
+			if (std::string::npos != pos)
 				exceptionFqn.replace(pos, toSearch.size(), ">>");
-			}
 #endif
 
 			std::vector<std::string> expectedDiagLines{

--- a/jenkins/catapult/baseImageDockerfileGenerator.py
+++ b/jenkins/catapult/baseImageDockerfileGenerator.py
@@ -184,6 +184,9 @@ class OptionsManager:
 		if self.compiler.c.startswith('gcc') and 12 == self.compiler.version:
 			descriptor.cxxflags += ['-Wno-error=maybe-uninitialized']
 
+		if self.compiler.c.startswith('clang') and 15 == self.compiler.version:
+			descriptor.cxxflags += ['-Wno-error=unused-but-set-variable']
+
 		return self._cmake(descriptor)
 
 	def googletest(self):
@@ -195,6 +198,9 @@ class OptionsManager:
 	def googlebench(self):
 		descriptor = self.OptionsDescriptor()
 		descriptor.options += get_dependency_flags('google_benchmark')
+		if self.compiler.c.startswith('clang') and 15 == self.compiler.version:
+			descriptor.cxxflags += ['-Wno-error=unused-but-set-variable']
+
 		return self._cmake(descriptor)
 
 	@property

--- a/jenkins/catapult/compilers/clang-latest.yaml
+++ b/jenkins/catapult/compilers/clang-latest.yaml
@@ -1,15 +1,15 @@
 c: clang
 cpp: clang++
-version: 14
+version: 15
 
 stl:
   version: c++1y
   lib: libc++
 
 deps:
-  - /usr/lib/llvm-14/lib/libc++.so.*
-  - /usr/lib/llvm-14/lib/libc++abi.so.*
-  - /usr/lib/llvm-14/lib/libunwind.*
+  - /usr/lib/llvm-15/lib/libc++.so.*
+  - /usr/lib/llvm-15/lib/libc++abi.so.*
+  - /usr/lib/llvm-15/lib/libunwind.*
 
-  - /usr/lib/llvm-14/bin/llvm-symbolizer
-  - /usr/lib/x86_64-linux-gnu/libLLVM-14.*
+  - /usr/lib/llvm-15/bin/llvm-symbolizer
+  - /usr/lib/x86_64-linux-gnu/libLLVM-15.*

--- a/jenkins/catapult/compilers/clang-prior.yaml
+++ b/jenkins/catapult/compilers/clang-prior.yaml
@@ -1,15 +1,15 @@
 c: clang
 cpp: clang++
-version: 13
+version: 14
 
 stl:
   version: c++1y
   lib: libc++
 
 deps:
-  - /usr/lib/llvm-13/lib/libc++.so.*
-  - /usr/lib/llvm-13/lib/libc++abi.so.*
-  - /usr/lib/llvm-13/lib/libunwind.*
+  - /usr/lib/llvm-14/lib/libc++.so.*
+  - /usr/lib/llvm-14/lib/libc++abi.so.*
+  - /usr/lib/llvm-14/lib/libunwind.*
 
-  - /usr/lib/llvm-13/bin/llvm-symbolizer
-  - /usr/lib/x86_64-linux-gnu/libLLVM-13.*
+  - /usr/lib/llvm-14/bin/llvm-symbolizer
+  - /usr/lib/x86_64-linux-gnu/libLLVM-14.*

--- a/jenkins/catapult/compilers/ubuntu-clang/Dockerfile
+++ b/jenkins/catapult/compilers/ubuntu-clang/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update >/dev/null && \
 	wget 
 
 # Use the latest Clang version.
-ARG COMPILER_VERSION=14
+ARG COMPILER_VERSION=15
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /etc/apt/trusted.gpg.d/clang.gpg  && \
 	echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${COMPILER_VERSION} main" > /etc/apt/sources.list.d/clang.list && \
 	apt-get update >/dev/null && \
@@ -26,4 +26,5 @@ RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /etc/
 	update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${COMPILER_VERSION} 100 && \
 	update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100 && \
 	update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100 && \
-	rm -rf /var/lib/apt/lists/*
+	rm -rf /var/lib/apt/lists/* && \
+	clang --version

--- a/jenkins/catapult/dependency_flags.py
+++ b/jenkins/catapult/dependency_flags.py
@@ -38,7 +38,10 @@ DEPENDENCY_FLAGS = {
 WINDOWS_DEPENDENCY_FLAGS = {
 	'facebook_rocksdb': ['-DROCKSDB_INSTALL_ON_WINDOWS=ON'],
 
-	'google_googletest': ['-Dgtest_force_shared_crt=on']
+	'google_googletest': ['-Dgtest_force_shared_crt=on'],
+
+	'mongodb_mongo-c-driver': ['-DENABLE_EXTRA_ALIGNMENT=0'],
+	'mongodb_mongo-cxx-driver': ['-DENABLE_TESTS=OFF']
 }
 
 

--- a/jenkins/catapult/installDepsLocal.py
+++ b/jenkins/catapult/installDepsLocal.py
@@ -123,11 +123,10 @@ class Builder:
 		self.process_manager.dispatch_subprocess(['nmake'])
 		self.process_manager.dispatch_subprocess(['nmake', 'install_sw', 'install_ssldirs'])
 
-
 	def build_openssl_unix(self):
-		compiler = 'linux-x86_64-clang' if self.is_clang else 'linux-x86_64'
+		compiler = 'linux-x86_64-clang' if self.is_clang else ''
 		openssl_destinations = [f'--{key}={self.target_directory / "openssl"}' for key in ('prefix', 'openssldir', 'libdir')]
-		self.process_manager.dispatch_subprocess(['perl', './Configure', compiler] +  openssl_destinations)
+		self.process_manager.dispatch_subprocess(['perl', './Configure', compiler] + openssl_destinations)
 		self.process_manager.dispatch_subprocess(['make'])
 		self.process_manager.dispatch_subprocess(['make', 'install_sw', 'install_ssldirs'])
 

--- a/jenkins/catapult/installDepsLocal.py
+++ b/jenkins/catapult/installDepsLocal.py
@@ -33,12 +33,13 @@ class Downloader:
 	def download_boost_windows(self):
 		version = self.versions['boost']
 		archive_name = f'boost_1_{version}_0'
-		zip_filename = f'{archive_name}.zip'
+		zip_filename = f'{archive_name}.7z'
 		zip_source_path = f'https://boostorg.jfrog.io/artifactory/main/release/1.{version}.0/source/{zip_filename}'
 
 		self.process_manager.dispatch_subprocess(['powershell', '-Command', 'wget', zip_source_path, '-outfile', zip_filename])
-		self.process_manager.dispatch_subprocess(['powershell', '-Command', 'Expand-Archive', '-Path', zip_filename])
-		self.process_manager.dispatch_subprocess(['powershell', '-Command', 'Move-Item', rf'{archive_name}\{archive_name}', 'boost'])
+		self.process_manager.dispatch_subprocess(['powershell', '-Command', '7z', 'x', zip_filename])
+		self.process_manager.dispatch_subprocess(['powershell', '-Command', 'dir'])
+		self.process_manager.dispatch_subprocess(['powershell', '-Command', 'Move-Item', rf'{archive_name}', 'boost'])
 
 	def download_git_dependency(self, organization, project):
 		version = self.versions[f'{organization}_{project}']
@@ -92,7 +93,10 @@ class Builder:
 		if EnvironmentManager.is_windows_platform() and 'mongo-cxx-driver' == project:
 			# For build without a C++17 polyfill
 			# https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
-			cmake_options += ['-DCMAKE_CXX_FLAGS=\'/Zc:__cplusplus\'']
+			cmake_options += ['-DCMAKE_CXX_FLAGS="/Zc:__cplusplus"', f'-DCMAKE_PREFIX_PATH={self.target_directory / organization}']
+
+		if 'mongodb' == organization:
+			cmake_options += [f'-DOPENSSL_ROOT_DIR={self.target_directory / "openssl"}']
 
 		additional_cmake_options = get_dependency_flags(f'{organization}_{project}')
 		if additional_cmake_options:
@@ -104,6 +108,28 @@ class Builder:
 		else:
 			self.process_manager.dispatch_subprocess(['make', '-j', str(NUM_BUILD_CORES)])
 			self.process_manager.dispatch_subprocess(['make', 'install'])
+
+	def build_openssl(self):
+		self.environment_manager.chdir(self.target_directory / SOURCE_DIR_NAME / 'openssl')
+
+		if EnvironmentManager.is_windows_platform():
+			self.build_openssl_windows()
+		else:
+			self.build_openssl_unix()
+
+	def build_openssl_windows(self):
+		openssl_destinations = [f'--{key}={self.target_directory / "openssl"}' for key in ('prefix', 'openssldir')]
+		self.process_manager.dispatch_subprocess(['perl', './Configure', 'VC-WIN64A'] + openssl_destinations)
+		self.process_manager.dispatch_subprocess(['nmake'])
+		self.process_manager.dispatch_subprocess(['nmake', 'install_sw', 'install_ssldirs'])
+
+
+	def build_openssl_unix(self):
+		compiler = 'linux-x86_64-clang' if self.is_clang else 'linux-x86_64'
+		openssl_destinations = [f'--{key}={self.target_directory / "openssl"}' for key in ('prefix', 'openssldir', 'libdir')]
+		self.process_manager.dispatch_subprocess(['perl', './Configure', compiler] +  openssl_destinations)
+		self.process_manager.dispatch_subprocess(['make'])
+		self.process_manager.dispatch_subprocess(['make', 'install_sw', 'install_ssldirs'])
 
 
 def main():
@@ -145,6 +171,7 @@ def main():
 		print('[x] downloading all dependencies')
 		downloader = Downloader(versions, process_manager)
 		downloader.download_boost()
+		downloader.download_git_dependency('openssl', 'openssl')
 
 		for repository in dependency_repositories:
 			downloader.download_git_dependency(repository[0], repository[1])
@@ -156,6 +183,7 @@ def main():
 			builder.use_clang()
 
 		builder.build_boost()
+		builder.build_openssl()
 
 		for repository in dependency_repositories:
 			builder.build_git_dependency(repository[0], repository[1])

--- a/jenkins/catapult/templates/UbuntuReleaseBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuReleaseBaseImage.Dockerfile
@@ -1,6 +1,6 @@
 FROM {{BASE_IMAGE}}
 ENV DEBIAN_FRONTEND=noninteractive
-MAINTAINER Catapult Development Team
+LABEL maintainer="Catapult Development Team"
 RUN apt-get -y update && apt-get install -y \
 	gdb \
 	openssl \

--- a/jenkins/catapult/templates/UbuntuTestBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuTestBaseImage.Dockerfile
@@ -1,6 +1,6 @@
 FROM {{BASE_IMAGE}}
 ENV DEBIAN_FRONTEND=noninteractive
-MAINTAINER Catapult Development Team
+LABEL maintainer="Catapult Development Team"
 RUN apt-get -y update && apt-get install -y \
 	bison \
 	gdb \

--- a/jenkins/catapult/templates/UbuntuTestSanitizerBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuTestSanitizerBaseImage.Dockerfile
@@ -1,6 +1,6 @@
-FROM symbolplatform/symbol-server-compiler:ubuntu-clang-14
+FROM symbolplatform/symbol-server-compiler:ubuntu-clang-15
 ARG DEBIAN_FRONTEND=noninteractive
-MAINTAINER Catapult Development Team
+LABEL maintainer="Catapult Development Team"
 RUN apt-get -y update && apt-get install -y \
 	bison \
 	gdb \

--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -14,8 +14,8 @@ facebook_rocksdb = v7.7.3
 google_googletest = release-1.12.1
 google_benchmark = v1.7.1
 
-mongodb_mongo-c-driver = 1.23.1
-mongodb_mongo-cxx-driver = r3.7.0
+mongodb_mongo-c-driver = 1.22.0
+mongodb_mongo-cxx-driver = r3.6.7
 
 openssl_openssl = openssl-3.0.7
 

--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -14,7 +14,7 @@ facebook_rocksdb = v7.7.3
 google_googletest = release-1.12.1
 google_benchmark = v1.7.1
 
-mongodb_mongo-c-driver = 1.22.2
+mongodb_mongo-c-driver = 1.23.1
 mongodb_mongo-cxx-driver = r3.7.0
 
 openssl_openssl = openssl-3.0.7

--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -6,18 +6,18 @@ debian = 11.4
 windows = 2022
 
 boost = 80
-cmake = 3.23.2
+cmake = 3.25.0
 gosu = 1.14
 
-facebook_rocksdb = v7.4.3
+facebook_rocksdb = v7.7.3
 
 google_googletest = release-1.12.1
-google_benchmark = v1.7.0
+google_benchmark = v1.7.1
 
-mongodb_mongo-c-driver = 1.22.0
-mongodb_mongo-cxx-driver = r3.6.7
+mongodb_mongo-c-driver = 1.22.2
+mongodb_mongo-cxx-driver = r3.7.0
 
 openssl_openssl = openssl-3.0.7
 
 zeromq_libzmq = v4.3.4
-zeromq_cppzmq = v4.8.1
+zeromq_cppzmq = v4.9.0


### PR DESCRIPTION
## What's the issue?
clang compiler and deps are outdated

## How have you changed the behavior?
bump the version of deps to the latest
1. clang latest to 15
2. cmake to 3.25
3. rocksdb to 7.7.3
4. benchmark to 1.7.1
5. mongo-c-driver to 1.22.2
6. mongo-cxx-driver to 3.7.0
7. cppzmq to 4.9.0

## How was this change tested?
Tested in Jenkins.