### PR TITLE
[jenkins] fix: git verify commit message fails on Windows

### DIFF
--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -77,7 +77,10 @@ void call(Closure body) {
 		stages {
 			stage('setup environment') {
 				steps {
-					runScript('git submodule update --remote')
+					script {
+						runScript('git submodule update --remote')
+						author = sh(script: 'git log -1 --pretty=format:\'%an\'', returnStdout: true).trim()
+					}
 				}
 			}
 			stage('CI pipeline') {
@@ -126,8 +129,8 @@ void call(Closure body) {
 							script {
 								runStepRelativeToPackageRoot '.', {
 									final String[] exemptAuthor = ['github-actions[bot]', 'dependabot[bot]']
-									String author = runScript('git log -1 --pretty=format:\'%an\'', true)
 
+									println("Last commit author: ${author}")
 									if (exemptAuthor.contains(author)) {
 										println("Disabling max body line length rule for ${author}")
 										env.GITLINT_IGNORE = 'body-max-line-length'


### PR DESCRIPTION
## What is the current behavior?
The last git commit author is returned by executing ``git log`` in the cmd shell.

## What's the issue?
Jenkins will return the command line plus the output of the command when ``bat`` is called.
This causes the check for the author names to fail for dependabot and thus max line length is not disabled for gitlint.

## How have you changed the behavior?
Use ```sh`` to get the git author name which returns the correct value.

## How was this change tested?
Tested in Jenkins.
