### PR TITLE
[jenkins] fix: Upgrade to Node 18 for CI builds

### DIFF
--- a/jenkins/docker/ubuntu/javascript.Dockerfile
+++ b/jenkins/docker/ubuntu/javascript.Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:22.04
+ARG FROM_IMAGE='ubuntu:22.04'
+
+FROM ${FROM_IMAGE}
 
 # install tzdata first to prevent 'geographic area' prompt
 RUN apt-get update >/dev/null \
@@ -14,7 +16,13 @@ RUN apt-get install -y wget gnupg \
 	&& apt-get install -y mongodb-org
 
 # nodejs
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
+ARG NODE_MAJOR=18
+RUN apt-get install -y ca-certificates curl gnupg \
+	&& mkdir -p /etc/apt/keyrings \
+	&& curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+	&& echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" \
+	| tee /etc/apt/sources.list.d/nodesource.list \
+	&& apt-get update \
 	&& apt-get install -y nodejs
 
 # rest dependencies

--- a/jenkins/docker/ubuntu/javascript.Dockerfile
+++ b/jenkins/docker/ubuntu/javascript.Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get install -y wget gnupg \
 	&& apt-get install -y mongodb-org
 
 # nodejs
+ENV NODE_OPTIONS="--dns-result-order=ipv4first"
 ARG NODE_MAJOR=18
 RUN apt-get install -y ca-certificates curl gnupg \
 	&& mkdir -p /etc/apt/keyrings \


### PR DESCRIPTION
## What is the current behavior?
JavaScript projects are using Node 16.

## What's the issue?
Node 16 has reached the End Of Life.

## How have you changed the behavior?
Upgrade the JavaScript image to use Node 18.

## How was this change tested?
It was tested locally.
