### PR TITLE
[jenkins] fix: use latest codecov uploader

### DIFF
--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project.groovy
@@ -263,7 +263,7 @@ pipeline {
 										sh '''
 											curl -Os https://uploader.codecov.io/latest/linux/codecov
 											chmod +x codecov
-											./codecov --verbose --nonZero --rootDir . --flags client-catapult -X gcov --file client_coverage.info
+											./codecov --verbose --nonZero --rootDir . --flags client-catapult --file client_coverage.info
 										'''
 									}
 								}

--- a/jenkins/docker/java.Dockerfile
+++ b/jenkins/docker/java.Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get install -y shellcheck \
 	&& pip install gitlint
 
 # codecov uploader
-RUN curl -Os https://uploader.codecov.io/v0.1.20/linux/codecov \
+RUN curl -Os https://uploader.codecov.io/latest/linux/codecov \
 	&& chmod +x codecov \
 	&& mv codecov /usr/local/bin
 

--- a/jenkins/docker/javascript.Dockerfile
+++ b/jenkins/docker/javascript.Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get install -y shellcheck \
 	&& pip install gitlint
 
 # codecov uploader
-RUN curl -Os https://uploader.codecov.io/v0.1.20/linux/codecov \
+RUN curl -Os https://uploader.codecov.io/latest/linux/codecov \
 	&& chmod +x codecov \
 	&& mv codecov /usr/local/bin
 

--- a/jenkins/docker/postgres.Dockerfile
+++ b/jenkins/docker/postgres.Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get install -y shellcheck \
 	&& pip install gitlint
 
 # codecov uploader
-RUN curl -Os https://uploader.codecov.io/v0.1.20/linux/codecov \
+RUN curl -Os https://uploader.codecov.io/latest/linux/codecov \
 	&& chmod +x codecov \
 	&& mv codecov /usr/local/bin
 

--- a/jenkins/docker/python.Dockerfile
+++ b/jenkins/docker/python.Dockerfile
@@ -19,7 +19,7 @@ RUN pip install poetry
 RUN apt-get install -y zbar-tools
 
 # codecov uploader
-RUN curl -Os https://uploader.codecov.io/v0.1.20/linux/codecov \
+RUN curl -Os https://uploader.codecov.io/latest/linux/codecov \
 	&& chmod +x codecov \
 	&& mv codecov /usr/local/bin
 


### PR DESCRIPTION
## What's the issue?
Due to previous bugs in the codecov uploader, Jenkins is not using the latest.

## How have you changed the behavior?
Jenkins always uses the latest version of codecov uploader

## How was this change tested?
on my dev box.