### PR TITLE
[jenkins] fix: postgres docker image fails to build

### DIFF
--- a/jenkins/docker/postgres.Dockerfile
+++ b/jenkins/docker/postgres.Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:15
+FROM postgres:15-bullseye
 
 # install dependencies (install tzdata first to prevent 'geographic area' prompt)
 RUN apt-get update \

--- a/jenkins/infra/jenkins/build-ci-image.groovy
+++ b/jenkins/infra/jenkins/build-ci-image.groovy
@@ -45,6 +45,16 @@ pipeline {
 				}
 			}
 		}
+		stage('checkout') {
+			when {
+				triggeredBy 'UserIdCause'
+			}
+			steps {
+				script {
+					sh "git reset --hard origin/${env.MANUAL_GIT_BRANCH}"
+				}
+			}
+		}
 		stage('build image') {
 			steps {
 				script {


### PR DESCRIPTION
## What is the current behavior?
postgres docker image fails to build since its not able to find Java 11 package to install.

## What's the issue?
This seems postgres:15 update the base image to debian:bookworm-slim which only have Java 17.

## How have you changed the behavior?
switch the postgres ci image to use the postgres:bulleye as the base image.

Also add missing checkout step in the CI job.

## How was this change tested?
Test by building the docker image local