### PR TITLE
[client/rest] fix: reduce docker image size

### DIFF
--- a/client/rest/Dockerfile
+++ b/client/rest/Dockerfile
@@ -1,7 +1,30 @@
-FROM node:lts
+ARG UBUNTU_VERSION=22.04
+ARG NODE_VERSION=18
+
+FROM ubuntu:${UBUNTU_VERSION} as builder
+
+ARG NODE_VERSION
+
+RUN apt-get update && apt-get upgrade -y && apt-get install -y curl \
+    && curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
+    && apt-get install -y nodejs
+
+RUN apt-get install -y build-essential
 
 WORKDIR /app
 COPY . .
 RUN npm uninstall . && rm -rf node_modules && npm install
+
+FROM ubuntu:${UBUNTU_VERSION}
+
+ARG NODE_VERSION
+
+RUN apt-get update && apt-get upgrade -y && apt-get install -y curl \
+    && curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
+    && apt-get install -y nodejs
+
+WORKDIR /app
+COPY --from=builder /app .
+
 RUN node --version && npm --version
 EXPOSE 3000

--- a/client/rest/Dockerfile
+++ b/client/rest/Dockerfile
@@ -6,8 +6,8 @@ FROM ubuntu:${UBUNTU_VERSION} as builder
 ARG NODE_VERSION
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y curl \
-    && curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
-    && apt-get install -y nodejs
+	&& curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
+	&& apt-get install -y nodejs
 
 RUN apt-get install -y build-essential
 
@@ -20,8 +20,8 @@ FROM ubuntu:${UBUNTU_VERSION}
 ARG NODE_VERSION
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y curl \
-    && curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
-    && apt-get install -y nodejs
+	&& curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
+	&& apt-get install -y nodejs
 
 WORKDIR /app
 COPY --from=builder /app .


### PR DESCRIPTION
## What is the current behavior?
Rest client docker image is increased in size compared to the previous version

## What's the issue?
The base image was switched from Ubuntu 20.04 to node:lts

## How have you changed the behavior?
Switch back to use Ubuntu as the base image plus use docker multi-stage build.
The sizes of each version is listed below where v2.4.3 is build using the Dockerfile from this PR.
```
docker images
REPOSITORY                     TAG              IMAGE ID       CREATED          SIZE
symbolplatform/symbol-rest     2.4.3            2230ce4a1a04   15 seconds ago   406MB
symbolplatform/symbol-rest     2.4.2            bc52220035c3   4 months ago     1.17GB
symbolplatform/symbol-rest     2.4.0            cedc875cd97a   16 months ago    826MB
```

## How was this change tested?
Tested the image locally on dev box and do not see any issues calling rest endpoint.
