### PR TITLE
[jenkins] fix: only run unit test during CI

### DIFF
--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -29,6 +29,7 @@ void call(Closure body) {
 				description: 'ci environment'
 			booleanParam name: 'SHOULD_PUBLISH_IMAGE', description: 'true to publish image', defaultValue: false
 			booleanParam name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS', description: 'true to publish job status if failed', defaultValue: false
+			booleanParam name: 'SHOULD_RUN_ALL_TEST', description: 'true to run all the test stage', defaultValue: false
 		}
 
 		agent {
@@ -192,8 +193,13 @@ void call(Closure body) {
 					}
 					stage('run tests (examples)') {
 						when {
-							expression {
-								return fileExists(resolvePath(packageRootPath, env.TEST_EXAMPLES_SCRIPT_FILEPATH))
+							allOf {
+								expression {
+									return params.SHOULD_RUN_ALL_TEST?.toBoolean()
+								}
+								expression {
+									return fileExists(resolvePath(packageRootPath, env.TEST_EXAMPLES_SCRIPT_FILEPATH))
+								}
 							}
 						}
 						steps {
@@ -204,8 +210,13 @@ void call(Closure body) {
 					}
 					stage('run tests (vectors)') {
 						when {
-							expression {
-								return fileExists(resolvePath(packageRootPath, env.TEST_VECTORS_SCRIPT_FILEPATH))
+							allOf {
+								expression {
+									return params.SHOULD_RUN_ALL_TEST?.toBoolean()
+								}
+								expression {
+									return fileExists(resolvePath(packageRootPath, env.TEST_VECTORS_SCRIPT_FILEPATH))
+								}
 							}
 						}
 						steps {

--- a/jenkins/shared-library/vars/nightlyBuildPipeline.groovy
+++ b/jenkins/shared-library/vars/nightlyBuildPipeline.groovy
@@ -115,7 +115,8 @@ void triggerAllJobs(
 					string(name: 'TEST_MODE', value: 'code-coverage'),
 					string(name: 'ARCHITECTURE', value: params.ARCHITECTURE),
 					booleanParam(name: 'SHOULD_PUBLISH_IMAGE', value: false),
-					booleanParam(name: shouldPublishFailJobStatusName, value: shouldPublishFailJobStatusValue)],
+					booleanParam(name: shouldPublishFailJobStatusName, value: shouldPublishFailJobStatusValue),
+					booleanParam(name: 'SHOULD_RUN_ALL_TEST', value: true)],
 					wait: waitForDownStream
 			}
 		}

--- a/jenkins/shared-library/vars/weeklyBuildPipeline.groovy
+++ b/jenkins/shared-library/vars/weeklyBuildPipeline.groovy
@@ -147,7 +147,8 @@ void triggerAllJobs(
 						string(name: 'ARCHITECTURE', value: params.ARCHITECTURE),
 						string(name: 'CI_ENVIRONMENT', value: environment),
 						booleanParam(name: 'SHOULD_PUBLISH_IMAGE', value: false),
-						booleanParam(name: shouldPublishFailJobStatusName, value: shouldPublishFailJobStatusValue)],
+						booleanParam(name: shouldPublishFailJobStatusName, value: shouldPublishFailJobStatusValue),
+						booleanParam(name: 'SHOULD_RUN_ALL_TEST', value: true)],
 						wait: waitForDownStream
 				}
 			}


### PR DESCRIPTION
## What is the current behavior?
All tests are run during CI.

## What's the issue?
Some test suite(such as example & vector) takes longer to run.

## How have you changed the behavior?
Only run the unit tests during CI.
All the tests are executed during the nightly builds.

## How was this change tested?
Tested in Jenkins.