### PR TITLE
[jenkins] fix: check if multibranch job is active

### DIFF
--- a/jenkins/shared-library/vars/createMonorepoMultibranchJobs.groovy
+++ b/jenkins/shared-library/vars/createMonorepoMultibranchJobs.groovy
@@ -94,9 +94,18 @@ void removeOldJobs(String jobFolder, List<String> currentJobList) {
 	for (Item item in jobs) {
 		println("Checking Item remove: ${item.name}, ${item.getClass()} ${item.fullName}")
 		if (org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject == item.getClass()
-				&& currentJobList.indexOf(item.fullName) == -1) {
+				&& currentJobList.indexOf(item.fullName) == -1
+				&& !isJobActive(item)) {
 			println("Removing old job: ${item.fullName}")
 			item.delete()
 		}
 	}
+}
+
+boolean isJobActive(Item job) {
+	if (!job.isBuildable()) {
+		return false
+	}
+
+	return job.allJobs.any { item -> item.isBuildable() }
 }


### PR DESCRIPTION
## What is the current behavior?
Active multibranch jobs are getting remove when the job cleanup code runs

## What's the issue?
Multibranch job cleanup logic remove active jobs that are not in the current branch job configuration.
This is not correct since new projects that are not in dev branch will need their ci jobs.

## How have you changed the behavior?
When projects are removed or moved, the old multibranch job will not have any active jobs.
Add a check to make sure multibranch job has at least one active job for a branch before deleting it.
The downside of this is if someone manually creates a multibranch job then it will not be delete which should be OK.

## How was this change tested?
Tested in Jenkins