### PR TITLE
[jenkins] fix: add a controller job to manage CI builds

### DIFF
--- a/.github/jenkinsfile/controller.groovy
+++ b/.github/jenkinsfile/controller.groovy
@@ -1,0 +1,4 @@
+monorepoControllerPipeline {
+	operatingSystem = ['ubuntu']
+	instanceSize = 'small'
+}

--- a/jenkins/shared-library/vars/changedSetHelper.groovy
+++ b/jenkins/shared-library/vars/changedSetHelper.groovy
@@ -1,0 +1,52 @@
+// This will return list of files Jenkins thinks have changed, except for new branches where it will return an empty list.
+List<String> jenkinsChangedFiles() {
+	List<String> files = currentBuild.changeSets*.items*.affectedPaths
+	return files.flatten().unique()
+}
+
+// This will return all the files in the pull request
+List<String> pullRequestChangedFiles() {
+	// CHANGE_ID is set only for pull requests
+	return env.CHANGE_ID ? pullRequest.files*.filename : []
+}
+
+// Jenkins native interface to retrieve changes, i.e. `currentBuild.changeSets`, returns an empty list for newly
+// created branches (see https://issues.jenkins.io/browse/JENKINS-14138), so let's use `git` instead.
+List<String> lastCommitChangedFiles() {
+	return runScript('git diff-tree --no-commit-id --name-only -r HEAD', true).trim().split('\n')
+}
+
+List<String> resolveChangedList() {
+	List<Closure> changedFileHandler = [
+		this.&jenkinsChangedFiles,
+		this.&pullRequestChangedFiles,
+		this.&lastCommitChangedFiles
+	]
+
+	for (Closure handler in changedFileHandler) {
+		List<String> changedFiles = handler()
+		if (!changedFiles.isEmpty()) {
+			return changedFiles
+		}
+	}
+
+	return []
+}
+
+boolean isFileInChangedSet(String fileName) {
+	return resolveChangedList().find { changedFilePath -> changedFilePath == fileName }
+}
+
+Map<String, String> findRelevantMultibranchPipelines(List<String> changedFilesPath, Map<String, String> jenkinsBuilds) {
+	return jenkinsBuilds.findAll { build ->
+		changedFilesPath.find { changedFilePath -> changedFilePath.startsWith(build.value) }
+	}
+}
+
+Map<String, String> findMultibranchPipelinesToRun(Map<String, String> jenkinsBuilds) {
+	return findRelevantMultibranchPipelines(resolveChangedList(), jenkinsBuilds)
+}
+
+Map <String, String> resolveJenkinsfilesJobToRun(Map<String, String> allJenkinsfileMap) {
+	return findMultibranchPipelinesToRun(allJenkinsfileMap)
+}

--- a/jenkins/shared-library/vars/changedSetHelper.groovy
+++ b/jenkins/shared-library/vars/changedSetHelper.groovy
@@ -46,7 +46,3 @@ Map<String, String> findRelevantMultibranchPipelines(List<String> changedFilesPa
 Map<String, String> findMultibranchPipelinesToRun(Map<String, String> jenkinsBuilds) {
 	return findRelevantMultibranchPipelines(resolveChangedList(), jenkinsBuilds)
 }
-
-Map <String, String> resolveJenkinsfilesJobToRun(Map<String, String> allJenkinsfileMap) {
-	return findMultibranchPipelinesToRun(allJenkinsfileMap)
-}

--- a/jenkins/shared-library/vars/helper.groovy
+++ b/jenkins/shared-library/vars/helper.groovy
@@ -109,3 +109,19 @@ boolean tryRunCommand(Closure command) {
 String resolveWorkspacePath(String os) {
 	return 'windows' == os ? 'C:\\Users\\Administrator\\jenkins\\workspace\\' : '/home/ubuntu/jenkins/workspace/'
 }
+
+boolean isGitHubRepositoryPublic(String orgName, String repoName) {
+	try {
+		final URL url = "https://api.github.com/repos/${orgName}/${repoName}".toURL()
+		final Object repo = yamlHelper.readYamlFromText(url.text)
+
+		return repo.name == repoName && repo.visibility == 'public'
+	} catch (FileNotFoundException exception) {
+		println "Repository ${orgName}/${repoName} not found - ${exception}"
+		return false
+	}
+}
+
+String resolveGitHubCredentialsId() {
+	return scm.userRemoteConfigs[0].credentialsId
+}

--- a/jenkins/shared-library/vars/helper.groovy
+++ b/jenkins/shared-library/vars/helper.groovy
@@ -13,8 +13,7 @@ Boolean isPublicBuild(String buildConfiguration) {
 }
 
 String resolveRepoName() {
-	// groovylint-disable-next-line UnnecessaryGetter
-	return scm.getUserRemoteConfigs()[0].getUrl().tokenize('/').last()
+	return scm.userRemoteConfigs[0].url.tokenize('/').last()
 }
 
 void runInitializeScriptIfPresent() {
@@ -109,16 +108,4 @@ boolean tryRunCommand(Closure command) {
 
 String resolveWorkspacePath(String os) {
 	return 'windows' == os ? 'C:\\Users\\Administrator\\jenkins\\workspace\\' : '/home/ubuntu/jenkins/workspace/'
-}
-
-boolean isGitHubRepositoryPublic(String orgName, String repoName) {
-	try {
-		final URL url = "https://api.github.com/repos/${orgName}/${repoName}".toURL()
-		final Object repo = yamlHelper.readYamlFromText(url.text)
-
-		return repo.name == repoName && repo.visibility == 'public'
-	} catch (FileNotFoundException exception) {
-		println "Repository ${orgName}/${repoName} not found - ${exception}"
-		return false
-	}
 }

--- a/jenkins/shared-library/vars/jobHelper.groovy
+++ b/jenkins/shared-library/vars/jobHelper.groovy
@@ -23,8 +23,8 @@ List<String> readArrayParameterValue(String parameterValue) {
 	return values
 }
 
-Map<String, String> siblingJobNames(Map<String, String> displayNameJenkinsfileMap) {
-	Item project = Jenkins.get().getItemByFullName(currentBuild.fullProjectName)
+Map<String, String> siblingJobNames(Map<String, String> displayNameJenkinsfileMap, String jobFolder) {
+	Item project = Jenkins.get().getItemByFullName(jobFolder)
 	List<Item> siblingItems = project.parent.items
 
 	Map<String, String> targets = [:]
@@ -68,8 +68,11 @@ String resolveJobName(String jobFolder, String branchName) {
 	throw new IllegalStateException("Multibranch job folder ${jobFolder} does not contain a job with branch ${branchName}")
 }
 
-Map <String, String> loadJenkinsfileMap() {
-	Object buildConfiguration = yamlHelper.readYamlFromFile(helper.resolveBuildConfigurationFile())
+Object loadBuildConfigurationfile() {
+	return yamlHelper.readYamlFromFile(helper.resolveBuildConfigurationFile())
+}
+
+Map <String, String> loadJenkinsfileMap(Object buildConfiguration = loadBuildConfigurationfile()) {
 	Map<String, String> displayNameJenkinsfileMap = [:]
 
 	buildConfiguration.builds.each { build -> displayNameJenkinsfileMap.put(build.name, build.path) }

--- a/jenkins/shared-library/vars/monorepoControllerPipeline.groovy
+++ b/jenkins/shared-library/vars/monorepoControllerPipeline.groovy
@@ -98,7 +98,7 @@ void call(Closure body) {
 			stage('build jobs') {
 				steps {
 					script {
-						triggerJobs(helper.resolveBranchName(env.MANUAL_GIT_BRANCH), jenkinsfileParams)
+						triggerJobs(helper.resolveBranchName(env.MANUAL_GIT_BRANCH))
 					}
 				}
 			}

--- a/jenkins/shared-library/vars/monorepoControllerPipeline.groovy
+++ b/jenkins/shared-library/vars/monorepoControllerPipeline.groovy
@@ -106,7 +106,7 @@ void call(Closure body) {
 	}
 }
 
-void triggerJobs(String branchName, Map jenkinsfileParams) {
+void triggerJobs(String branchName) {
 	final Object buildConfiguration = jobHelper.loadBuildConfigurationfile()
 	final Map<String, String> allJenkinsfiles = jobHelper.loadJenkinsfileMap(buildConfiguration)
 	final Map<String, String> triggeredJenkinsfile = changedSetHelper.resolveJenkinsfilesJobToRun(allJenkinsfiles)

--- a/jenkins/shared-library/vars/monorepoControllerPipeline.groovy
+++ b/jenkins/shared-library/vars/monorepoControllerPipeline.groovy
@@ -1,0 +1,171 @@
+import java.nio.file.Paths
+
+// groovylint-disable-next-line MethodSize
+void call(Closure body) {
+	Map jenkinsfileParams = [:]
+	body.resolveStrategy = Closure.DELEGATE_FIRST
+	body.delegate = jenkinsfileParams
+	body()
+
+	pipeline {
+		parameters {
+			choice name: 'OPERATING_SYSTEM',
+				choices: jenkinsfileParams.operatingSystem ?: ['ubuntu'],
+				description: 'Run on specific OS'
+			choice name: 'ARCHITECTURE',
+				choices: ['arm64', 'amd64'],
+				description: 'Computer architecture'
+			booleanParam name: 'SHOULD_CREATE_PIPELINE', description: 'true re-create pipeline and multibranch jobs', defaultValue: false
+		}
+
+		agent {
+			label """${
+				env.OPERATING_SYSTEM = env.OPERATING_SYSTEM ?: "${jenkinsfileParams.operatingSystem[0]}"
+				env.ARCHITECTURE = env.ARCHITECTURE ?: 'arm64'
+				return helper.resolveAgentName(env.OPERATING_SYSTEM, env.ARCHITECTURE, jenkinsfileParams.instanceSize ?: 'small')
+			}"""
+		}
+
+		options {
+			ansiColor('css')
+			disableConcurrentBuilds(abortPrevious: true)
+			timestamps()
+		}
+
+		environment {
+			GITHUB_CREDENTIALS_ID = helper.resolveGitHubCredentialsId()
+			JENKINS_ROOT_FOLDER = Paths.get(currentBuild.fullProjectName).parent.parent.parent.toString()
+		}
+
+		stages {
+			stage('display environment') {
+				steps {
+					sh 'printenv'
+				}
+			}
+			stage('checkout') {
+				when {
+					expression { helper.isManualBuild(env.MANUAL_GIT_BRANCH) }
+				}
+				steps {
+					script {
+						sh "git checkout ${helper.resolveBranchName(env.MANUAL_GIT_BRANCH)}"
+						sh "git reset --hard origin/${helper.resolveBranchName(env.MANUAL_GIT_BRANCH)}"
+					}
+				}
+			}
+			stage('create pipeline jobs') {
+				when {
+					anyOf {
+						expression { changedSetHelper.isFileInChangedSet(helper.resolveBuildConfigurationFile()) }
+						expression { env.SHOULD_CREATE_PIPELINE?.toBoolean() }
+					}
+				}
+				stages {
+					stage('read build configuration') {
+						steps {
+							script {
+								buildConfiguration = yamlHelper.readYamlFromFile(helper.resolveBuildConfigurationFile())
+							}
+						}
+					}
+					stage('Multibranch job') {
+						when {
+							expression {
+								return null != buildConfiguration.builds
+							}
+						}
+						steps {
+							script {
+								createMonorepoMultibranchJobs(buildConfiguration, env.GIT_URL, env.JENKINS_ROOT_FOLDER, env.GITHUB_CREDENTIALS_ID)
+							}
+						}
+					}
+					stage('Pipeline job') {
+						when {
+							expression {
+								return null != buildConfiguration.customBuilds
+							}
+						}
+						steps {
+							script {
+								createMonorepoPipelineJobs(buildConfiguration, env.GIT_URL, env.JENKINS_ROOT_FOLDER, env.GITHUB_CREDENTIALS_ID)
+							}
+						}
+					}
+				}
+			}
+			stage('build jobs') {
+				steps {
+					script {
+						triggerJobs(helper.resolveBranchName(env.MANUAL_GIT_BRANCH), jenkinsfileParams)
+					}
+				}
+			}
+		}
+	}
+}
+
+void triggerJobs(String branchName, Map jenkinsfileParams) {
+	final Object buildConfiguration = jobHelper.loadBuildConfigurationfile()
+	final Map<String, String> allJenkinsfiles = jobHelper.loadJenkinsfileMap(buildConfiguration)
+	final Map<String, String> triggeredJenkinsfile = changedSetHelper.resolveJenkinsfilesJobToRun(allJenkinsfiles)
+	final Map<String, String> dependencyJenkinsfile = resolveDependencyJobMap(triggeredJenkinsfile, buildConfiguration)
+	final String currentJobName = Paths.get(currentBuild.fullProjectName).parent
+	final Map<String, String> jenkinsfilesJobToRun = triggeredJenkinsfile + dependencyJenkinsfile
+	Map<String, String> siblingNameMap = jobHelper.siblingJobNames(jenkinsfilesJobToRun, currentJobName)
+
+	if (siblingNameMap.size() == 0) {
+		return
+	}
+
+	Map<String, Closure> buildJobs = [:]
+	final String jobName = jobHelper.resolveJobName(siblingNameMap.keySet().toArray()[0], branchName)
+
+	siblingNameMap.each { String jobPath, String displayName ->
+		buildJobs["${displayName}"] = {
+			stage("${displayName}") {
+				final String fullJobName = jobPath + '/' + jobName
+				final String jenkinsfilePath = jenkinsfilesJobToRun.get(displayName)
+				final Map<String, String> jenkinsfileParameters = jobHelper.readJenkinsFileParameters(jenkinsfilePath)
+				final String osValue = jobHelper.resolveOperatingSystem(jenkinsfileParameters.operatingSystem)
+
+				// For new branches, Jenkins will receive an event from the version control system to provision the
+				// corresponding Pipeline under the Multibranch Pipeline item. We have to wait for Jenkins to process the
+				// event so a build can be triggered.
+				timeout(time: 5, unit: 'MINUTES') {
+					waitUntil(initialRecurrencePeriod: 1e3) {
+						Item pipeline = Jenkins.instance.getItemByFullName(fullJobName)
+						pipeline && !pipeline.isDisabled()
+					}
+				}
+
+				build job: "${fullJobName}", parameters: [
+					gitParameter(name: 'MANUAL_GIT_BRANCH', value: branchName),
+					string(name: 'OPERATING_SYSTEM', value: osValue ?: 'ubuntu'),
+					string(name: 'BUILD_CONFIGURATION', value: 'release-private'),
+					string(name: 'TEST_MODE', value: 'code-coverage'),
+					string(name: 'ARCHITECTURE', value: params.ARCHITECTURE),
+					booleanParam(name: 'SHOULD_PUBLISH_IMAGE', value: false),
+					booleanParam(name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS', value: false)],
+					wait: true,
+					propagate: true
+			}
+		}
+	}
+
+	parallel buildJobs
+}
+
+Map<String, String> resolveDependencyJobMap(Map<String, String> jenkinsfileMap, Object buildConfiguration) {
+	List<Object> dependencyBuilds =  jenkinsfileMap.collectMany { String displayName, String jenkinsfilePath ->
+		buildConfiguration.builds.findAll { build -> build.dependsOn.find { dependsOnPath -> dependsOnPath == jenkinsfilePath } }
+	}.unique()
+
+	println "triggered builds: ${jenkinsfileMap}"
+	println "dependency builds required: ${dependencyBuilds}"
+
+	Map<String, String> dependencyJobMap = [:]
+	dependencyBuilds.each { build -> dependencyJobMap.put(build.name, build.path) }
+	return dependencyJobMap
+}

--- a/jenkins/shared-library/vars/monorepoControllerPipeline.groovy
+++ b/jenkins/shared-library/vars/monorepoControllerPipeline.groovy
@@ -109,8 +109,8 @@ void call(Closure body) {
 void triggerJobs(String branchName) {
 	final Object buildConfiguration = jobHelper.loadBuildConfigurationfile()
 	final Map<String, String> allJenkinsfiles = jobHelper.loadJenkinsfileMap(buildConfiguration)
-	final Map<String, String> triggeredJenkinsfile = changedSetHelper.resolveJenkinsfilesJobToRun(allJenkinsfiles)
-	final Map<String, String> dependencyJenkinsfile = resolveDependencyJobMap(triggeredJenkinsfile, buildConfiguration)
+	final Map<String, String> triggeredJenkinsfile = changedSetHelper.findMultibranchPipelinesToRun(allJenkinsfiles)
+	final Map<String, String> dependencyJenkinsfile = findDependencyMultibranchPipelinesToRun(triggeredJenkinsfile, buildConfiguration)
 	final String currentJobName = Paths.get(currentBuild.fullProjectName).parent
 	final Map<String, String> jenkinsfilesJobToRun = triggeredJenkinsfile + dependencyJenkinsfile
 	Map<String, String> siblingNameMap = jobHelper.siblingJobNames(jenkinsfilesJobToRun, currentJobName)
@@ -157,7 +157,7 @@ void triggerJobs(String branchName) {
 	parallel buildJobs
 }
 
-Map<String, String> resolveDependencyJobMap(Map<String, String> jenkinsfileMap, Object buildConfiguration) {
+Map<String, String> findDependencyMultibranchPipelinesToRun(Map<String, String> jenkinsfileMap, Object buildConfiguration) {
 	List<Object> dependencyBuilds =  jenkinsfileMap.collectMany { String displayName, String jenkinsfilePath ->
 		buildConfiguration.builds.findAll { build -> build.dependsOn.find { dependsOnPath -> dependsOnPath == jenkinsfilePath } }
 	}.unique()

--- a/jenkins/shared-library/vars/nightlyBuildPipeline.groovy
+++ b/jenkins/shared-library/vars/nightlyBuildPipeline.groovy
@@ -95,7 +95,7 @@ void triggerAllJobs(
 		boolean shouldPublishFailJobStatusValue,
 		String manualGitBranchName) {
 	Map<String, String> displayNameJenkinsfileMap = jobHelper.loadJenkinsfileMap()
-	Map<String, String> siblingNameMap = jobHelper.siblingJobNames(displayNameJenkinsfileMap)
+	Map<String, String> siblingNameMap = jobHelper.siblingJobNames(displayNameJenkinsfileMap, currentBuild.fullProjectName)
 	Map<String, Closure> buildJobs = [:]
 	String jobName = jobHelper.resolveJobName(siblingNameMap.keySet().toArray()[0], branchName)
 

--- a/jenkins/shared-library/vars/weeklyBuildPipeline.groovy
+++ b/jenkins/shared-library/vars/weeklyBuildPipeline.groovy
@@ -121,7 +121,7 @@ void triggerAllJobs(
 	}
 
 	println "found weekly build projects - ${displayNameJenkinsfileMap}"
-	Map<String, String> siblingNameMap = jobHelper.siblingJobNames(displayNameJenkinsfileMap)
+	Map<String, String> siblingNameMap = jobHelper.siblingJobNames(displayNameJenkinsfileMap, currentBuild.fullProjectName)
 	Map<String, Closure> buildJobs = [:]
 	String jobName = jobHelper.resolveJobName(siblingNameMap.keySet().toArray()[0], branchName)
 	println "job name - ${jobName}"


### PR DESCRIPTION
## What is the current behavior?
All the CI jobs are triggered by GitHub calling into Jenkins.

## What's the issue?
For new branch/PR, Jenkins will do branch indexing where it does not have knowledge of the change list.
This will cause all the CI jobs to run.

## How have you changed the behavior?
A controller job has been added to manage which CI jobs to run.  The controller job will get the files in the commit and trigger the required CI jobs.
The controller job will get changed list in the following order
1. Check the ``currentBuild.changeSets`` Jenkins object for the files needs to build.
2. If pull request, get the file list from the PR
3. If all else fails, get the list of files from the last commit.

The file list is used to build a list of CI job that needs to be run.  The controller will trigger the jobs and wait for complete.
The controller job will now also create and update the builds when needed.
The seed job is only create the controller job.

## How was this change tested?
Will test in Jenkins.