### PR TITLE
[jenkins] fix: catapult tsan mongodb tests

### DIFF
--- a/jenkins/catapult/baseImageDockerfileGenerator.py
+++ b/jenkins/catapult/baseImageDockerfileGenerator.py
@@ -134,13 +134,14 @@ class OptionsManager:
 		return []
 
 	def mongo_c(self):
-		descriptor = self.OptionsDescriptor()
+		descriptor = self._enable_thread_san_descriptor()
 		descriptor.options += ['-DOPENSSL_ROOT_DIR=/usr/catapult/deps']
 		descriptor.options += get_dependency_flags('mongodb_mongo-c-driver')
+
 		return self._cmake(descriptor)
 
 	def mongo_cxx(self):
-		descriptor = self.OptionsDescriptor()
+		descriptor = self._enable_thread_san_descriptor()
 		descriptor.options += ['-DOPENSSL_ROOT_DIR=/usr/catapult/deps']
 		descriptor.options += get_dependency_flags('mongodb_mongo-cxx-driver')
 
@@ -152,7 +153,7 @@ class OptionsManager:
 		return self._cmake(descriptor)
 
 	def libzmq(self):
-		descriptor = self._zmq_descriptor()
+		descriptor = self._enable_thread_san_descriptor()
 		descriptor.options += get_dependency_flags('zeromq_libzmq')
 
 		if self.is_clang:
@@ -163,11 +164,11 @@ class OptionsManager:
 		return self._cmake(descriptor)
 
 	def cppzmq(self):
-		descriptor = self._zmq_descriptor()
+		descriptor = self._enable_thread_san_descriptor()
 		descriptor.options += get_dependency_flags('zeromq_cppzmq')
 		return self._cmake(descriptor)
 
-	def _zmq_descriptor(self):
+	def _enable_thread_san_descriptor(self):
 		descriptor = self.OptionsDescriptor()
 		if 'thread' in self.sanitizers:
 			descriptor.sanitizer = 'thread'


### PR DESCRIPTION
## What is the current behavior?
Catapult MongoDB tests are failing in thread sanitizer(tsan) run 

## What's the issue?
Thread sanitizer can report false positive when third party modules are not instrumented(i.e. compiled with -fsanitize=thread option).

## How have you changed the behavior?
Build the MongoDB drivers with thread sanitizer enabled( -fsanitize=thread) when building the catapult base image for tsan.

## How was this change tested?
rebuild the catapult tsan image and reran the tsan tests. 