### PR TITLE
[jenkins]: add support to build different version of python images

### DIFF
--- a/jenkins/docker/python.Dockerfile
+++ b/jenkins/docker/python.Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:22.04
+ARG FROM_IMAGE='ubuntu:22.04'
+
+FROM ${FROM_IMAGE}
 
 # install tzdata first to prevent 'geographic area' prompt
 RUN apt-get update >/dev/null \
@@ -6,23 +8,21 @@ RUN apt-get update >/dev/null \
 	&& apt-get install -y git curl
 
 # install python
-RUN apt-get install -y python3-pip
+RUN apt-get install -y python3-pip python3-venv
 
-# install shellcheck and gitlint
-RUN apt-get install -y shellcheck \
-	&& pip install gitlint
-
-# install poetry
-RUN pip install poetry
+# install shellcheck
+RUN apt-get install -y shellcheck
 
 # sdk dependencies
 RUN apt-get install -y zbar-tools libssl-dev
 
-# enable legacy providers in openssl(ripemd160)
-RUN sed -i '/^default = default_sect/a legacy = legacy_sect\n' /etc/ssl/openssl.cnf \
-	&& sed -i '/^\[default_sect\]/i [legacy_sect]\nactivate = 1\n' /etc/ssl/openssl.cnf \
-	&& sed -i 's/^# activate = 1/activate = 1/g' /etc/ssl/openssl.cnf \
-	&& cat /etc/ssl/openssl.cnf
+# enable legacy providers in openssl3(ripemd160)
+RUN if echo "$(openssl version)" |  grep -q "^OpenSSL 3"; then \
+		sed -i '/^default = default_sect/a legacy = legacy_sect\n' /etc/ssl/openssl.cnf \
+		&& sed -i '/^\[default_sect\]/i [legacy_sect]\nactivate = 1\n' /etc/ssl/openssl.cnf \
+		&& sed -i 's/^# activate = 1/activate = 1/g' /etc/ssl/openssl.cnf \
+		&& cat /etc/ssl/openssl.cnf; \
+	fi
 
 # codecov uploader
 RUN ARCH=$([ "$(uname -m)" = "x86_64" ] && echo "linux" || echo "aarch64") \
@@ -31,7 +31,14 @@ RUN ARCH=$([ "$(uname -m)" = "x86_64" ] && echo "linux" || echo "aarch64") \
 	&& mv codecov /usr/local/bin
 
 # add ubuntu user (used by jenkins)
-RUN useradd --uid 1000 -ms /bin/bash ubuntu
-ENV PATH=$PATH:/home/ubuntu/.local/bin
-
+RUN id -u "ubuntu" || useradd --uid 1000 -ms /bin/bash ubuntu
+USER ubuntu
 WORKDIR /home/ubuntu
+
+# create virtual environment which is required by Ubuntu 23.04
+ENV VIRTUAL_ENV=/home/ubuntu/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# install poetry and gitlint
+RUN pip install poetry gitlint wheel

--- a/jenkins/docker/python.Dockerfile
+++ b/jenkins/docker/python.Dockerfile
@@ -35,7 +35,7 @@ RUN id -u "ubuntu" || useradd --uid 1000 -ms /bin/bash ubuntu
 USER ubuntu
 WORKDIR /home/ubuntu
 
-# create virtual environment which is required by Ubuntu 23.04
+# create a virtual environment, which is required by Ubuntu 23.04
 ENV VIRTUAL_ENV=/home/ubuntu/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/jenkins/infra/jenkins/build-ci-image-all.groovy
+++ b/jenkins/infra/jenkins/build-ci-image-all.groovy
@@ -46,35 +46,35 @@ pipeline {
 				stage('cpp - ubuntu:22.04') {
 					steps {
 						script {
-							dispatchBuildCiImageJob('cpp', 'ubuntu:22.04')
+							dispatchBuildCiImageJob('cpp')
 						}
 					}
 				}
 				stage('java - ubuntu:22.04') {
 					steps {
 						script {
-							dispatchBuildCiImageJob('java', 'ubuntu:22.04')
+							dispatchBuildCiImageJob('java')
 						}
 					}
 				}
 				stage('javascript - ubuntu:22.04') {
 					steps {
 						script {
-							dispatchBuildCiImageJob('javascript', 'ubuntu:22.04')
+							dispatchBuildCiImageJob('javascript')
 						}
 					}
 				}
 				stage('linter - ubuntu:22.04') {
 					steps {
 						script {
-							dispatchBuildCiImageJob('linter', 'ubuntu:22.04')
+							dispatchBuildCiImageJob('linter')
 						}
 					}
 				}
 				stage('postgres - ubuntu:22.04') {
 					steps {
 						script {
-							dispatchBuildCiImageJob('postgres', 'ubuntu:22.04')
+							dispatchBuildCiImageJob('postgres')
 						}
 					}
 				}
@@ -82,7 +82,7 @@ pipeline {
 				stage('python - ubuntu:22.04') {
 					steps {
 						script {
-							dispatchBuildCiImageJob('python', 'ubuntu:22.04')
+							dispatchBuildCiImageJob('python')
 						}
 					}
 				}
@@ -131,7 +131,7 @@ pipeline {
 	}
 }
 
-void dispatchBuildCiImageJob(String ciImage, String baseImage) {
+void dispatchBuildCiImageJob(String ciImage, String baseImage = 'ubuntu:22.04') {
 	build job: 'build-ci-image', parameters: [
 		string(name: 'CI_IMAGE', value: "${ciImage}"),
 		string(name: 'MANUAL_GIT_BRANCH', value: "${params.MANUAL_GIT_BRANCH}"),

--- a/jenkins/infra/jenkins/build-ci-image-all.groovy
+++ b/jenkins/infra/jenkins/build-ci-image-all.groovy
@@ -43,57 +43,57 @@ pipeline {
 
 		stage('build ci images') {
 			parallel {
-				stage('cpp') {
+				stage('cpp - ubuntu:22.04') {
 					steps {
 						script {
-							dispatchBuildCiImageJob('cpp')
+							dispatchBuildCiImageJob('cpp', 'ubuntu:22.04')
 						}
 					}
 				}
-				stage('java') {
+				stage('java - ubuntu:22.04') {
 					steps {
 						script {
-							dispatchBuildCiImageJob('java')
+							dispatchBuildCiImageJob('java', 'ubuntu:22.04')
 						}
 					}
 				}
-				stage('javascript') {
+				stage('javascript - ubuntu:22.04') {
 					steps {
 						script {
-							dispatchBuildCiImageJob('javascript')
+							dispatchBuildCiImageJob('javascript', 'ubuntu:22.04')
 						}
 					}
 				}
-				stage('linter') {
+				stage('linter - ubuntu:22.04') {
 					steps {
 						script {
-							dispatchBuildCiImageJob('linter')
+							dispatchBuildCiImageJob('linter', 'ubuntu:22.04')
 						}
 					}
 				}
-				stage('postgres') {
+				stage('postgres - ubuntu:22.04') {
 					steps {
 						script {
-							dispatchBuildCiImageJob('postgres')
+							dispatchBuildCiImageJob('postgres', 'ubuntu:22.04')
 						}
 					}
 				}
 
-				stage('python') {
+				stage('python - ubuntu:22.04') {
 					steps {
 						script {
 							dispatchBuildCiImageJob('python', 'ubuntu:22.04')
 						}
 					}
 				}
-				stage('python') {
+				stage('python - ubuntu:20.04') {
 					steps {
 						script {
 							dispatchBuildCiImageJob('python', 'ubuntu:20.04')
 						}
 					}
 				}
-				stage('python') {
+				stage('python - ubuntu:23.04') {
 					steps {
 						script {
 							dispatchBuildCiImageJob('python', 'ubuntu:23.04' )
@@ -131,7 +131,7 @@ pipeline {
 	}
 }
 
-void dispatchBuildCiImageJob(String ciImage, String baseImage = 'ubuntu:22.04') {
+void dispatchBuildCiImageJob(String ciImage, String baseImage) {
 	build job: 'build-ci-image', parameters: [
 		string(name: 'CI_IMAGE', value: "${ciImage}"),
 		string(name: 'MANUAL_GIT_BRANCH', value: "${params.MANUAL_GIT_BRANCH}"),

--- a/jenkins/infra/jenkins/build-ci-image-all.groovy
+++ b/jenkins/infra/jenkins/build-ci-image-all.groovy
@@ -43,35 +43,35 @@ pipeline {
 
 		stage('build ci images') {
 			parallel {
-				stage('cpp - ubuntu:22.04') {
+				stage('cpp') {
 					steps {
 						script {
 							dispatchBuildCiImageJob('cpp')
 						}
 					}
 				}
-				stage('java - ubuntu:22.04') {
+				stage('java') {
 					steps {
 						script {
 							dispatchBuildCiImageJob('java')
 						}
 					}
 				}
-				stage('javascript - ubuntu:22.04') {
+				stage('javascript') {
 					steps {
 						script {
 							dispatchBuildCiImageJob('javascript')
 						}
 					}
 				}
-				stage('linter - ubuntu:22.04') {
+				stage('linter') {
 					steps {
 						script {
 							dispatchBuildCiImageJob('linter')
 						}
 					}
 				}
-				stage('postgres - ubuntu:22.04') {
+				stage('postgres') {
 					steps {
 						script {
 							dispatchBuildCiImageJob('postgres')
@@ -79,7 +79,7 @@ pipeline {
 					}
 				}
 
-				stage('python - ubuntu:22.04') {
+				stage('python') {
 					steps {
 						script {
 							dispatchBuildCiImageJob('python')

--- a/jenkins/infra/jenkins/build-ci-image-all.groovy
+++ b/jenkins/infra/jenkins/build-ci-image-all.groovy
@@ -96,7 +96,7 @@ pipeline {
 				stage('python - ubuntu:23.04') {
 					steps {
 						script {
-							dispatchBuildCiImageJob('python', 'ubuntu:23.04' )
+							dispatchBuildCiImageJob('python', 'ubuntu:23.04')
 						}
 					}
 				}

--- a/jenkins/infra/jenkins/build-ci-image-all.groovy
+++ b/jenkins/infra/jenkins/build-ci-image-all.groovy
@@ -82,7 +82,21 @@ pipeline {
 				stage('python') {
 					steps {
 						script {
-							dispatchBuildCiImageJob('python')
+							dispatchBuildCiImageJob('python', 'ubuntu:22.04')
+						}
+					}
+				}
+				stage('python') {
+					steps {
+						script {
+							dispatchBuildCiImageJob('python', 'ubuntu:20.04')
+						}
+					}
+				}
+				stage('python') {
+					steps {
+						script {
+							dispatchBuildCiImageJob('python', 'ubuntu:23.04' )
 						}
 					}
 				}
@@ -117,11 +131,12 @@ pipeline {
 	}
 }
 
-void dispatchBuildCiImageJob(String ciImage) {
+void dispatchBuildCiImageJob(String ciImage, String baseImage = 'ubuntu:22.04') {
 	build job: 'build-ci-image', parameters: [
 		string(name: 'CI_IMAGE', value: "${ciImage}"),
 		string(name: 'MANUAL_GIT_BRANCH', value: "${params.MANUAL_GIT_BRANCH}"),
 		string(name: 'ARCHITECTURE', value: "${params.ARCHITECTURE}"),
+		string(name: 'BASE_IMAGE', value: "${baseImage}"),
 		booleanParam(
 			name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS',
 			value: "${!env.SHOULD_PUBLISH_JOB_STATUS || env.SHOULD_PUBLISH_JOB_STATUS.toBoolean()}"

--- a/jenkins/infra/jenkins/build-ci-image.groovy
+++ b/jenkins/infra/jenkins/build-ci-image.groovy
@@ -7,6 +7,9 @@ pipeline {
 		choice name: 'ARCHITECTURE',
 			choices: ['amd64', 'arm64'],
 			description: 'Computer architecture'
+		choice name: 'BASE_IMAGE',
+				choices: ['ubuntu:22.04', 'ubuntu:20.04', 'ubuntu:23.04'],
+				description: 'Base image'
 		booleanParam name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS', description: 'true to publish job status if failed', defaultValue: false
 	}
 
@@ -31,7 +34,8 @@ pipeline {
 					steps {
 						script {
 							helper.runStepAndRecordFailure {
-								multiArchImageName = "symbolplatform/build-ci:${CI_IMAGE}"
+								baseImageName = "${BASE_IMAGE}".replace(':', '-')
+								multiArchImageName = "symbolplatform/build-ci:${CI_IMAGE}-${baseImageName}"
 								archImageName = "${multiArchImageName}-${ARCHITECTURE}"
 							}
 						}
@@ -65,7 +69,7 @@ pipeline {
 					helper.runStepAndRecordFailure {
 						dir('jenkins/docker')
 						{
-							String buildArg = "-f ${CI_IMAGE}.Dockerfile ."
+							String buildArg = "-f ${CI_IMAGE}.Dockerfile --build-arg BASE_IMAGE=${BASE_IMAGE} ."
 							dockerHelper.loginAndRunCommand(DOCKER_CREDENTIALS_ID) {
 								dockerHelper.dockerBuildAndPushImage(archImageName, buildArg)
 								dockerHelper.updateDockerImage(multiArchImageName, archImageName, "${ARCHITECTURE}")

--- a/jenkins/infra/jenkins/build-ci-image.groovy
+++ b/jenkins/infra/jenkins/build-ci-image.groovy
@@ -8,8 +8,8 @@ pipeline {
 			choices: ['amd64', 'arm64'],
 			description: 'Computer architecture'
 		choice name: 'BASE_IMAGE',
-				choices: ['ubuntu:22.04', 'ubuntu:20.04', 'ubuntu:23.04'],
-				description: 'Base image'
+			choices: ['ubuntu:22.04', 'ubuntu:20.04', 'ubuntu:23.04'],
+			description: 'Base image'
 		booleanParam name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS', description: 'true to publish job status if failed', defaultValue: false
 	}
 


### PR DESCRIPTION
## What is the current behavior?
Test are only run in Ubuntu 22.04

## What's the issue?
shoestring is run on multiple version of Ubuntu which leads to failures for end users on Ubuntu 20.04 and Ubuntu 23.04.

## How have you changed the behavior?
create test images for Ubuntu 20.04 and 23.04 which will be run on a weekly schedule.

## How was this change tested?
run docker build locally to test.