### PR TITLE
[client/catapult]: MosaicSupplyRevocation is not correlated with SourceAddress

### DIFF
--- a/client/catapult/plugins/txes/mosaic/src/plugins/MosaicSupplyRevocationTransactionPlugin.cpp
+++ b/client/catapult/plugins/txes/mosaic/src/plugins/MosaicSupplyRevocationTransactionPlugin.cpp
@@ -40,13 +40,15 @@ namespace catapult { namespace plugins {
 				// consequently, MosaicSupplyRevocation transactions will be rejected until then because of Revokable flag requirement
 				sub.notify(MosaicRequiredNotification(context.SignerAddress, transaction.Mosaic.MosaicId, requiredMosaicFlags));
 
-				sub.notify(AddressInteractionNotification(context.SignerAddress, transaction.Type, { transaction.SourceAddress }));
+				sub.notify(AccountAddressNotification(transaction.SourceAddress)); // mark SourceAddress as affected by this transaction
 
 				sub.notify(BalanceTransferNotification(
 						transaction.SourceAddress,
 						context.SignerAddress,
 						transaction.Mosaic.MosaicId,
 						transaction.Mosaic.Amount));
+
+				// don't raise an AddressInteractionNotification because revocation should be allowed irrespective of restrictions
 			};
 		}
 	}

--- a/client/catapult/plugins/txes/mosaic/tests/plugins/MosaicSupplyRevocationTransactionPluginTests.cpp
+++ b/client/catapult/plugins/txes/mosaic/tests/plugins/MosaicSupplyRevocationTransactionPluginTests.cpp
@@ -65,7 +65,7 @@ namespace catapult { namespace plugins {
 			// Act + Assert:
 			test::TransactionPluginTestUtils<TTraits>::AssertNotificationTypes(transaction, {
 				MosaicRequiredNotification::Notification_Type,
-				AddressInteractionNotification::Notification_Type,
+				AccountAddressNotification::Notification_Type,
 				BalanceTransferNotification::Notification_Type
 			}, utils::ParseByteArray<Address>(Nemesis_Address));
 		}
@@ -98,10 +98,10 @@ namespace catapult { namespace plugins {
 				EXPECT_EQ(transaction.Mosaic.MosaicId, notification.MosaicId.unresolved());
 				EXPECT_EQ(utils::to_underlying_type(expectedPropertyFlagMask), notification.PropertyFlagMask);
 			});
-			builder.template addExpectation<AddressInteractionNotification>([&transaction](const auto& notification) {
-				EXPECT_EQ(GetSignerAddress(transaction), notification.Source);
-				EXPECT_EQ(transaction.Type, notification.TransactionType);
-				EXPECT_EQ(UnresolvedAddressSet{ transaction.SourceAddress }, notification.ParticipantsByAddress);
+			builder.template addExpectation<AccountAddressNotification>([&transaction](const auto& notification) {
+				EXPECT_FALSE(notification.Address.isResolved());
+
+				EXPECT_EQ(transaction.SourceAddress, notification.Address.unresolved());
 			});
 			builder.template addExpectation<BalanceTransferNotification>([&transaction](const auto& notification) {
 				EXPECT_FALSE(notification.Sender.isResolved());


### PR DESCRIPTION
 problem: ExtractAddresses should include MosaicSupplyRevocation::SourceAddress
solution: raise AccountAddressNotification

 problem: revocation can be blocked by mosaic restriction(s)
solution: stop raising AddressInteractionNotification