### PR TITLE
[sdk/javascript]: drop wee_alloc support

### DIFF
--- a/sdk/javascript/wasm/Cargo.toml
+++ b/sdk/javascript/wasm/Cargo.toml
@@ -16,12 +16,6 @@ wasm-bindgen = "0.2.63"
 # code size when deploying.
 console_error_panic_hook = { version = "0.1.6", optional = true }
 
-# `wee_alloc` is a tiny allocator for wasm that is only ~1K in code size
-# compared to the default allocator's ~10K. It is slower than the default
-# allocator, however.
-#
-# Unfortunately, `wee_alloc` requires nightly Rust when targeting wasm for now.
-wee_alloc = { version = "0.4.5", optional = true }
 sha3 = "0.10.2"
 js-sys = "0.3.59"
 

--- a/sdk/javascript/wasm/src/lib.rs
+++ b/sdk/javascript/wasm/src/lib.rs
@@ -8,11 +8,6 @@
 
 #![cfg_attr(not(test), forbid(unsafe_code))]
 
-// when the `wee_alloc` feature is enabled, use `wee_alloc` as the global allocator
-#[cfg(feature = "wee_alloc")]
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
-
 extern crate curve25519_dalek;
 use curve25519_dalek::scalar::Scalar;
 use curve25519_dalek::edwards::{CompressedEdwardsY, EdwardsPoint};


### PR DESCRIPTION
 problem: wee_alloc is no longer maintained
solution: always use default allocator
