### PR TITLE
[jenkins] fix: install conan 1.x

### DIFF
--- a/jenkins/catapult/baseImageDockerfileGenerator.py
+++ b/jenkins/catapult/baseImageDockerfileGenerator.py
@@ -472,7 +472,7 @@ class LinuxSystemGenerator:
 		print_line([
 			'RUN apt-get -y update',
 			'apt-get install -y {APT_PACKAGES}',
-			'python3 -m pip install -U "conan>=1.33.0"'
+			'python3 -m pip install -U "conan>=1.33.0,<2.0"',
 		], APT_PACKAGES=' '.join(apt_packages))
 
 
@@ -593,7 +593,7 @@ class WindowsSystemGenerator:
 
 		print_powershell_lines([
 			'scoop update',
-			'python3 -m pip install -U conan',
+			'python3 -m pip install -U "conan>=1.33.0,<2.0"',
 			'echo "docker image build $BUILD_NUMBER"'
 		])
 

--- a/jenkins/catapult/baseImageDockerfileGenerator.py
+++ b/jenkins/catapult/baseImageDockerfileGenerator.py
@@ -472,7 +472,7 @@ class LinuxSystemGenerator:
 		print_line([
 			'RUN apt-get -y update',
 			'apt-get install -y {APT_PACKAGES}',
-			'python3 -m pip install -U "conan>=1.33.0,<2.0"',
+			'python3 -m pip install -U "conan<2.0"',
 		], APT_PACKAGES=' '.join(apt_packages))
 
 
@@ -593,7 +593,7 @@ class WindowsSystemGenerator:
 
 		print_powershell_lines([
 			'scoop update',
-			'python3 -m pip install -U "conan>=1.33.0,<2.0"',
+			'python3 -m pip install -U "conan<2.0"',
 			'echo "docker image build $BUILD_NUMBER"'
 		])
 


### PR DESCRIPTION
## What's the issue?
Conan 2 was released and got installed in catapult image.
Openssl recipe is not compatible with Conan 2.
open issue on Conan - ``https://github.com/conan-io/conan/issues/13322``

## How have you changed the behavior?
Only install Conan versions less than 2.

## How was this change tested?
Tested locally on dev box.