### PR TITLE
[jenkins] fix: linter dockerfile missing node version

### DIFF
--- a/jenkins/docker/ubuntu/linter.Dockerfile
+++ b/jenkins/docker/ubuntu/linter.Dockerfile
@@ -6,6 +6,8 @@ RUN apt-get update >/dev/null \
 	&& apt-get install -y git curl
 
 # install npm-groovy-lint
+ENV NODE_OPTIONS="--dns-result-order=ipv4first"
+ARG NODE_MAJOR=18
 RUN apt-get install -y default-jre ca-certificates curl gnupg \
 	&& mkdir -p /etc/apt/keyrings \
 	&& curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \


### PR DESCRIPTION
## What's the issue?
Linter Dockerfile is missing the NodeJs version required to build.

## How have you changed the behavior?
Set the NodeJs version to 18

## How was this change tested?
Tested in Jenkins.
