### PR TITLE
[jenkins] fix: CI and Catapult images can be stale

### DIFF
--- a/jenkins/catapult/jenkins/catapult-client-build-base-image-all.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-base-image-all.groovy
@@ -9,7 +9,7 @@ pipeline {
 		label """${
 			env.ARCHITECTURE = env.ARCHITECTURE ?: 'arm64'
 			helper.resolveAgentName('ubuntu', "${env.ARCHITECTURE}", 'small')
-		}}"""
+		}"""
 	}
 
 	options {

--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project-daily.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project-daily.groovy
@@ -25,7 +25,7 @@ pipeline {
 			steps {
 				script {
 					// even days are amd64, odd days are arm64
-					ARCHITECTURE = helper.determineArchitecture()
+					env.ARCHITECTURE = helper.determineArchitecture()
 				}
 			}
 		}
@@ -33,8 +33,8 @@ pipeline {
 			steps {
 				echo """
 							env.GIT_BRANCH: ${env.GIT_BRANCH}
-						 MANUAL_GIT_BRANCH: ${MANUAL_GIT_BRANCH}
-							  ARCHITECTURE: ${ARCHITECTURE}
+						 MANUAL_GIT_BRANCH: ${env.MANUAL_GIT_BRANCH}
+							  ARCHITECTURE: ${env.ARCHITECTURE}
 				"""
 			}
 		}
@@ -44,14 +44,14 @@ pipeline {
 				stage('gcc latest (conan)') {
 					steps {
 						script {
-							dispatchUbuntuBuildJob('gcc-latest', 'tests-conan', "${ARCHITECTURE}")
+							dispatchUbuntuBuildJob('gcc-latest', 'tests-conan', "${env.ARCHITECTURE}")
 						}
 					}
 				}
 				stage('gcc latest (metal)') {
 					steps {
 						script {
-							dispatchUbuntuBuildJob('gcc-latest', 'tests-metal', "${ARCHITECTURE}")
+							dispatchUbuntuBuildJob('gcc-latest', 'tests-metal', "${env.ARCHITECTURE}")
 						}
 					}
 				}
@@ -59,14 +59,14 @@ pipeline {
 				stage('clang latest (conan)') {
 					steps {
 						script {
-							dispatchUbuntuBuildJob('clang-latest', 'tests-conan', "${ARCHITECTURE}")
+							dispatchUbuntuBuildJob('clang-latest', 'tests-conan', "${env.ARCHITECTURE}")
 						}
 					}
 				}
 				stage('clang latest (metal)') {
 					steps {
 						script {
-							dispatchUbuntuBuildJob('clang-latest', 'tests-metal', "${ARCHITECTURE}")
+							dispatchUbuntuBuildJob('clang-latest', 'tests-metal', "${env.ARCHITECTURE}")
 						}
 					}
 				}
@@ -74,7 +74,7 @@ pipeline {
 				stage('clang ausan') {
 					when {
 						expression {
-							helper.isAmd64Architecture(params.ARCHITECTURE)
+							helper.isAmd64Architecture(env.ARCHITECTURE)
 						}
 					}
 					steps {
@@ -86,7 +86,7 @@ pipeline {
 				stage('clang tsan') {
 					when {
 						expression {
-							helper.isAmd64Architecture(params.ARCHITECTURE)
+							helper.isAmd64Architecture(env.ARCHITECTURE)
 						}
 					}
 					steps {
@@ -98,21 +98,21 @@ pipeline {
 				stage('clang diagnostics') {
 					steps {
 						script {
-							dispatchUbuntuBuildJob('clang-latest', 'tests-diagnostics', "${ARCHITECTURE}")
+							dispatchUbuntuBuildJob('clang-latest', 'tests-diagnostics', "${env.ARCHITECTURE}")
 						}
 					}
 				}
 				stage('code coverage (gcc latest)') {
 					steps {
 						script {
-							dispatchUbuntuBuildJob('gcc-code-coverage', 'tests-metal', "${ARCHITECTURE}")
+							dispatchUbuntuBuildJob('gcc-code-coverage', 'tests-metal', "${env.ARCHITECTURE}")
 						}
 					}
 				}
 				stage('msvc latest (conan)') {
 					when {
 						expression {
-							helper.isAmd64Architecture(params.ARCHITECTURE)
+							helper.isAmd64Architecture(env.ARCHITECTURE)
 						}
 					}
 					steps {

--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project-weekly.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project-weekly.groovy
@@ -6,7 +6,10 @@ pipeline {
 	}
 
 	agent {
-		label "${helper.resolveAgentName('ubuntu', env.ARCHITECTURE ?: 'amd64', 'small')}"
+		label """${
+			env.ARCHITECTURE = env.ARCHITECTURE ?: 'amd64'
+			helper.resolveAgentName('ubuntu', env.ARCHITECTURE, 'small')
+		}}"""
 	}
 
 	options {
@@ -19,8 +22,8 @@ pipeline {
 			steps {
 				echo """
 							env.GIT_BRANCH: ${env.GIT_BRANCH}
-						 MANUAL_GIT_BRANCH: ${MANUAL_GIT_BRANCH}
-							  ARCHITECTURE: ${ARCHITECTURE}
+						 MANUAL_GIT_BRANCH: ${env.MANUAL_GIT_BRANCH}
+							  ARCHITECTURE: ${env.ARCHITECTURE}
 				"""
 			}
 		}
@@ -30,7 +33,7 @@ pipeline {
 				stage('gcc (metal) [debian]') {
 					steps {
 						script {
-							dispatchBuildJob('gcc-debian', 'tests-metal', 'debian', "${ARCHITECTURE}")
+							dispatchBuildJob('gcc-debian', 'tests-metal', 'debian', "${env.ARCHITECTURE}")
 						}
 					}
 				}
@@ -38,7 +41,7 @@ pipeline {
 				stage('gcc (westmere)') {
 					when {
 						expression {
-							helper.isAmd64Architecture(params.ARCHITECTURE)
+							helper.isAmd64Architecture(env.ARCHITECTURE)
 						}
 					}
 					steps {
@@ -51,7 +54,7 @@ pipeline {
 				stage('gcc (metal) [fedora]') {
 					steps {
 						script {
-							dispatchBuildJob('gcc-latest', 'tests-metal', 'fedora', "${ARCHITECTURE}")
+							dispatchBuildJob('gcc-latest', 'tests-metal', 'fedora', "${env.ARCHITECTURE}")
 						}
 					}
 				}
@@ -59,7 +62,7 @@ pipeline {
 				stage('clang prior (metal)') {
 					steps {
 						script {
-							dispatchBuildJob('clang-prior', 'tests-metal', 'ubuntu', "${ARCHITECTURE}")
+							dispatchBuildJob('clang-prior', 'tests-metal', 'ubuntu', "${env.ARCHITECTURE}")
 						}
 					}
 				}
@@ -67,7 +70,7 @@ pipeline {
 				stage('clang prior (conan)') {
 					steps {
 						script {
-							dispatchBuildJob('clang-prior', 'tests-conan', 'ubuntu', "${ARCHITECTURE}")
+							dispatchBuildJob('clang-prior', 'tests-conan', 'ubuntu', "${env.ARCHITECTURE}")
 						}
 					}
 				}
@@ -75,7 +78,7 @@ pipeline {
 				stage('gcc prior (metal)') {
 					steps {
 						script {
-							dispatchBuildJob('gcc-prior', 'tests-metal', 'ubuntu', "${ARCHITECTURE}")
+							dispatchBuildJob('gcc-prior', 'tests-metal', 'ubuntu', "${env.ARCHITECTURE}")
 						}
 					}
 				}
@@ -83,7 +86,7 @@ pipeline {
 				stage('gcc prior (conan)') {
 					steps {
 						script {
-							dispatchBuildJob('gcc-prior', 'tests-conan', 'ubuntu', "${ARCHITECTURE}")
+							dispatchBuildJob('gcc-prior', 'tests-conan', 'ubuntu', "${env.ARCHITECTURE}")
 						}
 					}
 				}
@@ -91,7 +94,7 @@ pipeline {
 				stage('msvc prior (metal)') {
 					when {
 						expression {
-							helper.isAmd64Architecture(params.ARCHITECTURE)
+							helper.isAmd64Architecture(env.ARCHITECTURE)
 						}
 					}
 					steps {

--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project-weekly.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project-weekly.groovy
@@ -9,7 +9,7 @@ pipeline {
 		label """${
 			env.ARCHITECTURE = env.ARCHITECTURE ?: 'amd64'
 			helper.resolveAgentName('ubuntu', env.ARCHITECTURE, 'small')
-		}}"""
+		}"""
 	}
 
 	options {

--- a/jenkins/catapult/jenkins/catapult-client-build-compiler-image-all.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-compiler-image-all.groovy
@@ -1,12 +1,15 @@
 pipeline {
 	parameters {
 		gitParameter branchFilter: 'origin/(.*)', defaultValue: 'dev', name: 'MANUAL_GIT_BRANCH', type: 'PT_BRANCH'
-		choice name: 'ARCHITECTURE', choices: ['amd64', 'arm64'], description: 'Computer architecture'
+		choice name: 'ARCHITECTURE', choices: ['arm64', 'amd64'], description: 'Computer architecture'
 		booleanParam name: 'SHOULD_PUBLISH_JOB_STATUS', description: 'true to publish job status', defaultValue: true
 	}
 
 	agent {
-		label "${helper.resolveAgentName('ubuntu', "${ARCHITECTURE}", 'small')}"
+		label """${
+			env.ARCHITECTURE = env.ARCHITECTURE ?: 'arm64'
+			helper.resolveAgentName('ubuntu', "${env.ARCHITECTURE}", 'small')
+		}}"""
 	}
 
 	options {
@@ -27,7 +30,7 @@ pipeline {
 			steps {
 				script {
 					// even days are amd64, odd days are arm64
-					ARCHITECTURE = helper.determineArchitecture()
+					env.ARCHITECTURE = helper.determineArchitecture()
 				}
 			}
 		}
@@ -35,8 +38,8 @@ pipeline {
 			steps {
 				echo """
 							env.GIT_BRANCH: ${env.GIT_BRANCH}
-						 MANUAL_GIT_BRANCH: ${MANUAL_GIT_BRANCH}
-							  ARCHITECTURE: ${ARCHITECTURE}
+						 MANUAL_GIT_BRANCH: ${env.MANUAL_GIT_BRANCH}
+							  ARCHITECTURE: ${env.ARCHITECTURE}
 				"""
 			}
 		}
@@ -46,28 +49,28 @@ pipeline {
 				stage('gcc prior') {
 					steps {
 						script {
-							dispatchBuildCompilerImageJob('gcc-prior', 'ubuntu', "${ARCHITECTURE}")
+							dispatchBuildCompilerImageJob('gcc-prior', 'ubuntu', "${env.ARCHITECTURE}")
 						}
 					}
 				}
 				stage('gcc latest') {
 					steps {
 						script {
-							dispatchBuildCompilerImageJob('gcc-latest', 'ubuntu', "${ARCHITECTURE}")
+							dispatchBuildCompilerImageJob('gcc-latest', 'ubuntu', "${env.ARCHITECTURE}")
 						}
 					}
 				}
 				stage('gcc [debian]') {
 					steps {
 						script {
-							dispatchBuildCompilerImageJob('gcc-debian', 'debian', "${ARCHITECTURE}")
+							dispatchBuildCompilerImageJob('gcc-debian', 'debian', "${env.ARCHITECTURE}")
 						}
 					}
 				}
 				stage('gcc [fedora]') {
 					steps {
 						script {
-							dispatchBuildCompilerImageJob('gcc-latest', 'fedora', "${ARCHITECTURE}")
+							dispatchBuildCompilerImageJob('gcc-latest', 'fedora', "${env.ARCHITECTURE}")
 						}
 					}
 				}
@@ -75,14 +78,14 @@ pipeline {
 				stage('clang prior') {
 					steps {
 						script {
-							dispatchBuildCompilerImageJob('clang-prior', 'ubuntu', "${ARCHITECTURE}")
+							dispatchBuildCompilerImageJob('clang-prior', 'ubuntu', "${env.ARCHITECTURE}")
 						}
 					}
 				}
 				stage('clang latest') {
 					steps {
 						script {
-							dispatchBuildCompilerImageJob('clang-latest', 'ubuntu', "${ARCHITECTURE}")
+							dispatchBuildCompilerImageJob('clang-latest', 'ubuntu', "${env.ARCHITECTURE}")
 						}
 					}
 				}
@@ -90,7 +93,7 @@ pipeline {
 				stage('msvc latest') {
 					when {
 						expression {
-							helper.isAmd64Architecture(params.ARCHITECTURE)
+							helper.isAmd64Architecture(env.ARCHITECTURE)
 						}
 					}
 					steps {
@@ -102,7 +105,7 @@ pipeline {
 				stage('msvc prior') {
 					when {
 						expression {
-							helper.isAmd64Architecture(params.ARCHITECTURE)
+							helper.isAmd64Architecture(env.ARCHITECTURE)
 						}
 					}
 					steps {

--- a/jenkins/catapult/jenkins/catapult-client-build-compiler-image-all.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-compiler-image-all.groovy
@@ -9,7 +9,7 @@ pipeline {
 		label """${
 			env.ARCHITECTURE = env.ARCHITECTURE ?: 'arm64'
 			helper.resolveAgentName('ubuntu', "${env.ARCHITECTURE}", 'small')
-		}}"""
+		}"""
 	}
 
 	options {

--- a/jenkins/infra/jenkins/build-ci-image-all.groovy
+++ b/jenkins/infra/jenkins/build-ci-image-all.groovy
@@ -1,12 +1,15 @@
 pipeline {
 	parameters {
 		gitParameter branchFilter: 'origin/(.*)', defaultValue: 'dev', name: 'MANUAL_GIT_BRANCH', type: 'PT_BRANCH'
-		choice name: 'ARCHITECTURE', choices: ['amd64', 'arm64'], description: 'Computer architecture'
+		choice name: 'ARCHITECTURE', choices: ['arm64', 'amd64'], description: 'Computer architecture'
 		booleanParam name: 'SHOULD_PUBLISH_JOB_STATUS', description: 'true to publish job status', defaultValue: true
 	}
 
 	agent {
-		label "${helper.resolveAgentName('ubuntu', "${ARCHITECTURE}", 'small')}"
+		label """${
+			env.ARCHITECTURE = env.ARCHITECTURE ?: 'arm64'
+			helper.resolveAgentName('ubuntu', "${env.ARCHITECTURE}", 'small')
+		}}"""
 	}
 
 	options {
@@ -27,7 +30,7 @@ pipeline {
 			steps {
 				script {
 					// even days are amd64, odd days are arm64
-					ARCHITECTURE = helper.determineArchitecture()
+					env.ARCHITECTURE = helper.determineArchitecture()
 				}
 			}
 		}
@@ -35,8 +38,8 @@ pipeline {
 			steps {
 				echo """
 							env.GIT_BRANCH: ${env.GIT_BRANCH}
-						 MANUAL_GIT_BRANCH: ${MANUAL_GIT_BRANCH}
-							  ARCHITECTURE: ${ARCHITECTURE}
+						 MANUAL_GIT_BRANCH: ${env.MANUAL_GIT_BRANCH}
+							  ARCHITECTURE: ${env.ARCHITECTURE}
 				"""
 			}
 		}
@@ -68,7 +71,7 @@ pipeline {
 				stage('javascript - windows') {
 					when {
 						expression {
-							helper.isAmd64Architecture(params.ARCHITECTURE)
+							helper.isAmd64Architecture(env.ARCHITECTURE)
 						}
 					}
 					steps {
@@ -117,7 +120,7 @@ pipeline {
 				stage('python - windows') {
 					when {
 						expression {
-							helper.isAmd64Architecture(params.ARCHITECTURE)
+							helper.isAmd64Architecture(env.ARCHITECTURE)
 						}
 					}
 					steps {
@@ -162,7 +165,7 @@ void dispatchBuildCiImageJob(String ciImage, String baseImage = 'lts', String op
 		string(name: 'OPERATING_SYSTEM', value: operatingSystem),
 		string(name: 'CI_IMAGE', value: ciImage),
 		string(name: 'MANUAL_GIT_BRANCH', value: params.MANUAL_GIT_BRANCH),
-		string(name: 'ARCHITECTURE', value: params.ARCHITECTURE),
+		string(name: 'ARCHITECTURE', value: env.ARCHITECTURE),
 		string(name: 'BASE_IMAGE', value: baseImage),
 		booleanParam(
 			name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS',

--- a/jenkins/infra/jenkins/build-ci-image-all.groovy
+++ b/jenkins/infra/jenkins/build-ci-image-all.groovy
@@ -9,7 +9,7 @@ pipeline {
 		label """${
 			env.ARCHITECTURE = env.ARCHITECTURE ?: 'arm64'
 			helper.resolveAgentName('ubuntu', "${env.ARCHITECTURE}", 'small')
-		}}"""
+		}"""
 	}
 
 	options {

--- a/jenkins/infra/jenkins/build-ci-image.groovy
+++ b/jenkins/infra/jenkins/build-ci-image.groovy
@@ -8,7 +8,7 @@ pipeline {
 			choices: ['cpp', 'java', 'javascript', 'linter', 'postgres', 'python'],
 			description: 'continuous integration image'
 		choice name: 'ARCHITECTURE',
-			choices: ['amd64', 'arm64'],
+			choices: ['arm64', 'amd64'],
 			description: 'Computer architecture'
 		choice name: 'BASE_IMAGE',
 			choices: ['lts', 'base', 'latest'],
@@ -17,7 +17,10 @@ pipeline {
 	}
 
 	agent {
-		label "${helper.resolveAgentName(params.OPERATING_SYSTEM, params.ARCHITECTURE, 'medium')}"
+		label """${
+			env.ARCHITECTURE = env.ARCHITECTURE ?: 'arm64'
+			helper.resolveAgentName(params.OPERATING_SYSTEM, env.ARCHITECTURE, 'medium')
+		}}"""
 	}
 
 	environment {
@@ -42,7 +45,7 @@ pipeline {
 								dockerFromImage = buildEnvironment[baseImageName]
 
 								multiArchImageName = "symbolplatform/build-ci:${CI_IMAGE}-${baseImageName}"
-								archImageName = "${multiArchImageName}-${ARCHITECTURE}"
+								archImageName = "${multiArchImageName}-${env.ARCHITECTURE}"
 							}
 						}
 					}
@@ -51,9 +54,9 @@ pipeline {
 					steps {
 						echo """
 									env.GIT_BRANCH: ${env.GIT_BRANCH}
-								 MANUAL_GIT_BRANCH: ${MANUAL_GIT_BRANCH}
-								  OPERATING_SYSTEM: ${OPERATING_SYSTEM}
-									  ARCHITECTURE: ${ARCHITECTURE}
+								 MANUAL_GIT_BRANCH: ${env.MANUAL_GIT_BRANCH}
+								  OPERATING_SYSTEM: ${env.OPERATING_SYSTEM}
+									  ARCHITECTURE: ${env.ARCHITECTURE}
 
 								     destImageName: ${multiArchImageName}
 						"""

--- a/jenkins/infra/jenkins/build-ci-image.groovy
+++ b/jenkins/infra/jenkins/build-ci-image.groovy
@@ -20,7 +20,7 @@ pipeline {
 		label """${
 			env.ARCHITECTURE = env.ARCHITECTURE ?: 'arm64'
 			helper.resolveAgentName(params.OPERATING_SYSTEM, env.ARCHITECTURE, 'medium')
-		}}"""
+		}"""
 	}
 
 	environment {


### PR DESCRIPTION
## What's the issue?
Alternating builds between arm64 and amd64 are not working correctly due to the ``ARCHITECTURE = helper.determineArchitecture()`` which sets a local variable instead of the env value.
This would cause one of the architecture images not to build and become stale.

## How have you changed the behavior?
Set the ``env.ARCHITECTURE`` when calling the helper.determineArchitecture().

## How was this change tested?
Will test in Jenkins