### PR TITLE
[sdk/javascript] fix: specify which files to publish

### DIFF
--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -44,5 +44,6 @@
     "bitcore-mnemonic": "^10.0.2",
     "ripemd160": "^2.0.2",
     "tweetnacl": "^1.0.3"
-  }
+  },
+  "files": ["src/*", "wasm/pkg/*"]
 }


### PR DESCRIPTION
## What is the current behavior?
npm package is missing the wasm pkg

## What's the issue?
npm publish does include the correct set of files

## How have you changed the behavior?
add a file list to package.json to include wasm pkg

## How was this change tested?
tested by running ``npm publish --dry-run``