### PR TITLE
[catapult/client]: require connections to provide SSL certificate

### DIFF
--- a/client/catapult/src/catapult/ionet/PacketSocket.cpp
+++ b/client/catapult/src/catapult/ionet/PacketSocket.cpp
@@ -361,7 +361,7 @@ namespace catapult { namespace ionet {
 
 		namespace {
 			void ConfigureSslVerify(Socket& socket, Key& publicKey, const predicate<PacketSocketSslVerifyContext&>& verifyCallback) {
-				socket.set_verify_mode(boost::asio::ssl::verify_peer);
+				socket.set_verify_mode(boost::asio::ssl::verify_peer | boost::asio::ssl::verify_fail_if_no_peer_cert);
 				socket.set_verify_depth(1);
 				socket.set_verify_callback([&publicKey, verifyCallback](auto preverified, auto& asioVerifyContext) {
 					PacketSocketSslVerifyContext verifyContext(preverified, asioVerifyContext, publicKey);

--- a/client/catapult/tools/ssl/CertificateDirectoryGenerator.h
+++ b/client/catapult/tools/ssl/CertificateDirectoryGenerator.h
@@ -51,6 +51,9 @@ namespace catapult { namespace tools { namespace ssl {
 		/// Expired CA certificate.
 		Expired_Ca_Certificate,
 
+		/// No peer certificate.
+		No_Peer_Certificate,
+
 		/// Sentinel value.
 		Max_Value
 	};

--- a/client/catapult/tools/ssl/SslClient.cpp
+++ b/client/catapult/tools/ssl/SslClient.cpp
@@ -42,8 +42,10 @@ namespace catapult { namespace tools { namespace ssl {
 				| boost::asio::ssl::context::no_tlsv1_1
 				| boost::asio::ssl::context::no_tlsv1_2);
 
-		m_pSslContext->use_certificate_chain_file(certificateDirectory + "/node.full.crt.pem");
-		m_pSslContext->use_private_key_file(certificateDirectory + "/node.key.pem", boost::asio::ssl::context::pem);
+		if (ScenarioId::No_Peer_Certificate != scenarioId) {
+			m_pSslContext->use_certificate_chain_file(certificateDirectory + "/node.full.crt.pem");
+			m_pSslContext->use_private_key_file(certificateDirectory + "/node.key.pem", boost::asio::ssl::context::pem);
+		}
 
 		// pick curve supported by server
 		std::array<int, 1> curves{ NID_X25519 };

--- a/client/catapult/tools/ssl/main.cpp
+++ b/client/catapult/tools/ssl/main.cpp
@@ -58,7 +58,8 @@ namespace catapult { namespace tools { namespace ssl {
 						" 4 - two-level certificate chain with same key,\n"
 						" 5 - three-level certificate chain,\n"
 						" 6 - expired node certificate,\n"
-						" 7 - expired CA certificate");
+						" 7 - expired CA certificate,\n"
+						" 8 - no peer certificate");
 				optionsBuilder(
 						"tempCertificateDirectory,t",
 						OptionsValue<std::string>(m_tempCertificateDirectory),


### PR DESCRIPTION
 problem: clients are able to initiate connections without certificates
solution: require connections to provide certificates by passing SSL_VERIFY_FAIL_IF_NO_PEER_CERT