### PR TITLE
[jenkins] fix: handle testcase decode output failure 

### DIFF
--- a/jenkins/catapult/process.py
+++ b/jenkins/catapult/process.py
@@ -9,6 +9,15 @@ class ProcessManager:
 	def __init__(self, dry_run=False):
 		self.dry_run = dry_run
 
+	@staticmethod
+	def _decode_line(line_bin):
+		try:
+			return line_bin.decode('utf-8')
+		except UnicodeDecodeError as ex:
+			err = f'Failed to decode line: {line_bin}\n Exception: {str(ex)}\n'
+			print(err)
+			return err
+
 	def dispatch_subprocess(self, command_line, show_output=True, handle_error=True, redirect_filename=None):
 		self._print_command(command_line)
 
@@ -18,7 +27,7 @@ class ProcessManager:
 		with Popen(command_line, stdout=PIPE, stderr=STDOUT) as process:
 			process_lines = []
 			for line_bin in iter(process.stdout.readline, b''):
-				line = line_bin.decode('utf-8')
+				line = self._decode_line(line_bin)
 
 				if show_output:
 					sys.stdout.write(line)
@@ -52,7 +61,7 @@ class ProcessManager:
 			process_lines = []
 			is_filtered_output = 'max' != verbosity
 			for line_bin in iter(process.stdout.readline, b''):
-				line = line_bin.decode('utf-8')
+				line = self._decode_line(line_bin)
 				process_lines.append(line)
 
 				if is_filtered_output:

--- a/jenkins/catapult/process.py
+++ b/jenkins/catapult/process.py
@@ -11,7 +11,7 @@ class ProcessManager:
 
 	@staticmethod
 	def _decode_line(line_bin):
-		return line_bin.rstrip().decode('utf-8', errors='ignore')
+		return line_bin.decode('utf-8', errors='ignore')
 
 	def dispatch_subprocess(self, command_line, show_output=True, handle_error=True, redirect_filename=None):
 		self._print_command(command_line)

--- a/jenkins/catapult/process.py
+++ b/jenkins/catapult/process.py
@@ -14,9 +14,7 @@ class ProcessManager:
 		try:
 			return line_bin.decode('utf-8')
 		except UnicodeDecodeError as ex:
-			err = f'Failed to decode line: {line_bin}\n Exception: {str(ex)}\n'
-			print(err)
-			return err
+			return f'Failed to decode line: {line_bin}\n Exception: {str(ex)}\n'
 
 	def dispatch_subprocess(self, command_line, show_output=True, handle_error=True, redirect_filename=None):
 		self._print_command(command_line)

--- a/jenkins/catapult/process.py
+++ b/jenkins/catapult/process.py
@@ -19,7 +19,7 @@ class ProcessManager:
 		with Popen(command_line, stdout=PIPE, stderr=STDOUT) as process:
 			process_lines = []
 			for line_bin in iter(process.stdout.readline, b''):
-				line = line_bin.decode('utf-8')
+				line = line_bin.decode('utf-8', self.decode_error)
 
 				if show_output:
 					sys.stdout.write(line)

--- a/jenkins/catapult/process.py
+++ b/jenkins/catapult/process.py
@@ -11,10 +11,7 @@ class ProcessManager:
 
 	@staticmethod
 	def _decode_line(line_bin):
-		try:
-			return line_bin.decode('utf-8')
-		except UnicodeDecodeError as ex:
-			return f'Failed to decode line: {line_bin}\n Exception: {str(ex)}\n'
+		return line_bin.rstrip().decode('utf-8', errors='ignore')
 
 	def dispatch_subprocess(self, command_line, show_output=True, handle_error=True, redirect_filename=None):
 		self._print_command(command_line)

--- a/jenkins/catapult/process.py
+++ b/jenkins/catapult/process.py
@@ -6,8 +6,9 @@ MAX_LINE_LENGTH = 140
 
 
 class ProcessManager:
-	def __init__(self, dry_run=False):
+	def __init__(self, dry_run=False, decode_error='strict'):
 		self.dry_run = dry_run
+		self.decode_error = decode_error
 
 	def dispatch_subprocess(self, command_line, show_output=True, handle_error=True, redirect_filename=None):
 		self._print_command(command_line)
@@ -52,7 +53,7 @@ class ProcessManager:
 			process_lines = []
 			is_filtered_output = 'max' != verbosity
 			for line_bin in iter(process.stdout.readline, b''):
-				line = line_bin.decode('utf-8')
+				line = line_bin.decode('utf-8', error=self.decode_error)
 				process_lines.append(line)
 
 				if is_filtered_output:

--- a/jenkins/catapult/process.py
+++ b/jenkins/catapult/process.py
@@ -53,7 +53,7 @@ class ProcessManager:
 			process_lines = []
 			is_filtered_output = 'max' != verbosity
 			for line_bin in iter(process.stdout.readline, b''):
-				line = line_bin.decode('utf-8', error=self.decode_error)
+				line = line_bin.decode('utf-8', self.decode_error)
 				process_lines.append(line)
 
 				if is_filtered_output:

--- a/jenkins/catapult/process.py
+++ b/jenkins/catapult/process.py
@@ -9,10 +9,6 @@ class ProcessManager:
 	def __init__(self, dry_run=False):
 		self.dry_run = dry_run
 
-	@staticmethod
-	def _decode_line(line_bin):
-		return line_bin.decode('utf-8', errors='ignore')
-
 	def dispatch_subprocess(self, command_line, show_output=True, handle_error=True, redirect_filename=None):
 		self._print_command(command_line)
 
@@ -22,7 +18,7 @@ class ProcessManager:
 		with Popen(command_line, stdout=PIPE, stderr=STDOUT) as process:
 			process_lines = []
 			for line_bin in iter(process.stdout.readline, b''):
-				line = self._decode_line(line_bin)
+				line = line_bin.decode('utf-8')
 
 				if show_output:
 					sys.stdout.write(line)
@@ -56,7 +52,7 @@ class ProcessManager:
 			process_lines = []
 			is_filtered_output = 'max' != verbosity
 			for line_bin in iter(process.stdout.readline, b''):
-				line = self._decode_line(line_bin)
+				line = line_bin.decode('utf-8')
 				process_lines.append(line)
 
 				if is_filtered_output:

--- a/jenkins/catapult/runDockerTestsInnerTest.py
+++ b/jenkins/catapult/runDockerTestsInnerTest.py
@@ -143,7 +143,7 @@ def main():
 	parser.add_argument('--source-path', help='path to the catapult source code', required=True)
 	args = parser.parse_args()
 
-	process_manager = ProcessManager(args.dry_run)
+	process_manager = ProcessManager(args.dry_run, 'ignore') if EnvironmentManager.is_windows_platform() else ProcessManager(args.dry_run)
 	environment_manager = EnvironmentManager(args.dry_run)
 
 	compiler_configuration = load_compiler_configuration(args.compiler_configuration)
@@ -175,9 +175,6 @@ def main():
 			f'--gtest_output=xml:{base_output_filepath}.xml',
 			Path(args.exe_path) if EnvironmentManager.is_windows_platform() else Path(args.exe_path) / '..' / 'lib'
 		]
-
-		if EnvironmentManager.is_windows_platform():
-			test_args.append('--gtest_color=no')
 
 		if process_manager.dispatch_test_subprocess(test_args, args.verbosity):
 			for core_path in Path('.').glob('core*'):

--- a/jenkins/catapult/runDockerTestsInnerTest.py
+++ b/jenkins/catapult/runDockerTestsInnerTest.py
@@ -176,6 +176,9 @@ def main():
 			Path(args.exe_path) if EnvironmentManager.is_windows_platform() else Path(args.exe_path) / '..' / 'lib'
 		]
 
+		if EnvironmentManager.is_windows_platform():
+			test_args.append('--gtest_color=no')
+
 		if process_manager.dispatch_test_subprocess(test_args, args.verbosity):
 			for core_path in Path('.').glob('core*'):
 				handle_core_file(process_manager, core_path, test_exe_filepath, base_output_filepath)


### PR DESCRIPTION
## What's the issue?
Occasionally catapult tests on Windows fails due to invalid bytes get included in the tests output.

```
15:52:24  catapult-client-build-catapult-project-test-1  | Failed to decode line: b'[----------] 1 test from FutureTests\xfb\xc0\r\n'

15:52:24  catapult-client-build-catapult-project-test-1  |  Exception: 'utf-8' codec can't decode byte 0xfb in position 36: invalid start byte
```

## How have you changed the behavior?
Instead of failing the tests run when decode of the output fails, it will log the failure and continue running the tests.

## How was this change tested?
Ran in Jenkins