### PR TITLE
[jenkins] fix: switch to using ARM for CI builds

### DIFF
--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -19,7 +19,7 @@ void call(Closure body) {
 				choices: ['release-private', 'release-public'],
 				description: 'build configuration'
 			choice name: 'ARCHITECTURE',
-				choices: ['amd64', 'arm64'],
+				choices: ['arm64', 'amd64'],
 				description: 'Computer architecture'
 			choice name: 'TEST_MODE',
 				choices: ['code-coverage', 'test'],
@@ -37,7 +37,7 @@ void call(Closure body) {
 				// ARCHITECTURE can be null on first job due to https://issues.jenkins.io/browse/JENKINS-41929
 				label """${
 					env.OPERATING_SYSTEM = env.OPERATING_SYSTEM ?: "${jenkinsfileParams.operatingSystem[0]}"
-					env.ARCHITECTURE = env.ARCHITECTURE ?: 'amd64'
+					env.ARCHITECTURE = env.ARCHITECTURE ?: 'arm64'
 					return helper.resolveAgentName(env.OPERATING_SYSTEM, env.ARCHITECTURE, jenkinsfileParams.instanceSize ?: 'medium')
 				}"""
 				customWorkspace "${helper.resolveWorkspacePath(env.OPERATING_SYSTEM)}"

--- a/jenkins/shared-library/vars/nightlyBuildPipeline.groovy
+++ b/jenkins/shared-library/vars/nightlyBuildPipeline.groovy
@@ -18,7 +18,7 @@ void call(Closure body) {
 				sortMode: 'ASCENDING',
 				useRepository: "${helper.resolveRepoName()}"
 			choice name: 'ARCHITECTURE',
-				choices: ['amd64', 'arm64'],
+				choices: ['arm64', 'amd64'],
 				description: 'Computer architecture'
 			booleanParam name: shouldPublishFailJobStatusName, description: 'true to publish job status if failed', defaultValue: true
 			booleanParam name: 'WAIT_FOR_BUILDS', description: 'true to wait for trigger build to complete', defaultValue: true
@@ -26,7 +26,7 @@ void call(Closure body) {
 
 		agent {
 			label """${
-				env.ARCHITECTURE = env.ARCHITECTURE ?: 'amd64'
+				env.ARCHITECTURE = env.ARCHITECTURE ?: 'arm64'
 				return helper.resolveAgentName('ubuntu', env.ARCHITECTURE, 'small')
 			}"""
 		}


### PR DESCRIPTION
## What is the current behavior?
CI builds are run on Intel architecture

## What's the issue?
Intel architecture is usually slower than ARM.

## How have you changed the behavior?
Switch to using ARM architecture as the default for CI.
Catapult daily builds will run on alternate days for intel and ARM.

## How was this change tested?
Will test in Jenkins.