### PR TITLE
[sdk/python]: drop (deprecated) pysha3 dependency 

### DIFF
--- a/sdk/python/requirements.txt
+++ b/sdk/python/requirements.txt
@@ -2,8 +2,8 @@ cryptography==40.0.1
 mnemonic==0.20
 Pillow==9.5.0
 pynacl==1.5.0
-pysha3==1.0.2
 PyYAML==6.0
 pyzbar==0.1.9
-ripemd-hash==1.0.0
 qrcode==7.4.2
+ripemd-hash==1.0.0
+safe-pysha3==1.0.3

--- a/sdk/python/symbolchain/facade/SymbolFacade.py
+++ b/sdk/python/symbolchain/facade/SymbolFacade.py
@@ -1,4 +1,4 @@
-import sha3
+import hashlib
 
 from .. import sc
 from ..CryptoTypes import Hash256, PublicKey, Signature
@@ -60,7 +60,7 @@ class SymbolFacade:
 
 	def hash_transaction(self, transaction):
 		"""Hashes a Symbol transaction."""
-		hasher = sha3.sha3_256()
+		hasher = hashlib.sha3_256()
 		hasher.update(transaction.signature.bytes)
 		hasher.update(transaction.signer_public_key.bytes)
 		hasher.update(self.network.generation_hash_seed.bytes)
@@ -97,7 +97,7 @@ class SymbolFacade:
 		"""Hashes embedded transactions of an aggregate."""
 		hash_builder = MerkleHashBuilder()
 		for embedded_transaction in embedded_transactions:
-			hash_builder.update(Hash256(sha3.sha3_256(embedded_transaction.serialize()).digest()))
+			hash_builder.update(Hash256(hashlib.sha3_256(embedded_transaction.serialize()).digest()))
 
 		return hash_builder.final()
 

--- a/sdk/python/symbolchain/symbol/IdGenerator.py
+++ b/sdk/python/symbolchain/symbol/IdGenerator.py
@@ -1,11 +1,11 @@
-import sha3
+import hashlib
 
 NAMESPACE_FLAG = 1 << 63
 
 
 def generate_mosaic_id(owner_address, nonce):
 	"""Generates a mosaic id from an owner address and a nonce."""
-	hasher = sha3.sha3_256()
+	hasher = hashlib.sha3_256()
 	hasher.update(nonce.to_bytes(4, 'little'))
 	hasher.update(owner_address.bytes)
 	digest = hasher.digest()
@@ -19,7 +19,7 @@ def generate_mosaic_id(owner_address, nonce):
 
 def generate_namespace_id(name, parent_namespace_id=0):
 	"""Generates a namespace id from a name and an optional parent namespace id."""
-	hasher = sha3.sha3_256()
+	hasher = hashlib.sha3_256()
 	hasher.update(parent_namespace_id.to_bytes(8, 'little'))
 	hasher.update(name.encode('utf8'))
 	digest = hasher.digest()

--- a/sdk/python/symbolchain/symbol/Merkle.py
+++ b/sdk/python/symbolchain/symbol/Merkle.py
@@ -1,9 +1,8 @@
+import hashlib
 from binascii import hexlify
 from collections import namedtuple
 from enum import Enum
 from functools import reduce
-
-import sha3
 
 from ..BufferReader import BufferReader
 from ..CryptoTypes import Hash256
@@ -34,7 +33,7 @@ class MerkleHashBuilder:
 		while num_remaining_hashes > 1:
 			i = 0
 			while i < num_remaining_hashes:
-				hasher = sha3.sha3_256()
+				hasher = hashlib.sha3_256()
 				hasher.update(self.hashes[i])
 
 				if i + 1 < num_remaining_hashes:
@@ -63,7 +62,7 @@ def prove_merkle(leaf_hash, merkle_path, root_hash):
 	"""
 
 	def calculate_next_hash(working_hash, merkle_part):
-		hasher = sha3.sha3_256()
+		hasher = hashlib.sha3_256()
 		if merkle_part.is_left:
 			hasher.update(merkle_part.hash.bytes)
 			hasher.update(working_hash.bytes)
@@ -110,7 +109,7 @@ class LeafNode:
 	def calculate_hash(self):
 		"""Calculates node hash."""
 
-		hasher = sha3.sha3_256()
+		hasher = hashlib.sha3_256()
 		hasher.update(_encode_path(self.path, True))
 		hasher.update(self.value.bytes)
 		return Hash256(hasher.digest())
@@ -126,7 +125,7 @@ class BranchNode:
 	def calculate_hash(self):
 		"""Calculates node hash."""
 
-		hasher = sha3.sha3_256()
+		hasher = hashlib.sha3_256()
 		hasher.update(_encode_path(self.path, False))
 		for link in self.links:
 			hasher.update((link if link else Hash256.zero()).bytes)
@@ -198,7 +197,7 @@ class PatriciaMerkleProofResult(Enum):
 
 
 def _check_state_hash(state_hash, subcache_merkle_roots):
-	hasher = sha3.sha3_256()
+	hasher = hashlib.sha3_256()
 	for root in subcache_merkle_roots:
 		hasher.update(root.bytes)
 

--- a/sdk/python/symbolchain/symbol/Network.py
+++ b/sdk/python/symbolchain/symbol/Network.py
@@ -1,7 +1,6 @@
 import base64
 import datetime
-
-import sha3
+import hashlib
 
 from ..ByteArray import ByteArray
 from ..CryptoTypes import Hash256
@@ -53,7 +52,7 @@ class Network(BasicNetwork):
 		self.generation_hash_seed = generation_hash_seed
 
 	def address_hasher(self):
-		return sha3.sha3_256()
+		return hashlib.sha3_256()
 
 	def create_address(self, address_without_checksum, checksum):
 		return Address(address_without_checksum + checksum[0:3])

--- a/sdk/python/testvectors/__main__.py
+++ b/sdk/python/testvectors/__main__.py
@@ -1,11 +1,10 @@
 import argparse
 import copy
+import hashlib
 import importlib
 import json
 from binascii import hexlify
 from pathlib import Path
-
-import sha3
 
 from symbolchain import nc, sc
 from symbolchain.ByteArray import ByteArray
@@ -98,8 +97,8 @@ class SymbolHelper:
 		return handler_mapping[object_name]
 
 	def set_common_fields(self, descriptor, test_name):
-		descriptor['signer_public_key'] = sha3.sha3_256(test_name.encode('utf8')).hexdigest().upper()
-		descriptor['signature'] = self.Signature(sha3.sha3_512(test_name.encode('utf8')).hexdigest())
+		descriptor['signer_public_key'] = hashlib.sha3_256(test_name.encode('utf8')).hexdigest().upper()
+		descriptor['signature'] = self.Signature(hashlib.sha3_512(test_name.encode('utf8')).hexdigest())
 		descriptor['fee'] = 0xFEEFEEFEEFEEFEE0
 		descriptor['deadline'] = 0x71E71E71E71E71E0
 
@@ -118,8 +117,8 @@ class SymbolHelper:
 	def create_cosignature_descriptor(test_name, index):
 		name = f'{test_name}_cosig_{index+1}'
 		return {
-			'signer_public_key': sha3.sha3_256(name.encode('utf8')).hexdigest(),
-			'signature': sha3.sha3_512(name.encode('utf8')).hexdigest()
+			'signer_public_key': hashlib.sha3_256(name.encode('utf8')).hexdigest(),
+			'signature': hashlib.sha3_512(name.encode('utf8')).hexdigest()
 		}
 
 	@staticmethod
@@ -165,8 +164,8 @@ class SymbolHelper:
 		printable_descriptor['transactions'] = transaction_descriptors
 
 		# boring fields
-		printable_descriptor['signature'] = self.Signature(sha3.sha3_512(test_name.encode('utf8')).hexdigest())
-		printable_descriptor['signer_public_key'] = sha3.sha3_256(test_name.encode('utf8')).hexdigest()
+		printable_descriptor['signature'] = self.Signature(hashlib.sha3_512(test_name.encode('utf8')).hexdigest())
+		printable_descriptor['signer_public_key'] = hashlib.sha3_256(test_name.encode('utf8')).hexdigest()
 		printable_descriptor['timestamp'] = 0x71E71E71E71E71E0
 
 		descriptor = copy.copy(printable_descriptor)
@@ -228,8 +227,8 @@ class NemHelper:
 		return handler_mapping[object_name]
 
 	def set_common_fields(self, descriptor, test_name):
-		descriptor['signer_public_key'] = sha3.sha3_256(test_name.encode('utf8')).hexdigest().upper()
-		descriptor['signature'] = self.Signature(sha3.sha3_512(test_name.encode('utf8')).hexdigest())
+		descriptor['signer_public_key'] = hashlib.sha3_256(test_name.encode('utf8')).hexdigest().upper()
+		descriptor['signature'] = self.Signature(hashlib.sha3_512(test_name.encode('utf8')).hexdigest())
 		descriptor['fee'] = 0xFEEFEEFEEFEEFEE0
 		descriptor['timestamp'] = 0x71E71E70
 
@@ -264,7 +263,7 @@ class NemHelper:
 		name = f'{test_name}_cosig_{index+1}'
 		descriptor = {
 			# note: `type: cosignature`` is not present, it's handled by TransactionDescriptorProcessor
-			'multisig_transaction_hash': sha3.sha3_256(test_name.encode('utf8')).hexdigest(),
+			'multisig_transaction_hash': hashlib.sha3_256(test_name.encode('utf8')).hexdigest(),
 			'multisig_account_address': 'TBT7GACQQLYXUFBSQCUHXXWQMSRDAJPACTNJ724W'
 		}
 		self.set_common_fields(descriptor, name)


### PR DESCRIPTION
1. use sha3 functions from hashlib
2. replace deprecated pysha3 with safe-pysha3 for keccak hashes

