### PR TITLE
[jenkins] fix: Code coverage fails the CI job when expected.

### DIFF
--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -238,6 +238,13 @@ void call(Closure body) {
 								expression {
 									return  null != jenkinsfileParams.codeCoverageTool
 								}
+								expression {
+									// If all the tests are not run then code coverage will fail to meet the required minimum
+									// Nightly builds will run all tests.
+									return (params.SHOULD_RUN_ALL_TEST?.toBoolean()
+										|| (!fileExists(resolvePath(packageRootPath, env.TEST_EXAMPLES_SCRIPT_FILEPATH))
+										&& !fileExists(resolvePath(packageRootPath, env.TEST_VECTORS_SCRIPT_FILEPATH))))
+								}
 							}
 						}
 						steps {


### PR DESCRIPTION
## What's the issue?
Since not all tests are run during CI then code coverage will fail to meet the minimum requirement.
If code coverage runs it will cause Codecov to report failure since there is a drop in coverage.

## How have you changed the behavior?
During CI, disable code coverage if there are other tests defined other than unit tests for the project.
Nightly builds will run all tests and fail if the code coverage limit is not met.

## How was this change tested?
Tested in Jenkins