### PR TITLE
[sdk] fixes for node 18 AND  fixes for python 3.11

### DIFF
--- a/sdk/javascript/src/nem/MessageEncoder.js
+++ b/sdk/javascript/src/nem/MessageEncoder.js
@@ -66,8 +66,8 @@ export default class MessageEncoder {
 			// eslint-disable-next-line import/no-deprecated
 			() => decodeAesCbc(deriveSharedKeyDeprecated, this._keyPair, recipientPublicKey, encodedMessage.message),
 			[
-				'digital envelope routines:EVP_DecryptFinal_ex:bad decrypt',
-				'digital envelope routines:EVP_DecryptFinal_ex:wrong final block length',
+				'bad decrypt',
+				'wrong final block length',
 				'Invalid initialization vector'
 			]
 		);

--- a/sdk/python/symbolchain/RuleBasedTransactionFactory.py
+++ b/sdk/python/symbolchain/RuleBasedTransactionFactory.py
@@ -71,6 +71,7 @@ class RuleBasedTransactionFactory:
 		"""Creates flag type parser."""
 		flags_class = self._get_module_class(name)
 		string_to_enum = dict(map(lambda key: (key.name.lower(), key), flags_class))
+		string_to_enum['none'] = flags_class(0)  # automatically add none => 0 mapping (required for python 3.11+)
 
 		def parser(flags):
 			if isinstance(flags, str):

--- a/sdk/python/tests/test_RuleBasedTransactionFactory.py
+++ b/sdk/python/tests/test_RuleBasedTransactionFactory.py
@@ -139,6 +139,9 @@ class RuleBasedTransactionFactoryTest(unittest.TestCase):
 		# Assert:
 		self.assertEqual(expected_value, parsed)
 
+	def test_flags_parser_can_handle_none_string_flag(self):
+		self._assert_flags_parser('none', Module.MosaicFlags.NONE)
+
 	def test_flags_parser_can_handle_single_string_flag(self):
 		self._assert_flags_parser('restrictable', Module.MosaicFlags.RESTRICTABLE)
 


### PR DESCRIPTION
    [sdk/python]: fixes for python 3.11
    
     problem: 3.11+ removes named zero flags from Flag class
    solution: manually add 'none' => 0 mapping in add_flags_parser

    [sdk/javascript]: fixes for Node 18
    
     problem: exceptions filtered by MessageEncoder (NEM) are too specific
    solution: use more generic filters that work with both Node 16 and 18