### PR TITLE
[jenkins] fix: Javascript sdk fails to build on arm64 Linux

### DIFF
--- a/jenkins/docker/javascript.Dockerfile
+++ b/jenkins/docker/javascript.Dockerfile
@@ -27,6 +27,11 @@ RUN apt-get install -y python3-pip
 RUN apt-get install -y shellcheck \
 	&& pip install gitlint
 
+# rust dependencies - https://docs.rs/crate/openssl-sys/0.9.19
+RUN apt-get install -y libssl-dev pkg-config \
+# there is no aarch64 build of binaryen -  https://github.com/WebAssembly/binaryen/issues/5337
+	&& if [ "$(uname -m)" = "aarch64" ] apt-get install -y binaryen; fi \
+
 # codecov uploader
 RUN ARCH=$([ "$(uname -m)" = "x86_64" ] && echo "linux" || echo "aarch64") \
 	&& curl -Os "https://uploader.codecov.io/latest/${ARCH}/codecov" \

--- a/jenkins/docker/javascript.Dockerfile
+++ b/jenkins/docker/javascript.Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get install -y shellcheck \
 # rust dependencies - https://docs.rs/crate/openssl-sys/0.9.19
 RUN apt-get install -y libssl-dev pkg-config \
 # there is no aarch64 build of binaryen -  https://github.com/WebAssembly/binaryen/issues/5337
-	&& if [ "$(uname -m)" = "aarch64" ] apt-get install -y binaryen; fi \
+	&& if [ "$(uname -m)" = "aarch64" ]; then apt-get install -y binaryen; fi
 
 # codecov uploader
 RUN ARCH=$([ "$(uname -m)" = "x86_64" ] && echo "linux" || echo "aarch64") \


### PR DESCRIPTION
## What is the current behavior?
Javascript SDK fails to build wasm module on Linux arm64 due to missing dependencies.

## What's the issue?
openssl-sys requires libssl-dev and pkg-config to be installed but not sure it currently works on amd64  - https://docs.rs/crate/openssl-sys/0.9.19

there is no aarch64 build of binaryen so build with fails due to no wasm_opt - https://github.com/WebAssembly/binaryen/issues/5337

## How have you changed the behavior?
Install libssl-dev and pkg-config package in the CI image.
Install binaryen on arm64 Linux to be able to use the wasm_opt feature.  This is not needed for amd64 since wasm_pack will use the prebuilt binary

## How was this change tested?
Tested on arm64 linux