### PR TITLE
[jenkins] fix: downgrade pylint to 2.x

### DIFF
--- a/jenkins/catapult/baseImageDockerfileGenerator.py
+++ b/jenkins/catapult/baseImageDockerfileGenerator.py
@@ -292,7 +292,7 @@ class UbuntuSystem:
 			'RUN apt-get -y update',
 			'apt-get remove -y --purge pylint',
 			'apt-get install -y {APT_PACKAGES}',
-			'python3 -m pip install -U pycodestyle pylint pyyaml'
+			'python3 -m pip install -U pycodestyle "pylint<3.0.0" pyyaml'
 		], APT_PACKAGES=' '.join(apt_packages))
 
 
@@ -329,7 +329,7 @@ class FedoraSystem:
 			'RUN dnf update --assumeyes',
 			'dnf remove --assumeyes pylint',
 			'dnf install --assumeyes {RPM_PACKAGES}',
-			'python3 -m pip install -U pycodestyle pylint pyyaml',
+			'python3 -m pip install -U pycodestyle "pylint<3.0.0" pyyaml',
 			'dnf clean all',
 			'rm -rf /var/cache/yum'
 		], RPM_PACKAGES=' '.join(rpm_packages))
@@ -354,7 +354,7 @@ class WindowsSystem:
 	def add_test_packages():
 		print_powershell_lines([
 			'scoop update',
-			'python3 -m pip install -U pycodestyle pylint pyyaml'
+			'python3 -m pip install -U pycodestyle "pylint<3.0.0" pyyaml'
 		])
 
 

--- a/jenkins/catapult/templates/FedoraTestBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/FedoraTestBaseImage.Dockerfile
@@ -20,4 +20,4 @@ RUN dnf update --assumeyes && dnf install --assumeyes \
 	&& \
 	dnf clean all && \
 	rm -rf /var/cache/yum && \
-	pip3 install -U colorama cryptography gitpython pycodestyle pylint pylint-quotes PyYAML
+	pip3 install -U colorama cryptography gitpython pycodestyle "pylint<3.0.0" pylint-quotes PyYAML

--- a/jenkins/catapult/templates/UbuntuTestBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuTestBaseImage.Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get -y update && apt-get install -y \
 	libslang2-dev \
 	&& \
 	rm -rf /var/lib/apt/lists/* && \
-	pip3 install -U colorama cryptography gitpython pycodestyle pylint pylint-quotes PyYAML && \
+	pip3 install -U colorama cryptography gitpython pycodestyle "pylint<3.0.0" pylint-quotes PyYAML && \
 	git clone https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git linux.git && \
 	cd linux.git/tools/perf && \
 	NO_LIBTRACEEVENT=1 make && \

--- a/jenkins/catapult/templates/UbuntuTestSanitizerBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuTestSanitizerBaseImage.Dockerfile
@@ -20,5 +20,5 @@ RUN apt-get -y update && apt-get install -y \
 	libslang2-dev \
 	&& \
 	rm -rf /var/lib/apt/lists/* && \
-	pip3 install -U colorama cryptography gitpython pycodestyle pylint pylint-quotes PyYAML
+	pip3 install -U colorama cryptography gitpython pycodestyle "pylint<3.0.0" pylint-quotes PyYAML
 

--- a/jenkins/catapult/templates/WindowsTestBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/WindowsTestBaseImage.Dockerfile
@@ -14,7 +14,7 @@ RUN Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser; `
 	del c:\scoop.ps1; `
 	scoop install python git shellcheck; `
 	python3 -m pip install --upgrade pip; `
-	python3 -m pip install --upgrade colorama cryptography gitpython ply pycodestyle pylint pylint-quotes PyYAML
+	python3 -m pip install --upgrade colorama cryptography gitpython ply pycodestyle "pylint<3.0.0" pylint-quotes PyYAML
 	
 RUN "'ACP', 'OEMCP', 'MACCP' | Set-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Nls\CodePage' -Name { $_ } 65001"; `
 	Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Nls\CodePage'


### PR DESCRIPTION
## What's the issue?
pylint 3.x has breaking change by the removal of pylint.interfaces.
This breaks the pylint quotes plugin which is used in our linting
``https://github.com/pylint-dev/pylint/issues/9094#issuecomment-1743859788``

## How have you changed the behavior?
downgrade to pylint 2.x until all plugins supports pylint 3.x

## How was this change tested?
Tested in Jenkins