### PR TITLE
[client/catapult] fix: update catapult conan artifact endpoint

### DIFF
--- a/client/catapult/docs/BUILD-conan.md
+++ b/client/catapult/docs/BUILD-conan.md
@@ -73,7 +73,7 @@ While Conan will be building and installing packages, you might want to go for a
 as this will probably take *a bit*.
 
 ```sh
-conan remote add nemtech https://catapult.jfrog.io/artifactory/api/conan/symbol-conan
+conan remote add nemtech https://conan.symbol.dev/artifactory/api/conan/catapult
 
 git clone https://github.com/symbol/symbol.git
 cd symbol/client/catapult


### PR DESCRIPTION
## What's the issue?
catapult docs has the old endpoint used when building with Conan

## How have you changed the behavior?
update the catapult docs with the latest endpoint

issue: https://github.com/symbol/symbol/issues/790