### PR TITLE
 [jenkins] feat: add jenkins file to build ci images

### DIFF
--- a/jenkins/infra/jenkins/build-ci-image-all.groovy
+++ b/jenkins/infra/jenkins/build-ci-image-all.groovy
@@ -1,0 +1,115 @@
+pipeline {
+	agent {
+		label 'ubuntu-agent'
+	}
+
+	parameters {
+		gitParameter branchFilter: 'origin/(.*)', defaultValue: 'dev', name: 'MANUAL_GIT_BRANCH', type: 'PT_BRANCH'
+		booleanParam name: 'SHOULD_PUBLISH_JOB_STATUS', description: 'true to publish job status', defaultValue: true
+	}
+
+	options {
+		ansiColor('css')
+		timestamps()
+	}
+
+	triggers {
+		cron('@weekly')
+	}
+
+	stages {
+		stage('print env') {
+			steps {
+				echo """
+							env.GIT_BRANCH: ${env.GIT_BRANCH}
+						 MANUAL_GIT_BRANCH: ${MANUAL_GIT_BRANCH}
+				"""
+			}
+		}
+
+		stage('build ci images') {
+			parallel {
+				stage('cpp') {
+					steps {
+						script {
+							dispatchBuildCiImageJob('cpp')
+						}
+					}
+				}
+				stage('java') {
+					steps {
+						script {
+							dispatchBuildCiImageJob('java')
+						}
+					}
+				}
+				stage('javascript') {
+					steps {
+						script {
+							dispatchBuildCiImageJob('javascript')
+						}
+					}
+				}
+				stage('linter') {
+					steps {
+						script {
+							dispatchBuildCiImageJob('linter')
+						}
+					}
+				}
+				stage('postgres') {
+					steps {
+						script {
+							dispatchBuildCiImageJob('postgres')
+						}
+					}
+				}
+
+				stage('python') {
+					steps {
+						script {
+							dispatchBuildCiImageJob('python')
+						}
+					}
+				}
+			}
+		}
+	}
+	post {
+		success {
+			script {
+				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
+					helper.sendDiscordNotification(
+						':confetti_ball: CI Image All Job Successfully completed',
+						'Not much to see here, all is good',
+						env.BUILD_URL,
+						currentBuild.currentResult
+					)
+				}
+			}
+		}
+		unsuccessful {
+			script {
+				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
+					helper.sendDiscordNotification(
+						":worried: CI Image All Job Failed for ${currentBuild.fullDisplayName}",
+						"At least one job failed for Build#${env.BUILD_NUMBER} which has a result of ${currentBuild.currentResult}.",
+						env.BUILD_URL,
+						currentBuild.currentResult
+					)
+				}
+			}
+		}
+	}
+}
+
+void dispatchBuildCiImageJob(String ciImage) {
+	build job: 'build-ci-image', parameters: [
+		string(name: 'CI_IMAGE', value: "${ciImage}"),
+		string(name: 'MANUAL_GIT_BRANCH', value: "${params.MANUAL_GIT_BRANCH}"),
+		booleanParam(
+			name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS',
+			value: "${!env.SHOULD_PUBLISH_JOB_STATUS || env.SHOULD_PUBLISH_JOB_STATUS.toBoolean()}"
+		)
+	]
+}

--- a/jenkins/infra/jenkins/build-ci-image.groovy
+++ b/jenkins/infra/jenkins/build-ci-image.groovy
@@ -49,7 +49,7 @@ pipeline {
 			steps {
 				script {
 					helper.runStepAndRecordFailure {
-						dir("jenkins/docker")
+						dir('jenkins/docker')
 						{
 							String buildArg = "-f ${CI_IMAGE}.Dockerfile ."
 							docker.withRegistry(DOCKER_URL, DOCKER_CREDENTIALS_ID) {

--- a/jenkins/infra/jenkins/build-ci-image.groovy
+++ b/jenkins/infra/jenkins/build-ci-image.groovy
@@ -1,0 +1,79 @@
+pipeline {
+	parameters {
+		gitParameter branchFilter: 'origin/(.*)', defaultValue: 'dev', name: 'MANUAL_GIT_BRANCH', type: 'PT_BRANCH'
+		choice name: 'CI_IMAGE',
+			choices: ['cpp', 'java', 'javascript', 'linter', 'postgres', 'python'],
+			description: 'continuous integration image'
+		booleanParam name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS', description: 'true to publish job status if failed', defaultValue: false
+	}
+
+	agent {
+		label 'ubuntu-agent'
+	}
+
+	environment {
+		DOCKER_URL = 'https://registry.hub.docker.com'
+		DOCKER_CREDENTIALS_ID = 'docker-hub-token-symbolserverbot'
+	}
+
+	options {
+		ansiColor('css')
+		timestamps()
+	}
+
+	stages {
+		stage('prepare') {
+			stages {
+				stage('prepare variables') {
+					steps {
+						script {
+							helper.runStepAndRecordFailure {
+								destImageName = "symbolplatform/build-ci:${CI_IMAGE}"
+							}
+						}
+					}
+				}
+				stage('print env') {
+					steps {
+						echo """
+									env.GIT_BRANCH: ${env.GIT_BRANCH}
+								 MANUAL_GIT_BRANCH: ${MANUAL_GIT_BRANCH}
+
+								     destImageName: ${destImageName}
+						"""
+					}
+				}
+			}
+		}
+		stage('build image') {
+			steps {
+				script {
+					helper.runStepAndRecordFailure {
+						dir("jenkins/docker")
+						{
+							String buildArg = "-f ${CI_IMAGE}.Dockerfile ."
+							docker.withRegistry(DOCKER_URL, DOCKER_CREDENTIALS_ID) {
+								docker.build(destImageName, buildArg).push()
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+	post {
+		unsuccessful {
+			script {
+				if (env.SHOULD_PUBLISH_FAIL_JOB_STATUS?.toBoolean()) {
+					helper.sendDiscordNotification(
+						"CI Image Job Failed for ${currentBuild.fullDisplayName}",
+						"Job for ${CI_IMAGE} has result of ${currentBuild.currentResult} in"
+						+ " stage **${env.FAILED_STAGE_NAME}** with message: **${env.FAILURE_MESSAGE}**.",
+						env.BUILD_URL,
+						currentBuild.currentResult
+					)
+				}
+			}
+		}
+	}
+}

--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -72,7 +72,7 @@ void call(Closure body) {
 						image null == params.ciBuildDockerImage
 								? "symbolplatform/build-ci:${get_docker_tag(params.ciBuildDockerfile)}"
 								: "${params.ciBuildDockerImage}"
-						args null == params.dockerArgs ? "" : "${params.dockerArgs}"
+						args null == params.dockerArgs ? '' : "${params.dockerArgs}"
 
 						// using the same node and the same workspace mounted to the container
 						reuseNode true

--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -68,10 +68,11 @@ void call(Closure body) {
 			}
 			stage('CI pipeline') {
 				agent {
-					dockerfile {
-						dir 'jenkins/docker'
-						filename "${params.ciBuildDockerfile}"
-						args params.dockerArgs == null ? '' : "${params.dockerArgs}"
+					docker {
+						image null == params.ciBuildDockerImage
+								? "symbolplatform/build-ci:${get_docker_tag(params.ciBuildDockerfile)}"
+								: "${params.ciBuildDockerImage}"
+						args null == params.dockerArgs ? "" : "${params.dockerArgs}"
 
 						// using the same node and the same workspace mounted to the container
 						reuseNode true
@@ -322,4 +323,10 @@ String resolvePath(String rootPath, String path) {
 
 Boolean shouldPublishImage(String shouldPublish) {
 	return shouldPublish == null ? false : shouldPublish.toBoolean()
+}
+
+String get_docker_tag(String dockerfile) {
+	String[] parts = dockerfile.split('\\.')
+	println("dockerfile: ${dockerfile} tag:${parts[0]}")
+	return parts[0]
 }


### PR DESCRIPTION
## What is the current behavior?
Each Jenkins CI job has to build docker images

## What's the issue?
Building the docker image can take a long time or fail during CI.

## How have you changed the behavior?
Create docker images and host them in docker hub.  
The docker images be  pulled at CI time.  Later these will be cache for better performance.

## How was this change tested?
Tested with Jenkins