### PR TITLE
[client/rest] fix: rest shows mongodb down 

### DIFF
--- a/client/rest/package-lock.json
+++ b/client/rest/package-lock.json
@@ -12,7 +12,7 @@
         "@noble/hashes": "^1.2.0",
         "ini": "^3.0.1",
         "long": "^5.2.1",
-        "mongodb": "^5.1.0",
+        "mongodb": "^4.14.0",
         "restify": "^11.1.0",
         "restify-errors": "^8.0.2",
         "ripemd160": "^2.0.2",
@@ -44,6 +44,1080 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "optional": true
+    },
+    "node_modules/@aws-sdk/abort-controller": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.292.0.tgz",
+      "integrity": "sha512-lf+OPptL01kvryIJy7+dvFux5KbJ6OTwLPPEekVKZ2AfEvwcVtOZWFUhyw3PJCBTVncjKB1Kjl3V/eTS3YuPXQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.294.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.294.0.tgz",
+      "integrity": "sha512-QMk/QratNvAvmnJ77pu9KDjpfUf/5LOJplHcLKcY962ewJGBtFFY4XZVnmUgQMSG0phRODtex7pyH//FueGKLQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.294.0",
+        "@aws-sdk/config-resolver": "3.292.0",
+        "@aws-sdk/credential-provider-node": "3.294.0",
+        "@aws-sdk/fetch-http-handler": "3.292.0",
+        "@aws-sdk/hash-node": "3.292.0",
+        "@aws-sdk/invalid-dependency": "3.292.0",
+        "@aws-sdk/middleware-content-length": "3.292.0",
+        "@aws-sdk/middleware-endpoint": "3.292.0",
+        "@aws-sdk/middleware-host-header": "3.292.0",
+        "@aws-sdk/middleware-logger": "3.292.0",
+        "@aws-sdk/middleware-recursion-detection": "3.292.0",
+        "@aws-sdk/middleware-retry": "3.293.0",
+        "@aws-sdk/middleware-serde": "3.292.0",
+        "@aws-sdk/middleware-signing": "3.292.0",
+        "@aws-sdk/middleware-stack": "3.292.0",
+        "@aws-sdk/middleware-user-agent": "3.293.0",
+        "@aws-sdk/node-config-provider": "3.292.0",
+        "@aws-sdk/node-http-handler": "3.292.0",
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/smithy-client": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/url-parser": "3.292.0",
+        "@aws-sdk/util-base64": "3.292.0",
+        "@aws-sdk/util-body-length-browser": "3.292.0",
+        "@aws-sdk/util-body-length-node": "3.292.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.292.0",
+        "@aws-sdk/util-defaults-mode-node": "3.292.0",
+        "@aws-sdk/util-endpoints": "3.293.0",
+        "@aws-sdk/util-retry": "3.292.0",
+        "@aws-sdk/util-user-agent-browser": "3.292.0",
+        "@aws-sdk/util-user-agent-node": "3.292.0",
+        "@aws-sdk/util-utf8": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.294.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.294.0.tgz",
+      "integrity": "sha512-+FuxQTi5WvnaXM5JbNLkBIzQ3An4gA0ox61N1u+3xled+nywKb1yQ7WmRpyMG5bLbkmnj3aqoo5/uskFc4c4EA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.292.0",
+        "@aws-sdk/fetch-http-handler": "3.292.0",
+        "@aws-sdk/hash-node": "3.292.0",
+        "@aws-sdk/invalid-dependency": "3.292.0",
+        "@aws-sdk/middleware-content-length": "3.292.0",
+        "@aws-sdk/middleware-endpoint": "3.292.0",
+        "@aws-sdk/middleware-host-header": "3.292.0",
+        "@aws-sdk/middleware-logger": "3.292.0",
+        "@aws-sdk/middleware-recursion-detection": "3.292.0",
+        "@aws-sdk/middleware-retry": "3.293.0",
+        "@aws-sdk/middleware-serde": "3.292.0",
+        "@aws-sdk/middleware-stack": "3.292.0",
+        "@aws-sdk/middleware-user-agent": "3.293.0",
+        "@aws-sdk/node-config-provider": "3.292.0",
+        "@aws-sdk/node-http-handler": "3.292.0",
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/smithy-client": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/url-parser": "3.292.0",
+        "@aws-sdk/util-base64": "3.292.0",
+        "@aws-sdk/util-body-length-browser": "3.292.0",
+        "@aws-sdk/util-body-length-node": "3.292.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.292.0",
+        "@aws-sdk/util-defaults-mode-node": "3.292.0",
+        "@aws-sdk/util-endpoints": "3.293.0",
+        "@aws-sdk/util-retry": "3.292.0",
+        "@aws-sdk/util-user-agent-browser": "3.292.0",
+        "@aws-sdk/util-user-agent-node": "3.292.0",
+        "@aws-sdk/util-utf8": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso-oidc": {
+      "version": "3.294.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.294.0.tgz",
+      "integrity": "sha512-/ZfDud76MdSPJ/TxjV2xLE30XbBQDZwKQ32axwoK1eziPvrAIUBYVgpBwj+m0quhoiQhBKkg3aFl6j39AF2thw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.292.0",
+        "@aws-sdk/fetch-http-handler": "3.292.0",
+        "@aws-sdk/hash-node": "3.292.0",
+        "@aws-sdk/invalid-dependency": "3.292.0",
+        "@aws-sdk/middleware-content-length": "3.292.0",
+        "@aws-sdk/middleware-endpoint": "3.292.0",
+        "@aws-sdk/middleware-host-header": "3.292.0",
+        "@aws-sdk/middleware-logger": "3.292.0",
+        "@aws-sdk/middleware-recursion-detection": "3.292.0",
+        "@aws-sdk/middleware-retry": "3.293.0",
+        "@aws-sdk/middleware-serde": "3.292.0",
+        "@aws-sdk/middleware-stack": "3.292.0",
+        "@aws-sdk/middleware-user-agent": "3.293.0",
+        "@aws-sdk/node-config-provider": "3.292.0",
+        "@aws-sdk/node-http-handler": "3.292.0",
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/smithy-client": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/url-parser": "3.292.0",
+        "@aws-sdk/util-base64": "3.292.0",
+        "@aws-sdk/util-body-length-browser": "3.292.0",
+        "@aws-sdk/util-body-length-node": "3.292.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.292.0",
+        "@aws-sdk/util-defaults-mode-node": "3.292.0",
+        "@aws-sdk/util-endpoints": "3.293.0",
+        "@aws-sdk/util-retry": "3.292.0",
+        "@aws-sdk/util-user-agent-browser": "3.292.0",
+        "@aws-sdk/util-user-agent-node": "3.292.0",
+        "@aws-sdk/util-utf8": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sts": {
+      "version": "3.294.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.294.0.tgz",
+      "integrity": "sha512-AefqwhFjTDzelZuSYhriJbiI+GQwf2yKiKAnCt0gRj6rswewStM63Gtlhfb01sFPp+ZiqPcyQ47LqUaHp1mz/g==",
+      "optional": true,
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.292.0",
+        "@aws-sdk/credential-provider-node": "3.294.0",
+        "@aws-sdk/fetch-http-handler": "3.292.0",
+        "@aws-sdk/hash-node": "3.292.0",
+        "@aws-sdk/invalid-dependency": "3.292.0",
+        "@aws-sdk/middleware-content-length": "3.292.0",
+        "@aws-sdk/middleware-endpoint": "3.292.0",
+        "@aws-sdk/middleware-host-header": "3.292.0",
+        "@aws-sdk/middleware-logger": "3.292.0",
+        "@aws-sdk/middleware-recursion-detection": "3.292.0",
+        "@aws-sdk/middleware-retry": "3.293.0",
+        "@aws-sdk/middleware-sdk-sts": "3.292.0",
+        "@aws-sdk/middleware-serde": "3.292.0",
+        "@aws-sdk/middleware-signing": "3.292.0",
+        "@aws-sdk/middleware-stack": "3.292.0",
+        "@aws-sdk/middleware-user-agent": "3.293.0",
+        "@aws-sdk/node-config-provider": "3.292.0",
+        "@aws-sdk/node-http-handler": "3.292.0",
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/smithy-client": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/url-parser": "3.292.0",
+        "@aws-sdk/util-base64": "3.292.0",
+        "@aws-sdk/util-body-length-browser": "3.292.0",
+        "@aws-sdk/util-body-length-node": "3.292.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.292.0",
+        "@aws-sdk/util-defaults-mode-node": "3.292.0",
+        "@aws-sdk/util-endpoints": "3.293.0",
+        "@aws-sdk/util-retry": "3.292.0",
+        "@aws-sdk/util-user-agent-browser": "3.292.0",
+        "@aws-sdk/util-user-agent-node": "3.292.0",
+        "@aws-sdk/util-utf8": "3.292.0",
+        "fast-xml-parser": "4.1.2",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/config-resolver": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.292.0.tgz",
+      "integrity": "sha512-cB3twnNR7vYvlt2jvw8VlA1+iv/tVzl+/S39MKqw2tepU+AbJAM0EHwb/dkf1OKSmlrnANXhshx80MHF9zL4mA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/signature-v4": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/util-config-provider": "3.292.0",
+        "@aws-sdk/util-middleware": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.294.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.294.0.tgz",
+      "integrity": "sha512-YSPqHEbLC0dnbFF5LdlMH0B50sMSN/CyG/sHkPYUwL/hkbUk9URnVW7ZJlt6lRftT7X4C7muzLqUP8sJAaiJEA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.294.0",
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.292.0.tgz",
+      "integrity": "sha512-YbafSG0ZEKE2969CJWVtUhh3hfOeLPecFVoXOtegCyAJgY5Ghtu4TsVhL4DgiGAgOC30ojAmUVQEXzd7xJF5xA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-imds": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.292.0.tgz",
+      "integrity": "sha512-W/peOgDSRYulgzFpUhvgi1pCm6piBz6xrVN17N4QOy+3NHBXRVMVzYk6ct2qpLPgJUSEZkcpP+Gds+bBm8ed1A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.292.0",
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/url-parser": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.294.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.294.0.tgz",
+      "integrity": "sha512-pdTPbaAb5bWA+DnuKoL2TpXeNDp6Ejpv/OYt+bw2gdzl9w5r/ZCtUTTbW+Vvejr4WL5s3c1bY96kwdqCn7iLqA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.292.0",
+        "@aws-sdk/credential-provider-imds": "3.292.0",
+        "@aws-sdk/credential-provider-process": "3.292.0",
+        "@aws-sdk/credential-provider-sso": "3.294.0",
+        "@aws-sdk/credential-provider-web-identity": "3.292.0",
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/shared-ini-file-loader": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.294.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.294.0.tgz",
+      "integrity": "sha512-zUL1Qhb4BsQIZCs/TPpG4oIYH/9YsGiS+Se1tasSGjTOLfBy7jhOZ0QIdpEeyAx/EP8blOBredM9xWfEXgiHVA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.292.0",
+        "@aws-sdk/credential-provider-imds": "3.292.0",
+        "@aws-sdk/credential-provider-ini": "3.294.0",
+        "@aws-sdk/credential-provider-process": "3.292.0",
+        "@aws-sdk/credential-provider-sso": "3.294.0",
+        "@aws-sdk/credential-provider-web-identity": "3.292.0",
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/shared-ini-file-loader": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.292.0.tgz",
+      "integrity": "sha512-CFVXuMuUvg/a4tknzRikEDwZBnKlHs1LZCpTXIGjBdUTdosoi4WNzDLzGp93ZRTtcgFz+4wirz2f7P3lC0NrQw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/shared-ini-file-loader": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.294.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.294.0.tgz",
+      "integrity": "sha512-UxrcAA/0l7j9+3tolYcG5M61D/IE1Bjd/9H87H1i2A2BrwUUBhW1Dp/vvROEDrrywlMDG3CDF3T/7ADtTak+sg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.294.0",
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/shared-ini-file-loader": "3.292.0",
+        "@aws-sdk/token-providers": "3.294.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.292.0.tgz",
+      "integrity": "sha512-4DbtIEM9gGVfqYlMdYXg3XY+vBhemjB1zXIequottW8loLYM8Vuz4/uGxxKNze6evVVzowsA0wKrYclE1aj/Rg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.294.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.294.0.tgz",
+      "integrity": "sha512-CRGwCs6F31mQzjYi5YF2Z6c1T+UrFKtJSa6Ff/Q1rrPnROexyhBVnpP8WzpkODx/pZxKtTX50IX7ehIxbFDIyQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.294.0",
+        "@aws-sdk/client-sso": "3.294.0",
+        "@aws-sdk/client-sts": "3.294.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.294.0",
+        "@aws-sdk/credential-provider-env": "3.292.0",
+        "@aws-sdk/credential-provider-imds": "3.292.0",
+        "@aws-sdk/credential-provider-ini": "3.294.0",
+        "@aws-sdk/credential-provider-node": "3.294.0",
+        "@aws-sdk/credential-provider-process": "3.292.0",
+        "@aws-sdk/credential-provider-sso": "3.294.0",
+        "@aws-sdk/credential-provider-web-identity": "3.292.0",
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/shared-ini-file-loader": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/fetch-http-handler": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.292.0.tgz",
+      "integrity": "sha512-zh3bhUJbL8RSa39ZKDcy+AghtUkIP8LwcNlwRIoxMQh3Row4D1s4fCq0KZCx98NJBEXoiTLyTQlZxxI//BOb1Q==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/querystring-builder": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/util-base64": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/hash-node": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.292.0.tgz",
+      "integrity": "sha512-1yLxmIsvE+eK36JXEgEIouTITdykQLVhsA5Oai//Lar6Ddgu1sFpLDbdkMtKbrh4I0jLN9RacNCkeVQjZPTCCQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/util-buffer-from": "3.292.0",
+        "@aws-sdk/util-utf8": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/invalid-dependency": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.292.0.tgz",
+      "integrity": "sha512-39OUV78CD3TmEbjhpt+V+Fk4wAGWhixqHxDSN8+4WL0uB4Fl7k5m3Z9hNY78AttHQSl2twR7WtLztnXPAFsriw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/is-array-buffer": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.292.0.tgz",
+      "integrity": "sha512-kW/G5T/fzI0sJH5foZG6XJiNCevXqKLxV50qIT4B1pMuw7regd4ALIy0HwSqj1nnn9mSbRWBfmby0jWCJsMcwg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-content-length": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.292.0.tgz",
+      "integrity": "sha512-2gMWzQus5mj14menolpPDbYBeaOYcj7KNFZOjTjjI3iQ0KqyetG6XasirNrcJ/8QX1BRmpTol8Xjp2Ue3Gbzwg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-endpoint": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.292.0.tgz",
+      "integrity": "sha512-cPMkiSxpZGG6tYlW4OS+ucS6r43f9ddX9kcUoemJCY10MOuogdPjulCAjE0HTs2PLKSOrrG4CTP4Q4wWDrH4Bw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-serde": "3.292.0",
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/signature-v4": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/url-parser": "3.292.0",
+        "@aws-sdk/util-config-provider": "3.292.0",
+        "@aws-sdk/util-middleware": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.292.0.tgz",
+      "integrity": "sha512-mHuCWe3Yg2S5YZ7mB7sKU6C97XspfqrimWjMW9pfV2usAvLA3R0HrB03jpR5vpZ3P4q7HB6wK3S6CjYMGGRNag==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.292.0.tgz",
+      "integrity": "sha512-yZNY1XYmG3NG+uonET7jzKXNiwu61xm/ZZ6i/l51SusuaYN+qQtTAhOFsieQqTehF9kP4FzbsWgPDwD8ZZX9lw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.292.0.tgz",
+      "integrity": "sha512-kA3VZpPko0Zqd7CYPTKAxhjEv0HJqFu2054L04dde1JLr43ro+2MTdX7vsHzeAFUVRphqatFFofCumvXmU6Mig==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry": {
+      "version": "3.293.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.293.0.tgz",
+      "integrity": "sha512-7tiaz2GzRecNHaZ6YnF+Nrtk3au8qF6oiipf11R7MJiqJ0fkMLnz/iRrlakDziS9qF/a9v+3yxb4W4NHK3f4Tw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/service-error-classification": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/util-middleware": "3.292.0",
+        "@aws-sdk/util-retry": "3.292.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "optional": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-sts": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.292.0.tgz",
+      "integrity": "sha512-GN5ZHEqXZqDi+HkVbaXRX9HaW/vA5rikYpWKYsmxTUZ7fB7ijvEO3co3lleJv2C+iGYRtUIHC4wYNB5xgoTCxg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-signing": "3.292.0",
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/signature-v4": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-serde": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.292.0.tgz",
+      "integrity": "sha512-6hN9mTQwSvV8EcGvtXbS/MpK7WMCokUku5Wu7X24UwCNMVkoRHLIkYcxHcvBTwttuOU0d8hph1/lIX4dkLwkQw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-signing": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.292.0.tgz",
+      "integrity": "sha512-GVfoSjDjEQ4TaO6x9MffyP3uRV+2KcS5FtexLCYOM9pJcnE9tqq9FJOrZ1xl1g+YjUVKxo4x8lu3tpEtIb17qg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/signature-v4": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/util-middleware": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-stack": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.292.0.tgz",
+      "integrity": "sha512-WdQpRkuMysrEwrkByCM1qCn2PPpFGGQ2iXqaFha5RzCdZDlxJni9cVNb6HzWUcgjLEYVTXCmOR9Wxm3CNW44Qg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.293.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.293.0.tgz",
+      "integrity": "sha512-gZ7/e6XwpKk9mvgA78q4Ffc796jTn02TUKx2qMDnkLVbeJXBNN2jnvYEKq8v70+o7fd/ALRudg8gBDmkkhM/Hw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/util-endpoints": "3.293.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-config-provider": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.292.0.tgz",
+      "integrity": "sha512-S3NnC9dQ5GIbJYSDIldZb4zdpCOEua1tM7bjYL3VS5uqCEM93kIi/o/UkIUveMp/eqTS2LJa5HjNIz5Te6je0A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/shared-ini-file-loader": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/node-http-handler": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.292.0.tgz",
+      "integrity": "sha512-L/E3UDSwXLXjt1XWWh0RBD55F+aZI1AEdPwdES9i1PjnZLyuxuDhEDptVibNN56+I9/4Q3SbmuVRVlOD0uzBag==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/abort-controller": "3.292.0",
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/querystring-builder": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/property-provider": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.292.0.tgz",
+      "integrity": "sha512-dHArSvsiqhno/g55N815gXmAMrmN8DP7OeFNqJ4wJG42xsF2PFN3DAsjIuHuXMwu+7A3R1LHqIpvv0hA9KeoJQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.292.0.tgz",
+      "integrity": "sha512-NLi4fq3k41aXIh1I97yX0JTy+3p6aW1NdwFwdMa674z86QNfb4SfRQRZBQe9wEnAZ/eWHVnlKIuII+U1URk/Kg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-builder": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.292.0.tgz",
+      "integrity": "sha512-XElIFJaReIm24eEvBtV2dOtZvcm3gXsGu/ftG8MLJKbKXFKpAP1q+K6En0Bs7/T88voKghKdKpKT+eZUWgTqlg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/util-uri-escape": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/querystring-parser": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.292.0.tgz",
+      "integrity": "sha512-iTYpYo7a8X9RxiPbjjewIpm6XQPx2EOcF1dWCPRII9EFlmZ4bwnX+PDI36fIo9oVs8TIKXmwNGODU9nsg7CSAw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/service-error-classification": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.292.0.tgz",
+      "integrity": "sha512-X1k3sixCeC45XSNHBe+kRBQBwPDyTFtFITb8O5Qw4dS9XWGhrUJT4CX0qE5aj8qP3F9U5nRizs9c2mBVVP0Caw==",
+      "optional": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/shared-ini-file-loader": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.292.0.tgz",
+      "integrity": "sha512-Av2TTYg1Jig2kbkD56ybiqZJB6vVrYjv1W5UQwY/q3nA/T2mcrgQ20ByCOt5Bv9VvY7FSgC+znj+L4a7RLGmBg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.292.0.tgz",
+      "integrity": "sha512-+rw47VY5mvBecn13tDQTl1ipGWg5tE63faWgmZe68HoBL87ZiDzsd7bUKOvjfW21iMgWlwAppkaNNQayYRb2zg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/util-hex-encoding": "3.292.0",
+        "@aws-sdk/util-middleware": "3.292.0",
+        "@aws-sdk/util-uri-escape": "3.292.0",
+        "@aws-sdk/util-utf8": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/smithy-client": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.292.0.tgz",
+      "integrity": "sha512-S8PKzjPkZ6SXYZuZiU787dMsvQ0d/LFEhw2OI4Oe2An9Fc2IwJ2FYukyHoQJOV2tV0DiuMebPo7eMyQyjKElvA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/middleware-stack": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.294.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.294.0.tgz",
+      "integrity": "sha512-6nwO04LtC5f4AsUvGZXyjaswuEK4Rr2VsuANpMKrPCgunRfI58a8YXLniudOSXN6e7CFJ6M3uo/h5YXqtnzGug==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/client-sso-oidc": "3.294.0",
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/shared-ini-file-loader": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.292.0.tgz",
+      "integrity": "sha512-1teYAY2M73UXZxMAxqZxVS2qwXjQh0OWtt7qyLfha0TtIk/fZ1hRwFgxbDCHUFcdNBSOSbKH/ESor90KROXLCQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/url-parser": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.292.0.tgz",
+      "integrity": "sha512-NZeAuZCk1x6TIiWuRfbOU6wHPBhf0ly2qOHzWut4BCH+b4RrDmFF8EmXcH1auEfGhE7yRyR6XqIN0t3S+hYACA==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/querystring-parser": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-base64": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.292.0.tgz",
+      "integrity": "sha512-zjNCwNdy617yFvEjZorepNWXB2sQCVfsShCwFy/kIQ5iW5tT2jQKaqc0K77diU9atkooxw9p1W9m9sOgrkOFNw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-browser": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.292.0.tgz",
+      "integrity": "sha512-Wd/BM+JsMiKvKs/bN3z6TredVEHh2pKudGfg3CSjTRpqFpOG903KDfyHBD42yg5PuCHoHoewJvTPKwgn7/vhaw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-body-length-node": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.292.0.tgz",
+      "integrity": "sha512-BBgipZ2P6RhogWE/qj0oqpdlyd3iSBYmb+aD/TBXwB2lA/X8A99GxweBd/kp06AmcJRoMS9WIXgbWkiiBlRlSA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-buffer-from": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.292.0.tgz",
+      "integrity": "sha512-RxNZjLoXNxHconH9TYsk5RaEBjSgTtozHeyIdacaHPj5vlQKi4hgL2hIfKeeNiAfQEVjaUFF29lv81xpNMzVMQ==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/is-array-buffer": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-config-provider": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.292.0.tgz",
+      "integrity": "sha512-t3noYll6bPRSxeeNNEkC5czVjAiTPcsq00OwfJ2xyUqmquhLEfLwoJKmrT1uP7DjIEXdUtfoIQ2jWiIVm/oO5A==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.292.0.tgz",
+      "integrity": "sha512-7+zVUlMGfa8/KT++9humHo6IDxTnxMCmWUj5jVNlkpk6h7Ecmppf7aXotviyVIA43lhtz0p2AErs0N0ekEUK+w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-defaults-mode-node": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.292.0.tgz",
+      "integrity": "sha512-SSIw85eF4BVs0fOJRyshT+R3b/UmBPhiVKCUZm2rq6+lIGkDPiSwQU3d/80AhXtiL5SFT/IzAKKgQd8qMa7q3A==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/config-resolver": "3.292.0",
+        "@aws-sdk/credential-provider-imds": "3.292.0",
+        "@aws-sdk/node-config-provider": "3.292.0",
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.293.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.293.0.tgz",
+      "integrity": "sha512-R/99aNV49Refpv5guiUjEUrZYlvnfaNBniB+/ZtMO3ixxUopapssCrUivuJrmhccmrYaTCZw7dRzIWjU1jJhKg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-hex-encoding": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.292.0.tgz",
+      "integrity": "sha512-qBd5KFIUywQ3qSSbj814S2srk0vfv8A6QMI+Obs1y2LHZFdQN5zViptI4UhXhKOHe+NnrHWxSuLC/LMH6q3SmA==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.292.0.tgz",
+      "integrity": "sha512-6xnFJXZI9pKw5lQCDvuWA5PnOaUtNRKWwdxvGkkLx5orboFaoVMS6zowjSQxwVNRjW82u6dYNkhmj9mZ8VSjWg==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-middleware": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.292.0.tgz",
+      "integrity": "sha512-KjhS7flfoBKDxbiBZjLjMvEizXgjfQb7GQEItgzGoI9rfGCmZtvqCcqQQoIlxb8bIzGRggAUHtBGWnlLbpb+GQ==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-retry": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.292.0.tgz",
+      "integrity": "sha512-JEHyF7MpVeRF5uR4LDYgpOKcFpOPiAj8TqN46SVOQQcL1K+V7cSr7O7N7J6MwJaN9XOzAcBadeIupMm7/BFbgw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/service-error-classification": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-uri-escape": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.292.0.tgz",
+      "integrity": "sha512-hOQtUMQ4VcQ9iwKz50AoCp1XBD5gJ9nly/gJZccAM7zSA5mOO8RRKkbdonqquVHxrO0CnYgiFeCh3V35GFecUw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.292.0.tgz",
+      "integrity": "sha512-dld+lpC3QdmTQHdBWJ0WFDkXDSrJgfz03q6mQ8+7H+BC12ZhT0I0g9iuvUjolqy7QR00OxOy47Y9FVhq8EC0Gg==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/types": "3.292.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.292.0.tgz",
+      "integrity": "sha512-f+NfIMal5E61MDc5WGhUEoicr7b1eNNhA+GgVdSB/Hg5fYhEZvFK9RZizH5rrtsLjjgcr9nPYSR7/nDKCJLumw==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/node-config-provider": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.292.0.tgz",
+      "integrity": "sha512-FPkj+Z59/DQWvoVu2wFaRncc3KVwe/pgK3MfVb0Lx+Ibey5KUx+sNpJmYcVYHUAe/Nv/JeIpOtYuC96IXOnI6w==",
+      "optional": true,
+      "dependencies": {
+        "@aws-sdk/util-buffer-from": "3.292.0",
+        "tslib": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1152,6 +2226,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "optional": true
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1210,11 +2290,37 @@
       }
     },
     "node_modules/bson": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.1.0.tgz",
-      "integrity": "sha512-FEecNHkhYRBe7X9KDkdG12xNuz5VHGeH6mCE0B5sBmYtiR/Ux/9vUH/v4NUoBCDr6NuEhvahjoLiiRogptVW0A==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
+      "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
+      "dependencies": {
+        "buffer": "^5.6.0"
+      },
       "engines": {
-        "node": ">=14.20.1"
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/caching-transform": {
@@ -2350,6 +3456,22 @@
       "integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "optional": true,
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
       }
     },
     "node_modules/fastq": {
@@ -3913,35 +5035,20 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.1.0.tgz",
-      "integrity": "sha512-qgKb7y+EI90y4weY3z5+lIgm8wmexbonz0GalHkSElQXVKtRuwqXuhXKccyvIjXCJVy9qPV82zsinY0W1FBnJw==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.14.0.tgz",
+      "integrity": "sha512-coGKkWXIBczZPr284tYKFLg+KbGPPLlSbdgfKAb6QqCFt5bo5VFZ50O3FFzsw4rnkqjwT6D8Qcoo9nshYKM7Mg==",
       "dependencies": {
-        "bson": "^5.0.1",
-        "mongodb-connection-string-url": "^2.6.0",
+        "bson": "^4.7.0",
+        "mongodb-connection-string-url": "^2.5.4",
         "socks": "^2.7.1"
       },
       "engines": {
-        "node": ">=14.20.1"
+        "node": ">=12.9.0"
       },
       "optionalDependencies": {
+        "@aws-sdk/credential-providers": "^3.186.0",
         "saslprep": "^1.0.3"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.201.0",
-        "mongodb-client-encryption": "^2.3.0",
-        "snappy": "^7.2.2"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-providers": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        }
       }
     },
     "node_modules/mongodb-connection-string-url": {
@@ -5597,6 +6704,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "optional": true
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5747,6 +6860,12 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
     },
     "node_modules/tweetnacl": {
       "version": "0.14.5",
@@ -6146,6 +7265,919 @@
       "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "^0.3.0"
+      }
+    },
+    "@aws-crypto/ie11-detection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
+      "optional": true,
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-crypto/sha256-browser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/ie11-detection": "^3.0.0",
+        "@aws-crypto/sha256-js": "^3.0.0",
+        "@aws-crypto/supports-web-crypto": "^3.0.0",
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-crypto/sha256-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-crypto/supports-web-crypto": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/abort-controller": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.292.0.tgz",
+      "integrity": "sha512-lf+OPptL01kvryIJy7+dvFux5KbJ6OTwLPPEekVKZ2AfEvwcVtOZWFUhyw3PJCBTVncjKB1Kjl3V/eTS3YuPXQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-cognito-identity": {
+      "version": "3.294.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.294.0.tgz",
+      "integrity": "sha512-QMk/QratNvAvmnJ77pu9KDjpfUf/5LOJplHcLKcY962ewJGBtFFY4XZVnmUgQMSG0phRODtex7pyH//FueGKLQ==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/client-sts": "3.294.0",
+        "@aws-sdk/config-resolver": "3.292.0",
+        "@aws-sdk/credential-provider-node": "3.294.0",
+        "@aws-sdk/fetch-http-handler": "3.292.0",
+        "@aws-sdk/hash-node": "3.292.0",
+        "@aws-sdk/invalid-dependency": "3.292.0",
+        "@aws-sdk/middleware-content-length": "3.292.0",
+        "@aws-sdk/middleware-endpoint": "3.292.0",
+        "@aws-sdk/middleware-host-header": "3.292.0",
+        "@aws-sdk/middleware-logger": "3.292.0",
+        "@aws-sdk/middleware-recursion-detection": "3.292.0",
+        "@aws-sdk/middleware-retry": "3.293.0",
+        "@aws-sdk/middleware-serde": "3.292.0",
+        "@aws-sdk/middleware-signing": "3.292.0",
+        "@aws-sdk/middleware-stack": "3.292.0",
+        "@aws-sdk/middleware-user-agent": "3.293.0",
+        "@aws-sdk/node-config-provider": "3.292.0",
+        "@aws-sdk/node-http-handler": "3.292.0",
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/smithy-client": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/url-parser": "3.292.0",
+        "@aws-sdk/util-base64": "3.292.0",
+        "@aws-sdk/util-body-length-browser": "3.292.0",
+        "@aws-sdk/util-body-length-node": "3.292.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.292.0",
+        "@aws-sdk/util-defaults-mode-node": "3.292.0",
+        "@aws-sdk/util-endpoints": "3.293.0",
+        "@aws-sdk/util-retry": "3.292.0",
+        "@aws-sdk/util-user-agent-browser": "3.292.0",
+        "@aws-sdk/util-user-agent-node": "3.292.0",
+        "@aws-sdk/util-utf8": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sso": {
+      "version": "3.294.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.294.0.tgz",
+      "integrity": "sha512-+FuxQTi5WvnaXM5JbNLkBIzQ3An4gA0ox61N1u+3xled+nywKb1yQ7WmRpyMG5bLbkmnj3aqoo5/uskFc4c4EA==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.292.0",
+        "@aws-sdk/fetch-http-handler": "3.292.0",
+        "@aws-sdk/hash-node": "3.292.0",
+        "@aws-sdk/invalid-dependency": "3.292.0",
+        "@aws-sdk/middleware-content-length": "3.292.0",
+        "@aws-sdk/middleware-endpoint": "3.292.0",
+        "@aws-sdk/middleware-host-header": "3.292.0",
+        "@aws-sdk/middleware-logger": "3.292.0",
+        "@aws-sdk/middleware-recursion-detection": "3.292.0",
+        "@aws-sdk/middleware-retry": "3.293.0",
+        "@aws-sdk/middleware-serde": "3.292.0",
+        "@aws-sdk/middleware-stack": "3.292.0",
+        "@aws-sdk/middleware-user-agent": "3.293.0",
+        "@aws-sdk/node-config-provider": "3.292.0",
+        "@aws-sdk/node-http-handler": "3.292.0",
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/smithy-client": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/url-parser": "3.292.0",
+        "@aws-sdk/util-base64": "3.292.0",
+        "@aws-sdk/util-body-length-browser": "3.292.0",
+        "@aws-sdk/util-body-length-node": "3.292.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.292.0",
+        "@aws-sdk/util-defaults-mode-node": "3.292.0",
+        "@aws-sdk/util-endpoints": "3.293.0",
+        "@aws-sdk/util-retry": "3.292.0",
+        "@aws-sdk/util-user-agent-browser": "3.292.0",
+        "@aws-sdk/util-user-agent-node": "3.292.0",
+        "@aws-sdk/util-utf8": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sso-oidc": {
+      "version": "3.294.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.294.0.tgz",
+      "integrity": "sha512-/ZfDud76MdSPJ/TxjV2xLE30XbBQDZwKQ32axwoK1eziPvrAIUBYVgpBwj+m0quhoiQhBKkg3aFl6j39AF2thw==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.292.0",
+        "@aws-sdk/fetch-http-handler": "3.292.0",
+        "@aws-sdk/hash-node": "3.292.0",
+        "@aws-sdk/invalid-dependency": "3.292.0",
+        "@aws-sdk/middleware-content-length": "3.292.0",
+        "@aws-sdk/middleware-endpoint": "3.292.0",
+        "@aws-sdk/middleware-host-header": "3.292.0",
+        "@aws-sdk/middleware-logger": "3.292.0",
+        "@aws-sdk/middleware-recursion-detection": "3.292.0",
+        "@aws-sdk/middleware-retry": "3.293.0",
+        "@aws-sdk/middleware-serde": "3.292.0",
+        "@aws-sdk/middleware-stack": "3.292.0",
+        "@aws-sdk/middleware-user-agent": "3.293.0",
+        "@aws-sdk/node-config-provider": "3.292.0",
+        "@aws-sdk/node-http-handler": "3.292.0",
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/smithy-client": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/url-parser": "3.292.0",
+        "@aws-sdk/util-base64": "3.292.0",
+        "@aws-sdk/util-body-length-browser": "3.292.0",
+        "@aws-sdk/util-body-length-node": "3.292.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.292.0",
+        "@aws-sdk/util-defaults-mode-node": "3.292.0",
+        "@aws-sdk/util-endpoints": "3.293.0",
+        "@aws-sdk/util-retry": "3.292.0",
+        "@aws-sdk/util-user-agent-browser": "3.292.0",
+        "@aws-sdk/util-user-agent-node": "3.292.0",
+        "@aws-sdk/util-utf8": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-sts": {
+      "version": "3.294.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.294.0.tgz",
+      "integrity": "sha512-AefqwhFjTDzelZuSYhriJbiI+GQwf2yKiKAnCt0gRj6rswewStM63Gtlhfb01sFPp+ZiqPcyQ47LqUaHp1mz/g==",
+      "optional": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "3.0.0",
+        "@aws-crypto/sha256-js": "3.0.0",
+        "@aws-sdk/config-resolver": "3.292.0",
+        "@aws-sdk/credential-provider-node": "3.294.0",
+        "@aws-sdk/fetch-http-handler": "3.292.0",
+        "@aws-sdk/hash-node": "3.292.0",
+        "@aws-sdk/invalid-dependency": "3.292.0",
+        "@aws-sdk/middleware-content-length": "3.292.0",
+        "@aws-sdk/middleware-endpoint": "3.292.0",
+        "@aws-sdk/middleware-host-header": "3.292.0",
+        "@aws-sdk/middleware-logger": "3.292.0",
+        "@aws-sdk/middleware-recursion-detection": "3.292.0",
+        "@aws-sdk/middleware-retry": "3.293.0",
+        "@aws-sdk/middleware-sdk-sts": "3.292.0",
+        "@aws-sdk/middleware-serde": "3.292.0",
+        "@aws-sdk/middleware-signing": "3.292.0",
+        "@aws-sdk/middleware-stack": "3.292.0",
+        "@aws-sdk/middleware-user-agent": "3.293.0",
+        "@aws-sdk/node-config-provider": "3.292.0",
+        "@aws-sdk/node-http-handler": "3.292.0",
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/smithy-client": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/url-parser": "3.292.0",
+        "@aws-sdk/util-base64": "3.292.0",
+        "@aws-sdk/util-body-length-browser": "3.292.0",
+        "@aws-sdk/util-body-length-node": "3.292.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.292.0",
+        "@aws-sdk/util-defaults-mode-node": "3.292.0",
+        "@aws-sdk/util-endpoints": "3.293.0",
+        "@aws-sdk/util-retry": "3.292.0",
+        "@aws-sdk/util-user-agent-browser": "3.292.0",
+        "@aws-sdk/util-user-agent-node": "3.292.0",
+        "@aws-sdk/util-utf8": "3.292.0",
+        "fast-xml-parser": "4.1.2",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/config-resolver": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.292.0.tgz",
+      "integrity": "sha512-cB3twnNR7vYvlt2jvw8VlA1+iv/tVzl+/S39MKqw2tepU+AbJAM0EHwb/dkf1OKSmlrnANXhshx80MHF9zL4mA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/signature-v4": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/util-config-provider": "3.292.0",
+        "@aws-sdk/util-middleware": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.294.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.294.0.tgz",
+      "integrity": "sha512-YSPqHEbLC0dnbFF5LdlMH0B50sMSN/CyG/sHkPYUwL/hkbUk9URnVW7ZJlt6lRftT7X4C7muzLqUP8sJAaiJEA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.294.0",
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-env": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.292.0.tgz",
+      "integrity": "sha512-YbafSG0ZEKE2969CJWVtUhh3hfOeLPecFVoXOtegCyAJgY5Ghtu4TsVhL4DgiGAgOC30ojAmUVQEXzd7xJF5xA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-imds": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.292.0.tgz",
+      "integrity": "sha512-W/peOgDSRYulgzFpUhvgi1pCm6piBz6xrVN17N4QOy+3NHBXRVMVzYk6ct2qpLPgJUSEZkcpP+Gds+bBm8ed1A==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.292.0",
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/url-parser": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-ini": {
+      "version": "3.294.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.294.0.tgz",
+      "integrity": "sha512-pdTPbaAb5bWA+DnuKoL2TpXeNDp6Ejpv/OYt+bw2gdzl9w5r/ZCtUTTbW+Vvejr4WL5s3c1bY96kwdqCn7iLqA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.292.0",
+        "@aws-sdk/credential-provider-imds": "3.292.0",
+        "@aws-sdk/credential-provider-process": "3.292.0",
+        "@aws-sdk/credential-provider-sso": "3.294.0",
+        "@aws-sdk/credential-provider-web-identity": "3.292.0",
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/shared-ini-file-loader": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-node": {
+      "version": "3.294.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.294.0.tgz",
+      "integrity": "sha512-zUL1Qhb4BsQIZCs/TPpG4oIYH/9YsGiS+Se1tasSGjTOLfBy7jhOZ0QIdpEeyAx/EP8blOBredM9xWfEXgiHVA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/credential-provider-env": "3.292.0",
+        "@aws-sdk/credential-provider-imds": "3.292.0",
+        "@aws-sdk/credential-provider-ini": "3.294.0",
+        "@aws-sdk/credential-provider-process": "3.292.0",
+        "@aws-sdk/credential-provider-sso": "3.294.0",
+        "@aws-sdk/credential-provider-web-identity": "3.292.0",
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/shared-ini-file-loader": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-process": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.292.0.tgz",
+      "integrity": "sha512-CFVXuMuUvg/a4tknzRikEDwZBnKlHs1LZCpTXIGjBdUTdosoi4WNzDLzGp93ZRTtcgFz+4wirz2f7P3lC0NrQw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/shared-ini-file-loader": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-sso": {
+      "version": "3.294.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.294.0.tgz",
+      "integrity": "sha512-UxrcAA/0l7j9+3tolYcG5M61D/IE1Bjd/9H87H1i2A2BrwUUBhW1Dp/vvROEDrrywlMDG3CDF3T/7ADtTak+sg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-sso": "3.294.0",
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/shared-ini-file-loader": "3.292.0",
+        "@aws-sdk/token-providers": "3.294.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-provider-web-identity": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.292.0.tgz",
+      "integrity": "sha512-4DbtIEM9gGVfqYlMdYXg3XY+vBhemjB1zXIequottW8loLYM8Vuz4/uGxxKNze6evVVzowsA0wKrYclE1aj/Rg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/credential-providers": {
+      "version": "3.294.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.294.0.tgz",
+      "integrity": "sha512-CRGwCs6F31mQzjYi5YF2Z6c1T+UrFKtJSa6Ff/Q1rrPnROexyhBVnpP8WzpkODx/pZxKtTX50IX7ehIxbFDIyQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-cognito-identity": "3.294.0",
+        "@aws-sdk/client-sso": "3.294.0",
+        "@aws-sdk/client-sts": "3.294.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.294.0",
+        "@aws-sdk/credential-provider-env": "3.292.0",
+        "@aws-sdk/credential-provider-imds": "3.292.0",
+        "@aws-sdk/credential-provider-ini": "3.294.0",
+        "@aws-sdk/credential-provider-node": "3.294.0",
+        "@aws-sdk/credential-provider-process": "3.292.0",
+        "@aws-sdk/credential-provider-sso": "3.294.0",
+        "@aws-sdk/credential-provider-web-identity": "3.292.0",
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/shared-ini-file-loader": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/fetch-http-handler": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.292.0.tgz",
+      "integrity": "sha512-zh3bhUJbL8RSa39ZKDcy+AghtUkIP8LwcNlwRIoxMQh3Row4D1s4fCq0KZCx98NJBEXoiTLyTQlZxxI//BOb1Q==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/querystring-builder": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/util-base64": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/hash-node": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.292.0.tgz",
+      "integrity": "sha512-1yLxmIsvE+eK36JXEgEIouTITdykQLVhsA5Oai//Lar6Ddgu1sFpLDbdkMtKbrh4I0jLN9RacNCkeVQjZPTCCQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/util-buffer-from": "3.292.0",
+        "@aws-sdk/util-utf8": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/invalid-dependency": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.292.0.tgz",
+      "integrity": "sha512-39OUV78CD3TmEbjhpt+V+Fk4wAGWhixqHxDSN8+4WL0uB4Fl7k5m3Z9hNY78AttHQSl2twR7WtLztnXPAFsriw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/is-array-buffer": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.292.0.tgz",
+      "integrity": "sha512-kW/G5T/fzI0sJH5foZG6XJiNCevXqKLxV50qIT4B1pMuw7regd4ALIy0HwSqj1nnn9mSbRWBfmby0jWCJsMcwg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-content-length": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.292.0.tgz",
+      "integrity": "sha512-2gMWzQus5mj14menolpPDbYBeaOYcj7KNFZOjTjjI3iQ0KqyetG6XasirNrcJ/8QX1BRmpTol8Xjp2Ue3Gbzwg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-endpoint": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.292.0.tgz",
+      "integrity": "sha512-cPMkiSxpZGG6tYlW4OS+ucS6r43f9ddX9kcUoemJCY10MOuogdPjulCAjE0HTs2PLKSOrrG4CTP4Q4wWDrH4Bw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/middleware-serde": "3.292.0",
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/signature-v4": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/url-parser": "3.292.0",
+        "@aws-sdk/util-config-provider": "3.292.0",
+        "@aws-sdk/util-middleware": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-host-header": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.292.0.tgz",
+      "integrity": "sha512-mHuCWe3Yg2S5YZ7mB7sKU6C97XspfqrimWjMW9pfV2usAvLA3R0HrB03jpR5vpZ3P4q7HB6wK3S6CjYMGGRNag==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-logger": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.292.0.tgz",
+      "integrity": "sha512-yZNY1XYmG3NG+uonET7jzKXNiwu61xm/ZZ6i/l51SusuaYN+qQtTAhOFsieQqTehF9kP4FzbsWgPDwD8ZZX9lw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.292.0.tgz",
+      "integrity": "sha512-kA3VZpPko0Zqd7CYPTKAxhjEv0HJqFu2054L04dde1JLr43ro+2MTdX7vsHzeAFUVRphqatFFofCumvXmU6Mig==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-retry": {
+      "version": "3.293.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.293.0.tgz",
+      "integrity": "sha512-7tiaz2GzRecNHaZ6YnF+Nrtk3au8qF6oiipf11R7MJiqJ0fkMLnz/iRrlakDziS9qF/a9v+3yxb4W4NHK3f4Tw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/service-error-classification": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/util-middleware": "3.292.0",
+        "@aws-sdk/util-retry": "3.292.0",
+        "tslib": "^2.3.1",
+        "uuid": "^8.3.2"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "8.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+          "optional": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-sdk-sts": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.292.0.tgz",
+      "integrity": "sha512-GN5ZHEqXZqDi+HkVbaXRX9HaW/vA5rikYpWKYsmxTUZ7fB7ijvEO3co3lleJv2C+iGYRtUIHC4wYNB5xgoTCxg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/middleware-signing": "3.292.0",
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/signature-v4": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-serde": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.292.0.tgz",
+      "integrity": "sha512-6hN9mTQwSvV8EcGvtXbS/MpK7WMCokUku5Wu7X24UwCNMVkoRHLIkYcxHcvBTwttuOU0d8hph1/lIX4dkLwkQw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-signing": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.292.0.tgz",
+      "integrity": "sha512-GVfoSjDjEQ4TaO6x9MffyP3uRV+2KcS5FtexLCYOM9pJcnE9tqq9FJOrZ1xl1g+YjUVKxo4x8lu3tpEtIb17qg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/signature-v4": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/util-middleware": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-stack": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.292.0.tgz",
+      "integrity": "sha512-WdQpRkuMysrEwrkByCM1qCn2PPpFGGQ2iXqaFha5RzCdZDlxJni9cVNb6HzWUcgjLEYVTXCmOR9Wxm3CNW44Qg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-user-agent": {
+      "version": "3.293.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.293.0.tgz",
+      "integrity": "sha512-gZ7/e6XwpKk9mvgA78q4Ffc796jTn02TUKx2qMDnkLVbeJXBNN2jnvYEKq8v70+o7fd/ALRudg8gBDmkkhM/Hw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/util-endpoints": "3.293.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/node-config-provider": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.292.0.tgz",
+      "integrity": "sha512-S3NnC9dQ5GIbJYSDIldZb4zdpCOEua1tM7bjYL3VS5uqCEM93kIi/o/UkIUveMp/eqTS2LJa5HjNIz5Te6je0A==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/shared-ini-file-loader": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/node-http-handler": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.292.0.tgz",
+      "integrity": "sha512-L/E3UDSwXLXjt1XWWh0RBD55F+aZI1AEdPwdES9i1PjnZLyuxuDhEDptVibNN56+I9/4Q3SbmuVRVlOD0uzBag==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/abort-controller": "3.292.0",
+        "@aws-sdk/protocol-http": "3.292.0",
+        "@aws-sdk/querystring-builder": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/property-provider": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.292.0.tgz",
+      "integrity": "sha512-dHArSvsiqhno/g55N815gXmAMrmN8DP7OeFNqJ4wJG42xsF2PFN3DAsjIuHuXMwu+7A3R1LHqIpvv0hA9KeoJQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/protocol-http": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.292.0.tgz",
+      "integrity": "sha512-NLi4fq3k41aXIh1I97yX0JTy+3p6aW1NdwFwdMa674z86QNfb4SfRQRZBQe9wEnAZ/eWHVnlKIuII+U1URk/Kg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/querystring-builder": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.292.0.tgz",
+      "integrity": "sha512-XElIFJaReIm24eEvBtV2dOtZvcm3gXsGu/ftG8MLJKbKXFKpAP1q+K6En0Bs7/T88voKghKdKpKT+eZUWgTqlg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/util-uri-escape": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/querystring-parser": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.292.0.tgz",
+      "integrity": "sha512-iTYpYo7a8X9RxiPbjjewIpm6XQPx2EOcF1dWCPRII9EFlmZ4bwnX+PDI36fIo9oVs8TIKXmwNGODU9nsg7CSAw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/service-error-classification": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.292.0.tgz",
+      "integrity": "sha512-X1k3sixCeC45XSNHBe+kRBQBwPDyTFtFITb8O5Qw4dS9XWGhrUJT4CX0qE5aj8qP3F9U5nRizs9c2mBVVP0Caw==",
+      "optional": true
+    },
+    "@aws-sdk/shared-ini-file-loader": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.292.0.tgz",
+      "integrity": "sha512-Av2TTYg1Jig2kbkD56ybiqZJB6vVrYjv1W5UQwY/q3nA/T2mcrgQ20ByCOt5Bv9VvY7FSgC+znj+L4a7RLGmBg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/signature-v4": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.292.0.tgz",
+      "integrity": "sha512-+rw47VY5mvBecn13tDQTl1ipGWg5tE63faWgmZe68HoBL87ZiDzsd7bUKOvjfW21iMgWlwAppkaNNQayYRb2zg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "@aws-sdk/util-hex-encoding": "3.292.0",
+        "@aws-sdk/util-middleware": "3.292.0",
+        "@aws-sdk/util-uri-escape": "3.292.0",
+        "@aws-sdk/util-utf8": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/smithy-client": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.292.0.tgz",
+      "integrity": "sha512-S8PKzjPkZ6SXYZuZiU787dMsvQ0d/LFEhw2OI4Oe2An9Fc2IwJ2FYukyHoQJOV2tV0DiuMebPo7eMyQyjKElvA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/token-providers": {
+      "version": "3.294.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.294.0.tgz",
+      "integrity": "sha512-6nwO04LtC5f4AsUvGZXyjaswuEK4Rr2VsuANpMKrPCgunRfI58a8YXLniudOSXN6e7CFJ6M3uo/h5YXqtnzGug==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/client-sso-oidc": "3.294.0",
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/shared-ini-file-loader": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/types": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.292.0.tgz",
+      "integrity": "sha512-1teYAY2M73UXZxMAxqZxVS2qwXjQh0OWtt7qyLfha0TtIk/fZ1hRwFgxbDCHUFcdNBSOSbKH/ESor90KROXLCQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/url-parser": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.292.0.tgz",
+      "integrity": "sha512-NZeAuZCk1x6TIiWuRfbOU6wHPBhf0ly2qOHzWut4BCH+b4RrDmFF8EmXcH1auEfGhE7yRyR6XqIN0t3S+hYACA==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/querystring-parser": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-base64": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.292.0.tgz",
+      "integrity": "sha512-zjNCwNdy617yFvEjZorepNWXB2sQCVfsShCwFy/kIQ5iW5tT2jQKaqc0K77diU9atkooxw9p1W9m9sOgrkOFNw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-body-length-browser": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.292.0.tgz",
+      "integrity": "sha512-Wd/BM+JsMiKvKs/bN3z6TredVEHh2pKudGfg3CSjTRpqFpOG903KDfyHBD42yg5PuCHoHoewJvTPKwgn7/vhaw==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-body-length-node": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.292.0.tgz",
+      "integrity": "sha512-BBgipZ2P6RhogWE/qj0oqpdlyd3iSBYmb+aD/TBXwB2lA/X8A99GxweBd/kp06AmcJRoMS9WIXgbWkiiBlRlSA==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-buffer-from": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.292.0.tgz",
+      "integrity": "sha512-RxNZjLoXNxHconH9TYsk5RaEBjSgTtozHeyIdacaHPj5vlQKi4hgL2hIfKeeNiAfQEVjaUFF29lv81xpNMzVMQ==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-config-provider": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.292.0.tgz",
+      "integrity": "sha512-t3noYll6bPRSxeeNNEkC5czVjAiTPcsq00OwfJ2xyUqmquhLEfLwoJKmrT1uP7DjIEXdUtfoIQ2jWiIVm/oO5A==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-browser": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.292.0.tgz",
+      "integrity": "sha512-7+zVUlMGfa8/KT++9humHo6IDxTnxMCmWUj5jVNlkpk6h7Ecmppf7aXotviyVIA43lhtz0p2AErs0N0ekEUK+w==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-defaults-mode-node": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.292.0.tgz",
+      "integrity": "sha512-SSIw85eF4BVs0fOJRyshT+R3b/UmBPhiVKCUZm2rq6+lIGkDPiSwQU3d/80AhXtiL5SFT/IzAKKgQd8qMa7q3A==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/config-resolver": "3.292.0",
+        "@aws-sdk/credential-provider-imds": "3.292.0",
+        "@aws-sdk/node-config-provider": "3.292.0",
+        "@aws-sdk/property-provider": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-endpoints": {
+      "version": "3.293.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.293.0.tgz",
+      "integrity": "sha512-R/99aNV49Refpv5guiUjEUrZYlvnfaNBniB+/ZtMO3ixxUopapssCrUivuJrmhccmrYaTCZw7dRzIWjU1jJhKg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-hex-encoding": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.292.0.tgz",
+      "integrity": "sha512-qBd5KFIUywQ3qSSbj814S2srk0vfv8A6QMI+Obs1y2LHZFdQN5zViptI4UhXhKOHe+NnrHWxSuLC/LMH6q3SmA==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-locate-window": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.292.0.tgz",
+      "integrity": "sha512-6xnFJXZI9pKw5lQCDvuWA5PnOaUtNRKWwdxvGkkLx5orboFaoVMS6zowjSQxwVNRjW82u6dYNkhmj9mZ8VSjWg==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-middleware": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.292.0.tgz",
+      "integrity": "sha512-KjhS7flfoBKDxbiBZjLjMvEizXgjfQb7GQEItgzGoI9rfGCmZtvqCcqQQoIlxb8bIzGRggAUHtBGWnlLbpb+GQ==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-retry": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.292.0.tgz",
+      "integrity": "sha512-JEHyF7MpVeRF5uR4LDYgpOKcFpOPiAj8TqN46SVOQQcL1K+V7cSr7O7N7J6MwJaN9XOzAcBadeIupMm7/BFbgw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/service-error-classification": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-uri-escape": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.292.0.tgz",
+      "integrity": "sha512-hOQtUMQ4VcQ9iwKz50AoCp1XBD5gJ9nly/gJZccAM7zSA5mOO8RRKkbdonqquVHxrO0CnYgiFeCh3V35GFecUw==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-user-agent-browser": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.292.0.tgz",
+      "integrity": "sha512-dld+lpC3QdmTQHdBWJ0WFDkXDSrJgfz03q6mQ8+7H+BC12ZhT0I0g9iuvUjolqy7QR00OxOy47Y9FVhq8EC0Gg==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/types": "3.292.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-user-agent-node": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.292.0.tgz",
+      "integrity": "sha512-f+NfIMal5E61MDc5WGhUEoicr7b1eNNhA+GgVdSB/Hg5fYhEZvFK9RZizH5rrtsLjjgcr9nPYSR7/nDKCJLumw==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/node-config-provider": "3.292.0",
+        "@aws-sdk/types": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8": {
+      "version": "3.292.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.292.0.tgz",
+      "integrity": "sha512-FPkj+Z59/DQWvoVu2wFaRncc3KVwe/pgK3MfVb0Lx+Ibey5KUx+sNpJmYcVYHUAe/Nv/JeIpOtYuC96IXOnI6w==",
+      "optional": true,
+      "requires": {
+        "@aws-sdk/util-buffer-from": "3.292.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "optional": true,
+      "requires": {
+        "tslib": "^2.3.1"
       }
     },
     "@babel/code-frame": {
@@ -6994,6 +9026,12 @@
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
     },
+    "bowser": {
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
+      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "optional": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -7033,9 +9071,21 @@
       }
     },
     "bson": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.1.0.tgz",
-      "integrity": "sha512-FEecNHkhYRBe7X9KDkdG12xNuz5VHGeH6mCE0B5sBmYtiR/Ux/9vUH/v4NUoBCDr6NuEhvahjoLiiRogptVW0A=="
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
+      "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
+      "requires": {
+        "buffer": "^5.6.0"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "caching-transform": {
       "version": "4.0.0",
@@ -7916,6 +9966,15 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-3.1.2.tgz",
       "integrity": "sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw=="
+    },
+    "fast-xml-parser": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.1.2.tgz",
+      "integrity": "sha512-CDYeykkle1LiA/uqQyNwYpFbyF6Axec6YapmpUP+/RHWIoR1zKjocdvNaTsxCxZzQ6v9MLXaSYm9Qq0thv0DHg==",
+      "optional": true,
+      "requires": {
+        "strnum": "^1.0.5"
+      }
     },
     "fastq": {
       "version": "1.13.0",
@@ -9049,12 +11108,13 @@
       }
     },
     "mongodb": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.1.0.tgz",
-      "integrity": "sha512-qgKb7y+EI90y4weY3z5+lIgm8wmexbonz0GalHkSElQXVKtRuwqXuhXKccyvIjXCJVy9qPV82zsinY0W1FBnJw==",
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.14.0.tgz",
+      "integrity": "sha512-coGKkWXIBczZPr284tYKFLg+KbGPPLlSbdgfKAb6QqCFt5bo5VFZ50O3FFzsw4rnkqjwT6D8Qcoo9nshYKM7Mg==",
       "requires": {
-        "bson": "^5.0.1",
-        "mongodb-connection-string-url": "^2.6.0",
+        "@aws-sdk/credential-providers": "^3.186.0",
+        "bson": "^4.7.0",
+        "mongodb-connection-string-url": "^2.5.4",
         "saslprep": "^1.0.3",
         "socks": "^2.7.1"
       }
@@ -10319,6 +12379,12 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "optional": true
+    },
     "supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -10438,6 +12504,12 @@
           "peer": true
         }
       }
+    },
+    "tslib": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==",
+      "optional": true
     },
     "tweetnacl": {
       "version": "0.14.5",

--- a/client/rest/package.json
+++ b/client/rest/package.json
@@ -30,7 +30,7 @@
     "@noble/hashes": "^1.2.0",
     "ini": "^3.0.1",
     "long": "^5.2.1",
-    "mongodb": "^5.1.0",
+    "mongodb": "^4.2.0",
     "restify": "^11.1.0",
     "restify-errors": "^8.0.2",
     "ripemd160": "^2.0.2",

--- a/client/rest/package.json
+++ b/client/rest/package.json
@@ -30,7 +30,7 @@
     "@noble/hashes": "^1.2.0",
     "ini": "^3.0.1",
     "long": "^5.2.1",
-    "mongodb": "^4.2.0",
+    "mongodb": "^4.14.0",
     "restify": "^11.1.0",
     "restify-errors": "^8.0.2",
     "ripemd160": "^2.0.2",

--- a/client/rest/resources/rest.json
+++ b/client/rest/resources/rest.json
@@ -41,7 +41,7 @@
     "maxConnectionAttempts": 5,
     "baseRetryDelay": 500,
     "connectionPoolSize": 10,
-    "connectionTimeout": 10000
+    "connectionTimeout": 500
   },
 
   "apiNode": {

--- a/client/rest/resources/rest.json
+++ b/client/rest/resources/rest.json
@@ -40,7 +40,8 @@
     "pageSizeDefault": 20,
     "maxConnectionAttempts": 5,
     "baseRetryDelay": 500,
-    "connectionPoolSize": 10
+    "connectionPoolSize": 10,
+    "connectionTimeout": 10000
   },
 
   "apiNode": {

--- a/client/rest/src/db/CatapultDb.js
+++ b/client/rest/src/db/CatapultDb.js
@@ -119,8 +119,7 @@ class CatapultDb {
 			.then(client => {
 				this.client = client;
 				this.database = client.db();
-			})
-			.then(() => this.isConnected());
+			});
 	}
 
 	close() {
@@ -132,15 +131,6 @@ class CatapultDb {
 			this.client = undefined;
 			this.database = undefined;
 		});
-	}
-
-	isConnected() {
-		return this.client.db().admin().ping()
-			.then(() => winston.verbose('Connection to mongodb is established.'))
-			.catch(err => {
-				winston.error(`failed to verify connection to mongodb: ${err}`);
-				return Promise.reject(err);
-			});
 	}
 
 	// endregion

--- a/client/rest/src/db/connector.js
+++ b/client/rest/src/db/connector.js
@@ -23,15 +23,15 @@ const MongoDb = require('mongodb');
 const winston = require('winston');
 
 const connector = {
-	connectToDatabase(url, dbName, connectionPoolSize) {
+	connectToDatabase(url, dbName, connectionPoolSize, timeout) {
 		const connectionString = `${url}${dbName}`;
 		return MongoDb.MongoClient.connect(connectionString, {
 			minPoolSize: connectionPoolSize,
-			promoteLongs: false,
-			useNewUrlParser: true
+			connectTimeoutMS: timeout,
+			serverSelectionTimeoutMS: timeout
 		})
 			.then(client => {
-				winston.verbose(`connected to mongo at ${connectionString}`);
+				winston.verbose(`connecting to mongo at ${connectionString}`);
 				return client;
 			});
 	}

--- a/client/rest/src/db/connector.js
+++ b/client/rest/src/db/connector.js
@@ -27,6 +27,7 @@ const connector = {
 		const connectionString = `${url}${dbName}`;
 		return MongoDb.MongoClient.connect(connectionString, {
 			minPoolSize: connectionPoolSize,
+			promoteLongs: false,
 			connectTimeoutMS: timeout,
 			serverSelectionTimeoutMS: timeout
 		})

--- a/client/rest/src/index.js
+++ b/client/rest/src/index.js
@@ -98,7 +98,7 @@ const createServiceManager = () => {
 };
 
 const connectToDbWithRetry = (db, config) => catapult.utils.future.makeRetryable(
-	() => db.connect(config.url, config.name, config.connectionPoolSize),
+	() => db.connect(config.url, config.name, config.connectionPoolSize, config.connectionTimeout),
 	config.maxConnectionAttempts,
 	(i, err) => {
 		const waitTime = (2 ** (i - 1)) * config.baseRetryDelay;

--- a/client/rest/src/routes/nodeRoutes.js
+++ b/client/rest/src/routes/nodeRoutes.js
@@ -71,7 +71,9 @@ module.exports = {
 					connection.pushPull(packetBuffer, services.config.apiNode.timeout))
 				.then(packet => parseNodeInfoPacket(packet));
 
-			return Promise.allSettled([db.isConnected(), apiNodeStatusPromise]).then(results => {
+			const dbStatusPromise = db.client.db().admin().ping();
+
+			return Promise.allSettled([dbStatusPromise, apiNodeStatusPromise]).then(results => {
 				const statusCode = results.some(result => 'fulfilled' !== result.status) ? 503 : 200;
 				const checkResult = result => ('fulfilled' === result.status ? ServiceStatus.up : ServiceStatus.down);
 

--- a/client/rest/src/routes/nodeRoutes.js
+++ b/client/rest/src/routes/nodeRoutes.js
@@ -60,14 +60,6 @@ module.exports = {
 				down: 'down'
 			});
 
-			// Check database status
-			const dbStatusPromise = new Promise((resolve, reject) => {
-				if (db.database.serverConfig.isConnected())
-					resolve();
-				else
-					reject();
-			});
-
 			// Check apiNode status
 			const packetBuffer = packetHeader.createBuffer(
 				PacketType.nodeDiscoveryPullPing,
@@ -79,7 +71,7 @@ module.exports = {
 					connection.pushPull(packetBuffer, services.config.apiNode.timeout))
 				.then(packet => parseNodeInfoPacket(packet));
 
-			return Promise.allSettled([dbStatusPromise, apiNodeStatusPromise]).then(results => {
+			return Promise.allSettled([db.isConnected(), apiNodeStatusPromise]).then(results => {
 				const statusCode = results.some(result => 'fulfilled' !== result.status) ? 503 : 200;
 				const checkResult = result => ('fulfilled' === result.status ? ServiceStatus.up : ServiceStatus.down);
 

--- a/client/rest/test/routes/nodeRoutes_spec.js
+++ b/client/rest/test/routes/nodeRoutes_spec.js
@@ -72,7 +72,13 @@ describe('node routes', () => {
 			};
 
 			const createMockDb = status => ({
-				isConnected: () => (true === status ? Promise.resolve() : Promise.reject(new Error('db is down')))
+				client: {
+					db: () => ({
+						admin: () => ({
+							ping: () => (true === status ? Promise.resolve() : Promise.reject(new Error('db is down')))
+						})
+					})
+				}
 			});
 
 			it('can check node health', () => {

--- a/client/rest/test/routes/nodeRoutes_spec.js
+++ b/client/rest/test/routes/nodeRoutes_spec.js
@@ -72,11 +72,7 @@ describe('node routes', () => {
 			};
 
 			const createMockDb = status => ({
-				database: {
-					serverConfig: {
-						isConnected: () => status
-					}
-				}
+				isConnected: () => (true === status ? Promise.resolve() : Promise.reject(new Error('db is down')))
 			});
 
 			it('can check node health', () => {


### PR DESCRIPTION
## What is the current behavior?
Rest endpoint ``/node/health`` shows mongodb database down

## What's the issue?
starting with mongo driver 4.x, mongodb removed the isconnected() method
see #203 

## How have you changed the behavior?
add logic to ping admin db to verify if db is available.
also reduce the connection timeout to 10s but configurable from config.
if mongodb is down it will take 10s for the ``/node/health`` endpoint to return.

## How was this change tested?
Tested on dev box.