### PR TITLE
[jenkins]: fix race condition with MongoDB starting and Catapult tests running

### DIFF
--- a/jenkins/catapult/templates/RunTest.yaml
+++ b/jenkins/catapult/templates/RunTest.yaml
@@ -1,4 +1,4 @@
-version: '2.1'
+version: '2.4'
 services:
   db:
     image: mongo:6.0
@@ -8,6 +8,12 @@ services:
         ipv6_address: 2001:3200:{{NETWORK_IP}}::25
     command: mongod --bind_ip_all --dbpath=/mongo --logpath /mongo/mongod.log
     stop_signal: SIGINT
+    healthcheck:
+      test: "/usr/bin/mongosh --eval 'printjson(db.version())'"
+      interval: 10s
+      timeout: 2s
+      retries: 5
+      start_period: 5s
     volumes:
       - ./mongo/{{BUILD_NUMBER}}:/mongo:rw
 
@@ -38,7 +44,8 @@ services:
       - '{{CATAPULT_SRC}}:/catapult-src'
       - '{{SCRIPT_PATH}}:/scripts'
     depends_on:
-      - db
+      db:
+        condition: service_healthy
 
 networks:
   test_net:

--- a/jenkins/catapult/templates/RunTest.yaml
+++ b/jenkins/catapult/templates/RunTest.yaml
@@ -9,7 +9,7 @@ services:
     command: mongod --bind_ip_all --dbpath=/mongo --logpath /mongo/mongod.log
     stop_signal: SIGINT
     healthcheck:
-      test: "/usr/bin/mongosh --eval 'printjson(db.version())'"
+      test: /usr/bin/mongosh --eval 'printjson(db.version())'
       interval: 10s
       timeout: 2s
       retries: 5


### PR DESCRIPTION
## What is the current behavior?
docker-compose ``depends_on`` by default does not wait for the MongoDB service to be ready, only for the container to be running.

## What's the issue?
Catapult tests will start before the MongoDB service is ready.  This will cause some Catapult MongoDB tests to fail.

## How have you changed the behavior?
Add a health check for the MongoDB container which make the service ready once it is up and running
Catapult tests will now wait for the MongoDB service to be healthy instead of the container to run.

## How was this change tested?
Ran the docker-compose locally to verify.
