### PR TITLE
[client/rest] fix: update rest image to node 18

### DIFF
--- a/client/rest/Dockerfile
+++ b/client/rest/Dockerfile
@@ -1,12 +1,17 @@
 ARG UBUNTU_VERSION=22.04
-ARG NODE_VERSION=18
+ARG NODE_MAJOR=18
 
 FROM ubuntu:${UBUNTU_VERSION} as builder
 
-ARG NODE_VERSION
+ARG NODE_MAJOR
+ARG NODE_OPTIONS="--dns-result-order=ipv4first"
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y curl \
-	&& curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y curl gnupg \
+	&& mkdir -p /etc/apt/keyrings \
+	&& curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+	&& echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" \
+	| tee /etc/apt/sources.list.d/nodesource.list \
+	&& apt-get update \
 	&& apt-get install -y nodejs
 
 RUN apt-get install -y build-essential
@@ -17,10 +22,14 @@ RUN npm uninstall . && rm -rf node_modules && npm install
 
 FROM ubuntu:${UBUNTU_VERSION}
 
-ARG NODE_VERSION
+ARG NODE_MAJOR
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y curl \
-	&& curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y curl gnupg \
+	&& mkdir -p /etc/apt/keyrings \
+	&& curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+	&& echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" \
+	| tee /etc/apt/sources.list.d/nodesource.list \
+	&& apt-get update \
 	&& apt-get install -y nodejs
 
 WORKDIR /app


### PR DESCRIPTION
## What is the current behavior?
Rest image ships with Node 16

## What's the issue?
Rest is using an unsupported Node version

## How have you changed the behavior?
Upgrade to Node 18 which is the latest LTS.

## How was this change tested?
Tested locally on my dev box