### PR TITLE
[sdk/javascript]: TS publishing fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ _temp/
 # js
 node_modules/
 npm-*.log*
+ts/
 
 # python
 __pycache__/

--- a/sdk/javascript/CHANGELOG.md
+++ b/sdk/javascript/CHANGELOG.md
@@ -5,7 +5,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 
 ## next
 
-## [3.0.8] - 27-Jul-2023
+## [3.0.10] - 27-Jul-2023
 
 ### Added
  - TypeScript support via JSDoc documentation
@@ -54,6 +54,6 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 ### Changed
  - complete SDK rewrite, see details in [readme](README.md)
 
-[3.0.8]: https://github.com/symbol/symbol/compare/sdk%2Fjavascript%2Fv3.0.7...sdk%2Fjavascript%2Fv3.0.8
+[3.0.10]: https://github.com/symbol/symbol/compare/sdk%2Fjavascript%2Fv3.0.7...sdk%2Fjavascript%2Fv3.0.10
 [3.0.7]: https://github.com/symbol/symbol/compare/sdk%2Fjavascript%2Fv3.0.0...sdk%2Fjavascript%2Fv3.0.7
 [3.0.0]: https://github.com/symbol/symbol/releases/tag/sdk%2Fjavascript%2Fv3.0.0

--- a/sdk/javascript/package-lock.json
+++ b/sdk/javascript/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "symbol-sdk",
-  "version": "3.0.7",
+  "version": "3.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -4,6 +4,7 @@
   "type": "module",
   "description": "JavaScript SDK for Symbol",
   "main": "src/index.js",
+  "types": "ts/src/index.d.ts",
   "scripts": {
     "lint": "eslint .",
     "test": "mocha --full-trace --recursive ./test",
@@ -53,6 +54,7 @@
   },
   "files": [
     "src/*",
-    "dist/*"
+    "dist/*",
+    "ts/*"
   ]
 }

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "symbol-sdk",
-  "version": "3.0.8",
+  "version": "3.0.10",
   "type": "module",
   "description": "JavaScript SDK for Symbol",
   "main": "src/index.js",

--- a/sdk/javascript/scripts/ci/build.sh
+++ b/sdk/javascript/scripts/ci/build.sh
@@ -17,6 +17,3 @@ npm run bundle
 # build TS bindings
 npx tsc -p ./tsconfig-generate.json
 npx tsc
-find src -name "*.ts" -type f -delete
-find test -name "*.ts" -type f -delete
-find vectors -name "*.ts" -type f -delete

--- a/sdk/javascript/src/utils/base32.js
+++ b/sdk/javascript/src/utils/base32.js
@@ -50,38 +50,36 @@ const decodeBlock = (input, inputOffset, output, outputOffset) => {
 
 // endregion
 
-const base32 = {
-	/**
-	 * Base32 encodes a binary buffer.
-	 * @param {Uint8Array} data Binary data to encode.
-	 * @returns {string} Base32 encoded string corresponding to the input data.
-	 */
-	encode: data => {
-		if (0 !== data.length % DECODED_BLOCK_SIZE)
-			throw Error(`decoded size must be multiple of ${DECODED_BLOCK_SIZE}`);
+/**
+ * Base32 encodes a binary buffer.
+ * @param {Uint8Array} data Binary data to encode.
+ * @returns {string} Base32 encoded string corresponding to the input data.
+ */
+const encode = data => {
+	if (0 !== data.length % DECODED_BLOCK_SIZE)
+		throw Error(`decoded size must be multiple of ${DECODED_BLOCK_SIZE}`);
 
-		const output = new Array(data.length / DECODED_BLOCK_SIZE * ENCODED_BLOCK_SIZE);
-		for (let i = 0; i < data.length / DECODED_BLOCK_SIZE; ++i)
-			encodeBlock(data, i * DECODED_BLOCK_SIZE, output, i * ENCODED_BLOCK_SIZE);
+	const output = new Array(data.length / DECODED_BLOCK_SIZE * ENCODED_BLOCK_SIZE);
+	for (let i = 0; i < data.length / DECODED_BLOCK_SIZE; ++i)
+		encodeBlock(data, i * DECODED_BLOCK_SIZE, output, i * ENCODED_BLOCK_SIZE);
 
-		return output.join('');
-	},
-
-	/**
-	 * Base32 decodes a base32 encoded string.
-	 * @param {string} encoded Base32 encoded string to decode.
-	 * @returns {Uint8Array} Binary data corresponding to the input string.
-	 */
-	decode: encoded => {
-		if (0 !== encoded.length % ENCODED_BLOCK_SIZE)
-			throw Error(`encoded size must be multiple of ${ENCODED_BLOCK_SIZE}`);
-
-		const output = new Uint8Array(encoded.length / ENCODED_BLOCK_SIZE * DECODED_BLOCK_SIZE);
-		for (let i = 0; i < encoded.length / ENCODED_BLOCK_SIZE; ++i)
-			decodeBlock(encoded, i * ENCODED_BLOCK_SIZE, output, i * DECODED_BLOCK_SIZE);
-
-		return output;
-	}
+	return output.join('');
 };
 
-export default base32;
+/**
+ * Base32 decodes a base32 encoded string.
+ * @param {string} encoded Base32 encoded string to decode.
+ * @returns {Uint8Array} Binary data corresponding to the input string.
+ */
+const decode = encoded => {
+	if (0 !== encoded.length % ENCODED_BLOCK_SIZE)
+		throw Error(`encoded size must be multiple of ${ENCODED_BLOCK_SIZE}`);
+
+	const output = new Uint8Array(encoded.length / ENCODED_BLOCK_SIZE * DECODED_BLOCK_SIZE);
+	for (let i = 0; i < encoded.length / ENCODED_BLOCK_SIZE; ++i)
+		decodeBlock(encoded, i * ENCODED_BLOCK_SIZE, output, i * DECODED_BLOCK_SIZE);
+
+	return output;
+};
+
+export default { encode, decode };

--- a/sdk/javascript/tsconfig-generate.json
+++ b/sdk/javascript/tsconfig-generate.json
@@ -14,6 +14,7 @@
         "allowJs": true,
         "declaration": true,
         "emitDeclarationOnly": true,
+        "declarationDir": "ts",
 
         "checkJs": true,
         "esModuleInterop": true

--- a/sdk/javascript/tsconfig.json
+++ b/sdk/javascript/tsconfig.json
@@ -11,5 +11,5 @@
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
-     "include": ["src/**/*.ts", "test/**/*.ts", "vectors/**/*.ts"]
+     "include": ["ts/src/**/*.ts", "ts/test/**/*.ts", "ts/vectors/**/*.ts"]
 }

--- a/sdk/python/CHANGELOG.md
+++ b/sdk/python/CHANGELOG.md
@@ -5,7 +5,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 
 ## next
 
-## [3.0.8] - 27-Jul-2023
+## [3.0.10] - 27-Jul-2023
 
 ### Added
  - lookup_transaction_name for generating friendly transaction name from transaction type and version
@@ -93,7 +93,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 ### Added
  - initial code release
 
-[3.0.8]: https://github.com/symbol/symbol/compare/sdk%2Fpython%2Fv3.0.7...sdk%2Fpython%2Fv3.0.8
+[3.0.10]: https://github.com/symbol/symbol/compare/sdk%2Fpython%2Fv3.0.7...sdk%2Fpython%2Fv3.0.10
 [3.0.7]: https://github.com/symbol/symbol/compare/sdk%2Fpython%2Fv3.0.3...sdk%2Fpython%2Fv3.0.7
 [3.0.3]: https://github.com/symbol/symbol/compare/sdk%2Fpython%2Fv3.0.2...sdk%2Fpython%2Fv3.0.3
 [3.0.2]: https://github.com/symbol/symbol/compare/sdk%2Fpython%2Fv3.0.1...sdk%2Fpython%2Fv3.0.2

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = 'symbol-sdk-python'
-version = '3.0.8'
+version = '3.0.10'
 description = 'Symbol SDK'
 authors = ['Symbol Contributors <contributors@symbol.dev>']
 maintainers = ['Symbol Contributors <contributors@symbol.dev>']


### PR DESCRIPTION
* export base32 as out of line functions to preserve documentation
* generate TS files in ts/ folder
* include ts/ folder in package
* bump version