### PR TITLE
[monorepo] task: Enable weekly builds for JavaScript and Python sdks

### DIFF
--- a/.github/buildConfiguration.yaml
+++ b/.github/buildConfiguration.yaml
@@ -102,3 +102,10 @@ customBuilds:
     jobName: /symbol/catapult-client/catapult-client-release-build
     scriptPath: jenkins/catapult/jenkins/catapult-client-release-build.groovy
     targetDirectory: symbol-mono
+
+  - name: Weekly Job
+    jobName: weeklyJob
+    scriptPath: .github/jenkinsfile/weeklyBuild.groovy
+    triggers:
+      - type: cron
+        schedule: '@weekly'

--- a/.github/jenkinsfile/weeklyBuild.groovy
+++ b/.github/jenkinsfile/weeklyBuild.groovy
@@ -1,0 +1,3 @@
+weeklyBuildPipeline {
+	projectNames = ['Sdk Python', 'Sdk Javascript']
+}

--- a/sdk/javascript/Jenkinsfile
+++ b/sdk/javascript/Jenkinsfile
@@ -1,8 +1,9 @@
 defaultCiPipeline {
-	operatingSystem = ['ubuntu']
+	operatingSystem = ['ubuntu', 'windows']
 	instanceSize = 'medium'
 
-	ciBuildDockerfile = 'javascript.Dockerfile'
+	environment = 'javascript'
+	otherEnvironments = ['javascript-windows-lts']
 
 	packageId = 'sdk-javascript'
 

--- a/sdk/javascript/scripts/ci/lint_python.sh
+++ b/sdk/javascript/scripts/ci/lint_python.sh
@@ -10,6 +10,9 @@ find . -type f -name "*.py" -print0 | PYTHONPATH=. xargs -0 python3 -m isort \
 	--check-only
 find . -type f -name "*.py" -print0 | PYTHONPATH=. xargs -0 python3 -m pycodestyle \
 	--config="$(git rev-parse --show-toplevel)/linters/python/.pycodestyle"
-find . -type f -name "*.py" -print0 | PYTHONPATH=".:$(git rev-parse --show-toplevel)/catbuffer/parser" xargs -0 python3 -m pylint \
+
+# Cygwin is install in our Windows images so pick the correct separator if Windows(Msys)
+SEPARATOR="$([ "$(uname -o)" = "Msys" ] && echo ";" || echo ":")"
+find . -type f -name "*.py" -print0 | PYTHONPATH=".${SEPARATOR}$(git rev-parse --show-toplevel)/catbuffer/parser" xargs -0 python3 -m pylint \
 	--rcfile "$(git rev-parse --show-toplevel)/linters/python/.pylintrc" \
 	--load-plugins pylint_quotes

--- a/sdk/python/Jenkinsfile
+++ b/sdk/python/Jenkinsfile
@@ -1,8 +1,9 @@
 defaultCiPipeline {
-	operatingSystem = ['ubuntu']
+	operatingSystem = ['ubuntu', 'windows']
 	instanceSize = 'medium'
 
-	ciBuildDockerfile = 'python.Dockerfile'
+	environment = 'python'
+	otherEnvironments = ['python-ubuntu-base', 'python-ubuntu-latest', 'python-windows-lts']
 
 	packageId = 'sdk-python'
 

--- a/sdk/python/scripts/ci/lint.sh
+++ b/sdk/python/scripts/ci/lint.sh
@@ -12,8 +12,11 @@ find . -type f -name "*.py" -print0 | xargs -0 git check-ignore -nv | grep :: | 
 find . -name "nc" -prune -o -name "sc" -prune -o -type f -name "*.py" -print0 | xargs -0 git check-ignore -nv | grep :: | cut -f2- | \
 	PYTHONPATH=. xargs python3 -m pycodestyle \
 	--config="$(git rev-parse --show-toplevel)/linters/python/.pycodestyle"
+
+# Cygwin is install in our Windows images so pick the correct separator if Windows(Msys)
+SEPARATOR="$([ "$(uname -o)" = "Msys" ] && echo ";" || echo ":")"
 find . -name "nc" -prune -o -name "sc" -prune -o -type f -name "*.py" -print0 | xargs -0 git check-ignore -nv | grep :: | cut -f2- | \
-	PYTHONPATH=".:$(git rev-parse --show-toplevel)/catbuffer/parser" xargs python3 -m pylint \
+	PYTHONPATH=".${SEPARATOR}$(git rev-parse --show-toplevel)/catbuffer/parser" xargs python3 -m pylint \
 	--rcfile "$(git rev-parse --show-toplevel)/linters/python/.pylintrc" \
 	--load-plugins pylint_quotes
 
@@ -23,7 +26,7 @@ find . -name "nc" -o -name "sc" -o -type f -name "*.py" -print0 | xargs -0 git c
 	--config="$(git rev-parse --show-toplevel)/linters/python/.pycodestyle" \
 	--max-line-length=215
 find . -name "nc" -o -name "sc" -o -type f -name "*.py" -print0 | xargs -0 git check-ignore -nv | grep :: | cut -f2- | \
-	PYTHONPATH=".:$(git rev-parse --show-toplevel)/catbuffer/parser" xargs python3 -m pylint \
+	PYTHONPATH=".${SEPARATOR}$(git rev-parse --show-toplevel)/catbuffer/parser" xargs python3 -m pylint \
 	--rcfile "$(git rev-parse --show-toplevel)/linters/python/.pylintrc" \
 	--load-plugins pylint_quotes \
 	--disable=duplicate-code


### PR DESCRIPTION
## What is the current behavior?
JavaScript and Python SDKs only test in one environment

## What's the issue?
JavaScript and Python SDKs cannot run tests in other Python environments

## How have you changed the behavior?
Enable weekly builds for JavaScript and Python SDKs.
JavaScript SDKs will run in a Windows environment
Python SDKs will run in Windows and different versions of Python on Ubuntu.

## How was this change tested?
Tested locally and in Jenkins.
The build will currently fail with Python 3.11.