### PR TITLE
[jenkins] fix: ccache for catapult Windows build

### DIFF
--- a/client/catapult/CMakeLists.txt
+++ b/client/catapult/CMakeLists.txt
@@ -44,7 +44,7 @@ message("boost    libs: ${Boost_LIBRARIES}")
 if(ENABLE_TESTS)
 	message("--- locating gtest dependencies ---")
 
-	find_package(GTest 1.12.1 EXACT REQUIRED)
+	find_package(GTest 1.13.0 EXACT REQUIRED)
 	message("GTest   found: ${GTest_FOUND}")
 	message("GTest     inc: ${GTEST_INCLUDE_DIRS}")
 	message("GTest     ver: ${GTest_VERSION}")

--- a/client/catapult/CMakeLists.txt
+++ b/client/catapult/CMakeLists.txt
@@ -3,6 +3,9 @@ project(catapult_server)
 option(ENABLE_CODE_COVERAGE "Enable code coverage" OFF)
 option(ENABLE_TESTS "Enable tests" ON)
 
+# ccache on windows requires real binary instead of the shims used by scoop to be in the path
+option(USE_CCACHE_ON_WINDOWS "Enable use ccache on Windows" OFF)
+
 include(CMakeGlobalSettings.cmake)
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)

--- a/client/catapult/conanfile.txt
+++ b/client/catapult/conanfile.txt
@@ -9,7 +9,7 @@ rocksdb/7.7.3@nemtech/stable
 
 # test dependencies
 benchmark/1.7.1@nemtech/stable
-gtest/1.12.1
+gtest/1.13.0
 
 [generators]
 cmake

--- a/jenkins/catapult/baseImageDockerfileGenerator.py
+++ b/jenkins/catapult/baseImageDockerfileGenerator.py
@@ -47,7 +47,7 @@ def format_multivalue_options(key, values):
 
 
 def print_powershell_lines(lines, separator='; `\n', **kwargs):
-	run_line = 'RUN powershell -Command $ErrorActionPreference = \'Stop\''
+	run_line = 'RUN pwsh -Command $ErrorActionPreference = \'Stop\''
 	print(separator.join([run_line] + lines).format(**kwargs))
 
 
@@ -327,7 +327,7 @@ class WindowsSystem:
 	@staticmethod
 	def add_base_os_packages():
 		scoop_packages = [
-			'sccache',
+			'ccache',
 			'git',
 			'python',
 			'cmake',
@@ -506,7 +506,7 @@ class WindowsSystemGenerator:
 		}
 
 		print_powershell_lines([
-			'wget {BOOST_URI}/{BOOST_ARCHIVE}.7z -outfile {BOOST_ARCHIVE}.7z',
+			'Invoke-WebRequest {BOOST_URI}/{BOOST_ARCHIVE}.7z -outfile {BOOST_ARCHIVE}.7z',
 			r'7z x .\{BOOST_ARCHIVE}.7z',
 			r'cd {BOOST_ARCHIVE}',
 			r'.\bootstrap.bat {BOOTSTRAP_OPTIONS} --prefix={PREFIX_PATH}',

--- a/jenkins/catapult/compilers/windows-msvc/Dockerfile
+++ b/jenkins/catapult/compilers/windows-msvc/Dockerfile
@@ -1,12 +1,12 @@
 # escape=`
 
-# Use the latest Windows Server Core 2022 image.
-ARG FROM_IMAGE=mcr.microsoft.com/windows/servercore:ltsc2022
+# Use the latest Windows Powershell image.
+ARG FROM_IMAGE=mcr.microsoft.com/powershell:latest
 FROM ${FROM_IMAGE}
 LABEL maintainer="Catapult Development Team"
 
-# Restore the default Windows shell for correct batch processing.
-SHELL ["cmd", "/S", "/C"]
+# use the latest powershell.
+SHELL ["pwsh.exe", "-Command"]
 
 RUN reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
 
@@ -29,7 +29,7 @@ RUN C:\Temp\vs_buildtools.exe `
 	|| IF "%ERRORLEVEL%"=="3010" EXIT 0
 
 # Install scoop and git(required to update scoop)
-RUN powershell.exe -ExecutionPolicy RemoteSigned `
+RUN pwsh.exe -ExecutionPolicy RemoteSigned `
 	(new-object net.webclient).DownloadFile('https://get.scoop.sh','c:\Temp\scoop.ps1'); `
 	$command='c:\Temp\scoop.ps1 -RunAsAdmin'; `
 	iex $command; `

--- a/jenkins/catapult/compilers/windows-msvc/Dockerfile
+++ b/jenkins/catapult/compilers/windows-msvc/Dockerfile
@@ -5,8 +5,8 @@ ARG FROM_IMAGE=mcr.microsoft.com/powershell:latest
 FROM ${FROM_IMAGE}
 LABEL maintainer="Catapult Development Team"
 
-# use the latest powershell.
-SHELL ["pwsh.exe", "-Command"]
+# Restore the default Windows shell for correct batch processing.
+SHELL ["cmd", "/S", "/C"]
 
 RUN reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1 /f
 
@@ -29,7 +29,7 @@ RUN C:\Temp\vs_buildtools.exe `
 	|| IF "%ERRORLEVEL%"=="3010" EXIT 0
 
 # Install scoop and git(required to update scoop)
-RUN pwsh.exe -ExecutionPolicy RemoteSigned `
+RUN pwsh.exe -ExecutionPolicy RemoteSigned -Command $ErrorActionPreference = 'Stop'; `
 	(new-object net.webclient).DownloadFile('https://get.scoop.sh','c:\Temp\scoop.ps1'); `
 	$command='c:\Temp\scoop.ps1 -RunAsAdmin'; `
 	iex $command; `

--- a/jenkins/catapult/process.py
+++ b/jenkins/catapult/process.py
@@ -6,9 +6,8 @@ MAX_LINE_LENGTH = 140
 
 
 class ProcessManager:
-	def __init__(self, dry_run=False, decode_error='strict'):
+	def __init__(self, dry_run=False):
 		self.dry_run = dry_run
-		self.decode_error = decode_error
 
 	def dispatch_subprocess(self, command_line, show_output=True, handle_error=True, redirect_filename=None):
 		self._print_command(command_line)
@@ -19,7 +18,7 @@ class ProcessManager:
 		with Popen(command_line, stdout=PIPE, stderr=STDOUT) as process:
 			process_lines = []
 			for line_bin in iter(process.stdout.readline, b''):
-				line = line_bin.decode('utf-8', self.decode_error)
+				line = line_bin.decode('utf-8')
 
 				if show_output:
 					sys.stdout.write(line)
@@ -53,7 +52,7 @@ class ProcessManager:
 			process_lines = []
 			is_filtered_output = 'max' != verbosity
 			for line_bin in iter(process.stdout.readline, b''):
-				line = line_bin.decode('utf-8', self.decode_error)
+				line = line_bin.decode('utf-8')
 				process_lines.append(line)
 
 				if is_filtered_output:

--- a/jenkins/catapult/process.py
+++ b/jenkins/catapult/process.py
@@ -18,20 +18,11 @@ class ProcessManager:
 		with Popen(command_line, stdout=PIPE, stderr=STDOUT) as process:
 			process_lines = []
 			for line_bin in iter(process.stdout.readline, b''):
-				line = ''
-				try:
-					line = line_bin.decode('utf-8')
-				except UnicodeDecodeError as ex:
-					print(f'line decode failed for {line_bin}')
-					print(ex)
+				line = line_bin.decode('utf-8')
 
 				if show_output:
-					try:
-						sys.stdout.write(line)
-						sys.stdout.flush()
-					except UnicodeEncodeError as ex:
-						print(f'write failed for {line}')
-						print(ex)
+					sys.stdout.write(line)
+					sys.stdout.flush()
 
 				process_lines.append(line)
 
@@ -61,13 +52,7 @@ class ProcessManager:
 			process_lines = []
 			is_filtered_output = 'max' != verbosity
 			for line_bin in iter(process.stdout.readline, b''):
-				line = ''
-				try:
-					line = line_bin.decode('utf-8')
-				except UnicodeDecodeError as ex:
-					print(f'test line decode failed for {line_bin}')
-					print(ex)
-
+				line = line_bin.decode('utf-8')
 				process_lines.append(line)
 
 				if is_filtered_output:
@@ -77,12 +62,8 @@ class ProcessManager:
 					if 'suite' == verbosity and any(line.startswith(prefix) for prefix in ('[ RUN      ]', '[       OK ]')):
 						continue
 
-				try:
-					sys.stdout.write(line)
-					sys.stdout.flush()
-				except UnicodeEncodeError as ex:
-					print(f'write failed for {line}')
-					print(ex)
+				sys.stdout.write(line)
+				sys.stdout.flush()
 
 			process.wait()
 

--- a/jenkins/catapult/process.py
+++ b/jenkins/catapult/process.py
@@ -18,11 +18,20 @@ class ProcessManager:
 		with Popen(command_line, stdout=PIPE, stderr=STDOUT) as process:
 			process_lines = []
 			for line_bin in iter(process.stdout.readline, b''):
-				line = line_bin.decode('utf-8')
+				line = ''
+				try:
+					line = line_bin.decode('utf-8')
+				except UnicodeDecodeError as ex:
+					print(f'line decode failed for {line_bin}')
+					print(ex)
 
 				if show_output:
-					sys.stdout.write(line)
-					sys.stdout.flush()
+					try:
+						sys.stdout.write(line)
+						sys.stdout.flush()
+					except UnicodeEncodeError as ex:
+						print(f'write failed for {line}')
+						print(ex)
 
 				process_lines.append(line)
 
@@ -52,7 +61,13 @@ class ProcessManager:
 			process_lines = []
 			is_filtered_output = 'max' != verbosity
 			for line_bin in iter(process.stdout.readline, b''):
-				line = line_bin.decode('utf-8')
+				line = ''
+				try:
+					line = line_bin.decode('utf-8')
+				except UnicodeDecodeError as ex:
+					print(f'test line decode failed for {line_bin}')
+					print(ex)
+
 				process_lines.append(line)
 
 				if is_filtered_output:
@@ -62,8 +77,12 @@ class ProcessManager:
 					if 'suite' == verbosity and any(line.startswith(prefix) for prefix in ('[ RUN      ]', '[       OK ]')):
 						continue
 
-				sys.stdout.write(line)
-				sys.stdout.flush()
+				try:
+					sys.stdout.write(line)
+					sys.stdout.flush()
+				except UnicodeEncodeError as ex:
+					print(f'write failed for {line}')
+					print(ex)
 
 			process.wait()
 

--- a/jenkins/catapult/runDockerBuild.py
+++ b/jenkins/catapult/runDockerBuild.py
@@ -65,14 +65,15 @@ class OptionsManager(BasicBuildManager):
 		return CONAN_ROOT / 'gcc'
 
 	def docker_run_settings(self):
-		if self.is_msvc:
-			return []
-
 		settings = [
-			('CC', self.compiler.c),
-			('CXX', self.compiler.cpp),
 			('CCACHE_DIR', '/ccache')
 		]
+
+		if not self.is_msvc:
+			settings.append(
+				('CC', self.compiler.c),
+				('CXX', self.compiler.cpp)
+			)
 
 		return [f'--env={key}={value}' for key, value in sorted(settings)]
 

--- a/jenkins/catapult/runDockerBuild.py
+++ b/jenkins/catapult/runDockerBuild.py
@@ -52,7 +52,10 @@ class OptionsManager(BasicBuildManager):
 		if self.enable_code_coverage:
 			return CCACHE_ROOT / 'cc'
 
-		return CCACHE_ROOT / ('release' if self.is_release else 'all')
+		if self.is_release:
+			return CCACHE_ROOT / 'release'
+
+		return CCACHE_ROOT / ('conan' if self.use_conan else 'all')
 
 	@property
 	def conan_path(self):

--- a/jenkins/catapult/runDockerBuild.py
+++ b/jenkins/catapult/runDockerBuild.py
@@ -73,10 +73,10 @@ class OptionsManager(BasicBuildManager):
 		]
 
 		if not self.is_msvc:
-			settings.append(
+			settings.extend([
 				('CC', self.compiler.c),
 				('CXX', self.compiler.cpp)
-			)
+			])
 
 		return [f'--env={key}={value}' for key, value in sorted(settings)]
 

--- a/jenkins/catapult/runDockerTestsInnerTest.py
+++ b/jenkins/catapult/runDockerTestsInnerTest.py
@@ -173,7 +173,7 @@ def main():
 		test_args = [
 			test_exe_filepath,
 			f'--gtest_output=xml:{base_output_filepath}.xml',
-			Path(args.exe_path) / '..' / 'lib'
+			Path(args.exe_path) if EnvironmentManager.is_windows_platform() else Path(args.exe_path) / '..' / 'lib'
 		]
 
 		if process_manager.dispatch_test_subprocess(test_args, args.verbosity):

--- a/jenkins/catapult/runDockerTestsInnerTest.py
+++ b/jenkins/catapult/runDockerTestsInnerTest.py
@@ -173,7 +173,7 @@ def main():
 		test_args = [
 			test_exe_filepath,
 			f'--gtest_output=xml:{base_output_filepath}.xml',
-			Path(args.exe_path) if EnvironmentManager.is_windows_platform() else Path(args.exe_path) / '..' / 'lib'
+			Path(args.exe_path) / '..' / 'lib'
 		]
 
 		if process_manager.dispatch_test_subprocess(test_args, args.verbosity):

--- a/jenkins/catapult/runDockerTestsInnerTest.py
+++ b/jenkins/catapult/runDockerTestsInnerTest.py
@@ -143,7 +143,7 @@ def main():
 	parser.add_argument('--source-path', help='path to the catapult source code', required=True)
 	args = parser.parse_args()
 
-	process_manager = ProcessManager(args.dry_run, 'ignore') if EnvironmentManager.is_windows_platform() else ProcessManager(args.dry_run)
+	process_manager = ProcessManager(args.dry_run)
 	environment_manager = EnvironmentManager(args.dry_run)
 
 	compiler_configuration = load_compiler_configuration(args.compiler_configuration)

--- a/jenkins/catapult/templates/DebianTestBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/DebianTestBaseImage.Dockerfile
@@ -1,5 +1,8 @@
-FROM {{BASE_IMAGE}}
-ENV DEBIAN_FRONTEND=noninteractive
+# image name required as ARG
+ARG FROM_IMAGE=''
+ARG DEBIAN_FRONTEND=noninteractive
+
+FROM ${FROM_IMAGE}
 MAINTAINER Catapult Development Team
 RUN apt-get -y update && apt-get install -y \
 	bison \

--- a/jenkins/catapult/templates/FedoraTestBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/FedoraTestBaseImage.Dockerfile
@@ -1,5 +1,8 @@
-FROM {{BASE_IMAGE}}
-ENV DEBIAN_FRONTEND=noninteractive
+# image name required as ARG
+ARG FROM_IMAGE=''
+ARG DEBIAN_FRONTEND=noninteractive
+
+FROM ${FROM_IMAGE}
 MAINTAINER Catapult Development Team
 RUN dnf update --assumeyes && dnf install --assumeyes \
 	bison \

--- a/jenkins/catapult/templates/UbuntuReleaseBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuReleaseBaseImage.Dockerfile
@@ -1,5 +1,8 @@
-FROM {{BASE_IMAGE}}
-ENV DEBIAN_FRONTEND=noninteractive
+# image name required as ARG
+ARG FROM_IMAGE=''
+ARG DEBIAN_FRONTEND=noninteractive
+
+FROM ${FROM_IMAGE}
 LABEL maintainer="Catapult Development Team"
 RUN apt-get -y update && apt-get install -y \
 	gdb \

--- a/jenkins/catapult/templates/UbuntuTestBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuTestBaseImage.Dockerfile
@@ -1,5 +1,8 @@
-FROM {{BASE_IMAGE}}
-ENV DEBIAN_FRONTEND=noninteractive
+# image name required as ARG
+ARG FROM_IMAGE=''
+ARG DEBIAN_FRONTEND=noninteractive
+
+FROM ${FROM_IMAGE}
 LABEL maintainer="Catapult Development Team"
 RUN apt-get -y update && apt-get install -y \
 	bison \

--- a/jenkins/catapult/templates/UbuntuTestSanitizerBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuTestSanitizerBaseImage.Dockerfile
@@ -1,5 +1,8 @@
-FROM symbolplatform/symbol-server-compiler:ubuntu-clang-15
+# image name required as ARG
+ARG FROM_IMAGE=''
 ARG DEBIAN_FRONTEND=noninteractive
+
+FROM ${FROM_IMAGE}
 LABEL maintainer="Catapult Development Team"
 RUN apt-get -y update && apt-get install -y \
 	bison \

--- a/jenkins/catapult/templates/WindowsTestBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/WindowsTestBaseImage.Dockerfile
@@ -16,5 +16,13 @@ RUN pwsh.exe -ExecutionPolicy RemoteSigned -Command `
 	python3 -m pip install --upgrade pip; `
 	python3 -m pip install --upgrade colorama cryptography gitpython ply pycodestyle pylint pylint-quotes PyYAML
 	
-ENTRYPOINT ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'Continue'; $verbosePreference='Continue';"]
+RUN "'ACP', 'OEMCP', 'MACCP' | Set-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Nls\CodePage' -Name { $_ } 65001"; `
+	Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Nls\CodePage'
+
+RUN Set-ItemProperty 'HKLM:\Software\Microsoft\Command Processor' -Name Autorun 'chcp 65001'; `
+	Get-ItemProperty -Path 'HKLM:\Software\Microsoft\Command Processor'
+
+RUN '$OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = [System.Text.Utf8Encoding]::new()' + [Environment]::Newline + (Get-Content -Raw $PROFILE.AllUsersCurrentHost -ErrorAction SilentlyContinue) | Set-Content -Encoding utf8 $PROFILE.AllUsersCurrentHost
+	
+ENTRYPOINT ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'Continue'; $verbosePreference='Continue'; $OutputEncoding;"]
 CMD ["pwsh.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]

--- a/jenkins/catapult/templates/WindowsTestBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/WindowsTestBaseImage.Dockerfile
@@ -1,10 +1,13 @@
 # escape=`
 
-FROM {{BASE_IMAGE}}
-LABEL maintainer="Catapult Development Team"
-SHELL ["cmd", "/S", "/C"]
+ARG FROM_IMAGE=mcr.microsoft.com/powershell:latest
 
-RUN powershell.exe -ExecutionPolicy RemoteSigned `
+FROM ${FROM_IMAGE}
+LABEL maintainer="Catapult Development Team"
+
+SHELL ["pwsh","-command"]
+
+RUN pwsh.exe -ExecutionPolicy RemoteSigned -Command `
 	(new-object net.webclient).DownloadFile('https://get.scoop.sh','c:\scoop.ps1'); `
 	$command='c:\scoop.ps1 -RunAsAdmin'; `
 	iex $command; `
@@ -12,5 +15,6 @@ RUN powershell.exe -ExecutionPolicy RemoteSigned `
 	scoop install python git shellcheck; `
 	python3 -m pip install --upgrade pip; `
 	python3 -m pip install --upgrade colorama cryptography gitpython ply pycodestyle pylint pylint-quotes PyYAML
-
-CMD ["powershell.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]
+	
+ENTRYPOINT ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'Continue'; $verbosePreference='Continue';"]
+CMD ["pwsh.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]

--- a/jenkins/catapult/templates/WindowsTestBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/WindowsTestBaseImage.Dockerfile
@@ -5,9 +5,9 @@ ARG FROM_IMAGE=mcr.microsoft.com/powershell:latest
 FROM ${FROM_IMAGE}
 LABEL maintainer="Catapult Development Team"
 
-SHELL ["pwsh","-command"]
+SHELL ["pwsh","-command", "$ErrorActionPreference = 'Stop';"]
 
-RUN pwsh.exe -ExecutionPolicy RemoteSigned -Command `
+RUN Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser; `
 	(new-object net.webclient).DownloadFile('https://get.scoop.sh','c:\scoop.ps1'); `
 	$command='c:\scoop.ps1 -RunAsAdmin'; `
 	iex $command; `
@@ -22,7 +22,8 @@ RUN "'ACP', 'OEMCP', 'MACCP' | Set-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\
 RUN Set-ItemProperty 'HKLM:\Software\Microsoft\Command Processor' -Name Autorun 'chcp 65001'; `
 	Get-ItemProperty -Path 'HKLM:\Software\Microsoft\Command Processor'
 
-RUN '$OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = [System.Text.Utf8Encoding]::new()' + [Environment]::Newline + (Get-Content -Raw $PROFILE.AllUsersCurrentHost -ErrorAction SilentlyContinue) | Set-Content -Encoding utf8 $PROFILE.AllUsersCurrentHost
+RUN '$OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding = [System.Text.Utf8Encoding]::new()' + [Environment]::Newline + `
+	(Get-Content -Raw $PROFILE.AllUsersCurrentHost -ErrorAction SilentlyContinue) | Set-Content -Encoding utf8 $PROFILE.AllUsersCurrentHost
 	
-ENTRYPOINT ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'Continue'; $verbosePreference='Continue'; $OutputEncoding;"]
+ENTRYPOINT ["pwsh.exe", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'Continue'; $verbosePreference='Continue';"]
 CMD ["pwsh.exe", "-NoLogo", "-ExecutionPolicy", "Bypass"]

--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -11,7 +11,7 @@ gosu = 1.14
 
 facebook_rocksdb = v7.7.3
 
-google_googletest = release-1.12.1
+google_googletest = v1.13.0
 google_benchmark = v1.7.1
 
 mongodb_mongo-c-driver = 1.22.0


### PR DESCRIPTION
## What is the current behavior?
Catapult Windows builds takes a long time to build.

## What's the issue?
There was no caching on Windows for the build files.

## How have you changed the behavior?
ccache is now enabled as part of the Catapult build on Windows.  This reduces the build time by 40% to around 25 mins.
By default is it off due to an issue when ccache is installed by a package manager, Scoop or chocolatey, they will install a shim in the PATH instead of the actual binary for ccache.  CMake will copy the shim version.
It also requires using ``/Z7`` instead of ``Zi`` for generating the debug files
https://github.com/ccache/ccache/wiki/MS-Visual-Studio

Also change to use the latest Powershell 7 which uses UTF-8 by default.

## How was this change tested?
By running in Jenkins.
