### PR TITLE
[jenkins] fix: downgrade npm-groovy-lint to 11.x

### DIFF
--- a/jenkins/docker/ubuntu/linter.Dockerfile
+++ b/jenkins/docker/ubuntu/linter.Dockerfile
@@ -6,10 +6,14 @@ RUN apt-get update >/dev/null \
 	&& apt-get install -y git curl
 
 # install npm-groovy-lint
-RUN apt-get install -y default-jre \
-	&& curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
+RUN apt-get install -y default-jre ca-certificates curl gnupg \
+	&& mkdir -p /etc/apt/keyrings \
+	&& curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
+	&& echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" \
+	| tee /etc/apt/sources.list.d/nodesource.list \
+	&& apt-get update \
 	&& apt-get install -y nodejs \
-	&& npm install -g npm-groovy-lint
+	&& npm install -g npm-groovy-lint@11.1.1
 
 # install python
 RUN apt-get install -y python3-pip


### PR DESCRIPTION
## What's the issue?
The latest CI image now has npm-groovy-lint 12.  This requires Java 17.  I created new images with Java 17 which works on AMD but fails on ARM with ``Unsupported architecture``.
Already couple of issues on this - https://github.com/nvuillam/npm-groovy-lint/issues/296#issuecomment-1802168710

## How have you changed the behavior?
Downgrade ``npm-groovy-lint`` to 11.x until the issues are resolved.

## How was this change tested?
Tested locally on my Mac.