### PR TITLE
[client/catapult]: AddResolvedAddresses is not properly applying resolutions from previous transactions

### DIFF
--- a/client/catapult/CMakeGlobalSettings.cmake
+++ b/client/catapult/CMakeGlobalSettings.cmake
@@ -17,7 +17,7 @@ if(CCACHE_EXE)
 	else()
 		set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
 		set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
-	endif(MSVC)
+	endif()
 endif(CCACHE_EXE)
 
 ### set general cmake settings


### PR DESCRIPTION
     problem: if a resolution entry is added for a transaction, it should stay in scope for the rest of the block
              AddResolvedAddresses is incorrectly scoping a resolution entry to the transaction that triggered it
    solution: extend the scope of a resolution entry to last until the end of the block