### PR TITLE
[add]search blocks by timestamp

### DIFF
--- a/client/rest/src/db/CatapultDb.js
+++ b/client/rest/src/db/CatapultDb.js
@@ -208,7 +208,7 @@ class CatapultDb {
 	 * `pageSize` and `pageNumber`. 'sortField' must be within allowed 'sortingOptions'.
 	 * @returns {Promise.<object>} Blocks page.
 	 */
-	blocks(signerPublicKey, beneficiaryAddress, options) {
+	blocks(signerPublicKey, beneficiaryAddress, fromTimestamp, toTimestamp, options) {
 		const sortingOptions = {
 			id: '_id',
 			height: 'block.height'
@@ -226,6 +226,15 @@ class CatapultDb {
 		if (undefined !== beneficiaryAddress)
 			conditions['block.beneficiaryAddress'] = Buffer.from(beneficiaryAddress);
 
+		if (undefined !== fromTimestamp || undefined !== toTimestamp) {
+			conditions['block.timestamp'] = {};
+			if (undefined !== fromTimestamp)
+				conditions['block.timestamp'].$gte = convertToLong(fromTimestamp);
+				
+			if (undefined !== toTimestamp)
+					conditions['block.timestamp'].$lte = convertToLong(toTimestamp);
+		}
+		
 		const removeFields = ['meta.transactionMerkleTree', 'meta.statementMerkleTree'];
 
 		const sortConditions = { [sortingOptions[options.sortField]]: options.sortDirection };

--- a/client/rest/src/routes/blockRoutes.js
+++ b/client/rest/src/routes/blockRoutes.js
@@ -36,13 +36,16 @@ module.exports = {
 				? routeUtils.parseArgument(params, 'beneficiaryAddress', 'address')
 				: undefined;
 
+			const fromTimestamp = params.fromTimestamp ? routeUtils.parseArgument(params, 'fromTimestamp', 'uint64') : undefined;
+			const toTimestamp = params.toTimestamp ? routeUtils.parseArgument(params, 'toTimestamp', 'uint64') : undefined;
+			
 			const offsetParsers = {
 				id: 'objectId',
 				height: 'uint64'
 			};
 			const options = routeUtils.parsePaginationArguments(params, services.config.pageSize, offsetParsers);
 
-			return db.blocks(signerPublicKey, beneficiaryAddress, options)
+			return db.blocks(signerPublicKey, beneficiaryAddress, fromTimestamp, toTimestamp, options)
 				.then(result => routeUtils.createSender(routeResultTypes.block).sendPage(res, next)(result));
 		});
 


### PR DESCRIPTION
## What's the issue?
We have cases where we want to get information on transactions, etc. by specifying a time.

## How have you changed the behavior?
Information on blocks can be obtained by specifying a range of timestamps.
It is also possible to specify a range of transactions based on the block information.