### PR TITLE
[monorepo]: enable dependabot group update for each project

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,6 +9,13 @@ updates:
     target-branch: dev
     commit-message:
       prefix: '[dependency]'
+    groups:
+      actions-dependencies:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: pip
     directory: /catbuffer/parser
@@ -20,6 +27,13 @@ updates:
     versioning-strategy: increase-if-necessary
     commit-message:
       prefix: '[dependency]'
+    groups:
+      catbuffer-dependencies:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: pip
     directory: /client/catapult/scripts
@@ -31,6 +45,13 @@ updates:
     versioning-strategy: increase-if-necessary
     commit-message:
       prefix: '[dependency]'
+    groups:
+      catapult-dependencies:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: npm
     directory: /client/rest
@@ -42,6 +63,13 @@ updates:
     versioning-strategy: increase-if-necessary
     commit-message:
       prefix: '[dependency]'
+    groups:
+      rest-dependencies:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: pip
     directory: /jenkins/catapult
@@ -53,6 +81,13 @@ updates:
     versioning-strategy: increase-if-necessary
     commit-message:
       prefix: '[dependency]'
+    groups:
+      jenkins-dependencies:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: pip
     directory: /linters/cpp
@@ -64,6 +99,13 @@ updates:
     versioning-strategy: increase-if-necessary
     commit-message:
       prefix: '[dependency]'
+    groups:
+      linter-cpp-dependencies:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: pip
     directory: /linters/python
@@ -75,6 +117,13 @@ updates:
     versioning-strategy: increase-if-necessary
     commit-message:
       prefix: '[dependency]'
+    groups:
+      linter-python-dependencies:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: npm
     directory: /sdk/javascript
@@ -86,6 +135,13 @@ updates:
     versioning-strategy: increase-if-necessary
     commit-message:
       prefix: '[dependency]'
+    groups:
+      sdk-javascript-dependencies:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: pip
     directory: /sdk/javascript/generator
@@ -97,17 +153,13 @@ updates:
     versioning-strategy: increase-if-necessary
     commit-message:
       prefix: '[dependency]'
-
-  - package-ecosystem: pip
-    directory: /sdk/python
-    schedule:
-      interval: weekly
-      day: sunday
-    target-branch: dev
-    labels: [sdk-python]
-    versioning-strategy: increase-if-necessary
-    commit-message:
-      prefix: '[dependency]'
+    groups:
+      sdk-javascript-generator-dependencies:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
 
   - package-ecosystem: cargo
     directory: /sdk/javascript/wasm
@@ -119,3 +171,28 @@ updates:
     versioning-strategy: auto
     commit-message:
       prefix: '[sdk/javascript]'
+    groups:
+      sdk-javascript-wasm-dependencies:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: pip
+    directory: /sdk/python
+    schedule:
+      interval: weekly
+      day: sunday
+    target-branch: dev
+    labels: [sdk-python]
+    versioning-strategy: increase-if-necessary
+    commit-message:
+      prefix: '[dependency]'
+    groups:
+      sdk-python-dependencies:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## What is the current behavior?
Dependabot will create one PR for each dependency update.

## What's the issue?
Grouping these Dependabot PR can lead to conflict when trying to merge them

## How have you changed the behavior?
Enable the Dependabot group which will resolve all conflicts at the project level.
Merging PRs at the project level should not lead to any conflict.
Left out major dependency updates from the grouping since these can cause CI failures so a separate PR is created.

## How was this change tested?
Will test with GitHub