### PR TITLE
[jenkins] fix: ARCHITECTURE value is missing during branch discovery

### DIFF
--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -30,11 +30,11 @@ void call(Closure body) {
 
 		agent {
 			// ARCHITECTURE can be null on first job due to https://issues.jenkins.io/browse/JENKINS-41929
-			label """${helper.resolveAgentName(
-					env.OPERATING_SYSTEM ?: "${params.operatingSystem[0]}",
-					env.ARCHITECTURE ?: 'amd64',
-					params.instanceSize ?: 'medium'
-			)}"""
+			label """${
+				env.OPERATING_SYSTEM  = env.OPERATING_SYSTEM ?: "${params.operatingSystem[0]}"
+				env.ARCHITECTURE  = env.ARCHITECTURE ?: 'amd64'
+				return helper.resolveAgentName(env.OPERATING_SYSTEM, env.ARCHITECTURE, params.instanceSize ?: 'medium')
+			}"""
 		}
 
 		options {


### PR DESCRIPTION
## What is the current behavior?
Jenkins does not set any of the parameters to default values during branch discovery job.

## What's the issue?
Catapult project depends on the ARCHITECTURE value to be set but it is null during branch discovery jobs.

## How have you changed the behavior?
Set the default value for ARCHITECTURE so its available for the entire pipeline

## How was this change tested?
Currently testing in Jenkins
