### PR TITLE
[client/catapult] fix: upgrade to openssl 3.1.0 

### DIFF
--- a/client/catapult/CMakeLists.txt
+++ b/client/catapult/CMakeLists.txt
@@ -54,7 +54,7 @@ endif()
 ### setup openssl
 message("--- locating openssl dependencies ---")
 
-find_package(OpenSSL 3.0.8 EXACT REQUIRED)
+find_package(OpenSSL 3.1.0 EXACT REQUIRED)
 message("OpenSSL   ver: ${OPENSSL_VERSION}")
 message("OpenSSL  root: ${OPENSSL_ROOT_DIR}")
 message("OpenSSL   inc: ${OPENSSL_INCLUDE_DIR}")

--- a/client/catapult/conanfile.txt
+++ b/client/catapult/conanfile.txt
@@ -1,7 +1,7 @@
 [requires]
 # release dependencies
 boost/1.80.0
-openssl/3.0.8
+openssl/3.1.0
 
 cppzmq/4.9.0@nemtech/stable
 mongo-cxx-driver/3.7.1@nemtech/stable

--- a/client/catapult/docs/BUILD-manual.md
+++ b/client/catapult/docs/BUILD-manual.md
@@ -8,7 +8,7 @@ For Windows, [Build with CONAN](BUILD-conan.md) is strongly encouraged.
 
 - ``git``.
 - ``python`` 3.7+.
-- ``openssl`` 3.0.8+.
+- ``openssl`` 3.1.0+.
 - About 15 GB of free disk space.
 
 These instructions have been verified to work on Ubuntu 20.04 with 8 GB of RAM and 4 CPU cores.

--- a/client/catapult/src/catapult/crypto/OpensslContexts.cpp
+++ b/client/catapult/src/catapult/crypto/OpensslContexts.cpp
@@ -37,11 +37,15 @@ namespace catapult { namespace crypto {
 	// region OpensslDigestContext
 
 	OpensslDigestContext::OpensslDigestContext() {
-		m_buffer = UniquePtr(EVP_MD_CTX_new(), [](context_type* p) { EVP_MD_CTX_free(p); });
+		std::memset(&m_buffer, 0, CountOf(m_buffer));
+	}
+
+	OpensslDigestContext::~OpensslDigestContext() {
+		reset();
 	}
 
 	OpensslDigestContext::context_type* OpensslDigestContext::get() {
-		return m_buffer.get();
+		return reinterpret_cast<context_type*>(m_buffer);
 	}
 
 	void OpensslDigestContext::reset() {
@@ -53,11 +57,16 @@ namespace catapult { namespace crypto {
 	// region OpensslCipherContext
 
 	OpensslCipherContext::OpensslCipherContext() {
-		m_buffer = UniquePtr(EVP_CIPHER_CTX_new(), [](context_type* p) { EVP_CIPHER_CTX_free(p); });
+		std::memset(&m_buffer, 0, CountOf(m_buffer));
+		reset();
+	}
+
+	OpensslCipherContext::~OpensslCipherContext() {
+		reset();
 	}
 
 	OpensslCipherContext::context_type* OpensslCipherContext::get() {
-		return m_buffer.get();
+		return reinterpret_cast<context_type*>(m_buffer);
 	}
 
 	void OpensslCipherContext::reset() {

--- a/client/catapult/src/catapult/crypto/OpensslContexts.cpp
+++ b/client/catapult/src/catapult/crypto/OpensslContexts.cpp
@@ -37,15 +37,11 @@ namespace catapult { namespace crypto {
 	// region OpensslDigestContext
 
 	OpensslDigestContext::OpensslDigestContext() {
-		std::memset(&m_buffer, 0, CountOf(m_buffer));
-	}
-
-	OpensslDigestContext::~OpensslDigestContext() {
-		reset();
+		m_buffer = UniquePtr(EVP_MD_CTX_new(), [](context_type* p) { EVP_MD_CTX_free(p); });
 	}
 
 	OpensslDigestContext::context_type* OpensslDigestContext::get() {
-		return reinterpret_cast<context_type*>(m_buffer);
+		return m_buffer.get();
 	}
 
 	void OpensslDigestContext::reset() {
@@ -57,15 +53,11 @@ namespace catapult { namespace crypto {
 	// region OpensslCipherContext
 
 	OpensslCipherContext::OpensslCipherContext() {
-		std::memset(&m_buffer, 0, CountOf(m_buffer));
-	}
-
-	OpensslCipherContext::~OpensslCipherContext() {
-		reset();
+		m_buffer = UniquePtr(EVP_CIPHER_CTX_new(), [](context_type* p) { EVP_CIPHER_CTX_free(p); });
 	}
 
 	OpensslCipherContext::context_type* OpensslCipherContext::get() {
-		return reinterpret_cast<context_type*>(m_buffer);
+		return m_buffer.get();
 	}
 
 	void OpensslCipherContext::reset() {

--- a/client/catapult/src/catapult/crypto/OpensslContexts.h
+++ b/client/catapult/src/catapult/crypto/OpensslContexts.h
@@ -21,6 +21,7 @@
 
 #pragma once
 #include "catapult/exceptions.h"
+#include "catapult/functions.h"
 #include "catapult/preprocessor.h"
 
 struct MAY_ALIAS evp_cipher_ctx_st;
@@ -34,7 +35,7 @@ namespace catapult { namespace crypto {
 	class alignas(32) OpensslDigestContext {
 	private:
 		using context_type = evp_md_ctx_st;
-		using UniquePtr = std::unique_ptr<context_type, std::function<void(context_type *)>>;
+		using UniquePtr = std::unique_ptr<context_type, consumer<context_type*>>;
 
 	public:
 		/// Creates a new context.
@@ -66,7 +67,7 @@ namespace catapult { namespace crypto {
 	class alignas(32) OpensslCipherContext {
 	private:
 		using context_type = evp_cipher_ctx_st;
-		using UniquePtr = std::unique_ptr<context_type, std::function<void(context_type *)>>;
+		using UniquePtr = std::unique_ptr<context_type, consumer<context_type*>>;
 
 	public:
 		/// Creates a new context.

--- a/client/catapult/src/catapult/crypto/OpensslContexts.h
+++ b/client/catapult/src/catapult/crypto/OpensslContexts.h
@@ -34,13 +34,11 @@ namespace catapult { namespace crypto {
 	class alignas(32) OpensslDigestContext {
 	private:
 		using context_type = evp_md_ctx_st;
+		using UniquePtr = std::unique_ptr<context_type, std::function<void(context_type *)>>;
 
 	public:
 		/// Creates a new context.
 		OpensslDigestContext();
-
-		/// Destroys the context.
-		~OpensslDigestContext();
 
 	public:
 		/// Dispatches an openssl digest call to \a func with \a args.
@@ -57,7 +55,7 @@ namespace catapult { namespace crypto {
 		void reset();
 
 	private:
-		uint8_t m_buffer[256];
+		UniquePtr m_buffer;
 	};
 
 	// endregion
@@ -68,13 +66,11 @@ namespace catapult { namespace crypto {
 	class alignas(32) OpensslCipherContext {
 	private:
 		using context_type = evp_cipher_ctx_st;
+		using UniquePtr = std::unique_ptr<context_type, std::function<void(context_type *)>>;
 
 	public:
 		/// Creates a new context.
 		OpensslCipherContext();
-
-		/// Destroys the context.
-		~OpensslCipherContext();
 
 	public:
 		/// Dispatches an openssl cipher call to \a func with \a args.
@@ -97,7 +93,7 @@ namespace catapult { namespace crypto {
 		void reset();
 
 	private:
-		uint8_t m_buffer[512];
+		UniquePtr m_buffer;
 	};
 
 	// endregion

--- a/client/catapult/src/catapult/crypto/OpensslContexts.h
+++ b/client/catapult/src/catapult/crypto/OpensslContexts.h
@@ -21,7 +21,6 @@
 
 #pragma once
 #include "catapult/exceptions.h"
-#include "catapult/functions.h"
 #include "catapult/preprocessor.h"
 
 struct MAY_ALIAS evp_cipher_ctx_st;
@@ -35,11 +34,13 @@ namespace catapult { namespace crypto {
 	class alignas(32) OpensslDigestContext {
 	private:
 		using context_type = evp_md_ctx_st;
-		using UniquePtr = std::unique_ptr<context_type, consumer<context_type*>>;
 
 	public:
 		/// Creates a new context.
 		OpensslDigestContext();
+
+		/// Destroys the context.
+		~OpensslDigestContext();
 
 	public:
 		/// Dispatches an openssl digest call to \a func with \a args.
@@ -56,7 +57,7 @@ namespace catapult { namespace crypto {
 		void reset();
 
 	private:
-		UniquePtr m_buffer;
+		uint8_t m_buffer[256];
 	};
 
 	// endregion
@@ -67,11 +68,13 @@ namespace catapult { namespace crypto {
 	class alignas(32) OpensslCipherContext {
 	private:
 		using context_type = evp_cipher_ctx_st;
-		using UniquePtr = std::unique_ptr<context_type, consumer<context_type*>>;
 
 	public:
 		/// Creates a new context.
 		OpensslCipherContext();
+
+		/// Destroys the context.
+		~OpensslCipherContext();
 
 	public:
 		/// Dispatches an openssl cipher call to \a func with \a args.
@@ -94,7 +97,7 @@ namespace catapult { namespace crypto {
 		void reset();
 
 	private:
-		UniquePtr m_buffer;
+		uint8_t m_buffer[512];
 	};
 
 	// endregion

--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -17,7 +17,7 @@ google_benchmark = v1.7.1
 mongodb_mongo-c-driver = 1.23.2
 mongodb_mongo-cxx-driver = r3.7.1
 
-openssl_openssl = openssl-3.0.8
+openssl_openssl = openssl-3.1.0
 
 zeromq_libzmq = v4.3.4
 zeromq_cppzmq = v4.9.0


### PR DESCRIPTION
## What's the issue?
catapult client is using an older version of openssl

## How have you changed the behavior?
upgrade openssl to version v3.1.0

## How was this change tested?
ran the catapult tests on my dev box.