### PR TITLE
[client/catapult] fix: catapult pylint failure

### DIFF
--- a/client/catapult/scripts/sdk/publishSdk.py
+++ b/client/catapult/scripts/sdk/publishSdk.py
@@ -18,12 +18,12 @@ def find_subdirectories(directory):
 
 def require_existence(path):
 	if not os.path.exists(path):
-		raise Exception(f'{path} does not exist')
+		raise RuntimeError(f'{path} does not exist')
 
 
 def require_non_existence(path):
 	if os.path.exists(path):
-		raise Exception(f'{path} already exists')
+		raise RuntimeError(f'{path} already exists')
 
 
 def force_empty(directory):

--- a/linters/cpp/HeaderParser.py
+++ b/linters/cpp/HeaderParser.py
@@ -124,6 +124,7 @@ class HeaderParser:
 					line = line.strip()
 					first_continuation = True
 				else:
+					tabs_count = 0
 					if first_continuation:
 						tabs_match = re.match(r'^\t+', line)
 						tabs_count = len(tabs_match.group(0)) if tabs_match else 0

--- a/linters/cpp/Rules.py
+++ b/linters/cpp/Rules.py
@@ -378,7 +378,7 @@ class ToolsRules:
 	def first_test_include_check(sorted_includes, path_elements):
 		del sorted_includes
 		del path_elements
-		raise Exception('first_test_include_check called for a tool')
+		raise RuntimeError('first_test_include_check called for a tool')
 
 
 RULE_ID_TO_CLASS_MAP = {

--- a/linters/python/.pylintrc
+++ b/linters/python/.pylintrc
@@ -387,4 +387,4 @@ known-third-party=enchant
 
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
-overgeneral-exceptions=Exception
+overgeneral-exceptions=builtins.Exception

--- a/sdk/python/generator/Generator.py
+++ b/sdk/python/generator/Generator.py
@@ -42,7 +42,7 @@ def generate_files(ast_models, output_directory: Path):
 #
 # pylint: disable=line-too-long, invalid-name, redefined-builtin
 # pylint: disable=too-many-lines, too-many-instance-attributes, too-many-locals, too-many-statements, too-many-public-methods
-# pylint: disable=duplicate-code
+# pylint: disable=duplicate-code, superfluous-parens
 
 from __future__ import annotations
 

--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -6,4 +6,4 @@ pysha3==1.0.2
 PyYAML==6.0
 pyzbar==0.1.9
 ripemd-hash==1.0.0
-qrcode==7.4.1
+qrcode==7.4.2

--- a/sdk/python/symbolchain/nc/__init__.py
+++ b/sdk/python/symbolchain/nc/__init__.py
@@ -4,7 +4,7 @@
 #
 # pylint: disable=line-too-long, invalid-name, redefined-builtin
 # pylint: disable=too-many-lines, too-many-instance-attributes, too-many-locals, too-many-statements, too-many-public-methods
-# pylint: disable=duplicate-code
+# pylint: disable=duplicate-code, superfluous-parens
 
 from __future__ import annotations
 

--- a/sdk/python/symbolchain/sc/__init__.py
+++ b/sdk/python/symbolchain/sc/__init__.py
@@ -14976,7 +14976,7 @@ class BlockFactory:
 			(NormalBlockV1.BLOCK_TYPE): NormalBlockV1,
 			(ImportanceBlockV1.BLOCK_TYPE): ImportanceBlockV1
 		}
-		discriminator = (parent.type_)
+		discriminator = parent.type_
 		factory_class = mapping[discriminator]
 		return factory_class.deserialize(buffer)
 
@@ -15014,7 +15014,7 @@ class ReceiptFactory:
 			(NamespaceDeletedReceipt.RECEIPT_TYPE): NamespaceDeletedReceipt,
 			(NamespaceRentalFeeReceipt.RECEIPT_TYPE): NamespaceRentalFeeReceipt
 		}
-		discriminator = (parent.type_)
+		discriminator = parent.type_
 		factory_class = mapping[discriminator]
 		return factory_class.deserialize(buffer)
 

--- a/sdk/python/symbolchain/sc/__init__.py
+++ b/sdk/python/symbolchain/sc/__init__.py
@@ -4,7 +4,7 @@
 #
 # pylint: disable=line-too-long, invalid-name, redefined-builtin
 # pylint: disable=too-many-lines, too-many-instance-attributes, too-many-locals, too-many-statements, too-many-public-methods
-# pylint: disable=duplicate-code
+# pylint: disable=duplicate-code, superfluous-parens
 
 from __future__ import annotations
 
@@ -14976,7 +14976,7 @@ class BlockFactory:
 			(NormalBlockV1.BLOCK_TYPE): NormalBlockV1,
 			(ImportanceBlockV1.BLOCK_TYPE): ImportanceBlockV1
 		}
-		discriminator = parent.type_
+		discriminator = (parent.type_)
 		factory_class = mapping[discriminator]
 		return factory_class.deserialize(buffer)
 
@@ -15014,7 +15014,7 @@ class ReceiptFactory:
 			(NamespaceDeletedReceipt.RECEIPT_TYPE): NamespaceDeletedReceipt,
 			(NamespaceRentalFeeReceipt.RECEIPT_TYPE): NamespaceRentalFeeReceipt
 		}
-		discriminator = parent.type_
+		discriminator = (parent.type_)
 		factory_class = mapping[discriminator]
 		return factory_class.deserialize(buffer)
 

--- a/sdk/python/tests/test_QrStorage.py
+++ b/sdk/python/tests/test_QrStorage.py
@@ -2,8 +2,6 @@ import os
 import tempfile
 import unittest
 
-import qrcode
-
 from symbolchain.QrStorage import QrStorage
 
 from .test.TestUtils import TestUtils

--- a/sdk/python/tests/test_QrStorage.py
+++ b/sdk/python/tests/test_QrStorage.py
@@ -49,7 +49,7 @@ class QrStorageTest(unittest.TestCase):
 			buffer = TestUtils.randbytes(MAX_DATA_BYTES + 1)
 
 			# Act + Assert:
-			with self.assertRaises(qrcode.exceptions.DataOverflowError):
+			with self.assertRaises(ValueError):
 				storage.save('foo', buffer)
 
 	# endregion

--- a/sdk/python/tests/vectors/catbuffer.py
+++ b/sdk/python/tests/vectors/catbuffer.py
@@ -19,7 +19,7 @@ def prepare_test_cases(network_name, includes=None, excludes=None):
 	schemas_path = Path(os.environ.get('SCHEMAS_PATH', '.')) / network_name / 'models'
 
 	if not schemas_path.exists():
-		raise Exception(f'could not find any cases because {schemas_path} does not exist')
+		raise RuntimeError(f'could not find any cases because {schemas_path} does not exist')
 
 	for filepath in schemas_path.glob('*.json'):
 		if includes and not any(include in filepath.name for include in includes):
@@ -34,7 +34,7 @@ def prepare_test_cases(network_name, includes=None, excludes=None):
 			cases += json.load(infile)
 
 	if not cases:
-		raise Exception(f'could not find any cases in {schemas_path}')
+		raise RuntimeError(f'could not find any cases in {schemas_path}')
 
 	return cases
 


### PR DESCRIPTION
## What's the issue?
With Pylint 2.16 catapult lint is failing with ``[W0719(broad-exception-raised), require_non_existence] Raising too general exception: Exception``.
This is due to pylint adds a new checker for broad-exception-raised - ``https://github.com/PyCQA/pylint/issues/7494``

## How have you changed the behavior?
Switch from Exception to RuntimeError 

## How was this change tested?
Run the linting on dev box.
