### PR TITLE
Fix: SDK - Testnet epoch adjustment value

### DIFF
--- a/sdk/javascript/src/symbol/Network.js
+++ b/sdk/javascript/src/symbol/Network.js
@@ -94,7 +94,7 @@ Network.MAINNET = new Network(
 Network.TESTNET = new Network(
 	'testnet',
 	0x98,
-	new Date(Date.UTC(2021, 10, 25, 14, 0, 47)),
+	new Date(Date.UTC(2022, 9, 31, 21, 7, 47)),
 	new Hash256('49D6E1CE276A85B70EAFE52349AACCA389302E7A9754BCF1221E79494FC665A4')
 );
 Network.NETWORKS = [Network.MAINNET, Network.TESTNET];

--- a/sdk/python/symbolchain/symbol/Network.py
+++ b/sdk/python/symbolchain/symbol/Network.py
@@ -67,6 +67,6 @@ Network.MAINNET = Network(
 Network.TESTNET = Network(
 	'testnet',
 	0x98,
-	datetime.datetime(2021, 11, 25, 14, 0, 47, tzinfo=datetime.timezone.utc),
+	datetime.datetime(2022, 10, 31, 21, 7, 47, tzinfo=datetime.timezone.utc),
 	Hash256('49D6E1CE276A85B70EAFE52349AACCA389302E7A9754BCF1221E79494FC665A4'))
 Network.NETWORKS = [Network.MAINNET, Network.TESTNET]


### PR DESCRIPTION
## What is the current behavior?

The epoch adjustment value is invalid (it wasn't updated during the post-reset configuration update).

## What's the fix?

Fix testnet epoch adjustment value to reflect the current sai network.