### PR TITLE
[client/rest] fix: prepare release 2.4.3

### DIFF
--- a/client/rest/CHANGELOG.md
+++ b/client/rest/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [v2.4.3] - 06-Apr-2023
+
+### Fixed
+
+- Mongodb driver 4.x, fix mongodb shown as down in /node/health
+- Reduced the Rest Gateway docker image size
+- Exclude protocol treasury from the circulating supply
+
+## [v2.4.2] - 26-Oct-2022
+
+### Fixed
+
+- Replace yarn with npm
+- Remove spammer and tools subpackages
+- Add nodeMetadata object to config that is served up over /node/metadata
+- Replace js-sha3 with noble
+- Cache parsed server configuration objects
+
 ## [v2.4.0] - 16-Nov-2021
 
 ### Fixed

--- a/client/rest/package-lock.json
+++ b/client/rest/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "symbol-api-rest",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "symbol-api-rest",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "license": "ISC",
       "dependencies": {
         "@noble/hashes": "^1.3.0",

--- a/client/rest/package.json
+++ b/client/rest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symbol-api-rest",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "description": "Symbol API REST",
   "main": "src/index.js",
   "scripts": {

--- a/client/rest/test/routes/nodeRoutes_spec.js
+++ b/client/rest/test/routes/nodeRoutes_spec.js
@@ -24,7 +24,7 @@ const nodeRoutes = require('../../src/routes/nodeRoutes');
 const errors = require('../../src/server/errors');
 const { expect } = require('chai');
 
-const restVersion = '2.4.2';
+const restVersion = '2.4.3';
 
 describe('node routes', () => {
 	describe('get', () => {


### PR DESCRIPTION
## What's the issue?
Change log is outdated.

## How have you changed the behavior?
Prepare change log for 2.4.3 release