### PR TITLE
[client/rest]: add inflation route(s)

### DIFF
--- a/client/rest/resources/rest.json
+++ b/client/rest/resources/rest.json
@@ -48,6 +48,8 @@
     "tlsClientCertificatePath": "/",
     "tlsClientKeyPath": "/",
     "tlsCaCertificatePath": "/",
+
+    "inflationPropertyFilePath": "/",
     "networkPropertyFilePath": "/",
     "nodePropertyFilePath": "/"
   },

--- a/client/rest/src/routes/networkRoutes.js
+++ b/client/rest/src/routes/networkRoutes.js
@@ -47,6 +47,26 @@ module.exports = {
 			contents => ini.parse(contents)
 		);
 
+		const readAndParseInflationPropertiesFile = () => fileLoader.readOnce(
+			services.config.apiNode.inflationPropertyFilePath,
+			contents => {
+				const inflationObject = ini.parse(contents).inflation;
+				const inflationInflectionPoints = Object.getOwnPropertyNames(inflationObject).map(key => ({
+					startHeight: BigInt(key.substring(key.lastIndexOf('-') + 1)),
+					rewardAmount: BigInt(inflationObject[key])
+				}));
+
+				// sort by start height
+				inflationInflectionPoints.sort((lhs, rhs) => {
+					if (lhs.startHeight === rhs.startHeight)
+						return 0;
+
+					return lhs.startHeight > rhs.startHeight ? 1 : -1;
+				});
+				return inflationInflectionPoints;
+			}
+		);
+
 		const sanitizeInput = value => value.replace(/[^0-9]/g, '');
 
 		server.get('/network', (req, res, next) => {
@@ -84,6 +104,47 @@ module.exports = {
 				next();
 			}).catch(() => {
 				res.send(errors.createInvalidArgumentError('there was an error reading the network properties file'));
+				next();
+			}));
+
+		server.get('/network/inflation', (req, res, next) => readAndParseInflationPropertiesFile()
+			.then(inflationInflectionPoints => {
+				res.send(inflationInflectionPoints.map(point => ({
+					// send BigInts over network as strings
+					startHeight: point.startHeight.toString(),
+					rewardAmount: point.rewardAmount.toString()
+				})));
+				next();
+			}).catch(() => {
+				res.send(errors.createInvalidArgumentError('there was an error reading the inflation properties file'));
+				next();
+			}));
+
+		server.get('/network/inflation/at/:height', (req, res, next) => readAndParseInflationPropertiesFile()
+			.then(inflationInflectionPoints => {
+				const height = BigInt(req.params.height);
+
+				const findMatchingPoint = () => {
+					const firstPoint = inflationInflectionPoints[0];
+					if (height < firstPoint.startHeight)
+						return { startHeight: 'N/A', rewardAmount: '0' };
+
+					for (let i = 1; i < inflationInflectionPoints.length; ++i) {
+						if (height < inflationInflectionPoints[i].startHeight)
+							return inflationInflectionPoints[i - 1];
+					}
+
+					return inflationInflectionPoints[inflationInflectionPoints.length - 1];
+				};
+
+				const point = findMatchingPoint();
+				res.send({
+					startHeight: point.startHeight.toString(),
+					rewardAmount: point.rewardAmount.toString()
+				});
+				next();
+			}).catch(() => {
+				res.send(errors.createInvalidArgumentError('there was an error reading the inflation properties file'));
 				next();
 			}));
 

--- a/client/rest/test/routes/allRoutes_spec.js
+++ b/client/rest/test/routes/allRoutes_spec.js
@@ -56,6 +56,8 @@ describe('all routes', () => {
 			'/finalization/proof/height/:height',
 
 			'/network',
+			'/network/inflation',
+			'/network/inflation/at/:height',
 			'/network/properties',
 			'/network/fees/transaction',
 			'/network/fees/rental',


### PR DESCRIPTION
 problem: there is no way to determine inflation (block rewards) from rest
solution: add API returning contents of config-inflation
          add API returning inflation given block height