### PR TITLE
[client/rest] fix: websocket tests fails with socket in use

### DIFF
--- a/client/rest/package-lock.json
+++ b/client/rest/package-lock.json
@@ -3678,20 +3678,6 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -10114,13 +10100,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
-    },
-    "fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",

--- a/client/rest/src/db/CatapultDb.js
+++ b/client/rest/src/db/CatapultDb.js
@@ -26,7 +26,6 @@ const { convertToLong, buildOffsetCondition, uniqueLongList } = require('./dbUti
 const catapult = require('../catapult-sdk/index');
 const MultisigDb = require('../plugins/multisig/MultisigDb');
 const MongoDb = require('mongodb');
-const winston = require('winston');
 
 const { EntityType } = catapult.model;
 const { ObjectId } = MongoDb;

--- a/client/rest/test/server/bootstrapper_spec.js
+++ b/client/rest/test/server/bootstrapper_spec.js
@@ -924,8 +924,9 @@ describe('server (bootstrapper)', () => {
 				// Assert: notice that payload is already formatted
 				expect(payload, `blockTag: ${blockTag}`).to.deep.equal(createFormattedBlock(blockTag));
 			},
-			onAllMessages: zsocket => {
+			onAllMessages: (zsocket, sockets) => {
 				// close mq socket and server, otherwise subsequent tests would fail
+				sockets.forEach(socket => socket.close());
 				zsocket.close();
 				server.close();
 				done();
@@ -964,10 +965,10 @@ describe('server (bootstrapper)', () => {
 					if (2 === ++counts.numAllConnectedHandlers)
 						createHandlers(server, done).onAllConnected(zsocket);
 				},
-				onAllMessages: zsocket => {
+				onAllMessages: (zsocket, sockets) => {
 					// - close the server only when messages from both websockets are received and processed
 					if (2 === ++counts.numAllMessagesHandlers)
-						createHandlers(server, done).onAllMessages(zsocket);
+						createHandlers(server, done).onAllMessages(zsocket, sockets);
 				}
 			};
 
@@ -1013,7 +1014,7 @@ describe('server (bootstrapper)', () => {
 							expect(socket.readyState).to.equal(WebSocket.OPEN);
 						});
 
-						defaultOnAllMessages(zsocket);
+						defaultOnAllMessages(zsocket, sockets);
 					}
 				})
 			);

--- a/client/rest/test/server/bootstrapper_spec.js
+++ b/client/rest/test/server/bootstrapper_spec.js
@@ -929,7 +929,18 @@ describe('server (bootstrapper)', () => {
 				sockets.forEach(socket => socket.close());
 				zsocket.close();
 				server.close();
-				done();
+
+				// wait for sockets to close
+				return new Promise(resolve => {
+					setTimeout(() => {
+						// Assert:
+						sockets.forEach(socket => {
+							expect(socket.readyState).to.equal(WebSocket.CLOSED);
+						});
+						resolve();
+						done();
+					}, 200);
+				});
 			}
 		});
 


### PR DESCRIPTION
## What is the current behavior?
websocket connections are not been closed.

## What's the issue?
some of the websocket tests occasionally fails. 

```
1) server (bootstrapper)
        websockets
          handles unsubscription of client from unknown channel:
      Error: Address already in use
```

## How have you changed the behavior?
close the client ws connections to the server

## How was this change tested?
I am not able to repo this issue but from looking at the tests this is what I think the issue might be.
