### PR TITLE
[jenkins] fix: add custom workspace for CI builds

### DIFF
--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -33,12 +33,15 @@ void call(Closure body) {
 		}
 
 		agent {
-			// ARCHITECTURE can be null on first job due to https://issues.jenkins.io/browse/JENKINS-41929
-			label """${
-				env.OPERATING_SYSTEM = env.OPERATING_SYSTEM ?: "${jenkinsfileParams.operatingSystem[0]}"
-				env.ARCHITECTURE = env.ARCHITECTURE ?: 'amd64'
-				return helper.resolveAgentName(env.OPERATING_SYSTEM, env.ARCHITECTURE, jenkinsfileParams.instanceSize ?: 'medium')
-			}"""
+			node {
+				// ARCHITECTURE can be null on first job due to https://issues.jenkins.io/browse/JENKINS-41929
+				label """${
+					env.OPERATING_SYSTEM = env.OPERATING_SYSTEM ?: "${jenkinsfileParams.operatingSystem[0]}"
+					env.ARCHITECTURE = env.ARCHITECTURE ?: 'amd64'
+					return helper.resolveAgentName(env.OPERATING_SYSTEM, env.ARCHITECTURE, jenkinsfileParams.instanceSize ?: 'medium')
+				}"""
+				customWorkspace "${helper.resolveWorkspacePath(env.OPERATING_SYSTEM)}"
+			}
 		}
 
 		options {

--- a/jenkins/shared-library/vars/helper.groovy
+++ b/jenkins/shared-library/vars/helper.groovy
@@ -106,3 +106,7 @@ boolean tryRunCommand(Closure command) {
 		return false
 	}
 }
+
+String resolveWorkspacePath(String os) {
+	return 'windows' == os ? 'C:\\Users\\Administrator\\jenkins\\workspace\\' : '/home/ubuntu/jenkins/workspace/'
+}


### PR DESCRIPTION
## What is the current behavior?
Jenkins includes the branch name as part of the workspace folder name.

## What's the issue?
C++ compilation which uses marco like ``__FILE__``, will cause ccache to have a lot of cache misses due to the differences in path.  This leads to longer compile times for Catapult.
https://ccache.dev/manual/latest.html#_compiling_in_different_directories

## How have you changed the behavior?
Add a custom workspace for CI builds.  This will allow faster builds for Catapult client.

## How was this change tested?
Tested locally and it seems to be faster.