### PR TITLE
[jenkins] feat: docker publish task optional build args param added

### DIFF
--- a/jenkins/shared-library/vars/publish.groovy
+++ b/jenkins/shared-library/vars/publish.groovy
@@ -30,7 +30,7 @@ void dockerPublisher(Map config, String phase) {
 	String version = readPackageVersion()
 	String imageVersionName = "${config.dockerImageName}:${version}"
 
-	Object imageName = docker.build(imageVersionName)
+	Object imageName = docker.build(imageVersionName, config.dockerBuildArgs)
 	docker.withRegistry(dockerUrl, DOCKERHUB_CREDENTIALS_ID) {
 		logger.logInfo("Pushing docker image ${imageVersionName}")
 		imageName.push()

--- a/jenkins/shared-library/vars/publish.groovy
+++ b/jenkins/shared-library/vars/publish.groovy
@@ -30,7 +30,7 @@ void dockerPublisher(Map config, String phase) {
 	String version = readPackageVersion()
 	String imageVersionName = "${config.dockerImageName}:${version}"
 
-	Object imageName = docker.build(imageVersionName, config.dockerBuildArgs)
+	Object imageName = docker.build(imageVersionName, config.dockerBuildArgs ?: '.')
 	docker.withRegistry(dockerUrl, DOCKERHUB_CREDENTIALS_ID) {
 		logger.logInfo("Pushing docker image ${imageVersionName}")
 		imageName.push()


### PR DESCRIPTION
## What was the issue?
it was not possible to pass docker build args to docker publish task in the jenkins pipeline.

## What's the fix?
setting `config.dockerBuildArgs` parameter in the jenkins pipeline will be possible like the following:

```
defaultCiPipeline {
	platform = ['ubuntu']

	publisher = 'docker'
	dockerImageName = 'nemofficial/nis-client'

	dockerBuildArgs = "--build-arg GIT_BRANCH_NAME=${env.BRANCH_NAME}"

	packageId = 'nem-infra'
}

```