### PR TITLE
[jenkins] fix: openssl 3 legacy providers disabled by default

### DIFF
--- a/jenkins/docker/python.Dockerfile
+++ b/jenkins/docker/python.Dockerfile
@@ -18,6 +18,12 @@ RUN pip install poetry
 # sdk dependencies
 RUN apt-get install -y zbar-tools libssl-dev
 
+# enable legacy providers in openssl(ripemd160)
+RUN sed -i '/^default = default_sect/a legacy = legacy_sect\n' /etc/ssl/openssl.cnf \
+	&& sed -i '/^\[default_sect\]/i [legacy_sect]\nactivate = 1\n' /etc/ssl/openssl.cnf \
+	&& sed -i 's/^# activate = 1/activate = 1/g' /etc/ssl/openssl.cnf \
+	&& cat /etc/ssl/openssl.cnf
+
 # codecov uploader
 RUN curl -Os https://uploader.codecov.io/latest/linux/codecov \
 	&& chmod +x codecov \


### PR DESCRIPTION
problem: ripemd160 is disabled in openssl 3 since its a legacy provider
solution: enable openssl 3 legacy provider

## What is the current behavior?
Tests that use ``ripemd160`` are failing.

## What's the issue?
In openssl 3 ``ripemd160`` is a legacy provider and is disabled by default.

## How have you changed the behavior?
Enabled the legacy provider in openssl 3 in the python ci image.

## How was this change tested?
Ran tests on dev box