### PR TITLE
[client/rest] fix: pin mongodb version to 3.x until bug fix

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -32,6 +32,11 @@ updates:
     commit-message:
       prefix: '[dependency]'
 
+    # ignore mongodb major update due to #203
+    ignore:
+      - dependency-name: mongodb
+        update-types: [version-update:semver-major]
+
   - package-ecosystem: pip
     directory: /jenkins/catapult
     schedule:

--- a/client/rest/package-lock.json
+++ b/client/rest/package-lock.json
@@ -12,7 +12,7 @@
         "@noble/hashes": "^1.2.0",
         "ini": "^3.0.1",
         "long": "^5.2.1",
-        "mongodb": "^4.13.0",
+        "mongodb": "^3.7.3",
         "restify": "^11.1.0",
         "restify-errors": "^8.0.2",
         "ripemd160": "^2.0.2",
@@ -44,1011 +44,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@aws-crypto/ie11-detection": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
-      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true
-    },
-    "node_modules/@aws-crypto/sha256-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
-      "optional": true,
-      "dependencies": {
-        "@aws-crypto/ie11-detection": "^2.0.0",
-        "@aws-crypto/sha256-js": "^2.0.0",
-        "@aws-crypto/supports-web-crypto": "^2.0.0",
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true
-    },
-    "node_modules/@aws-crypto/sha256-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
-      "optional": true,
-      "dependencies": {
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true
-    },
-    "node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
-      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true
-    },
-    "node_modules/@aws-crypto/util": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
-      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "^3.110.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-crypto/util/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "optional": true
-    },
-    "node_modules/@aws-sdk/abort-controller": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.198.0.tgz",
-      "integrity": "sha512-kmK1fNJ5nkBH23wOrAdxWcVtG/NNCaX66cxr90jnbGvSAeNRi5nLLqlmQOyZ0RRg+tpNCec+N/qqfxAmmD3NdQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.199.0.tgz",
-      "integrity": "sha512-F7VvJkaSYBBiAAtlrWO6Hq5GbqARMerihtlFvQra2Uy0bSX/okNgefurjjW1Gijh4xk6brWPO+46GD9OpZXtcQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.199.0",
-        "@aws-sdk/config-resolver": "3.198.0",
-        "@aws-sdk/credential-provider-node": "3.199.0",
-        "@aws-sdk/fetch-http-handler": "3.199.0",
-        "@aws-sdk/hash-node": "3.198.0",
-        "@aws-sdk/invalid-dependency": "3.198.0",
-        "@aws-sdk/middleware-content-length": "3.199.0",
-        "@aws-sdk/middleware-endpoint": "3.198.0",
-        "@aws-sdk/middleware-host-header": "3.198.0",
-        "@aws-sdk/middleware-logger": "3.198.0",
-        "@aws-sdk/middleware-recursion-detection": "3.198.0",
-        "@aws-sdk/middleware-retry": "3.198.0",
-        "@aws-sdk/middleware-serde": "3.198.0",
-        "@aws-sdk/middleware-signing": "3.198.0",
-        "@aws-sdk/middleware-stack": "3.198.0",
-        "@aws-sdk/middleware-user-agent": "3.198.0",
-        "@aws-sdk/node-config-provider": "3.198.0",
-        "@aws-sdk/node-http-handler": "3.199.0",
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/smithy-client": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/url-parser": "3.198.0",
-        "@aws-sdk/util-base64-browser": "3.188.0",
-        "@aws-sdk/util-base64-node": "3.188.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.188.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.198.0",
-        "@aws-sdk/util-defaults-mode-node": "3.198.0",
-        "@aws-sdk/util-endpoints": "3.198.0",
-        "@aws-sdk/util-user-agent-browser": "3.198.0",
-        "@aws-sdk/util-user-agent-node": "3.198.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.199.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.199.0.tgz",
-      "integrity": "sha512-xRTI39cLcCU1lGlSaE2arCPzRwUY16Oq46fGoe+9pwalDL3oKeE6uq/idTxPzPZdZFhzpLUVc0QdfwGDYhJpXg==",
-      "optional": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.198.0",
-        "@aws-sdk/fetch-http-handler": "3.199.0",
-        "@aws-sdk/hash-node": "3.198.0",
-        "@aws-sdk/invalid-dependency": "3.198.0",
-        "@aws-sdk/middleware-content-length": "3.199.0",
-        "@aws-sdk/middleware-endpoint": "3.198.0",
-        "@aws-sdk/middleware-host-header": "3.198.0",
-        "@aws-sdk/middleware-logger": "3.198.0",
-        "@aws-sdk/middleware-recursion-detection": "3.198.0",
-        "@aws-sdk/middleware-retry": "3.198.0",
-        "@aws-sdk/middleware-serde": "3.198.0",
-        "@aws-sdk/middleware-stack": "3.198.0",
-        "@aws-sdk/middleware-user-agent": "3.198.0",
-        "@aws-sdk/node-config-provider": "3.198.0",
-        "@aws-sdk/node-http-handler": "3.199.0",
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/smithy-client": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/url-parser": "3.198.0",
-        "@aws-sdk/util-base64-browser": "3.188.0",
-        "@aws-sdk/util-base64-node": "3.188.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.188.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.198.0",
-        "@aws-sdk/util-defaults-mode-node": "3.198.0",
-        "@aws-sdk/util-endpoints": "3.198.0",
-        "@aws-sdk/util-user-agent-browser": "3.198.0",
-        "@aws-sdk/util-user-agent-node": "3.198.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.199.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sts": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.199.0.tgz",
-      "integrity": "sha512-ly7kLi/KFRr9RrvTVVlDAXlROkInTMRy4BL02Ugw7brSPysUJabzdlDB5gxC+jbeq8qpai/vCybePf6lgrcvFw==",
-      "optional": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.198.0",
-        "@aws-sdk/credential-provider-node": "3.199.0",
-        "@aws-sdk/fetch-http-handler": "3.199.0",
-        "@aws-sdk/hash-node": "3.198.0",
-        "@aws-sdk/invalid-dependency": "3.198.0",
-        "@aws-sdk/middleware-content-length": "3.199.0",
-        "@aws-sdk/middleware-endpoint": "3.198.0",
-        "@aws-sdk/middleware-host-header": "3.198.0",
-        "@aws-sdk/middleware-logger": "3.198.0",
-        "@aws-sdk/middleware-recursion-detection": "3.198.0",
-        "@aws-sdk/middleware-retry": "3.198.0",
-        "@aws-sdk/middleware-sdk-sts": "3.199.0",
-        "@aws-sdk/middleware-serde": "3.198.0",
-        "@aws-sdk/middleware-signing": "3.198.0",
-        "@aws-sdk/middleware-stack": "3.198.0",
-        "@aws-sdk/middleware-user-agent": "3.198.0",
-        "@aws-sdk/node-config-provider": "3.198.0",
-        "@aws-sdk/node-http-handler": "3.199.0",
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/smithy-client": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/url-parser": "3.198.0",
-        "@aws-sdk/util-base64-browser": "3.188.0",
-        "@aws-sdk/util-base64-node": "3.188.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.188.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.198.0",
-        "@aws-sdk/util-defaults-mode-node": "3.198.0",
-        "@aws-sdk/util-endpoints": "3.198.0",
-        "@aws-sdk/util-user-agent-browser": "3.198.0",
-        "@aws-sdk/util-user-agent-node": "3.198.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.199.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/config-resolver": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.198.0.tgz",
-      "integrity": "sha512-CxpbkTOfOYZLWcNgcZqooSIlLnixzHVz6skDgxOfeN2vohNOgt8hwU0Dmif3sC4AeyeV0CBm7ew9tg/WzsBxhg==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/signature-v4": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/util-config-provider": "3.188.0",
-        "@aws-sdk/util-middleware": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.199.0.tgz",
-      "integrity": "sha512-vhdvaCq9Q/LPvAdTN9HFnsR713iDb1qI7yTmnGzJYym1J9a2pR4YQvZr1pRyXbn176ORkgEiPMNSoDw8CiCRlg==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.199.0",
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.198.0.tgz",
-      "integrity": "sha512-Psui5iNdbHrHNF14vejORMtSEaH7EOt51pQcfmP1jk8Tinf+KMMMdbOqyzL4LHYwLTLH9Cr6m6UGrJXdmFiIZA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-imds": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.198.0.tgz",
-      "integrity": "sha512-p2xMCo3whCnXd5/dH738rAVURXhlppjRNDv0sCkDcVtr3exn4s5x5ednFM8K0zNo/hsqjqFbK3jT4W72bgHphw==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.198.0",
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/url-parser": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.199.0.tgz",
-      "integrity": "sha512-6m3WtK+oKGyo7iCHjORwmHN4wUp4F9j79dSedEf0EYxDbHpH9yMnEE6hYV11GdmM+/i8x8DYA45apAZo8gCIcA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.198.0",
-        "@aws-sdk/credential-provider-imds": "3.198.0",
-        "@aws-sdk/credential-provider-sso": "3.199.0",
-        "@aws-sdk/credential-provider-web-identity": "3.198.0",
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/shared-ini-file-loader": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.199.0.tgz",
-      "integrity": "sha512-pgJhOnTHj+ZZkcN9v7R+m2VnkQi4vvyA7N6k3EDWMQ8tdo48ofwObORkzA4gPX+TPuIjpYa1lU03dpY4zuzJKQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.198.0",
-        "@aws-sdk/credential-provider-imds": "3.198.0",
-        "@aws-sdk/credential-provider-ini": "3.199.0",
-        "@aws-sdk/credential-provider-process": "3.198.0",
-        "@aws-sdk/credential-provider-sso": "3.199.0",
-        "@aws-sdk/credential-provider-web-identity": "3.198.0",
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/shared-ini-file-loader": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.198.0.tgz",
-      "integrity": "sha512-LWiwKDCui7ILr+6opBzLCCAho9ZOppuEthUdKZx6T7+yD2cQT0caN5PkVUBMtfTu9+DZnHD2bpIL1T2KEaqEUw==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/shared-ini-file-loader": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.199.0.tgz",
-      "integrity": "sha512-aMNZkEj/5RN6jSbfkVadjNblExJtHCJGvcnKnzIGfXLgqOFoWGzY+YIHmn/GTgCnpuMbN5hXYXV6w76HwIvWGw==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.199.0",
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/shared-ini-file-loader": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.198.0.tgz",
-      "integrity": "sha512-D+fhnmqN18P/Roq5oxVq53J3mqS9Oi9IJaIKdrbdK/FibqOyKmTERaLKWkONwG35qExSECOpoEGn7ioUMQgAgQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.199.0.tgz",
-      "integrity": "sha512-PpOgvV7akew9cXrrEEF+h6H/JGURVCPw+UsvN0yjN8oSexwe0sUzKG1AVIrHYiAWkZKIohtsv7NNzBAKvJ4Qmw==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.199.0",
-        "@aws-sdk/client-sso": "3.199.0",
-        "@aws-sdk/client-sts": "3.199.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.199.0",
-        "@aws-sdk/credential-provider-env": "3.198.0",
-        "@aws-sdk/credential-provider-imds": "3.198.0",
-        "@aws-sdk/credential-provider-ini": "3.199.0",
-        "@aws-sdk/credential-provider-node": "3.199.0",
-        "@aws-sdk/credential-provider-process": "3.198.0",
-        "@aws-sdk/credential-provider-sso": "3.199.0",
-        "@aws-sdk/credential-provider-web-identity": "3.198.0",
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/shared-ini-file-loader": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/fetch-http-handler": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.199.0.tgz",
-      "integrity": "sha512-o1jRUMoJR/HOhqA2euYIQxzKLkbqBGwMGH3ahm5eqEJ9kCp84c2KsxT/HOEqjvAQi3f3np8VlTPbuscvDKUN4w==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/querystring-builder": "3.199.0",
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/util-base64-browser": "3.188.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/hash-node": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.198.0.tgz",
-      "integrity": "sha512-+UTjEEQlvT4+IIwLpN36Qb1DOQHe3zHkvIVe6SjLln+Z/UEK6NhMI0tsJNbiW38WAfwOjJ+otrRBHuD93SBRxQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/util-buffer-from": "3.188.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/invalid-dependency": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.198.0.tgz",
-      "integrity": "sha512-lbwS+H7WYk/g9/nHoTgt7xkrZCJ/OJuBfsx41RvMxW7zPxJeHYD/PvgPvYOB9lTUBkr7SDCeMoS5PtGdAwVOfg==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/is-array-buffer": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.188.0.tgz",
-      "integrity": "sha512-n69N4zJZCNd87Rf4NzufPzhactUeM877Y0Tp/F3KiHqGeTnVjYUa4Lv1vLBjqtfjYb2HWT3NKlYn5yzrhaEwiQ==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-content-length": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.199.0.tgz",
-      "integrity": "sha512-Q76J6xZl36tqS401TGs/NPIu8lYbNG1EtqxM88CWe/u0SH+D4LIR9AMXq9c4PH0ldIMWAGVGbRLLc0/H3rPyBg==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-endpoint": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.198.0.tgz",
-      "integrity": "sha512-J/rQkIXUbFJAlD6LSDVGU4bGbwD/2pvF5N39ePzvaJ8SwV9Y78XER/2fIAERhFNppuYinGdBdMLiPsC6qPT6ZA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/middleware-serde": "3.198.0",
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/signature-v4": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/url-parser": "3.198.0",
-        "@aws-sdk/util-config-provider": "3.188.0",
-        "@aws-sdk/util-middleware": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.198.0.tgz",
-      "integrity": "sha512-keHstrdw0bFzEkUrkMQ9+UxaKu5b1K87cH6guqLf4JBo04CT+2kPRlDSma65XCi2U81zfTnWApk+/SPPFN3otA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.198.0.tgz",
-      "integrity": "sha512-IFvNO4MI80FyltPzrEpYHMG47EYXawcD5zTzcbimpeLTpyrLY/zkSJqh5cVFu+NcDWsuD6U1geuvfN+i+2Bg1Q==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.198.0.tgz",
-      "integrity": "sha512-VHyz5xBJOaLZwdL94XWB04XCA+pwbURy+4ESF66vIY1umWgfanbZPkvw1XlRaQJydOmyIDFqhNG2AzB28WN9iw==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.198.0.tgz",
-      "integrity": "sha512-dwv5QJYTPNkmjKcQ0RtClkNumFomECzxjXvSiyjD9Ft6AWHcUeyqJfGKbmP5mFHpezWckK1qcT6cPMVrJilgjw==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/service-error-classification": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/util-middleware": "3.198.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "optional": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-sdk-sts": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.199.0.tgz",
-      "integrity": "sha512-ISM3Lx1AM2IiHpcQPdwHHvnW/dRyC/jGy2fHQvmYxj8x2oIYnEXxk4vA7DFnrYupxwi2yTSp3k8On2+1VgMjiw==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/middleware-signing": "3.198.0",
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/signature-v4": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-serde": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.198.0.tgz",
-      "integrity": "sha512-RlAua2691KCFabp3kjnsd5p+1nQbULTK1Ia/jvlTAyG4tGOeA0x1At6KZoI1LfkN+VjstV5/3b9aOCtcFuxkhA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-signing": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.198.0.tgz",
-      "integrity": "sha512-HPY9d1c1CUiV6JBVxiiQQgYfmELl1cn6h0TI00EmOAM5/wxUoiYBX2cGWf2NRF9/iBTppZjxwAKMYPIqF5Tkvw==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/signature-v4": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/util-middleware": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-stack": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.198.0.tgz",
-      "integrity": "sha512-5mHRjiJFHxziXOiChW3kttQHjgqH5qW9xRIDJepyf+NRJ60L8bZj0t8oGecqVqo27S02+UvrFgOzoRvBbATVFw==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.198.0.tgz",
-      "integrity": "sha512-SMteVixqoSazxUN1ROMj+nSf/zgTMRVPaTCKU0iEAtrE7ilp9Xv6FEC7ffm1MM9xIoAZ2eY1eAtY3uN0yxBm4A==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-config-provider": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.198.0.tgz",
-      "integrity": "sha512-W+msdp94ZjR8mJMtGPHjWHsIdsOu3HaVX4x+AQq9cj7+pg/D5CvWw7fnbkUQeG+V8Ia/aqzBNxlUpr/FAeQY/g==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/shared-ini-file-loader": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/node-http-handler": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.199.0.tgz",
-      "integrity": "sha512-F+6T7MHHm0b3+GVRxEnFCuIyqUQb0b8a3Hne3QFV4cxtnX58O/SSF8KlpuGZwobivdRC/AKDaTdI/eA0PQfegA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/abort-controller": "3.198.0",
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/querystring-builder": "3.199.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/property-provider": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.198.0.tgz",
-      "integrity": "sha512-jnQeJgZlk+6YJS2/eFz6pm9+XHzvCB0jTxHBwt2zYwZfcJ98viRQWMYfkY1XsemuQb/uIoHRBRhFXaJSLpXVDQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/protocol-http": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.198.0.tgz",
-      "integrity": "sha512-x+Qc+kwYqaZvLJ/820rxoFUIgSnSS/XlUHwmS+CTn7nJ68CeL3dzmae6TVOslpVBLCvoS2CbEpEoBbofOpsbGw==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-builder": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.199.0.tgz",
-      "integrity": "sha512-P4MWPzCqtH3sgI9iXXVdYirYVgggtg4uq5MVefnfHW+osZu8ZR+UKJw5ojAFfOCqcnKOU/xJjz185RroOjrzYQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/util-uri-escape": "3.188.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/querystring-parser": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.198.0.tgz",
-      "integrity": "sha512-oMybZYINxNiwSELR7tOwqu+1S7CeEC3g5L4IQXk2wvVx96HEf3sQgLr1wbmV1b7lEnTuH9OrgI5RgDUBVqipdw==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/service-error-classification": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.198.0.tgz",
-      "integrity": "sha512-bVsWOIYuDtSmwJtPF1pU84x2TL20Pj02C0+/6ua4qLvRatVKFbj1wxWiU/nKvgjiGFX8VWuQUKMzXUYQfYn4nw==",
-      "optional": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/shared-ini-file-loader": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.198.0.tgz",
-      "integrity": "sha512-n3Ykuvtb6f+WQuhcMVumY9VxQwPp8+cMSc5s6YHptkvZkz/cd2wmPhO914gKE/i2MoC/zQsFCXT8Z1YnS7k8sA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/signature-v4": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.198.0.tgz",
-      "integrity": "sha512-8EIyEt7ElTK/tQamYyB16IGwc7EwtLlSVcksaiII780ZtYULnOjogi/UImCYqSejQw+EHhXfbj14HRQT56rqEQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.188.0",
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/util-hex-encoding": "3.188.0",
-        "@aws-sdk/util-middleware": "3.198.0",
-        "@aws-sdk/util-uri-escape": "3.188.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/smithy-client": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.198.0.tgz",
-      "integrity": "sha512-IKUzJSoIkxYkYpRdlrh6REtDcW5c87FKeqtMC8VTpaTxrXwnJOqbenp7IwArwOnbXp4aIVmzdxT/nvQrftlgWg==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/middleware-stack": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/types": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.198.0.tgz",
-      "integrity": "sha512-ljgY9Pgb2CSRrf4IeaNy5gkhTsBae9STKc/mqfScSzvZOvRHu+BOIAGM33fDoCwxD1viKNVJvU1KemiI57Gbvw==",
-      "optional": true,
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/url-parser": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.198.0.tgz",
-      "integrity": "sha512-wm3+OTDWKsMEOlLGvJ+jxCcOXMjgd5qBDVbu2bTiyTahc2poNlM7kKhSwL4I8PkmGZVAqfAlHD4Wj38WecHQPw==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/querystring-parser": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-base64-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.188.0.tgz",
-      "integrity": "sha512-qlH+5NZBLiyKziL335BEPedYxX6j+p7KFRWXvDQox9S+s+gLCayednpK+fteOhBenCcR9fUZOVuAPScy1I8qCg==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-base64-node": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.188.0.tgz",
-      "integrity": "sha512-r1dccRsRjKq+OhVRUfqFiW3sGgZBjHbMeHLbrAs9jrOjU2PTQ8PSzAXLvX/9lmp7YjmX17Qvlsg0NCr1tbB9OA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.188.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-body-length-node": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.188.0.tgz",
-      "integrity": "sha512-XwqP3vxk60MKp4YDdvDeCD6BPOiG2e+/Ou4AofZOy5/toB6NKz2pFNibQIUg2+jc7mPMnGnvOW3MQEgSJ+gu/Q==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-buffer-from": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.188.0.tgz",
-      "integrity": "sha512-NX1WXZ8TH20IZb4jPFT2CnLKSqZWddGxtfiWxD9M47YOtq/SSQeR82fhqqVjJn4P8w2F5E28f+Du4ntg/sGcxA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/is-array-buffer": "3.188.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-config-provider": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.188.0.tgz",
-      "integrity": "sha512-LBA7tLbi7v4uvbOJhSnjJrxbcRifKK/1ZVK94JTV2MNSCCyNkFotyEI5UWDl10YKriTIUyf7o5cakpiDZ3O4xg==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.198.0.tgz",
-      "integrity": "sha512-IG4iVKQdFjdVFMH5KbSUY2l48wL9aCX/qzoCyTPjKkVumvmwnfkt5OCslkNcaqRdvp5o7QL7aHbq0EZ3K7Ya0A==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-defaults-mode-node": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.198.0.tgz",
-      "integrity": "sha512-LBKSKJjEs0D8tjalblDNmq9DWYTDQ1wVUksAIBO2gQU+EZHJwPb9qxyAk32gbnVTOYceZpJ5/vAGT7speDzEyw==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/config-resolver": "3.198.0",
-        "@aws-sdk/credential-provider-imds": "3.198.0",
-        "@aws-sdk/node-config-provider": "3.198.0",
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.198.0.tgz",
-      "integrity": "sha512-fpeJNVoe/QsIcGybgJ+D2jZcUFi7d37FlMiZd9eVnS5LyMGDNH8tVS7aPT7dgb0z30/FKMBIKKG6QxDGxFaqjQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-hex-encoding": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.188.0.tgz",
-      "integrity": "sha512-QyWovTtjQ2RYxqVM+STPh65owSqzuXURnfoof778spyX4iQ4z46wOge1YV2ZtwS8w5LWd9eeVvDrLu5POPYOnA==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.188.0.tgz",
-      "integrity": "sha512-SxobBVLZkkLSawTCfeQnhVX3Azm9O+C2dngZVe1+BqtF8+retUbVTs7OfYeWBlawVkULKF2e781lTzEHBBjCzw==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-middleware": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.198.0.tgz",
-      "integrity": "sha512-hEdkuGRWhZdEb1plzkGCN2kT8SqiPrEQHngB+1q7pjFJcKWkYkmaLHGw2zhbg1EVNpcGmj5DzCSWzwoPkpDRsw==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-uri-escape": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.188.0.tgz",
-      "integrity": "sha512-4Y6AYZMT483Tiuq8dxz5WHIiPNdSFPGrl6tRTo2Oi2FcwypwmFhqgEGcqxeXDUJktvaCBxeA08DLr/AemVhPCg==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.198.0.tgz",
-      "integrity": "sha512-XIwaaKtrEsxsayk1yUNjx15AZenP6YRaRDa3f6dhGO+D6OOXP+0S38O5lakyDDGW7nkwkmXa2NIv/OPHPYJ+jQ==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.198.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.198.0.tgz",
-      "integrity": "sha512-21bi3pNO7jvo3l9LtMJyR48ERN69PuBqMnwnjsDVqyIFBbnZr/JR5rWQx7jdZ0iUt6mRlgZ17xHXlGUGMCxznA==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/node-config-provider": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-sdk/util-utf8-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@aws-sdk/util-utf8-node": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.199.0.tgz",
-      "integrity": "sha512-Kk3qCdGbe5k0PUE8EBgMsRxNstvDCoWStYWjNwsHWuc/hJitSf44PColzXw6xxHqH1sY+6LcgIaMwJZ5C4bB6w==",
-      "optional": true,
-      "dependencies": {
-        "@aws-sdk/util-buffer-from": "3.188.0",
-        "tslib": "^2.3.1"
-      },
-      "engines": {
-        "node": ">= 12.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1816,25 +811,6 @@
       "dev": true,
       "peer": true
     },
-    "node_modules/@types/node": {
-      "version": "18.11.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.8.tgz",
-      "integrity": "sha512-uGwPWlE0Hj972KkHtCDVwZ8O39GmyjfMane1Z3GUBGGnkZ2USDq7SxLpVIiIHpweY9DS0QTDH0Nw7RNBsAAZ5A=="
-    },
-    "node_modules/@types/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
-    },
-    "node_modules/@types/whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/webidl-conversions": "*"
-      }
-    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -2157,11 +1133,41 @@
         "node": ">=8"
       }
     },
-    "node_modules/bowser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "optional": true
+    "node_modules/bl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "dependencies": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
+    },
+    "node_modules/bl/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/bl/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -2221,37 +1227,11 @@
       }
     },
     "node_modules/bson": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
-      "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
-      "dependencies": {
-        "buffer": "^5.6.0"
-      },
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
+      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
       "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "node": ">=0.6.19"
       }
     },
     "node_modules/caching-transform": {
@@ -2665,6 +1645,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/denque": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw==",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/depd": {
@@ -3389,22 +2377,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/fast-xml-parser": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
-      "optional": true,
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      },
-      "funding": {
-        "type": "paypal",
-        "url": "https://paypal.me/naturalintelligence"
-      }
-    },
     "node_modules/fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -4061,11 +3033,6 @@
       "engines": {
         "node": ">= 0.4"
       }
-    },
-    "node_modules/ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
     },
     "node_modules/is-arrayish": {
       "version": "0.3.2",
@@ -4966,29 +3933,41 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.13.0.tgz",
-      "integrity": "sha512-+taZ/bV8d1pYuHL4U+gSwkhmDrwkWbH1l4aah4YpmpscMwgFBkufIKxgP/G7m87/NUuQzc2Z75ZTI7ZOyqZLbw==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
+      "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
       "dependencies": {
-        "bson": "^4.7.0",
-        "mongodb-connection-string-url": "^2.5.4",
-        "socks": "^2.7.1"
+        "bl": "^2.2.1",
+        "bson": "^1.1.4",
+        "denque": "^1.4.1",
+        "optional-require": "^1.1.8",
+        "safe-buffer": "^5.1.2"
       },
       "engines": {
-        "node": ">=12.9.0"
+        "node": ">=4"
       },
       "optionalDependencies": {
-        "@aws-sdk/credential-providers": "^3.186.0",
-        "saslprep": "^1.0.3"
-      }
-    },
-    "node_modules/mongodb-connection-string-url": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.4.tgz",
-      "integrity": "sha512-SeAxuWs0ez3iI3vvmLk/j2y+zHwigTDKQhtdxTgt5ZCOQQS5+HW4g45/Xw5vzzbn7oQXCNQ24Z40AkJsizEy7w==",
-      "dependencies": {
-        "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^11.0.0"
+        "saslprep": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws4": {
+          "optional": true
+        },
+        "bson-ext": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "mongodb-extjson": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        }
       }
     },
     "node_modules/ms": {
@@ -5409,6 +4388,17 @@
         "fn.name": "1.x.x"
       }
     },
+    "node_modules/optional-require": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
+      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
+      "dependencies": {
+        "require-at": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -5817,6 +4807,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -5935,6 +4926,14 @@
       "dependencies": {
         "es6-error": "^4.0.1"
       },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/require-at": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
+      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g==",
       "engines": {
         "node": ">=4"
       }
@@ -6357,28 +5356,6 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
-      "dependencies": {
-        "ip": "^2.0.0",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.13.0",
-        "npm": ">= 3.0.0"
-      }
-    },
     "node_modules/sonic-boom": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.2.0.tgz",
@@ -6635,12 +5612,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-      "optional": true
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -6740,17 +5711,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-      "dependencies": {
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/triple-beam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
@@ -6791,12 +5751,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "optional": true
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
@@ -6914,26 +5868,6 @@
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-      "dependencies": {
-        "tr46": "^3.0.0",
-        "webidl-conversions": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/which": {
@@ -7196,859 +6130,6 @@
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.0"
-      }
-    },
-    "@aws-crypto/ie11-detection": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
-      "integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
-      "optional": true,
-      "requires": {
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "optional": true
-        }
-      }
-    },
-    "@aws-crypto/sha256-browser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-      "integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
-      "optional": true,
-      "requires": {
-        "@aws-crypto/ie11-detection": "^2.0.0",
-        "@aws-crypto/sha256-js": "^2.0.0",
-        "@aws-crypto/supports-web-crypto": "^2.0.0",
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "optional": true
-        }
-      }
-    },
-    "@aws-crypto/sha256-js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-      "integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
-      "optional": true,
-      "requires": {
-        "@aws-crypto/util": "^2.0.0",
-        "@aws-sdk/types": "^3.1.0",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "optional": true
-        }
-      }
-    },
-    "@aws-crypto/supports-web-crypto": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
-      "integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
-      "optional": true,
-      "requires": {
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "optional": true
-        }
-      }
-    },
-    "@aws-crypto/util": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
-      "integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/types": "^3.110.0",
-        "@aws-sdk/util-utf8-browser": "^3.0.0",
-        "tslib": "^1.11.1"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "optional": true
-        }
-      }
-    },
-    "@aws-sdk/abort-controller": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.198.0.tgz",
-      "integrity": "sha512-kmK1fNJ5nkBH23wOrAdxWcVtG/NNCaX66cxr90jnbGvSAeNRi5nLLqlmQOyZ0RRg+tpNCec+N/qqfxAmmD3NdQ==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/client-cognito-identity": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.199.0.tgz",
-      "integrity": "sha512-F7VvJkaSYBBiAAtlrWO6Hq5GbqARMerihtlFvQra2Uy0bSX/okNgefurjjW1Gijh4xk6brWPO+46GD9OpZXtcQ==",
-      "optional": true,
-      "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/client-sts": "3.199.0",
-        "@aws-sdk/config-resolver": "3.198.0",
-        "@aws-sdk/credential-provider-node": "3.199.0",
-        "@aws-sdk/fetch-http-handler": "3.199.0",
-        "@aws-sdk/hash-node": "3.198.0",
-        "@aws-sdk/invalid-dependency": "3.198.0",
-        "@aws-sdk/middleware-content-length": "3.199.0",
-        "@aws-sdk/middleware-endpoint": "3.198.0",
-        "@aws-sdk/middleware-host-header": "3.198.0",
-        "@aws-sdk/middleware-logger": "3.198.0",
-        "@aws-sdk/middleware-recursion-detection": "3.198.0",
-        "@aws-sdk/middleware-retry": "3.198.0",
-        "@aws-sdk/middleware-serde": "3.198.0",
-        "@aws-sdk/middleware-signing": "3.198.0",
-        "@aws-sdk/middleware-stack": "3.198.0",
-        "@aws-sdk/middleware-user-agent": "3.198.0",
-        "@aws-sdk/node-config-provider": "3.198.0",
-        "@aws-sdk/node-http-handler": "3.199.0",
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/smithy-client": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/url-parser": "3.198.0",
-        "@aws-sdk/util-base64-browser": "3.188.0",
-        "@aws-sdk/util-base64-node": "3.188.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.188.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.198.0",
-        "@aws-sdk/util-defaults-mode-node": "3.198.0",
-        "@aws-sdk/util-endpoints": "3.198.0",
-        "@aws-sdk/util-user-agent-browser": "3.198.0",
-        "@aws-sdk/util-user-agent-node": "3.198.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.199.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/client-sso": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.199.0.tgz",
-      "integrity": "sha512-xRTI39cLcCU1lGlSaE2arCPzRwUY16Oq46fGoe+9pwalDL3oKeE6uq/idTxPzPZdZFhzpLUVc0QdfwGDYhJpXg==",
-      "optional": true,
-      "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.198.0",
-        "@aws-sdk/fetch-http-handler": "3.199.0",
-        "@aws-sdk/hash-node": "3.198.0",
-        "@aws-sdk/invalid-dependency": "3.198.0",
-        "@aws-sdk/middleware-content-length": "3.199.0",
-        "@aws-sdk/middleware-endpoint": "3.198.0",
-        "@aws-sdk/middleware-host-header": "3.198.0",
-        "@aws-sdk/middleware-logger": "3.198.0",
-        "@aws-sdk/middleware-recursion-detection": "3.198.0",
-        "@aws-sdk/middleware-retry": "3.198.0",
-        "@aws-sdk/middleware-serde": "3.198.0",
-        "@aws-sdk/middleware-stack": "3.198.0",
-        "@aws-sdk/middleware-user-agent": "3.198.0",
-        "@aws-sdk/node-config-provider": "3.198.0",
-        "@aws-sdk/node-http-handler": "3.199.0",
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/smithy-client": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/url-parser": "3.198.0",
-        "@aws-sdk/util-base64-browser": "3.188.0",
-        "@aws-sdk/util-base64-node": "3.188.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.188.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.198.0",
-        "@aws-sdk/util-defaults-mode-node": "3.198.0",
-        "@aws-sdk/util-endpoints": "3.198.0",
-        "@aws-sdk/util-user-agent-browser": "3.198.0",
-        "@aws-sdk/util-user-agent-node": "3.198.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.199.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/client-sts": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.199.0.tgz",
-      "integrity": "sha512-ly7kLi/KFRr9RrvTVVlDAXlROkInTMRy4BL02Ugw7brSPysUJabzdlDB5gxC+jbeq8qpai/vCybePf6lgrcvFw==",
-      "optional": true,
-      "requires": {
-        "@aws-crypto/sha256-browser": "2.0.0",
-        "@aws-crypto/sha256-js": "2.0.0",
-        "@aws-sdk/config-resolver": "3.198.0",
-        "@aws-sdk/credential-provider-node": "3.199.0",
-        "@aws-sdk/fetch-http-handler": "3.199.0",
-        "@aws-sdk/hash-node": "3.198.0",
-        "@aws-sdk/invalid-dependency": "3.198.0",
-        "@aws-sdk/middleware-content-length": "3.199.0",
-        "@aws-sdk/middleware-endpoint": "3.198.0",
-        "@aws-sdk/middleware-host-header": "3.198.0",
-        "@aws-sdk/middleware-logger": "3.198.0",
-        "@aws-sdk/middleware-recursion-detection": "3.198.0",
-        "@aws-sdk/middleware-retry": "3.198.0",
-        "@aws-sdk/middleware-sdk-sts": "3.199.0",
-        "@aws-sdk/middleware-serde": "3.198.0",
-        "@aws-sdk/middleware-signing": "3.198.0",
-        "@aws-sdk/middleware-stack": "3.198.0",
-        "@aws-sdk/middleware-user-agent": "3.198.0",
-        "@aws-sdk/node-config-provider": "3.198.0",
-        "@aws-sdk/node-http-handler": "3.199.0",
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/smithy-client": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/url-parser": "3.198.0",
-        "@aws-sdk/util-base64-browser": "3.188.0",
-        "@aws-sdk/util-base64-node": "3.188.0",
-        "@aws-sdk/util-body-length-browser": "3.188.0",
-        "@aws-sdk/util-body-length-node": "3.188.0",
-        "@aws-sdk/util-defaults-mode-browser": "3.198.0",
-        "@aws-sdk/util-defaults-mode-node": "3.198.0",
-        "@aws-sdk/util-endpoints": "3.198.0",
-        "@aws-sdk/util-user-agent-browser": "3.198.0",
-        "@aws-sdk/util-user-agent-node": "3.198.0",
-        "@aws-sdk/util-utf8-browser": "3.188.0",
-        "@aws-sdk/util-utf8-node": "3.199.0",
-        "fast-xml-parser": "4.0.11",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/config-resolver": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.198.0.tgz",
-      "integrity": "sha512-CxpbkTOfOYZLWcNgcZqooSIlLnixzHVz6skDgxOfeN2vohNOgt8hwU0Dmif3sC4AeyeV0CBm7ew9tg/WzsBxhg==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/signature-v4": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/util-config-provider": "3.188.0",
-        "@aws-sdk/util-middleware": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.199.0.tgz",
-      "integrity": "sha512-vhdvaCq9Q/LPvAdTN9HFnsR713iDb1qI7yTmnGzJYym1J9a2pR4YQvZr1pRyXbn176ORkgEiPMNSoDw8CiCRlg==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/client-cognito-identity": "3.199.0",
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/credential-provider-env": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.198.0.tgz",
-      "integrity": "sha512-Psui5iNdbHrHNF14vejORMtSEaH7EOt51pQcfmP1jk8Tinf+KMMMdbOqyzL4LHYwLTLH9Cr6m6UGrJXdmFiIZA==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/credential-provider-imds": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.198.0.tgz",
-      "integrity": "sha512-p2xMCo3whCnXd5/dH738rAVURXhlppjRNDv0sCkDcVtr3exn4s5x5ednFM8K0zNo/hsqjqFbK3jT4W72bgHphw==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/node-config-provider": "3.198.0",
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/url-parser": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/credential-provider-ini": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.199.0.tgz",
-      "integrity": "sha512-6m3WtK+oKGyo7iCHjORwmHN4wUp4F9j79dSedEf0EYxDbHpH9yMnEE6hYV11GdmM+/i8x8DYA45apAZo8gCIcA==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/credential-provider-env": "3.198.0",
-        "@aws-sdk/credential-provider-imds": "3.198.0",
-        "@aws-sdk/credential-provider-sso": "3.199.0",
-        "@aws-sdk/credential-provider-web-identity": "3.198.0",
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/shared-ini-file-loader": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/credential-provider-node": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.199.0.tgz",
-      "integrity": "sha512-pgJhOnTHj+ZZkcN9v7R+m2VnkQi4vvyA7N6k3EDWMQ8tdo48ofwObORkzA4gPX+TPuIjpYa1lU03dpY4zuzJKQ==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/credential-provider-env": "3.198.0",
-        "@aws-sdk/credential-provider-imds": "3.198.0",
-        "@aws-sdk/credential-provider-ini": "3.199.0",
-        "@aws-sdk/credential-provider-process": "3.198.0",
-        "@aws-sdk/credential-provider-sso": "3.199.0",
-        "@aws-sdk/credential-provider-web-identity": "3.198.0",
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/shared-ini-file-loader": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/credential-provider-process": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.198.0.tgz",
-      "integrity": "sha512-LWiwKDCui7ILr+6opBzLCCAho9ZOppuEthUdKZx6T7+yD2cQT0caN5PkVUBMtfTu9+DZnHD2bpIL1T2KEaqEUw==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/shared-ini-file-loader": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/credential-provider-sso": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.199.0.tgz",
-      "integrity": "sha512-aMNZkEj/5RN6jSbfkVadjNblExJtHCJGvcnKnzIGfXLgqOFoWGzY+YIHmn/GTgCnpuMbN5hXYXV6w76HwIvWGw==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/client-sso": "3.199.0",
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/shared-ini-file-loader": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/credential-provider-web-identity": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.198.0.tgz",
-      "integrity": "sha512-D+fhnmqN18P/Roq5oxVq53J3mqS9Oi9IJaIKdrbdK/FibqOyKmTERaLKWkONwG35qExSECOpoEGn7ioUMQgAgQ==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/credential-providers": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.199.0.tgz",
-      "integrity": "sha512-PpOgvV7akew9cXrrEEF+h6H/JGURVCPw+UsvN0yjN8oSexwe0sUzKG1AVIrHYiAWkZKIohtsv7NNzBAKvJ4Qmw==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/client-cognito-identity": "3.199.0",
-        "@aws-sdk/client-sso": "3.199.0",
-        "@aws-sdk/client-sts": "3.199.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.199.0",
-        "@aws-sdk/credential-provider-env": "3.198.0",
-        "@aws-sdk/credential-provider-imds": "3.198.0",
-        "@aws-sdk/credential-provider-ini": "3.199.0",
-        "@aws-sdk/credential-provider-node": "3.199.0",
-        "@aws-sdk/credential-provider-process": "3.198.0",
-        "@aws-sdk/credential-provider-sso": "3.199.0",
-        "@aws-sdk/credential-provider-web-identity": "3.198.0",
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/shared-ini-file-loader": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/fetch-http-handler": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.199.0.tgz",
-      "integrity": "sha512-o1jRUMoJR/HOhqA2euYIQxzKLkbqBGwMGH3ahm5eqEJ9kCp84c2KsxT/HOEqjvAQi3f3np8VlTPbuscvDKUN4w==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/querystring-builder": "3.199.0",
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/util-base64-browser": "3.188.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/hash-node": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.198.0.tgz",
-      "integrity": "sha512-+UTjEEQlvT4+IIwLpN36Qb1DOQHe3zHkvIVe6SjLln+Z/UEK6NhMI0tsJNbiW38WAfwOjJ+otrRBHuD93SBRxQ==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/util-buffer-from": "3.188.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/invalid-dependency": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.198.0.tgz",
-      "integrity": "sha512-lbwS+H7WYk/g9/nHoTgt7xkrZCJ/OJuBfsx41RvMxW7zPxJeHYD/PvgPvYOB9lTUBkr7SDCeMoS5PtGdAwVOfg==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/is-array-buffer": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.188.0.tgz",
-      "integrity": "sha512-n69N4zJZCNd87Rf4NzufPzhactUeM877Y0Tp/F3KiHqGeTnVjYUa4Lv1vLBjqtfjYb2HWT3NKlYn5yzrhaEwiQ==",
-      "optional": true,
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-content-length": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.199.0.tgz",
-      "integrity": "sha512-Q76J6xZl36tqS401TGs/NPIu8lYbNG1EtqxM88CWe/u0SH+D4LIR9AMXq9c4PH0ldIMWAGVGbRLLc0/H3rPyBg==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-endpoint": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.198.0.tgz",
-      "integrity": "sha512-J/rQkIXUbFJAlD6LSDVGU4bGbwD/2pvF5N39ePzvaJ8SwV9Y78XER/2fIAERhFNppuYinGdBdMLiPsC6qPT6ZA==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/middleware-serde": "3.198.0",
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/signature-v4": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/url-parser": "3.198.0",
-        "@aws-sdk/util-config-provider": "3.188.0",
-        "@aws-sdk/util-middleware": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-host-header": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.198.0.tgz",
-      "integrity": "sha512-keHstrdw0bFzEkUrkMQ9+UxaKu5b1K87cH6guqLf4JBo04CT+2kPRlDSma65XCi2U81zfTnWApk+/SPPFN3otA==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-logger": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.198.0.tgz",
-      "integrity": "sha512-IFvNO4MI80FyltPzrEpYHMG47EYXawcD5zTzcbimpeLTpyrLY/zkSJqh5cVFu+NcDWsuD6U1geuvfN+i+2Bg1Q==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-recursion-detection": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.198.0.tgz",
-      "integrity": "sha512-VHyz5xBJOaLZwdL94XWB04XCA+pwbURy+4ESF66vIY1umWgfanbZPkvw1XlRaQJydOmyIDFqhNG2AzB28WN9iw==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-retry": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.198.0.tgz",
-      "integrity": "sha512-dwv5QJYTPNkmjKcQ0RtClkNumFomECzxjXvSiyjD9Ft6AWHcUeyqJfGKbmP5mFHpezWckK1qcT6cPMVrJilgjw==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/service-error-classification": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/util-middleware": "3.198.0",
-        "tslib": "^2.3.1",
-        "uuid": "^8.3.2"
-      },
-      "dependencies": {
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "optional": true
-        }
-      }
-    },
-    "@aws-sdk/middleware-sdk-sts": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.199.0.tgz",
-      "integrity": "sha512-ISM3Lx1AM2IiHpcQPdwHHvnW/dRyC/jGy2fHQvmYxj8x2oIYnEXxk4vA7DFnrYupxwi2yTSp3k8On2+1VgMjiw==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/middleware-signing": "3.198.0",
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/signature-v4": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-serde": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.198.0.tgz",
-      "integrity": "sha512-RlAua2691KCFabp3kjnsd5p+1nQbULTK1Ia/jvlTAyG4tGOeA0x1At6KZoI1LfkN+VjstV5/3b9aOCtcFuxkhA==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-signing": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.198.0.tgz",
-      "integrity": "sha512-HPY9d1c1CUiV6JBVxiiQQgYfmELl1cn6h0TI00EmOAM5/wxUoiYBX2cGWf2NRF9/iBTppZjxwAKMYPIqF5Tkvw==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/signature-v4": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/util-middleware": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-stack": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.198.0.tgz",
-      "integrity": "sha512-5mHRjiJFHxziXOiChW3kttQHjgqH5qW9xRIDJepyf+NRJ60L8bZj0t8oGecqVqo27S02+UvrFgOzoRvBbATVFw==",
-      "optional": true,
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/middleware-user-agent": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.198.0.tgz",
-      "integrity": "sha512-SMteVixqoSazxUN1ROMj+nSf/zgTMRVPaTCKU0iEAtrE7ilp9Xv6FEC7ffm1MM9xIoAZ2eY1eAtY3uN0yxBm4A==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/node-config-provider": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.198.0.tgz",
-      "integrity": "sha512-W+msdp94ZjR8mJMtGPHjWHsIdsOu3HaVX4x+AQq9cj7+pg/D5CvWw7fnbkUQeG+V8Ia/aqzBNxlUpr/FAeQY/g==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/shared-ini-file-loader": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/node-http-handler": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.199.0.tgz",
-      "integrity": "sha512-F+6T7MHHm0b3+GVRxEnFCuIyqUQb0b8a3Hne3QFV4cxtnX58O/SSF8KlpuGZwobivdRC/AKDaTdI/eA0PQfegA==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/abort-controller": "3.198.0",
-        "@aws-sdk/protocol-http": "3.198.0",
-        "@aws-sdk/querystring-builder": "3.199.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/property-provider": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.198.0.tgz",
-      "integrity": "sha512-jnQeJgZlk+6YJS2/eFz6pm9+XHzvCB0jTxHBwt2zYwZfcJ98viRQWMYfkY1XsemuQb/uIoHRBRhFXaJSLpXVDQ==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/protocol-http": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.198.0.tgz",
-      "integrity": "sha512-x+Qc+kwYqaZvLJ/820rxoFUIgSnSS/XlUHwmS+CTn7nJ68CeL3dzmae6TVOslpVBLCvoS2CbEpEoBbofOpsbGw==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/querystring-builder": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.199.0.tgz",
-      "integrity": "sha512-P4MWPzCqtH3sgI9iXXVdYirYVgggtg4uq5MVefnfHW+osZu8ZR+UKJw5ojAFfOCqcnKOU/xJjz185RroOjrzYQ==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/util-uri-escape": "3.188.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/querystring-parser": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.198.0.tgz",
-      "integrity": "sha512-oMybZYINxNiwSELR7tOwqu+1S7CeEC3g5L4IQXk2wvVx96HEf3sQgLr1wbmV1b7lEnTuH9OrgI5RgDUBVqipdw==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/service-error-classification": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.198.0.tgz",
-      "integrity": "sha512-bVsWOIYuDtSmwJtPF1pU84x2TL20Pj02C0+/6ua4qLvRatVKFbj1wxWiU/nKvgjiGFX8VWuQUKMzXUYQfYn4nw==",
-      "optional": true
-    },
-    "@aws-sdk/shared-ini-file-loader": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.198.0.tgz",
-      "integrity": "sha512-n3Ykuvtb6f+WQuhcMVumY9VxQwPp8+cMSc5s6YHptkvZkz/cd2wmPhO914gKE/i2MoC/zQsFCXT8Z1YnS7k8sA==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/signature-v4": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.198.0.tgz",
-      "integrity": "sha512-8EIyEt7ElTK/tQamYyB16IGwc7EwtLlSVcksaiII780ZtYULnOjogi/UImCYqSejQw+EHhXfbj14HRQT56rqEQ==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/is-array-buffer": "3.188.0",
-        "@aws-sdk/types": "3.198.0",
-        "@aws-sdk/util-hex-encoding": "3.188.0",
-        "@aws-sdk/util-middleware": "3.198.0",
-        "@aws-sdk/util-uri-escape": "3.188.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/smithy-client": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.198.0.tgz",
-      "integrity": "sha512-IKUzJSoIkxYkYpRdlrh6REtDcW5c87FKeqtMC8VTpaTxrXwnJOqbenp7IwArwOnbXp4aIVmzdxT/nvQrftlgWg==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/middleware-stack": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/types": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.198.0.tgz",
-      "integrity": "sha512-ljgY9Pgb2CSRrf4IeaNy5gkhTsBae9STKc/mqfScSzvZOvRHu+BOIAGM33fDoCwxD1viKNVJvU1KemiI57Gbvw==",
-      "optional": true
-    },
-    "@aws-sdk/url-parser": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.198.0.tgz",
-      "integrity": "sha512-wm3+OTDWKsMEOlLGvJ+jxCcOXMjgd5qBDVbu2bTiyTahc2poNlM7kKhSwL4I8PkmGZVAqfAlHD4Wj38WecHQPw==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/querystring-parser": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-base64-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.188.0.tgz",
-      "integrity": "sha512-qlH+5NZBLiyKziL335BEPedYxX6j+p7KFRWXvDQox9S+s+gLCayednpK+fteOhBenCcR9fUZOVuAPScy1I8qCg==",
-      "optional": true,
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-base64-node": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-node/-/util-base64-node-3.188.0.tgz",
-      "integrity": "sha512-r1dccRsRjKq+OhVRUfqFiW3sGgZBjHbMeHLbrAs9jrOjU2PTQ8PSzAXLvX/9lmp7YjmX17Qvlsg0NCr1tbB9OA==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.188.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-body-length-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
-      "integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
-      "optional": true,
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-body-length-node": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.188.0.tgz",
-      "integrity": "sha512-XwqP3vxk60MKp4YDdvDeCD6BPOiG2e+/Ou4AofZOy5/toB6NKz2pFNibQIUg2+jc7mPMnGnvOW3MQEgSJ+gu/Q==",
-      "optional": true,
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-buffer-from": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.188.0.tgz",
-      "integrity": "sha512-NX1WXZ8TH20IZb4jPFT2CnLKSqZWddGxtfiWxD9M47YOtq/SSQeR82fhqqVjJn4P8w2F5E28f+Du4ntg/sGcxA==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/is-array-buffer": "3.188.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-config-provider": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.188.0.tgz",
-      "integrity": "sha512-LBA7tLbi7v4uvbOJhSnjJrxbcRifKK/1ZVK94JTV2MNSCCyNkFotyEI5UWDl10YKriTIUyf7o5cakpiDZ3O4xg==",
-      "optional": true,
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-defaults-mode-browser": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.198.0.tgz",
-      "integrity": "sha512-IG4iVKQdFjdVFMH5KbSUY2l48wL9aCX/qzoCyTPjKkVumvmwnfkt5OCslkNcaqRdvp5o7QL7aHbq0EZ3K7Ya0A==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-defaults-mode-node": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.198.0.tgz",
-      "integrity": "sha512-LBKSKJjEs0D8tjalblDNmq9DWYTDQ1wVUksAIBO2gQU+EZHJwPb9qxyAk32gbnVTOYceZpJ5/vAGT7speDzEyw==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/config-resolver": "3.198.0",
-        "@aws-sdk/credential-provider-imds": "3.198.0",
-        "@aws-sdk/node-config-provider": "3.198.0",
-        "@aws-sdk/property-provider": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-endpoints": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.198.0.tgz",
-      "integrity": "sha512-fpeJNVoe/QsIcGybgJ+D2jZcUFi7d37FlMiZd9eVnS5LyMGDNH8tVS7aPT7dgb0z30/FKMBIKKG6QxDGxFaqjQ==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-hex-encoding": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.188.0.tgz",
-      "integrity": "sha512-QyWovTtjQ2RYxqVM+STPh65owSqzuXURnfoof778spyX4iQ4z46wOge1YV2ZtwS8w5LWd9eeVvDrLu5POPYOnA==",
-      "optional": true,
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-locate-window": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.188.0.tgz",
-      "integrity": "sha512-SxobBVLZkkLSawTCfeQnhVX3Azm9O+C2dngZVe1+BqtF8+retUbVTs7OfYeWBlawVkULKF2e781lTzEHBBjCzw==",
-      "optional": true,
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-middleware": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.198.0.tgz",
-      "integrity": "sha512-hEdkuGRWhZdEb1plzkGCN2kT8SqiPrEQHngB+1q7pjFJcKWkYkmaLHGw2zhbg1EVNpcGmj5DzCSWzwoPkpDRsw==",
-      "optional": true,
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-uri-escape": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.188.0.tgz",
-      "integrity": "sha512-4Y6AYZMT483Tiuq8dxz5WHIiPNdSFPGrl6tRTo2Oi2FcwypwmFhqgEGcqxeXDUJktvaCBxeA08DLr/AemVhPCg==",
-      "optional": true,
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-user-agent-browser": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.198.0.tgz",
-      "integrity": "sha512-XIwaaKtrEsxsayk1yUNjx15AZenP6YRaRDa3f6dhGO+D6OOXP+0S38O5lakyDDGW7nkwkmXa2NIv/OPHPYJ+jQ==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/types": "3.198.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-user-agent-node": {
-      "version": "3.198.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.198.0.tgz",
-      "integrity": "sha512-21bi3pNO7jvo3l9LtMJyR48ERN69PuBqMnwnjsDVqyIFBbnZr/JR5rWQx7jdZ0iUt6mRlgZ17xHXlGUGMCxznA==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/node-config-provider": "3.198.0",
-        "@aws-sdk/types": "3.198.0",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-utf8-browser": {
-      "version": "3.188.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-      "integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
-      "optional": true,
-      "requires": {
-        "tslib": "^2.3.1"
-      }
-    },
-    "@aws-sdk/util-utf8-node": {
-      "version": "3.199.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.199.0.tgz",
-      "integrity": "sha512-Kk3qCdGbe5k0PUE8EBgMsRxNstvDCoWStYWjNwsHWuc/hJitSf44PColzXw6xxHqH1sY+6LcgIaMwJZ5C4bB6w==",
-      "optional": true,
-      "requires": {
-        "@aws-sdk/util-buffer-from": "3.188.0",
-        "tslib": "^2.3.1"
       }
     },
     "@babel/code-frame": {
@@ -8642,25 +6723,6 @@
       "dev": true,
       "peer": true
     },
-    "@types/node": {
-      "version": "18.11.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.8.tgz",
-      "integrity": "sha512-uGwPWlE0Hj972KkHtCDVwZ8O39GmyjfMane1Z3GUBGGnkZ2USDq7SxLpVIiIHpweY9DS0QTDH0Nw7RNBsAAZ5A=="
-    },
-    "@types/webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
-    },
-    "@types/whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
-      "requires": {
-        "@types/node": "*",
-        "@types/webidl-conversions": "*"
-      }
-    },
     "abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -8897,11 +6959,43 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
-    "bowser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-      "optional": true
+    "bl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+        },
+        "readable-stream": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -8942,21 +7036,9 @@
       }
     },
     "bson": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.0.tgz",
-      "integrity": "sha512-VrlEE4vuiO1WTpfof4VmaVolCVYkYTgB9iWgYNOrVlnifpME/06fhFRmONgBhClD5pFC1t9ZWqFUQEQAzY43bA==",
-      "requires": {
-        "buffer": "^5.6.0"
-      }
-    },
-    "buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
-      }
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
+      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg=="
     },
     "caching-transform": {
       "version": "4.0.0",
@@ -9280,6 +7362,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "dev": true
+    },
+    "denque": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.1.tgz",
+      "integrity": "sha512-XwE+iZ4D6ZUB7mfYRMb5wByE8L74HCn30FBN7sWnXksWc1LO1bPDl67pBR9o/kC4z/xSNAwkMYcGgqDV3BE3Hw=="
     },
     "depd": {
       "version": "2.0.0",
@@ -9838,15 +7925,6 @@
       "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
       "integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw=="
     },
-    "fast-xml-parser": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
-      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
-      "optional": true,
-      "requires": {
-        "strnum": "^1.0.5"
-      }
-    },
     "fastq": {
       "version": "1.13.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
@@ -10310,11 +8388,6 @@
         "has": "^1.0.3",
         "side-channel": "^1.0.4"
       }
-    },
-    "ip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.0.tgz",
-      "integrity": "sha512-WKa+XuLG1A1R0UWhl2+1XQSi+fZWMsYKffMZTTYsiZaUD8k2yDAj5atimTUD2TZkyCkNEeYE5NhFZmupOGtjYQ=="
     },
     "is-arrayish": {
       "version": "0.3.2",
@@ -10979,24 +9052,16 @@
       }
     },
     "mongodb": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.13.0.tgz",
-      "integrity": "sha512-+taZ/bV8d1pYuHL4U+gSwkhmDrwkWbH1l4aah4YpmpscMwgFBkufIKxgP/G7m87/NUuQzc2Z75ZTI7ZOyqZLbw==",
+      "version": "3.7.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.7.3.tgz",
+      "integrity": "sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==",
       "requires": {
-        "@aws-sdk/credential-providers": "^3.186.0",
-        "bson": "^4.7.0",
-        "mongodb-connection-string-url": "^2.5.4",
-        "saslprep": "^1.0.3",
-        "socks": "^2.7.1"
-      }
-    },
-    "mongodb-connection-string-url": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.5.4.tgz",
-      "integrity": "sha512-SeAxuWs0ez3iI3vvmLk/j2y+zHwigTDKQhtdxTgt5ZCOQQS5+HW4g45/Xw5vzzbn7oQXCNQ24Z40AkJsizEy7w==",
-      "requires": {
-        "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^11.0.0"
+        "bl": "^2.2.1",
+        "bson": "^1.1.4",
+        "denque": "^1.4.1",
+        "optional-require": "^1.1.8",
+        "safe-buffer": "^5.1.2",
+        "saslprep": "^1.0.0"
       }
     },
     "ms": {
@@ -11324,6 +9389,14 @@
         "fn.name": "1.x.x"
       }
     },
+    "optional-require": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/optional-require/-/optional-require-1.1.8.tgz",
+      "integrity": "sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==",
+      "requires": {
+        "require-at": "^1.0.6"
+      }
+    },
     "optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -11628,7 +9701,8 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -11712,6 +9786,11 @@
       "requires": {
         "es6-error": "^4.0.1"
       }
+    },
+    "require-at": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/require-at/-/require-at-1.0.6.tgz",
+      "integrity": "sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g=="
     },
     "require-directory": {
       "version": "2.1.1",
@@ -12040,20 +10119,6 @@
         }
       }
     },
-    "smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
-    },
-    "socks": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.7.1.tgz",
-      "integrity": "sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==",
-      "requires": {
-        "ip": "^2.0.0",
-        "smart-buffer": "^4.2.0"
-      }
-    },
     "sonic-boom": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-3.2.0.tgz",
@@ -12250,12 +10315,6 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
-    "strnum": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-      "optional": true
-    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -12331,14 +10390,6 @@
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
       "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="
     },
-    "tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-      "requires": {
-        "punycode": "^2.1.1"
-      }
-    },
     "triple-beam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.3.0.tgz",
@@ -12375,12 +10426,6 @@
           "peer": true
         }
       }
-    },
-    "tslib": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "optional": true
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -12473,20 +10518,6 @@
       "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
       "requires": {
         "minimalistic-assert": "^1.0.0"
-      }
-    },
-    "webidl-conversions": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
-    },
-    "whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-      "requires": {
-        "tr46": "^3.0.0",
-        "webidl-conversions": "^7.0.0"
       }
     },
     "which": {

--- a/client/rest/package.json
+++ b/client/rest/package.json
@@ -30,7 +30,7 @@
     "@noble/hashes": "^1.2.0",
     "ini": "^3.0.1",
     "long": "^5.2.1",
-    "mongodb": "^4.13.0",
+    "mongodb": "^3.7.3",
     "restify": "^11.1.0",
     "restify-errors": "^8.0.2",
     "ripemd160": "^2.0.2",


### PR DESCRIPTION
## What is the current behavior?
Rest show the database status as down with mongodb 4.x

## What's the issue?
see issue #203

## How have you changed the behavior?
downgrade mongodb to 3.x until bug is fix

## How was this change tested?
Tested with a testnet node