### PR TITLE
[client/catapult] fix: catapult client code coverage show as empty

### DIFF
--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project.groovy
@@ -261,6 +261,7 @@ pipeline {
 
 									withCredentials([string(credentialsId: 'SYMBOL_CODECOV_ID', variable: 'CODECOV_TOKEN')]) {
 										sh '''
+											cd /catapult-src
 											curl -Os https://uploader.codecov.io/latest/linux/codecov
 											chmod +x codecov
 											./codecov --verbose --nonZero --rootDir . --flags client-catapult --file client_coverage.info


### PR DESCRIPTION
## What is the current behavior?
Catapult code coverage upload by codecov is empty.

## What's the issue?
Even though Codecov was able to discover the code coverage file in the git repo, codecov tool needs to be run from within the git repo folder.

## How have you changed the behavior?
Change the current working folder to the git repo

## How was this change tested?
Ran a job in Jenkins and it seems to upload successfully.