### PR TITLE
[jenkins] fix: ignore codecov upload failures for private repo

### DIFF
--- a/jenkins/shared-library/vars/codeCoverage.groovy
+++ b/jenkins/shared-library/vars/codeCoverage.groovy
@@ -4,10 +4,18 @@ void call(Object config) {
 }
 
 void uploadCodeCoverage(String flag) {
-	String repoName = env.GIT_URL.tokenize('/').last().split('\\.')[0].toUpperCase()
-	withCredentials([string(credentialsId: "${repoName}_CODECOV_ID", variable: 'CODECOV_TOKEN')]) {
+	final String repositoryName = helper.resolveRepositoryName()
+	withCredentials([string(credentialsId: "${repositoryName.toUpperCase()}_CODECOV_ID", variable: 'CODECOV_TOKEN')]) {
+		final String ownerName = helper.resolveOrganizationName()
+		final Boolean isPublicRepo = helper.isGitHubRepositoryPublic(ownerName, repositoryName)
+		String codeCoverageCommand = "codecov --verbose --flags ${flag} --dir ."
+
+		if (isPublicRepo) {
+			codeCoverageCommand += ' --nonZero'
+		}
+
 		logger.logInfo("Uploading code coverage for ${flag}")
-		runScript("codecov --verbose --nonZero --rootDir ${env.WORKSPACE} --flags ${flag} --dir .")
+		runScript(codeCoverageCommand)
 	}
 }
 

--- a/jenkins/shared-library/vars/helper.groovy
+++ b/jenkins/shared-library/vars/helper.groovy
@@ -110,3 +110,15 @@ boolean tryRunCommand(Closure command) {
 String resolveWorkspacePath(String os) {
 	return 'windows' == os ? 'C:\\Users\\Administrator\\jenkins\\workspace\\' : '/home/ubuntu/jenkins/workspace/'
 }
+
+boolean isGitHubRepositoryPublic(String orgName, String repoName) {
+	try {
+		final URL url = "https://api.github.com/repos/${orgName}/${repoName}".toURL()
+		final Object repo = yamlHelper.readYamlFromText(url.text)
+
+		return repo.name == repoName && repo.visibility == 'public'
+	} catch (FileNotFoundException exception) {
+		println "Repository ${orgName}/${repoName} not found - ${exception}"
+		return false
+	}
+}

--- a/jenkins/shared-library/vars/publish.groovy
+++ b/jenkins/shared-library/vars/publish.groovy
@@ -30,7 +30,7 @@ void dockerPublisher(Map config, String phase) {
 	final String repositoryName = helper.resolveRepositoryName()
 	String dockerHost = 'registry.hub.docker.com'
 	String dockerCredentialsId = DOCKER_CREDENTIALS_ID
-	if (isAlphaRelease(phase) || !isGitHubRepositoryPublic(ownerName, repositoryName)) {
+	if (isAlphaRelease(phase) || !helper.isGitHubRepositoryPublic(ownerName, repositoryName)) {
 		dockerCredentialsId = "${ownerName.toUpperCase()}_ARTIFACTORY_LOGIN_ID"
 		dockerHost = helper.resolveUrlHostName(configureArtifactRepository.resolveRepositoryUrl(ownerName, 'docker-hosted'))
 	}
@@ -66,7 +66,7 @@ void npmPublisher(Map config, String phase) {
 
 	final String ownerName = helper.resolveOrganizationName()
 	final String repositoryName = helper.resolveRepositoryName()
-	if (isAlphaRelease(phase) || !isGitHubRepositoryPublic(ownerName, repositoryName)) {
+	if (isAlphaRelease(phase) || !helper.isGitHubRepositoryPublic(ownerName, repositoryName)) {
 		final String publishUrl = configureArtifactRepository.resolveRepositoryUrl(ownerName, 'npm-hosted')
 		final String environment = jobHelper.resolveCiEnvironmentName(config)
 
@@ -96,7 +96,7 @@ void pythonPublisher(Map config, String phase) {
 
 	final String ownerName = helper.resolveOrganizationName()
 	final String repositoryName = helper.resolveRepositoryName()
-	if (isAlphaRelease(phase) || !isGitHubRepositoryPublic(ownerName, repositoryName)) {
+	if (isAlphaRelease(phase) || !helper.isGitHubRepositoryPublic(ownerName, repositoryName)) {
 		withCredentials([usernamePassword(credentialsId: "${ownerName.toUpperCase()}_ARTIFACTORY_LOGIN_ID",
 			usernameVariable: 'USERNAME',
 			passwordVariable: 'PASSWORD')]) {
@@ -192,17 +192,5 @@ void publishArtifact(Closure defaultPublisher) {
 		runScript("${publishScriptFilePath} ${architecture}")
 	} else {
 		defaultPublisher.call()
-	}
-}
-
-boolean isGitHubRepositoryPublic(String orgName, String repoName) {
-	try {
-		final URL url = "https://api.github.com/repos/${orgName}/${repoName}".toURL()
-		final Object repo = yamlHelper.readYamlFromText(url.text)
-
-		return repo.name == repoName && repo.visibility == 'public'
-	} catch (FileNotFoundException exception) {
-		println "Repository ${orgName}/${repoName} not found - ${exception}"
-		return false
 	}
 }


### PR DESCRIPTION
## What is the current behavior?
Jenkins job for private repo will fail on Codecov uploads which we cannot fix.

## What's the issue?
Codecov has a 250 upload limit for private repo after which uploads will fail.
Codecov also throttles uploads when they are too frequent.

## How have you changed the behavior?
For private repo, do not pass the ``--nonZero`` flag to Codecov which forces a returned code on failure.

## How was this change tested?
Tested in Jenkins.