### PR TITLE
[client/catapult] fix: revert mongodb version bump

### DIFF
--- a/client/catapult/conanfile.txt
+++ b/client/catapult/conanfile.txt
@@ -4,7 +4,7 @@ boost/1.80.0
 openssl/3.0.7
 
 cppzmq/4.9.0@nemtech/stable
-mongo-cxx-driver/3.7.0@nemtech/stable
+mongo-cxx-driver/3.6.7@nemtech/stable
 rocksdb/7.7.3@nemtech/stable
 
 # test dependencies

--- a/client/catapult/extensions/mongo/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.14)
 
 message("--- locating mongo dependencies ---")
-find_package(MONGOCXX 3.7.0 EXACT REQUIRED)
-find_package(MONGOC-1.0 1.23.1 EXACT REQUIRED)
+find_package(MONGOCXX 3.6.7 EXACT REQUIRED)
+find_package(MONGOC-1.0 1.22.0 EXACT REQUIRED)
 
 message("mongocxx  ver: ${MONGOCXX_VERSION}")
 message("mongoc    ver: ${MONGOC-1.0_VERSION}")

--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -14,8 +14,8 @@ facebook_rocksdb = v7.7.3
 google_googletest = release-1.12.1
 google_benchmark = v1.7.1
 
-mongodb_mongo-c-driver = 1.23.1
-mongodb_mongo-cxx-driver = r3.7.0
+mongodb_mongo-c-driver = 1.22.0
+mongodb_mongo-cxx-driver = r3.6.7
 
 openssl_openssl = openssl-3.0.7
 


### PR DESCRIPTION
## What is the current behavior?
Mongodb-c-driver fails to build on MacOs

## What's the issue?
getpagesize() is removed in the later OS.

## How have you changed the behavior?
Downgrade the mongodb-c-driver to allow MacOs builds to work

## How was this change tested?
on dev box