### PR TITLE
[jenkins] feat: setup private repository

### DIFF
--- a/jenkins/catapult/jenkins/catapult-client-release-build.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-release-build.groovy
@@ -42,6 +42,14 @@ pipeline {
 								returnStdout: true
 							).trim()
 
+							final String ownerName = helper.resolveOrganizationName()
+							dockerCredentialId = helper.isPublicBuild(params.BUILD_CONFIGURATION)
+									? env.DOCKER_CREDENTIALS_ID
+									: "${ownerName.toUpperCase()}_ARTIFACTORY_LOGIN_ID"
+							dockerUrl = helper.isPublicBuild(params.BUILD_CONFIGURATION)
+									? env.DOCKER_URL
+									: helper.resolveUrlBase(configureArtifactRepository.resolveRepositoryUrl(ownerName, 'docker-hosted'))
+
 							compilerConfigurationFilepath = "symbol-mono/jenkins/catapult/configurations/${ARCHITECTURE}/${COMPILER_CONFIGURATION}.yaml"
 							imageLabel = resolveImageLabel(compilerConfigurationFilepath)
 							dockerRepoName = "symbolplatform/${resolveImageRepo()}"
@@ -126,11 +134,13 @@ pipeline {
 					}
 					steps {
 						script {
-							dockerHelper.loginAndRunCommand(DOCKER_CREDENTIALS_ID, DOCKER_URL) {
-								dockerHelper.pushImage(buildImageFullName, buildImageFullName)
-								String archImageName = "${dockerRepoName}:${resolveShortArchitectureImageLabel(compilerConfigurationFilepath)}"
+							dockerHelper.loginAndRunCommand(dockerCredentialId, dockerUrl) {
+								final String hostName = helper.resolveUrlHostName(dockerUrl)
+
+								dockerHelper.pushImage(buildImageFullName, "${hostName}/${buildImageFullName}")
+								String archImageName = "${hostName}/${dockerRepoName}:${resolveShortArchitectureImageLabel(compilerConfigurationFilepath)}"
 								dockerHelper.pushImage(buildImageFullName, archImageName)
-								String multiArchImageName = "${dockerRepoName}:${resolveShortImageLabel()}"
+								String multiArchImageName = "${hostName}/${dockerRepoName}:${resolveShortImageLabel()}"
 								dockerHelper.updateDockerImage(multiArchImageName, archImageName, "${ARCHITECTURE}")
 							}
 						}

--- a/jenkins/catapult/jenkins/catapult-client-release-build.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-release-build.groovy
@@ -126,7 +126,7 @@ pipeline {
 					}
 					steps {
 						script {
-							dockerHelper.loginAndRunCommand(DOCKER_CREDENTIALS_ID) {
+							dockerHelper.loginAndRunCommand(DOCKER_CREDENTIALS_ID, DOCKER_URL) {
 								dockerHelper.pushImage(buildImageFullName, buildImageFullName)
 								String archImageName = "${dockerRepoName}:${resolveShortArchitectureImageLabel(compilerConfigurationFilepath)}"
 								dockerHelper.pushImage(buildImageFullName, archImageName)

--- a/jenkins/shared-library/vars/configureArtifactRepository.groovy
+++ b/jenkins/shared-library/vars/configureArtifactRepository.groovy
@@ -1,0 +1,48 @@
+void call(String environment) {
+	final String ownerName = env.GIT_URL.tokenize('/')[2]
+	logger.logInfo("Configuring respository pull for ${environment}")
+
+	configureArtifactRepositoryUrl(environment, ownerName)
+	configureArtifactRepositoryLogin(environment, ownerName)
+}
+
+void configureNpmUrl(String url) {
+	env.NPM_URL = url
+	runScript('npm config set registry=$NPM_URL')
+}
+
+void npmLogin(String userName, String password) {
+	env.USERNAME_PASSWORD_ENCODING = "${userName}:${password}".bytes.encodeBase64().toString()
+	runScript('set +x; npm config set _auth=$USERNAME_PASSWORD_ENCODING')
+	runScript('npm config set always-auth=true')
+}
+
+void configurePipUrl(String url) {
+	env.PIP_INDEX_URL = url
+}
+
+void configureArtifactRepositoryUrl(String environment, String gitOrgName) {
+	Map<String, Closure> handler = [
+			'javascript' : this.&configureNpmUrl,
+			'python': this.&configurePipUrl
+	]
+
+	helper.tryRunWithStringCredentials("${gitOrgName.toUpperCase()}_${environment.toUpperCase()}_ARTIFACTORY_URL_ID") { String url ->
+		if (handler.containsKey(environment)) {
+			handler[environment](url)
+		}
+	}
+}
+
+void configureArtifactRepositoryLogin(String environment, String gitOrgName) {
+	Map<String, Closure> handler = [
+			'javascript' : this.&npmLogin
+	]
+
+	helper.tryRunWithUserCredentials("${gitOrgName.toUpperCase()}_${environment.toUpperCase()}_ARTIFACTORY_LOGIN_ID") { String userName,
+																														String password ->
+		if (handler.containsKey(environment)) {
+			handler[environment](userName, password)
+		}
+	}
+}

--- a/jenkins/shared-library/vars/configureArtifactRepository.groovy
+++ b/jenkins/shared-library/vars/configureArtifactRepository.groovy
@@ -45,15 +45,17 @@ void configureArtifactRepository(String environment, String gitOrgName) {
 		final String artifactoryUrlId = "${gitOrgName.toUpperCase()}_${environment.toUpperCase()}_ARTIFACTORY_URL_ID"
 		final String artifactoryLoginId = "${gitOrgName.toUpperCase()}_${environment.toUpperCase()}_ARTIFACTORY_LOGIN_ID"
 
-		helper.tryRunWithStringCredentials(artifactoryUrlId) { String url ->
+		boolean foundUrl = helper.tryRunWithStringCredentials(artifactoryUrlId) { String url ->
 			artifactRepositoryInfo.url = url
 		}
 
-		helper.tryRunWithUserCredentials(artifactoryLoginId) { String userName, String password ->
-			artifactRepositoryInfo.userName = userName
-			artifactRepositoryInfo.password = password
-		}
+		if (foundUrl) {
+			helper.tryRunWithUserCredentials(artifactoryLoginId) { String userName, String password ->
+				artifactRepositoryInfo.userName = userName
+				artifactRepositoryInfo.password = password
+			}
 
-		handler[environment](artifactRepositoryInfo)
+			handler[environment](artifactRepositoryInfo)
+		}
 	}
 }

--- a/jenkins/shared-library/vars/configureArtifactRepository.groovy
+++ b/jenkins/shared-library/vars/configureArtifactRepository.groovy
@@ -92,8 +92,8 @@ List<String> resolveRepositoryUserNamePassword(String ownerName) {
 void configure(String environment, String gitOrgName, String url) {
 	Map artifactRepositoryInfo = [:]
 	Map<String, List<Object>> repositoryHandlerMap = [
-			'javascript' : this.&configureNpm,
-			'python': this.&configurePypi
+		'javascript' : this.&configureNpm,
+		'python': this.&configurePypi
 	]
 
 	if (repositoryHandlerMap.containsKey(environment)) {

--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -91,6 +91,7 @@ void call(Closure body) {
 						steps {
 							println("Jenkinsfile parameters: ${jenkinsfileParams}")
 							runScript(isUnix() ? 'printenv' : 'set')
+							configureArtifactRepository(jobHelper.resolveCiEnvironmentName(jenkinsfileParams))
 						}
 					}
 					stage('checkout') {

--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -87,17 +87,17 @@ void call(Closure body) {
 					}
 				}
 				stages {
+					stage('display environment') {
+						steps {
+							println("Jenkinsfile parameters: ${jenkinsfileParams}")
+							runScript(isUnix() ? 'printenv' : 'set')
+						}
+					}
 					stage('setup docker environment') {
 						steps {
 							runStepRelativeToPackageRoot packageRootPath, {
 								configureArtifactRepository(jobHelper.resolveCiEnvironmentName(jenkinsfileParams))
 							}
-						}
-					}
-					stage('display environment') {
-						steps {
-							println("Jenkinsfile parameters: ${jenkinsfileParams}")
-							runScript(isUnix() ? 'printenv' : 'set')
 						}
 					}
 					stage('checkout') {

--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -87,11 +87,17 @@ void call(Closure body) {
 					}
 				}
 				stages {
+					stage('setup docker environment') {
+						steps {
+							runStepRelativeToPackageRoot packageRootPath, {
+								configureArtifactRepository(jobHelper.resolveCiEnvironmentName(jenkinsfileParams))
+							}
+						}
+					}
 					stage('display environment') {
 						steps {
 							println("Jenkinsfile parameters: ${jenkinsfileParams}")
 							runScript(isUnix() ? 'printenv' : 'set')
-							configureArtifactRepository(jobHelper.resolveCiEnvironmentName(jenkinsfileParams))
 						}
 					}
 					stage('checkout') {

--- a/jenkins/shared-library/vars/helper.groovy
+++ b/jenkins/shared-library/vars/helper.groovy
@@ -80,31 +80,25 @@ String resolveBuildArchitecture() {
 	return env.ARCHITECTURE ?: 'amd64'
 }
 
-boolean tryRunCommand(String failurePrefixMessage, Closure command) {
+String resolveOrganizationName() {
+	return env.GIT_URL.tokenize('/')[2]
+}
+
+String resolveRepositoryName() {
+	return env.GIT_URL.tokenize('/').last().split('\\.')[0]
+}
+
+String resolveUrlBase(String url) {
+	URL urlObject = new URL(url)
+	return "${urlObject.protocol}://${urlObject.host}"
+}
+
+boolean tryRunCommand(Closure command) {
 	try {
 		command()
 		return true
 		// groovylint-disable-next-line CatchException
-	} catch (Exception exception) {
-		println "${failurePrefixMessage}: ${exception}"
+	} catch (_) {
 		return false
-	}
-}
-
-boolean tryRunWithStringCredentials(String id, Closure command) {
-	return tryRunCommand("Failed to get string credentials with id ${id}") {
-		withCredentials([string(credentialsId: id, variable: 'STRING_CREDENTIALS')]) {
-			command(env.STRING_CREDENTIALS)
-		}
-	}
-}
-
-boolean tryRunWithUserCredentials(String id, Closure command) {
-	return tryRunCommand("Failed to get user credentials with id ${id}") {
-		withCredentials([usernamePassword(credentialsId: id,
-				usernameVariable: 'USERNAME',
-				passwordVariable: 'PASSWORD')]) {
-			command(env.USERNAME, env.PASSWORD)
-		}
 	}
 }

--- a/jenkins/shared-library/vars/helper.groovy
+++ b/jenkins/shared-library/vars/helper.groovy
@@ -93,6 +93,10 @@ String resolveUrlBase(String url) {
 	return "${urlObject.protocol}://${urlObject.host}"
 }
 
+String resolveUrlHostName(String url) {
+	return new URL(url).host
+}
+
 boolean tryRunCommand(Closure command) {
 	try {
 		command()

--- a/jenkins/shared-library/vars/helper.groovy
+++ b/jenkins/shared-library/vars/helper.groovy
@@ -79,3 +79,32 @@ boolean isAmd64Architecture(String architecture) {
 String resolveBuildArchitecture() {
 	return env.ARCHITECTURE ?: 'amd64'
 }
+
+boolean tryRunCommand(String failurePrefixMessage, Closure command) {
+	try {
+		command()
+		return true
+		// groovylint-disable-next-line CatchException
+	} catch (Exception exception) {
+		println "${failurePrefixMessage}: ${exception}"
+		return false
+	}
+}
+
+boolean tryRunWithStringCredentials(String id, Closure command) {
+	return tryRunCommand("Failed to get string credentials with id ${id}") {
+		withCredentials([string(credentialsId: id, variable: 'STRING_CREDENTIALS')]) {
+			command(env.STRING_CREDENTIALS)
+		}
+	}
+}
+
+boolean tryRunWithUserCredentials(String id, Closure command) {
+	return tryRunCommand("Failed to get user credentials with id ${id}") {
+		withCredentials([usernamePassword(credentialsId: id,
+				usernameVariable: 'USERNAME',
+				passwordVariable: 'PASSWORD')]) {
+			command(env.USERNAME, env.PASSWORD)
+		}
+	}
+}

--- a/jenkins/shared-library/vars/publish.groovy
+++ b/jenkins/shared-library/vars/publish.groovy
@@ -32,7 +32,7 @@ void dockerPublisher(Map config, String phase) {
 	String dockerCredentialsId = DOCKER_CREDENTIALS_ID
 	if (isAlphaRelease(phase) || !isGitHubRepositoryPublic(ownerName, repositoryName)) {
 		dockerCredentialsId = "${ownerName.toUpperCase()}_ARTIFACTORY_LOGIN_ID"
-		dockerHost = helper.resolveUrlBase(configureArtifactRepository.resolveRepositoryUrl(ownerName, 'docker-hosted')).toURL().host
+		dockerHost = helper.resolveUrlHostName(configureArtifactRepository.resolveRepositoryUrl(ownerName, 'docker-hosted'))
 	}
 
 	final String version = readPackageVersion()
@@ -45,7 +45,7 @@ void dockerPublisher(Map config, String phase) {
 			dockerHelper.dockerBuildAndPushImage(archImageName, args)
 			dockerHelper.updateDockerImage(imageVersionName, archImageName, "${ARCHITECTURE}")
 			if (isRelease(phase)) {
-				final String imageLatestName = "${config.dockerImageName}:latest"
+				final String imageLatestName = "${dockerHost}/${config.dockerImageName}:latest"
 
 				logger.logInfo('Releasing the latest image')
 				dockerHelper.updateDockerImage(imageLatestName, archImageName, "${ARCHITECTURE}")

--- a/jenkins/shared-library/vars/publish.groovy
+++ b/jenkins/shared-library/vars/publish.groovy
@@ -59,9 +59,9 @@ void npmPublisher(Map config, String phase) {
 		return
 	}
 
-	String npmPublishCommand = 'npm publish'
+	StringBuilder npmPublishCommand = new StringBuilder('npm publish')
 	if (isAlphaRelease(phase)) {
-		npmPublishCommand += ' --tag alpha'
+		npmPublishCommand.append(' --tag alpha')
 	}
 
 	final String ownerName = helper.resolveOrganizationName()
@@ -70,11 +70,11 @@ void npmPublisher(Map config, String phase) {
 		final String publishUrl = configureArtifactRepository.resolveRepositoryUrl(ownerName, 'npm-hosted')
 		final String environment = jobHelper.resolveCiEnvironmentName(config)
 
-		npmPublishCommand += ' --registry=' + publishUrl
+		npmPublishCommand.append(" --registry=${publishUrl}")
 		configureArtifactRepository.configure(environment, ownerName, publishUrl)
 		publishArtifact {
 			logger.logInfo("Publishing npm package ${readNpmPackageNameVersion()} to private repository")
-			runScript(npmPublishCommand)
+			runScript(npmPublishCommand.toString())
 		}
 	}
 	else
@@ -85,7 +85,7 @@ void npmPublisher(Map config, String phase) {
 		withCredentials([string(credentialsId: NPM_CREDENTIALS_ID, variable: 'NPM_TOKEN')]) {
 			publishArtifact {
 				logger.logInfo("Publishing npm package ${readNpmPackageNameVersion()}")
-				runScript(npmPublishCommand)
+				runScript(npmPublishCommand.toString())
 			}
 		}
 	}

--- a/jenkins/shared-library/vars/runScript.groovy
+++ b/jenkins/shared-library/vars/runScript.groovy
@@ -24,5 +24,5 @@ void call(String scriptFilepath, String label='', Boolean returnStdout, Boolean 
 }
 
 void withBash(String scriptFilepath) {
-	call("bash -c \"${scriptFilepath}\"", scriptFilepath, false)
+	call("bash -c '${scriptFilepath}'", scriptFilepath, false)
 }


### PR DESCRIPTION
## What is the current behavior?
All packages are updated from the public artifact repository.
Projects need to push test artifacts to a public repository.

## What's the issue?
Currently have no support for private artifact repos.

## How have you changed the behavior?
The following have been added to Jenkins.
1. Add support to publish to private NPM, PyPi, and Docker repositories.
2. Add support to install packages from a private repository during CI
3. Private GitHub repository always publishes to private artifact repo.

The Nexus OSS version has certain limitations.  One been is that artifacts cannot be pushed to a group repository.
Jenkins will configure the pull from the group repo and push it to the hosted repo.

## How was this change tested?
Tested in Jenkins.
