### PR TITLE
[jenkins] fix: disable body max line length rule for dependencies commits

### DIFF
--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -120,9 +120,6 @@ void call(Closure body) {
 							anyOf {
 								branch env.DEV_BRANCH
 								branch env.RELEASE_BRANCH
-
-								// Dependabot commits do not always conform to our commit message convention
-								environment name: 'CHANGE_AUTHOR', value: 'dependabot[bot]'
 							}
 						}
 						steps {

--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -125,12 +125,12 @@ void call(Closure body) {
 						steps {
 							script {
 								runStepRelativeToPackageRoot '.', {
-									final String[] exemptAuther = ['github-actions[bot]', 'dependabot[bot]']
+									final String[] exemptAuthor = ['github-actions[bot]', 'dependabot[bot]']
 									String author = runScript('git log -1 --pretty=format:\'%an\'', true)
 
-									if (exemptAuther.contains(author)) {
+									if (exemptAuthor.contains(author)) {
 										println("Disabling max body line length rule for ${author}")
-										env.GITLINT_IGNORE='body-max-line-length'
+										env.GITLINT_IGNORE = 'body-max-line-length'
 									}
 
 									verifyCommitMessage()

--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -123,8 +123,18 @@ void call(Closure body) {
 							}
 						}
 						steps {
-							runStepRelativeToPackageRoot '.', {
-								verifyCommitMessage()
+							script {
+								runStepRelativeToPackageRoot '.', {
+									final String[] exemptAuther = ['github-actions[bot]', 'dependabot[bot]']
+									String author = runScript('git log -1 --pretty=format:\'%an\'', true)
+
+									if (exemptAuther.contains(author)) {
+										println("Disabling max body line length rule for ${author}")
+										env.GITLINT_IGNORE='body-max-line-length'
+									}
+
+									verifyCommitMessage()
+								}
 							}
 						}
 					}


### PR DESCRIPTION
## What is the current behavior?
Verify commit enforces max body line length for every commit

## What's the issue?
For Dependabot and grouping of the Dependabot PRs, the max body length can exceed the max length value.
This causes the CI job to fail in the verify commit message stage.

## How have you changed the behavior?
Disable max body line length check for For Dependabot and grouping of the Dependabot PRs.

## How was this change tested?
Tested locally on dev box.
