### PR TITLE
[sdk] fix: Update the Javascript and Python SDKs to run on Windows.

### DIFF
--- a/jenkins/docker/windows/javascript.Dockerfile
+++ b/jenkins/docker/windows/javascript.Dockerfile
@@ -12,7 +12,9 @@ RUN Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser; `
 	$command='c:\scoop.ps1 -RunAsAdmin'; `
 	iex $command; `
 	del c:\scoop.ps1; `
-	scoop install python git shellcheck nodejs-lts cygwin rustup; `
+	scoop install git shellcheck openssl cmake cygwin; `
+	scoop bucket add versions; `
+	scoop install versions/python311; `
 	python3 -m pip install --upgrade pip; `
 	python3 -m pip install --upgrade gitlint wheel
 

--- a/jenkins/docker/windows/javascript.Dockerfile
+++ b/jenkins/docker/windows/javascript.Dockerfile
@@ -12,11 +12,14 @@ RUN Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser; `
 	$command='c:\scoop.ps1 -RunAsAdmin'; `
 	iex $command; `
 	del c:\scoop.ps1; `
-	scoop install git shellcheck openssl cmake cygwin; `
+	scoop install git shellcheck nodejs-lts cygwin rustup; `
 	scoop bucket add versions; `
 	scoop install versions/python311; `
 	python3 -m pip install --upgrade pip; `
 	python3 -m pip install --upgrade gitlint wheel
+
+# Set VS tools first in the path so the correct link.exe is used.
+RUN Set-Content -Path c:\Users\ContainerAdministrator\.bash_profile  -Value 'export PATH=${VCToolsInstallDir}bin/Hostx64/x64:${PATH}'
 
 # Install codecov
 RUN Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile c:\Windows\System32\codecov.exe

--- a/jenkins/docker/windows/python.Dockerfile
+++ b/jenkins/docker/windows/python.Dockerfile
@@ -22,6 +22,9 @@ RUN Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser; `
 	python3 -m pip install --upgrade pip; `
 	python3 -m pip install --upgrade gitlint wheel
 
+# Set VS tools first in the path so the correct link.exe is used.
+RUN Set-Content -Path c:\Users\ContainerAdministrator\.bash_profile  -Value 'export PATH=${VCToolsInstallDir}bin/Hostx64/x64:${PATH}'
+
 # Install codecov
 RUN Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile c:\Windows\System32\codecov.exe
 

--- a/jenkins/docker/windows/python.Dockerfile
+++ b/jenkins/docker/windows/python.Dockerfile
@@ -16,7 +16,9 @@ RUN Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser; `
 	$command='c:\scoop.ps1 -RunAsAdmin'; `
 	iex $command; `
 	del c:\scoop.ps1; `
-	scoop install python git shellcheck openssl cmake cygwin; `
+	scoop install git shellcheck openssl cmake cygwin; `
+	scoop bucket add versions; `
+	scoop install versions/python311; `
 	python3 -m pip install --upgrade pip; `
 	python3 -m pip install --upgrade gitlint wheel
 

--- a/jenkins/shared-library/vars/runScript.groovy
+++ b/jenkins/shared-library/vars/runScript.groovy
@@ -24,5 +24,11 @@ void call(String scriptFilepath, String label='', Boolean returnStdout, Boolean 
 }
 
 void withBash(String scriptFilepath) {
-	call("bash -c '${scriptFilepath}'", scriptFilepath, false)
+	if (isUnix()) {
+		call("bash -c '${scriptFilepath}'", scriptFilepath, false)
+	} else {
+		// Force the login scripts to run on Windows so that the PATH is set correctly
+		// from the user's profile.
+		call("bash --login -c '${scriptFilepath}'", scriptFilepath, false)
+	}
 }

--- a/sdk/javascript/examples/transaction_sign.js
+++ b/sdk/javascript/examples/transaction_sign.js
@@ -7,7 +7,7 @@
 import symbolSdk from '../src/index.js';
 import yargs from 'yargs';
 import path from 'path';
-import { fileURLToPath } from 'url';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 (() => {
 	class TransactionSample {
@@ -58,7 +58,7 @@ import { fileURLToPath } from 'url';
 			testsPending += 1;
 
 			const filepath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'descriptors', `${factoryName}.js`);
-			import(filepath).then(module => {
+			import(pathToFileURL(filepath)).then(module => {
 				const transactionDescriptors = module.default();
 				sample.processTransactionDescriptors(transactionDescriptors);
 				totalDescriptorsCount += transactionDescriptors.length;

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "mocha --full-trace --recursive ./test",
-    "vectors": "node ./vectors/all.js --vectors $(git rev-parse --show-toplevel)/tests/vectors/${BLOCKCHAIN}/crypto --blockchain ${BLOCKCHAIN}",
+    "vectors": "bash -c 'node ./vectors/all.js --vectors $(git rev-parse --show-toplevel)/tests/vectors/${BLOCKCHAIN}/crypto --blockchain ${BLOCKCHAIN}'",
     "catvectors": "mocha --full-trace ./vectors/catbuffer.js",
     "lint:jenkins": "eslint -o lint.sdk.javascript.xml -f junit . || exit 0",
     "test:jenkins": "c8 --require mocha --no-clean  --reporter=lcov npm run test",

--- a/sdk/javascript/scripts/run_catbuffer_generator.sh
+++ b/sdk/javascript/scripts/run_catbuffer_generator.sh
@@ -30,7 +30,7 @@ elif [[ "$1" = "dryrun" ]]; then
 	for name in "nem" "symbol";
 	do
 		generate_code "${name}" "${name}2"
-		diff "./src/${name}/models.js" "./src/${name}2/models.js"
+		diff --strip-trailing-cr "./src/${name}/models.js" "./src/${name}2/models.js"
 		rm -rf "./src/${name}2/models.js"
 	done
 else

--- a/sdk/python/scripts/run_catbuffer_generator.sh
+++ b/sdk/python/scripts/run_catbuffer_generator.sh
@@ -28,7 +28,7 @@ elif [[ "$1" = "dryrun" ]]; then
 
 	for name in "nc" "sc";
 	do
-		diff "./symbolchain/${name}/__init__.py" "./symbolchain/${name}2/__init__.py"
+		diff --strip-trailing-cr "./symbolchain/${name}/__init__.py" "./symbolchain/${name}2/__init__.py"
 		rm -rf "./symbolchain/${name}2"
 	done
 else

--- a/sdk/python/scripts/run_examples_docs_generator.sh
+++ b/sdk/python/scripts/run_examples_docs_generator.sh
@@ -11,7 +11,7 @@ function generate_examples_docs() {
 	jinja2 "${docs_folder}/__main__.py.tmpl" > "${docs_folder}/$1"
 
 	if [[ $2 -ne 0 ]]; then
-		diff "${docs_folder}/__main__.py" "${docs_folder}/$1"
+		diff --strip-trailing-cr "${docs_folder}/__main__.py" "${docs_folder}/$1"
 		rm "${docs_folder}/$1"
 	fi
 }

--- a/sdk/python/scripts/run_testvectors_generator.sh
+++ b/sdk/python/scripts/run_testvectors_generator.sh
@@ -18,7 +18,7 @@ elif [[ "$1" = "dryrun" ]]; then
 
 	for name in "nem" "symbol";
 	do
-		diff \
+		diff --strip-trailing-cr \
 			"$(git rev-parse --show-toplevel)/tests/vectors/${name}/models/transactions.json" \
 			"$(git rev-parse --show-toplevel)/tests/vectors2/${name}/models/transactions.json"
 	done


### PR DESCRIPTION
## What's the issue?
1. Windows by default installs Python 3.12 which is not supported by aiohttp
    ``https://github.com/aio-libs/aiohttp/issues/7646``
2. build scripts fail to diff current JSON files with the generated file on Windows due to extra ``cr``.
3. Javascript SDK is failing to build on Windows due to
         a. build using the linker from the git package instead of VS
         b. run of the vector scripts failed since Windows shell does not know BLOCKCHAIN env.  Windows shell requires %BLOCKCHAIN% vs ${BLOCKCHAIN}
         c. import file does match URL format(https://nodejs.org/api/esm.html#file-urls)
     
## How have you changed the behavior?
1. Windows install Python 3.11 which is supported by aiohttp
2. Ignore ``cr`` on the diff of JSON files.
3. Javascript SDK updates
         a. Put the VS tool first in the PATH in the user profile.
         b. run the vector scripts with bash so that the environment variable(BLOCKCHAIN) will get processed.
         c. convert the import file pathToFileURL to URL format

## How was this change tested?
Tested in Jenkins.
