### PR TITLE
[jenkins] feat: add generic AWS publisher to Jenkins

### DIFF
--- a/jenkins/shared-library/vars/publish.groovy
+++ b/jenkins/shared-library/vars/publish.groovy
@@ -198,13 +198,13 @@ boolean isGitHubRepositoryPublic(String orgName, String repoName) {
 }
 
 void awsPublisher(Map config, String phase) {
-	if (config.publisher != 'aws') {
+	if (config.publisher != 'aws' || !isRelease(phase)) {
 		return
 	}
 
 	withCredentials([usernamePassword(credentialsId: config.awsCredentialId,
 			usernameVariable: 'AWS_ACCESS_KEY_ID',
 			passwordVariable: 'AWS_SECRET_ACCESS_KEY')]) {
-		publishArtifact {}
+		publishArtifact { }
 	}
 }

--- a/jenkins/shared-library/vars/publish.groovy
+++ b/jenkins/shared-library/vars/publish.groovy
@@ -165,7 +165,8 @@ void publisher(Map config, String phase) {
 		this.&dockerPublisher,
 		this.&npmPublisher,
 		this.&pythonPublisher,
-		this.&gitHubPagesPublisher
+		this.&gitHubPagesPublisher,
+		this.&awsPublisher
 	]
 
 	strategies.each { publisher ->
@@ -193,5 +194,17 @@ boolean isGitHubRepositoryPublic(String orgName, String repoName) {
 	} catch (FileNotFoundException exception) {
 		println "Repository ${orgName}/${repoName} not found - ${exception}"
 		return false
+	}
+}
+
+void awsPublisher(Map config, String phase) {
+	if (config.publisher != 'aws') {
+		return
+	}
+
+	withCredentials([usernamePassword(credentialsId: config.awsCredentialId,
+			usernameVariable: 'AWS_ACCESS_KEY_ID',
+			passwordVariable: 'AWS_SECRET_ACCESS_KEY')]) {
+		publishArtifact {}
 	}
 }

--- a/jenkins/shared-library/vars/publish.groovy
+++ b/jenkins/shared-library/vars/publish.groovy
@@ -76,9 +76,7 @@ void npmPublisher(Map config, String phase) {
 			logger.logInfo("Publishing npm package ${readNpmPackageNameVersion()} to private repository")
 			runScript(npmPublishCommand.toString())
 		}
-	}
-	else
-	{
+	} else {
 		// groovylint-disable-next-line GStringExpressionWithinString
 		writeFile(file: '.npmrc', text: '//registry.npmjs.org/:_authToken=${NPM_TOKEN}')
 		runScript('cat .npmrc')
@@ -150,6 +148,18 @@ void gitHubPagesPublisher(Map config, String phase) {
 	}
 }
 
+void awsPublisher(Map config, String phase) {
+	if (config.publisher != 'aws' || !isRelease(phase)) {
+		return
+	}
+
+	withCredentials([usernamePassword(credentialsId: config.awsCredentialId,
+		usernameVariable: 'AWS_ACCESS_KEY_ID',
+		passwordVariable: 'AWS_SECRET_ACCESS_KEY')]) {
+		publishArtifact { }
+	}
+}
+
 void publisher(Map config, String phase) {
 	if (!config.publisher) {
 		logger.logInfo('No publisher is configured.')
@@ -194,17 +204,5 @@ boolean isGitHubRepositoryPublic(String orgName, String repoName) {
 	} catch (FileNotFoundException exception) {
 		println "Repository ${orgName}/${repoName} not found - ${exception}"
 		return false
-	}
-}
-
-void awsPublisher(Map config, String phase) {
-	if (config.publisher != 'aws' || !isRelease(phase)) {
-		return
-	}
-
-	withCredentials([usernamePassword(credentialsId: config.awsCredentialId,
-			usernameVariable: 'AWS_ACCESS_KEY_ID',
-			passwordVariable: 'AWS_SECRET_ACCESS_KEY')]) {
-		publishArtifact { }
 	}
 }


### PR DESCRIPTION
## What is the current behavior?
Jenkins only has permission to its own AWS account.

## What's the issue?
Jenkins cannot publish to different AWS accounts.

## How have you changed the behavior?
Add a generic AWS publisher which will set up credentials for a specific AWS account.
the published script will run to all specific operations on the AWS account.

## How was this change tested?
locally on my dev box.
