### PR TITLE
[jenkins] fix: remove openssl 1.1.1f dependency

### DIFF
--- a/client/catapult/scripts/ci/setup_test.sh
+++ b/client/catapult/scripts/ci/setup_test.sh
@@ -5,7 +5,7 @@ set -ex
 mongod --fork --logpath /data/mongod.log
 
 wait_period=10
-while ! /usr/bin/mongo --eval "printjson(db.version())" >/dev/null 2>&1; do
+while ! /usr/bin/mongosh --eval "printjson(db.version())" >/dev/null 2>&1; do
 	sleep 1
 	((--wait_period))
 	if [ "$wait_period" -le 1 ]; then

--- a/client/rest/scripts/ci/setup_test.sh
+++ b/client/rest/scripts/ci/setup_test.sh
@@ -5,7 +5,7 @@ set -ex
 mongod --fork --logpath /data/mongod.log
 
 wait_period=10
-while ! /usr/bin/mongo --eval "printjson(db.version())" >/dev/null 2>&1; do
+while ! /usr/bin/mongosh --eval "printjson(db.version())" >/dev/null 2>&1; do
 	sleep 1
 	((--wait_period))
 	if [ "$wait_period" -le 1 ]; then

--- a/jenkins/docker/cpp.Dockerfile
+++ b/jenkins/docker/cpp.Dockerfile
@@ -4,16 +4,14 @@ FROM symbolplatform/symbol-server-build-base:ubuntu-gcc-12-conan
 RUN apt-get install -y shellcheck
 RUN pip install gitlint
 
-# mongodb requires ssl 1.1 but ubuntu 22.04 ships with ssl 3
 ARG DEBIAN_FRONTEND=noninteractive
-ENV TZ=Etc/UTC 
+ENV TZ=Etc/UTC
+
+# mongodb 6.0
 RUN apt-get install -y wget gnupg \
-	&& wget -qO- https://www.mongodb.org/static/pgp/server-5.0.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/mongo.gpg \
-	&& echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" \
-	| tee /etc/apt/sources.list.d/mongodb-org-5.0.list \
-	&& wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb \
-	&& dpkg -i ./libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb \
-	&& rm -i ./libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb \
+	&& wget -qO - https://www.mongodb.org/static/pgp/server-6.0.asc |  gpg --dearmor | tee /usr/share/keyrings/mongodb.gpg > /dev/null \
+	&& echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse"  \
+	| tee /etc/apt/sources.list.d/mongodb-org-6.0.list \
 	&& apt-get update \
 	&& apt-get install -y mongodb-org
 

--- a/jenkins/docker/javascript.Dockerfile
+++ b/jenkins/docker/javascript.Dockerfile
@@ -5,19 +5,16 @@ RUN apt-get update >/dev/null \
 	&& apt-get install -y tzdata \
 	&& apt-get install -y git curl
 
-# mongodb
+# mongodb 6.0
 RUN apt-get install -y wget gnupg \
-	&& wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add - \
-	&& echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" \
-	| tee /etc/apt/sources.list.d/mongodb-org-5.0.list \
-	&& wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb \
-	&& dpkg -i ./libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb \
-	&& rm -i ./libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb \
+	&& wget -qO - https://www.mongodb.org/static/pgp/server-6.0.asc |  gpg --dearmor | tee /usr/share/keyrings/mongodb.gpg > /dev/null \
+	&& echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse"  \
+	| tee /etc/apt/sources.list.d/mongodb-org-6.0.list \
 	&& apt-get update \
 	&& apt-get install -y mongodb-org
 
 # nodejs
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
 	&& apt-get install -y nodejs
 
 # rest dependencies

--- a/jenkins/docker/javascript.Dockerfile
+++ b/jenkins/docker/javascript.Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get install -y wget gnupg \
 	&& apt-get install -y mongodb-org
 
 # nodejs
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
 	&& apt-get install -y nodejs
 
 # rest dependencies

--- a/sdk/javascript/src/impl/ed25519.js
+++ b/sdk/javascript/src/impl/ed25519.js
@@ -1,3 +1,5 @@
+/* eslint import/no-unresolved: [2, { ignore: ['../../wasm'] }] */
+
 import {
 	crypto_sign_keypair, crypto_private_sign, crypto_private_verify, HashMode
 } from '../../wasm/pkg/symbol_crypto_wasm.js'; // eslint-disable-line import/no-relative-packages

--- a/sdk/javascript/webpack.config.js
+++ b/sdk/javascript/webpack.config.js
@@ -1,7 +1,7 @@
 import WasmPackPlugin from '@wasm-tool/wasm-pack-plugin';
+import webpack from 'webpack';
 import path from 'path';
 import URL from 'url';
-import webpack from 'webpack';
 
 export default {
 	entry: './src/index.js',


### PR DESCRIPTION
## What's the issue?
build of the ci javascript and cpp images are failing due to the removal of libssl1.1_1.1.1f-1ubuntu2.16_amd64.deb from ubuntu
https://jenkins.symboldev.com/job/infra/job/build-ci-image/15/console

## How have you changed the behavior?
Upgrade to mongodb 6.0.4 which does not need openssl by default.

## How was this change tested?
build the images locally to test