### PR TITLE
fix typo in Validators.h

### DIFF
--- a/client/catapult/plugins/coresystem/src/validators/Validators.h
+++ b/client/catapult/plugins/coresystem/src/validators/Validators.h
@@ -82,7 +82,7 @@ namespace catapult { namespace validators {
 	/// Validator that applies to all importance block notifications and validates that:
 	/// - notification values match calculated values (excluding PreviousImportanceBlockHash, which is validated separately)
 	/// - voting statistics are calculated more accurately for blocks at and after \a totalVotingBalanceCalculationFixForkHeight
-	/// - specifed voting set grouping (\a votingSetGrouping) is used to convert heights to epochs
+	/// - specified voting set grouping (\a votingSetGrouping) is used to convert heights to epochs
 	DECLARE_STATEFUL_VALIDATOR(ImportanceBlock, model::ImportanceBlockNotification)(
 			Height totalVotingBalanceCalculationFixForkHeight,
 			uint64_t votingSetGrouping);


### PR DESCRIPTION
Fixed typo.
```
specifed -> specified
```

* [ ] My pull request title is prefixed with the directory and subdirectory it affects.
* [x] My pull request contains a single change or feature.
* [x] My commits are clearly labeled with one of the following: **feat | bug | fix | build | perf | task**
* [ ] My code has been linted.
* [ ] My code has comments, particularly in any hard to understand areas.
* [x] My code follows the style guidelines.
* [ ] I have written and supplied test cases (either unit tests or end-to-end, where relevant).
* [ ] I have made any corresponding changes to the documentation (where relevant).