### PR TITLE
[sdk] fix: bump sdks version to 3.0.7

### DIFF
--- a/sdk/javascript/CHANGELOG.md
+++ b/sdk/javascript/CHANGELOG.md
@@ -5,7 +5,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 
 ## next
 
-## [3.0.6] - 14-Apr-2023
+## [3.0.7] - 14-Apr-2023
 
 ### Changed
  - Network
@@ -43,5 +43,5 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 ### Changed
  - complete SDK rewrite, see details in [readme](README.md)
 
-[3.0.6]: https://github.com/symbol/sdk-python/compare/v3.0.0...v3.0.6
+[3.0.7]: https://github.com/symbol/sdk-python/compare/v3.0.0...v3.0.7
 [3.0.0]: https://github.com/symbol/sdk-python/releases/tag/v3.0.0

--- a/sdk/javascript/package-lock.json
+++ b/sdk/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "symbol-sdk",
-  "version": "3.0.0",
+  "version": "3.0.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "symbol-sdk",
-      "version": "3.0.0",
+      "version": "3.0.7",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^1.3.0",

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symbol-sdk",
-  "version": "3.0.6",
+  "version": "3.0.7",
   "type": "module",
   "description": "JavaScript SDK for Symbol",
   "main": "src/index.js",

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -5,7 +5,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 
 ## next
 
-## [3.0.6] - 14-Apr-2023
+## [3.0.7] - 14-Apr-2023
 
 ### Changed
  - Network
@@ -83,7 +83,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 ### Added
  - initial code release
 
-[3.0.6]: https://github.com/symbol/sdk-python/compare/v3.0.3...v3.0.6
+[3.0.7]: https://github.com/symbol/sdk-python/compare/v3.0.3...v3.0.7
 [3.0.3]: https://github.com/symbol/sdk-python/compare/v3.0.2...v3.0.3
 [3.0.2]: https://github.com/symbol/sdk-python/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/symbol/sdk-python/compare/v3.0.0...v3.0.1

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'symbol-sdk-python'
-version = '3.0.6'
+version = '3.0.7'
 description = 'Symbol SDK'
 authors = ['Symbol Contributors <contributors@symbol.dev>']
 maintainers = ['Symbol Contributors <contributors@symbol.dev>']


### PR DESCRIPTION
## What's the issue?
Python and JavaScript SDKs version need to increase for release

## How have you changed the behavior?
Bump SDK versions to 3.0.7