### PR TITLE
[client/catapult] fix: catapult client ionet failing on Windows

### DIFF
--- a/client/catapult/tests/catapult/ionet/PacketSocketTests.cpp
+++ b/client/catapult/tests/catapult/ionet/PacketSocketTests.cpp
@@ -66,7 +66,7 @@ namespace catapult { namespace ionet {
 					writeCode = code;
 				});
 
-				WAIT_FOR(readComplete);
+				test::waitForReadCompleteOrLog(readComplete);
 			});
 			auto pClientSocket = test::AddClientReadBufferTaskWithWait(pPool->ioContext(), receiveBuffer, readComplete);
 			pPool->join();
@@ -1214,7 +1214,7 @@ namespace catapult { namespace ionet {
 					CATAPULT_LOG(debug) << "write completed with code " << code;
 				});
 
-				WAIT_FOR(readComplete);
+				test::waitForReadCompleteOrLog(readComplete);
 			});
 
 			auto endpoint = test::CreateLocalHostNodeEndpoint();

--- a/client/catapult/tests/catapult/ionet/PacketSocketTests.cpp
+++ b/client/catapult/tests/catapult/ionet/PacketSocketTests.cpp
@@ -56,16 +56,19 @@ namespace catapult { namespace ionet {
 			auto bufferSize = payload.header().Size;
 			ByteBuffer receiveBuffer(bufferSize);
 			SocketOperationCode writeCode;
+			std::atomic_bool readComplete(false);
 
 			// Act: "server" - writes a payload to the socket
 			//      "client" - reads a payload from the socket
 			auto pPool = test::CreateStartedIoThreadPool();
-			test::SpawnPacketServerWork(pPool->ioContext(), options, [&payload, &writeCode](const auto& pServerSocket) {
+			test::SpawnPacketServerWork(pPool->ioContext(), options, [&payload, &writeCode, &readComplete](const auto& pServerSocket) {
 				pServerSocket->write(payload, [&writeCode](auto code) {
 					writeCode = code;
 				});
+
+				WAIT_FOR(readComplete);
 			});
-			auto pClientSocket = test::AddClientReadBufferTask(pPool->ioContext(), receiveBuffer);
+			auto pClientSocket = test::AddClientReadBufferTaskWithWait(pPool->ioContext(), receiveBuffer, readComplete);
 			pPool->join();
 
 			// Assert: the write succeeded and all data was read from the socket
@@ -1201,24 +1204,28 @@ namespace catapult { namespace ionet {
 			// Arrange:
 			auto sendBuffer = test::GenerateRandomPacketBuffer(bufferSize);
 			auto pPool = test::CreateStartedIoThreadPool();
+			std::atomic_bool readComplete(false);
 
 			// Act: "server" - accepts a connection and writes a buffer
 			//      "client" - connects to the server and reads a buffer
 			SendBuffersResult result;
-			test::SpawnPacketServerWork(pPool->ioContext(), [&sendBuffer](const auto& pServerSocket) {
+			test::SpawnPacketServerWork(pPool->ioContext(), [&sendBuffer, &readComplete](const auto& pServerSocket) {
 				pServerSocket->write(test::BufferToPacketPayload(sendBuffer), [](auto code) {
 					CATAPULT_LOG(debug) << "write completed with code " << code;
 				});
+
+				WAIT_FOR(readComplete);
 			});
 
 			auto endpoint = test::CreateLocalHostNodeEndpoint();
 			auto options = test::CreatePacketSocketOptions();
 			options.MaxPacketDataSize = bufferSize - sizeof(PacketHeader) - adjustmentSize;
-			ionet::Connect(pPool->ioContext(), options, endpoint, [&result](auto, const auto& connectedSocketInfo) {
+			ionet::Connect(pPool->ioContext(), options, endpoint, [&result, &readComplete](auto, const auto& connectedSocketInfo) {
 				auto pClientSocket = connectedSocketInfo.socket();
-				pClientSocket->read([pClientSocket, &result](auto code, const auto* pPacket) {
+				pClientSocket->read([pClientSocket, &result, &readComplete](auto code, const auto* pPacket) {
 					CATAPULT_LOG(debug) << "read completed with code " << code;
 					FillResult(result, pClientSocket, code, pPacket);
+					readComplete = true;
 				});
 			});
 			pPool->join();

--- a/client/catapult/tests/catapult/ionet/PacketSocketTests.cpp
+++ b/client/catapult/tests/catapult/ionet/PacketSocketTests.cpp
@@ -66,7 +66,7 @@ namespace catapult { namespace ionet {
 					writeCode = code;
 				});
 
-				test::waitForReadCompleteOrLog(readComplete);
+				test::waitForReadComplete(readComplete);
 			});
 			auto pClientSocket = test::AddClientReadBufferTaskWithWait(pPool->ioContext(), receiveBuffer, readComplete);
 			pPool->join();
@@ -1214,7 +1214,7 @@ namespace catapult { namespace ionet {
 					CATAPULT_LOG(debug) << "write completed with code " << code;
 				});
 
-				test::waitForReadCompleteOrLog(readComplete);
+				test::waitForReadComplete(readComplete);
 			});
 
 			auto endpoint = test::CreateLocalHostNodeEndpoint();

--- a/client/catapult/tests/test/net/ClientSocket.cpp
+++ b/client/catapult/tests/test/net/ClientSocket.cpp
@@ -298,6 +298,19 @@ namespace catapult { namespace test {
 		return pClientSocket;
 	}
 
+	std::shared_ptr<ClientSocket> AddClientReadBufferTaskWithWait(
+			boost::asio::io_context& ioContext,
+			ionet::ByteBuffer& receiveBuffer,
+			std::atomic_bool& readCompleted) {
+		auto pClientSocket = CreateClientSocket(ioContext);
+		pClientSocket->connect().then([&receiveBuffer, &readCompleted](auto&& socketFuture) {
+			auto size = socketFuture.get()->read(receiveBuffer).get();
+			CATAPULT_LOG(debug) << "client read complete: " << size;
+			readCompleted = true;
+			});
+		return pClientSocket;
+	}
+
 	std::shared_ptr<ClientSocket> AddClientWriteBuffersTask(
 			boost::asio::io_context& ioContext,
 			const std::vector<ionet::ByteBuffer>& sendBuffers) {

--- a/client/catapult/tests/test/net/ClientSocket.cpp
+++ b/client/catapult/tests/test/net/ClientSocket.cpp
@@ -307,7 +307,7 @@ namespace catapult { namespace test {
 			auto size = socketFuture.get()->read(receiveBuffer).get();
 			CATAPULT_LOG(debug) << "client read complete: " << size;
 			readCompleted = true;
-			});
+		});
 		return pClientSocket;
 	}
 

--- a/client/catapult/tests/test/net/ClientSocket.h
+++ b/client/catapult/tests/test/net/ClientSocket.h
@@ -82,7 +82,7 @@ namespace catapult { namespace test {
 	/// Spawns a task on \a ioContext that reads \a receiveBuffer from a client socket.
 	std::shared_ptr<ClientSocket> AddClientReadBufferTask(boost::asio::io_context& ioContext, ionet::ByteBuffer& receiveBuffer);
 
-	/// Spawns a task on \a ioContext that reads \a receiveBuffer from a client socket.  Sets the readComplete to true when successful.
+	/// Spawns a task on \a ioContext that reads \a receiveBuffer from a client socket. Sets the \a readComplete to \c true.
 	std::shared_ptr<ClientSocket> AddClientReadBufferTaskWithWait(
 			boost::asio::io_context& ioContext,
 			ionet::ByteBuffer& receiveBuffer,

--- a/client/catapult/tests/test/net/ClientSocket.h
+++ b/client/catapult/tests/test/net/ClientSocket.h
@@ -82,6 +82,12 @@ namespace catapult { namespace test {
 	/// Spawns a task on \a ioContext that reads \a receiveBuffer from a client socket.
 	std::shared_ptr<ClientSocket> AddClientReadBufferTask(boost::asio::io_context& ioContext, ionet::ByteBuffer& receiveBuffer);
 
+	/// Spawns a task on \a ioContext that reads \a receiveBuffer from a client socket.  Sets the readComplete to true when successful.
+	std::shared_ptr<ClientSocket> AddClientReadBufferTaskWithWait(
+			boost::asio::io_context& ioContext,
+			ionet::ByteBuffer& receiveBuffer,
+			std::atomic_bool& readComplete);
+
 	/// Spawns a task on \a ioContext that writes all \a sendBuffers to a client socket.
 	std::shared_ptr<ClientSocket> AddClientWriteBuffersTask(
 			boost::asio::io_context& ioContext,

--- a/client/catapult/tests/test/net/SocketTestUtils.cpp
+++ b/client/catapult/tests/test/net/SocketTestUtils.cpp
@@ -381,7 +381,7 @@ namespace catapult { namespace test {
 		};
 	}
 
-	void waitForReadCompleteOrLog(const std::atomic_bool& readComplete) {
+	void waitForReadComplete(const std::atomic_bool& readComplete) {
 #ifdef _WIN32
 		WAIT_FOR(readComplete);
 #else
@@ -409,7 +409,7 @@ namespace catapult { namespace test {
 				});
 			});
 
-			waitForReadCompleteOrLog(readComplete);
+			waitForReadComplete(readComplete);
 		});
 		auto pClientSocket = AddClientReadBufferTaskWithWait(pPool->ioContext(), receiveBuffer, readComplete);
 		pPool->join();
@@ -442,7 +442,7 @@ namespace catapult { namespace test {
 				payload2.Code = writeCode;
 			});
 
-			waitForReadCompleteOrLog(readComplete);
+			waitForReadComplete(readComplete);
 		});
 		auto pClientSocket = AddClientReadBufferTaskWithWait(pPool->ioContext(), receiveBuffer, readComplete);
 		pPool->join();

--- a/client/catapult/tests/test/net/SocketTestUtils.cpp
+++ b/client/catapult/tests/test/net/SocketTestUtils.cpp
@@ -381,6 +381,14 @@ namespace catapult { namespace test {
 		};
 	}
 
+	void waitForReadCompleteOrLog(const std::atomic_bool& readComplete) {
+#ifdef _WIN32
+		WAIT_FOR(readComplete);
+#else
+		CATAPULT_LOG(debug) << "readComplete: " << readComplete;
+#endif
+	}
+
 	void AssertWriteCanWriteMultipleConsecutivePayloads(const PacketIoTransform& transform) {
 		// Arrange: set up payloads
 		LargeWritePayload payload1(Large_Buffer_Size);
@@ -401,7 +409,7 @@ namespace catapult { namespace test {
 				});
 			});
 
-			WAIT_FOR(readComplete);
+			waitForReadCompleteOrLog(readComplete);
 		});
 		auto pClientSocket = AddClientReadBufferTaskWithWait(pPool->ioContext(), receiveBuffer, readComplete);
 		pPool->join();
@@ -434,7 +442,7 @@ namespace catapult { namespace test {
 				payload2.Code = writeCode;
 			});
 
-			WAIT_FOR(readComplete);
+			waitForReadCompleteOrLog(readComplete);
 		});
 		auto pClientSocket = AddClientReadBufferTaskWithWait(pPool->ioContext(), receiveBuffer, readComplete);
 		pPool->join();

--- a/client/catapult/tests/test/net/SocketTestUtils.h
+++ b/client/catapult/tests/test/net/SocketTestUtils.h
@@ -190,8 +190,8 @@ namespace catapult { namespace test {
 	/// Asserts that \a readCode indicates the socket was closed during read.
 	void AssertSocketClosedDuringRead(ionet::SocketOperationCode readCode);
 
-	/// Wait for read complete or log.
-	void waitForReadCompleteOrLog(const std::atomic_bool& readComplete);
+	/// Wait for read complete or log the \a readComplete value.
+	void waitForReadComplete(const std::atomic_bool& readComplete);
 
 	// endregion
 }}

--- a/client/catapult/tests/test/net/SocketTestUtils.h
+++ b/client/catapult/tests/test/net/SocketTestUtils.h
@@ -190,5 +190,8 @@ namespace catapult { namespace test {
 	/// Asserts that \a readCode indicates the socket was closed during read.
 	void AssertSocketClosedDuringRead(ionet::SocketOperationCode readCode);
 
+	/// Wait for read complete or log.
+	void waitForReadCompleteOrLog(const std::atomic_bool& readComplete);
+
 	// endregion
 }}


### PR DESCRIPTION
## What is the current behavior?
catapult ionet tests occasionally fails on Windows

## What's the issue?
catapult client ionet tests are failing on Windows due to race condition due to the server socket getting closed before the read is complete by the client.

## How have you changed the behavior?
add synchronization between the server and client threads so the server thread waits for read to be completed before the server thread exit.

## How was this change tested?
tested local on Windows and Linux nodes.
Havent been able to reproduce the issue on Windows.