### PR TITLE
[client/catapult] fix: update mongodb drivers

### DIFF
--- a/client/catapult/CMakeGlobalSettings.cmake
+++ b/client/catapult/CMakeGlobalSettings.cmake
@@ -97,7 +97,7 @@ endif()
 
 ### set compiler settings
 if(MSVC)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /WX /EHsc")
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /WX /EHsc /Zc:__cplusplus")
 	# in debug disable "potentially uninitialized local variable" (FP)
 	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MDd /D_SCL_SECURE_NO_WARNINGS /wd4701")
 	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /MD /Zi")

--- a/client/catapult/conanfile.txt
+++ b/client/catapult/conanfile.txt
@@ -4,7 +4,7 @@ boost/1.80.0
 openssl/3.0.7
 
 cppzmq/4.9.0@nemtech/stable
-mongo-cxx-driver/3.6.7@nemtech/stable
+mongo-cxx-driver/3.7.0@nemtech/stable
 rocksdb/7.7.3@nemtech/stable
 
 # test dependencies

--- a/client/catapult/extensions/mongo/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.14)
 
 message("--- locating mongo dependencies ---")
-find_package(MONGOCXX 3.6.7 EXACT REQUIRED)
-find_package(MONGOC-1.0 1.22.0 EXACT REQUIRED)
+find_package(MONGOCXX 3.7.0 EXACT REQUIRED)
+find_package(MONGOC-1.0 1.23.1 EXACT REQUIRED)
 
 message("mongocxx  ver: ${MONGOCXX_VERSION}")
 message("mongoc    ver: ${MONGOC-1.0_VERSION}")

--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -14,8 +14,8 @@ facebook_rocksdb = v7.7.3
 google_googletest = release-1.12.1
 google_benchmark = v1.7.1
 
-mongodb_mongo-c-driver = 1.22.0
-mongodb_mongo-cxx-driver = r3.6.7
+mongodb_mongo-c-driver = 1.23.1
+mongodb_mongo-cxx-driver = r3.7.0
 
 openssl_openssl = openssl-3.0.7
 


### PR DESCRIPTION
## What's the issue?
Catapult is not using the latest mongodb driver

## How have you changed the behavior?
Update to the latest mongodb drivers.

## How was this change tested?
Running in Jenkins