### PR TITLE
[jenkins] fix: docker build hangs due to network

### DIFF
--- a/jenkins/shared-library/vars/publish.groovy
+++ b/jenkins/shared-library/vars/publish.groovy
@@ -30,7 +30,9 @@ void dockerPublisher(Map config, String phase) {
 	String version = readPackageVersion()
 	String imageVersionName = "${config.dockerImageName}:${version}"
 
-	Object imageName = docker.build(imageVersionName, config.dockerBuildArgs ?: '.')
+	String args = config.dockerBuildArgs ?: '.'
+	args = '--network host ' + args
+	Object imageName = docker.build(imageVersionName,  args)
 	docker.withRegistry(dockerUrl, DOCKERHUB_CREDENTIALS_ID) {
 		logger.logInfo("Pushing docker image ${imageVersionName}")
 		imageName.push()


### PR DESCRIPTION
## What is the current behavior?
docker build fails for the REST Image

## What's the issue?
npm install is hangs/unable to reach some sites

## How have you changed the behavior?
add ``--network host`` flag to the docker build

## How was this change tested?
tested in jenkins
https://jenkins.symboldev.com/job/Symbol/job/generated/job/symbol/job/rest/job/fix%252Fdocker_build_hang/4/console