### PR TITLE
[monorepo] fix: enable dependabot update for Javascript Wasm sdk

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -101,3 +101,13 @@ updates:
     target-branch: dev
     commit-message:
       prefix: '[dependency]'
+
+  - package-ecosystem: cargo
+    directory: /sdk/javascript/wasm
+    schedule:
+      interval: weekly
+      day: sunday
+    target-branch: dev
+    labels: [sdk-javascript]
+    commit-message:
+      prefix: '[sdk/javascript]'


### PR DESCRIPTION
## What is the current behavior?
Javascript wasm sdk dependencies are not getting updated.

## What's the issue?
Dependabot is not configured for the Javascript SDK wasm folder.

## How have you changed the behavior?
Enable dependabot update for Javascript SDK wasm folder.