### PR TITLE
[monorepo] fix: allow projects to send message to different discord channel

### DIFF
--- a/catbuffer/parser/Jenkinsfile
+++ b/catbuffer/parser/Jenkinsfile
@@ -10,4 +10,6 @@ defaultCiPipeline {
 
 	codeCoverageTool = 'coverage'
 	minimumCodeCoverage = 95
+
+	discordWebHookUrlId = 'SDK_DISCORD_WEB_HOOK_URL_ID'
 }

--- a/catbuffer/parser/Jenkinsfile
+++ b/catbuffer/parser/Jenkinsfile
@@ -11,5 +11,5 @@ defaultCiPipeline {
 	codeCoverageTool = 'coverage'
 	minimumCodeCoverage = 95
 
-	discordWebHookUrlId = 'SDK_DISCORD_WEB_HOOK_URL_ID'
+	discordWebHookUrlId = 'CATBUFFER_DISCORD_WEB_HOOK_URL_ID'
 }

--- a/client/catapult/Jenkinsfile
+++ b/client/catapult/Jenkinsfile
@@ -12,4 +12,6 @@ defaultCiPipeline {
 		--ip6 2001:db8:1::20'
 
 	packageId = 'client-catapult'
+
+	discordWebHookUrlId = 'CLIENT_DISCORD_WEB_HOOK_URL_ID'
 }

--- a/client/rest/Jenkinsfile
+++ b/client/rest/Jenkinsfile
@@ -11,4 +11,6 @@ defaultCiPipeline {
 
 	codeCoverageTool = 'nyc'
 	minimumCodeCoverage = 90
+
+	discordWebHookUrlId = 'CLIENT_DISCORD_WEB_HOOK_URL_ID'
 }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -5,4 +5,6 @@ defaultCiPipeline {
 	ciBuildDockerfile = 'linter.Dockerfile'
 
 	packageId = 'jenkins'
+
+	discordWebHookUrlId = 'INFRA_DISCORD_WEB_HOOK_URL_ID'
 }

--- a/jenkins/catapult/jenkins/catapult-client-build-base-image-all.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-base-image-all.groovy
@@ -198,6 +198,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
+						'CLIENT_DISCORD_WEB_HOOK_URL_ID',
 						':confetti_ball: Catapult Client All Image Job Successfully completed',
 						'Not much to see here, all is good',
 						env.BUILD_URL,
@@ -210,6 +211,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
+						'CLIENT_DISCORD_WEB_HOOK_URL_ID',
 						":confused: Catapult Client All Image Job Failed for ${currentBuild.fullDisplayName}",
 						"At least an image job failed for Build#${env.BUILD_NUMBER} with a result of ${currentBuild.currentResult}.",
 						env.BUILD_URL,

--- a/jenkins/catapult/jenkins/catapult-client-build-base-image.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-base-image.groovy
@@ -127,6 +127,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_FAIL_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
+						'CLIENT_DISCORD_WEB_HOOK_URL_ID',
 						"Catapult Client Base Image Job Failed for ${currentBuild.fullDisplayName}",
 						"Job with ${COMPILER_CONFIGURATION} on ${OPERATING_SYSTEM} has result of ${currentBuild.currentResult} in"
 						+ " stage **${env.FAILED_STAGE_NAME}** with message: **${env.FAILURE_MESSAGE}**.",

--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project-daily.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project-daily.groovy
@@ -129,6 +129,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
+						'CLIENT_DISCORD_WEB_HOOK_URL_ID',
 						':tada: Catapult Client Daily Job Successfully completed',
 						'All is good with the client',
 						env.BUILD_URL,
@@ -141,6 +142,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
+						'CLIENT_DISCORD_WEB_HOOK_URL_ID',
 						":scream_cat: Catapult Client Daily Job Failed for ${currentBuild.fullDisplayName}",
 						"At least one daily job failed for Build#${env.BUILD_NUMBER} with a result of ${currentBuild.currentResult}.",
 						env.BUILD_URL,

--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project-weekly.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project-weekly.groovy
@@ -108,6 +108,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
+						'CLIENT_DISCORD_WEB_HOOK_URL_ID',
 						':partying_face: Catapult Client Weekly Job Successfully completed',
 						'All is good with the client',
 						env.BUILD_URL,
@@ -120,6 +121,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
+						'CLIENT_DISCORD_WEB_HOOK_URL_ID',
 						":face_with_monocle: Catapult Client Weekly Job Failed for ${currentBuild.fullDisplayName}",
 						"At least one job failed for Build#${env.BUILD_NUMBER} with a result of ${currentBuild.currentResult}.",
 						env.BUILD_URL,

--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project.groovy
@@ -298,6 +298,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_FAIL_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
+						'CLIENT_DISCORD_WEB_HOOK_URL_ID',
 						"Catapult Client Job Failed for ${currentBuild.fullDisplayName}",
 						"Job configuration ${COMPILER_CONFIGURATION} with ${BUILD_CONFIGURATION} on ${OPERATING_SYSTEM} has result of"
 						+ " ${currentBuild.currentResult} in stage **${env.FAILED_STAGE_NAME}** with message: **${env.FAILURE_MESSAGE}**.",

--- a/jenkins/catapult/jenkins/catapult-client-build-compiler-image-all.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-compiler-image-all.groovy
@@ -119,6 +119,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
+						'CLIENT_DISCORD_WEB_HOOK_URL_ID',
 						':confetti_ball: Compiler Image All Job Successfully completed',
 						'Not much to see here, all is good',
 						env.BUILD_URL,
@@ -131,6 +132,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
+						'CLIENT_DISCORD_WEB_HOOK_URL_ID',
 						":worried: Compiler Image All Job Failed for ${currentBuild.fullDisplayName}",
 						"At least one job failed for Build#${env.BUILD_NUMBER} which has a result of ${currentBuild.currentResult}.",
 						env.BUILD_URL,

--- a/jenkins/catapult/jenkins/catapult-client-build-compiler-image.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-compiler-image.groovy
@@ -94,6 +94,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_FAIL_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
+						'CLIENT_DISCORD_WEB_HOOK_URL_ID',
 						"Compiler Image Job Failed for ${currentBuild.fullDisplayName}",
 						"Job with ${COMPILER_CONFIGURATION} on ${OPERATING_SYSTEM} has result of ${currentBuild.currentResult} in"
 						+ " stage **${env.FAILED_STAGE_NAME}** with message: **${env.FAILURE_MESSAGE}**.",

--- a/jenkins/catapult/jenkins/catapult-client-prepare-base-image.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-prepare-base-image.groovy
@@ -115,6 +115,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_FAIL_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
+						'CLIENT_DISCORD_WEB_HOOK_URL_ID',
 						"Catapult Client Prepare Base Image Job Failed for ${currentBuild.fullDisplayName}",
 						"Job creating **${env.IMAGE_TYPE}** image on ${env.OPERATING_SYSTEM} has result of ${currentBuild.currentResult}"
 						+ " in stage **${env.FAILED_STAGE_NAME}** with message: **${env.FAILURE_MESSAGE}**.",

--- a/jenkins/infra/jenkins/build-ci-image-all.groovy
+++ b/jenkins/infra/jenkins/build-ci-image-all.groovy
@@ -134,7 +134,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
-						'CLIENT_DISCORD_WEB_HOOK_URL_ID',
+						'INFRA_DISCORD_WEB_HOOK_URL_ID',
 						':confetti_ball: CI Image All Job Successfully completed',
 						'Not much to see here, all is good',
 						env.BUILD_URL,
@@ -147,7 +147,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
-						'CLIENT_DISCORD_WEB_HOOK_URL_ID',
+						'INFRA_DISCORD_WEB_HOOK_URL_ID',
 						":worried: CI Image All Job Failed for ${currentBuild.fullDisplayName}",
 						"At least one job failed for Build#${env.BUILD_NUMBER} which has a result of ${currentBuild.currentResult}.",
 						env.BUILD_URL,

--- a/jenkins/infra/jenkins/build-ci-image-all.groovy
+++ b/jenkins/infra/jenkins/build-ci-image-all.groovy
@@ -134,6 +134,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
+						'CLIENT_DISCORD_WEB_HOOK_URL_ID',
 						':confetti_ball: CI Image All Job Successfully completed',
 						'Not much to see here, all is good',
 						env.BUILD_URL,
@@ -146,6 +147,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
+						'CLIENT_DISCORD_WEB_HOOK_URL_ID',
 						":worried: CI Image All Job Failed for ${currentBuild.fullDisplayName}",
 						"At least one job failed for Build#${env.BUILD_NUMBER} which has a result of ${currentBuild.currentResult}.",
 						env.BUILD_URL,

--- a/jenkins/infra/jenkins/build-ci-image.groovy
+++ b/jenkins/infra/jenkins/build-ci-image.groovy
@@ -99,6 +99,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_FAIL_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
+						'CLIENT_DISCORD_WEB_HOOK_URL_ID',
 						"CI Image Job Failed for ${currentBuild.fullDisplayName}",
 						"Job for ${CI_IMAGE} has result of ${currentBuild.currentResult} in"
 						+ " stage **${env.FAILED_STAGE_NAME}** with message: **${env.FAILURE_MESSAGE}**.",

--- a/jenkins/infra/jenkins/build-ci-image.groovy
+++ b/jenkins/infra/jenkins/build-ci-image.groovy
@@ -99,7 +99,7 @@ pipeline {
 			script {
 				if (env.SHOULD_PUBLISH_FAIL_JOB_STATUS?.toBoolean()) {
 					helper.sendDiscordNotification(
-						'CLIENT_DISCORD_WEB_HOOK_URL_ID',
+						'INFRA_DISCORD_WEB_HOOK_URL_ID',
 						"CI Image Job Failed for ${currentBuild.fullDisplayName}",
 						"Job for ${CI_IMAGE} has result of ${currentBuild.currentResult} in"
 						+ " stage **${env.FAILED_STAGE_NAME}** with message: **${env.FAILURE_MESSAGE}**.",

--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -320,6 +320,7 @@ void call(Closure body) {
 				script {
 					if (null != env.SHOULD_PUBLISH_FAIL_JOB_STATUS && env.SHOULD_PUBLISH_FAIL_JOB_STATUS.toBoolean()) {
 						helper.sendDiscordNotification(
+							jenkinsfileParams.discordWebHookUrlId,
 							"Jenkins Job Failed for ${currentBuild.fullDisplayName}",
 							"Build#${env.BUILD_NUMBER} has result of ${currentBuild.currentResult} in stage **${env.FAILED_STAGE_NAME}** " +
 									"with message: **${env.FAILURE_MESSAGE}**.",

--- a/jenkins/shared-library/vars/helper.groovy
+++ b/jenkins/shared-library/vars/helper.groovy
@@ -48,8 +48,8 @@ String resolveAgentName(String os, String architecture, String size) {
 	return 'windows' == os ? "windows-${size}-${architecture}-agent" : "ubuntu-${size}-${architecture}-agent"
 }
 
-void sendDiscordNotification(String title, String description, String url, String result, String footer = '') {
-	withCredentials([string(credentialsId: 'DISCORD_WEB_HOOK_URL_ID', variable: 'WEB_HOOK_URL')]) {
+void sendDiscordNotification(String webHookUrlId, String title, String description, String url, String result, String footer = '') {
+	withCredentials([string(credentialsId: webHookUrlId ?: 'DISCORD_WEB_HOOK_URL_ID', variable: 'WEB_HOOK_URL')]) {
 		discordSend description: description, footer: footer, link: url, result: result, title: title, webhookURL: "${env.WEB_HOOK_URL}"
 	}
 }

--- a/jenkins/shared-library/vars/nightlyBuildPipeline.groovy
+++ b/jenkins/shared-library/vars/nightlyBuildPipeline.groovy
@@ -71,20 +71,6 @@ void call(Closure body) {
 				}
 			}
 		}
-		post {
-			unsuccessful {
-				script {
-					if (null != env.SHOULD_PUBLISH_FAIL_JOB_STATUS && env.SHOULD_PUBLISH_FAIL_JOB_STATUS.toBoolean()) {
-						helper.sendDiscordNotification(
-							"Jenkins Job Failed for ${currentBuild.fullDisplayName}",
-							"At least one job failed for Build#${env.BUILD_NUMBER} which has a result of ${currentBuild.currentResult}.",
-							env.BUILD_URL,
-							currentBuild.currentResult
-						)
-					}
-				}
-			}
-		}
 	}
 }
 

--- a/jenkins/shared-library/vars/weeklyBuildPipeline.groovy
+++ b/jenkins/shared-library/vars/weeklyBuildPipeline.groovy
@@ -89,20 +89,6 @@ void call(Closure body) {
 				}
 			}
 		}
-		post {
-			unsuccessful {
-				script {
-					if (null != env.SHOULD_PUBLISH_FAIL_JOB_STATUS && env.SHOULD_PUBLISH_FAIL_JOB_STATUS.toBoolean()) {
-						helper.sendDiscordNotification(
-							"Jenkins Job Failed for ${currentBuild.fullDisplayName}",
-							"At least one job failed for Build#${env.BUILD_NUMBER} which has a result of ${currentBuild.currentResult}.",
-							env.BUILD_URL,
-							currentBuild.currentResult
-						)
-					}
-				}
-			}
-		}
 	}
 }
 

--- a/linters/Jenkinsfile
+++ b/linters/Jenkinsfile
@@ -5,4 +5,6 @@ defaultCiPipeline {
 	ciBuildDockerfile = 'linter.Dockerfile'
 
 	packageId = 'linters'
+
+	discordWebHookUrlId = 'INFRA_DISCORD_WEB_HOOK_URL_ID'
 }

--- a/sdk/javascript/Jenkinsfile
+++ b/sdk/javascript/Jenkinsfile
@@ -11,4 +11,6 @@ defaultCiPipeline {
 
 	codeCoverageTool = 'c8'
 	minimumCodeCoverage = 90
+
+	discordWebHookUrlId = 'SDK_DISCORD_WEB_HOOK_URL_ID'
 }

--- a/sdk/python/Jenkinsfile
+++ b/sdk/python/Jenkinsfile
@@ -11,4 +11,6 @@ defaultCiPipeline {
 
 	codeCoverageTool = 'coverage'
 	minimumCodeCoverage = 90
+
+	discordWebHookUrlId = 'SDK_DISCORD_WEB_HOOK_URL_ID'
 }


### PR DESCRIPTION
## What is the current behavior?
All build messages are sent to one discord channel.

## What's the issue?
As the team grows, each team will only be concerned with test failures from their test suite.

## How have you changed the behavior?
Each project can specify the discord channel to where their test failures get logged.

## How was this change tested?
Will test in Jenkins before check-in
