### PR TITLE
[jenkins] fix: update catapult tests to use mongodb 6

### DIFF
--- a/jenkins/catapult/templates/RunTest.yaml
+++ b/jenkins/catapult/templates/RunTest.yaml
@@ -1,7 +1,7 @@
 version: '2.1'
 services:
   db:
-    image: mongo:4.2-rc
+    image: mongo:6.0
     user: {{USER}}
     networks:
       test_net:

--- a/jenkins/catapult/templates/RunTestWindows.yaml
+++ b/jenkins/catapult/templates/RunTestWindows.yaml
@@ -1,7 +1,7 @@
 version: '2.1'
 services:
   db:
-    image: mongo:4.2-rc
+    image: mongo:6.0
     command: mongod --bind_ip_all --dbpath=c:\mongo --logpath c:\mongo\mongod.log
     volumes:
       - ./mongo/{{BUILD_NUMBER}}:c:\mongo:rw


### PR DESCRIPTION
## What's the issue?
catapult is been tested against mongo 4.x

## How have you changed the behavior?
update catapult tests to use the latest mongodb 6

## How was this change tested?
Ran tests on my dev box