### PR TITLE
[jenkins] feat: catapult dependency updater

### DIFF
--- a/.github/buildConfiguration.yaml
+++ b/.github/buildConfiguration.yaml
@@ -103,6 +103,13 @@ customBuilds:
     scriptPath: jenkins/catapult/jenkins/catapult-client-release-build.groovy
     targetDirectory: symbol-mono
 
+  - name: Catapult Dependency Updater
+    jobName: /symbol/catapult-client/catapult-dependency-updater
+    scriptPath: .github/jenkinsfile/catapultDependency.groovy
+    triggers:
+      - type: cron
+        schedule: '@monthly'
+
   - name: Weekly Job
     jobName: weeklyJob
     scriptPath: .github/jenkinsfile/weeklyBuild.groovy

--- a/.github/jenkinsfile/catapultDependency.groovy
+++ b/.github/jenkinsfile/catapultDependency.groovy
@@ -1,0 +1,7 @@
+gitPullRequestPipeline {
+	dockerImageName = 'symbolplatform/build-ci:cpp-ubuntu-lts'
+	branchName = 'fix/update_catapult_dependency'
+	scriptSetupCommand = 'python3 -m pip install -r jenkins/catapult/requirements.txt'
+	srcriptCommand = 'python3 jenkins/catapult/catapultDependencyUpdater.py --versions-file jenkins/catapult/versions.properties --source-path client/catapult'
+	reviewers = []
+}

--- a/.github/jenkinsfile/catapultDependency.groovy
+++ b/.github/jenkinsfile/catapultDependency.groovy
@@ -2,6 +2,6 @@ gitPullRequestPipeline {
 	dockerImageName = 'symbolplatform/build-ci:cpp-ubuntu-lts'
 	branchName = 'fix/update_catapult_dependency'
 	scriptSetupCommand = 'python3 -m pip install -r jenkins/catapult/requirements.txt'
-	srcriptCommand = 'python3 jenkins/catapult/catapultDependencyUpdater.py --versions-file jenkins/catapult/versions.properties --source-path client/catapult'
+	scriptCommand = 'python3 jenkins/catapult/catapultDependencyUpdater.py --versions-file jenkins/catapult/versions.properties --source-path client/catapult'
 	reviewers = []
 }

--- a/.github/jenkinsfile/catapultDependency.groovy
+++ b/.github/jenkinsfile/catapultDependency.groovy
@@ -1,6 +1,6 @@
 gitPullRequestPipeline {
 	dockerImageName = 'symbolplatform/build-ci:cpp-ubuntu-lts'
-	branchName = 'fix/update_catapult_dependency'
+	prBranchName = 'fix/update_catapult_dependency'
 	scriptSetupCommand = 'python3 -m pip install -r jenkins/catapult/requirements.txt'
 	scriptCommand = 'python3 jenkins/catapult/catapultDependencyUpdater.py --versions-file jenkins/catapult/versions.properties --source-path client/catapult'
 	reviewers = []

--- a/jenkins/catapult/baseImageDockerfileGenerator.py
+++ b/jenkins/catapult/baseImageDockerfileGenerator.py
@@ -402,8 +402,8 @@ class LinuxSystemGenerator:
 		boost_version = self.options.versions['boost']
 
 		print_args = {
-			'BOOST_ARCHIVE': f'boost_1_{boost_version}_0',
-			'BOOST_URI': f'https://boostorg.jfrog.io/artifactory/main/release/1.{boost_version}.0/source',
+			'BOOST_ARCHIVE': f'boost_{boost_version.replace(".", "_")}',
+			'BOOST_URI': f'https://boostorg.jfrog.io/artifactory/main/release/{boost_version}/source',
 			'BOOTSTRAP_OPTIONS': ' '.join(self.options.bootstrap()),
 			'B2_OPTIONS': ' '.join(self.options.b2()),
 			'BOOST_DISABLED_LIBS': ' '.join(BOOST_DISABLED_LIBS)
@@ -513,8 +513,8 @@ class WindowsSystemGenerator:
 
 		boost_version = self.options.versions['boost']
 		print_args = {
-			'BOOST_ARCHIVE': f'boost_1_{boost_version}_0',
-			'BOOST_URI': f'https://boostorg.jfrog.io/artifactory/main/release/1.{boost_version}.0/source',
+			'BOOST_ARCHIVE': f'boost_{boost_version.replace(".", "_")}',
+			'BOOST_URI': f'https://boostorg.jfrog.io/artifactory/main/release/{boost_version}/source',
 			'BOOTSTRAP_OPTIONS': ' '.join(self.options.bootstrap()),
 			'B2_OPTIONS': ' '.join(self.options.b2()),
 			'BOOST_DISABLED_LIBS': ' '.join(BOOST_DISABLED_LIBS),

--- a/jenkins/catapult/catapultDependencyUpdater.py
+++ b/jenkins/catapult/catapultDependencyUpdater.py
@@ -1,0 +1,153 @@
+import argparse
+import re
+import subprocess
+from pathlib import Path
+
+from configuration import load_versions_map
+from semver import compare
+
+CONAN_NEMTECH_REMOTE = 'https://conan.symbol.dev/artifactory/api/conan/catapult'
+NEMTECH_REMOTE_NAME = 'nemtech'
+
+# dependency name(conan) -> version property and cmake name
+DEPENDENCY_NAMES_MAP = {
+	'boost': ('boost', 'Boost'),
+	'benchmark': ('google_benchmark', 'benchmark'),
+	'gtest': ('google_googletest', 'GTest'),
+	'mongo-c-driver': ('mongodb_mongo-c-driver', 'MONGOC-1.0'),
+	'mongo-cxx-driver': ('mongodb_mongo-cxx-driver', 'MONGOCXX'),
+	'zeromq': ('zeromq_libzmq', None),
+	'cppzmq': ('zeromq_cppzmq', 'cppzmq'),
+	'rocksdb': ('facebook_rocksdb', 'RocksDB'),
+	'openssl': ('openssl_openssl', 'OpenSSL')
+}
+DEPENDENCIES_NAME = DEPENDENCY_NAMES_MAP.keys()
+
+
+def dispatch_subprocess(command_line, cwd=None, handle_error=True):
+	print(' '.join(command_line))
+	result = subprocess.run(command_line, check=False, cwd=cwd, capture_output=True)
+	if handle_error and 0 != result.returncode:
+		raise subprocess.SubprocessError(f'command failed with exit code {result.returncode}\n{result}')
+
+	output = result.stdout.decode('utf-8') if 0 == result.returncode else result.stderr.decode('utf-8')
+	if output:
+		print(output)
+
+	return output, result.returncode
+
+
+class CatapultDependencyUpdater:
+	def __init__(self, versions_file, source_path):
+		self.versions_file = Path(versions_file).absolute()
+		self.source_path = Path(source_path).absolute()
+		self.versions = load_versions_map(versions_file)
+		self._setup_conan_environment()
+
+	@staticmethod
+	def _setup_conan_environment():
+		_, error_code = dispatch_subprocess(['conan', 'profile', 'show', 'default'], handle_error=False)
+		if 0 != error_code:
+			dispatch_subprocess(['conan', 'profile', 'new', 'default', '--detect'])
+
+		dispatch_subprocess(['conan', 'profile', 'show', 'default'])
+		dispatch_subprocess(['conan', 'config', 'set', 'general.revisions_enabled=True'])
+		dispatch_subprocess(['conan', 'remote', 'add', '--force', NEMTECH_REMOTE_NAME, CONAN_NEMTECH_REMOTE])
+
+	@staticmethod
+	def _is_remote_nemtech(dependency_name):
+		return dependency_name in ['benchmark', 'cppzmq', 'libzmq', 'mongo-c-driver', 'mongo-cxx-driver', 'rocksdb']
+
+	def _get_conan_latest_version(self, name):
+		query = f'{name}/*' if not self._is_remote_nemtech(name) else f'{name}/*@{NEMTECH_REMOTE_NAME}/stable'
+		remote_name = NEMTECH_REMOTE_NAME if self._is_remote_nemtech(name) else 'conancenter'
+		output, _ = dispatch_subprocess(['conan', 'search', query, '--raw', '--remote', remote_name])
+		version_list = [line.split('/')[1].split('@')[0] for line in output.splitlines()]
+		filtered_versions = [version for version in version_list if version[0].isdigit()]
+		return filtered_versions[-1]
+
+	def get_available_update(self, dependencies):
+		dependencies_with_updates = []
+		for dependency in dependencies:
+			latest_version = self._get_conan_latest_version(dependency)
+			current_version = re.sub(r'[^\d\.]', '', self.versions[DEPENDENCY_NAMES_MAP[dependency][0]])
+			print(f'checking dependency {dependency} {current_version} -> {latest_version}')
+			if compare(latest_version, current_version, False) > 0:
+				print(f'{dependency} {current_version} -> {latest_version}')
+				dependencies_with_updates.append((dependency, current_version, latest_version))
+
+		return dependencies_with_updates
+
+	def update_dependencies(self, dependencies_to_update):
+		def update_version_in_file(name, filepath, old_version, new_version, get_current_version):
+			current_name_version = get_current_version(name, old_version)
+			new_name_version = current_name_version.replace(old_version, new_version)
+			print(f'updating dependency {current_name_version} -> {new_name_version}')
+			dispatch_subprocess(['sed', '-i', f's|{current_name_version}|{new_name_version}|g', str(filepath)])
+
+		dependency_files = {
+			'boost': ['CMakeLists.txt'],
+			'benchmark': ['tests/bench/CMakeLists.txt'],
+			'gtest': ['CMakeLists.txt'],
+			'mongo-c-driver': ['extensions/mongo/CMakeLists.txt'],
+			'mongo-cxx-driver': ['extensions/mongo/CMakeLists.txt'],
+			'cppzmq': ['extensions/zeromq/CMakeLists.txt'],
+			'openssl': ['CMakeLists.txt'],
+			'rocksdb': ['CMakeLists.txt'],
+		}
+
+		for dependency_name, current_version, latest_version in dependencies_to_update:
+			property_name, cmake_name = DEPENDENCY_NAMES_MAP[dependency_name]
+			print(f'updating dependency {dependency_name} from {current_version} -> {latest_version}')
+			update_version_in_file(
+				property_name,
+				self.versions_file,
+				current_version,
+				latest_version,
+				lambda name, version: f'{name} = {self.versions[property_name]}'  # pylint: disable=cell-var-from-loop
+			)
+
+			update_version_in_file(
+				dependency_name,
+				self.source_path.joinpath('conanfile.txt'),
+				current_version,
+				latest_version,
+				lambda name, version: f'{name}/{version}'
+			)
+
+			for cmake_file in dependency_files.get(dependency_name, []):
+				update_version_in_file(
+					cmake_name,
+					self.source_path.joinpath(cmake_file),
+					current_version,
+					latest_version,
+					lambda name, version: f'{name} {version}'
+				)
+
+
+def main():
+	parser = argparse.ArgumentParser(description='Update catapult dependencies')
+	parser.add_argument('--dependencies', choices=DEPENDENCIES_NAME, help='dependencies to update', default=DEPENDENCIES_NAME)
+	parser.add_argument('--versions-file', help='path to the versions file', required=True)
+	parser.add_argument('--source-path', help='path to the catapult source', required=True)
+	parser.add_argument('--commit', help='commit changes to git', action='store_false')
+	args = parser.parse_args()
+
+	dependency_updater = CatapultDependencyUpdater(args.versions_file, args.source_path)
+	dependencies_to_update = dependency_updater.get_available_update(args.dependencies)
+	print(f'dependencies to update: {dependencies_to_update}')
+	if not dependencies_to_update:
+		print('no dependencies to update')
+		return
+
+	dependency_updater.update_dependencies(dependencies_to_update)
+	update_message = '\n'.join([f'{dependency[0]} {dependency[1]} -> {dependency[2]}' for dependency in dependencies_to_update])
+	print(f'updated dependencies:\n{update_message}')
+
+	if args.commit:
+		dispatch_subprocess(['git', 'add', '.'])
+		dispatch_subprocess(['git', 'commit', '-m', f'[client/catapult] fix: update catapult dependency\n\n{update_message}'])
+
+
+if '__main__' == __name__:
+	main()

--- a/jenkins/catapult/installDepsLocal.py
+++ b/jenkins/catapult/installDepsLocal.py
@@ -23,18 +23,19 @@ class Downloader:
 
 	def download_boost_unix(self):
 		version = self.versions['boost']
-		tar_filename = f'boost_1_{version}_0.tar.gz'
-		tar_source_path = f'https://boostorg.jfrog.io/artifactory/main/release/1.{version}.0/source/{tar_filename}'
+		archive_name = f'boost_{version.replace(".", "_")}'
+		tar_filename = f'{archive_name}.tar.gz'
+		tar_source_path = f'https://boostorg.jfrog.io/artifactory/main/release/{version}/source/{tar_filename}'
 
 		self.process_manager.dispatch_subprocess(['curl', '-o', tar_filename, '-SL', tar_source_path])
 		self.process_manager.dispatch_subprocess(['tar', '-xzf', tar_filename])
-		self.process_manager.dispatch_subprocess(['mv', f'boost_1_{version}_0', 'boost'])
+		self.process_manager.dispatch_subprocess(['mv', archive_name, 'boost'])
 
 	def download_boost_windows(self):
 		version = self.versions['boost']
-		archive_name = f'boost_1_{version}_0'
+		archive_name = f'boost_{version.replace(".", "_")}'
 		zip_filename = f'{archive_name}.7z'
-		zip_source_path = f'https://boostorg.jfrog.io/artifactory/main/release/1.{version}.0/source/{zip_filename}'
+		zip_source_path = f'https://boostorg.jfrog.io/artifactory/main/release/{version}/source/{zip_filename}'
 
 		self.process_manager.dispatch_subprocess(['powershell', '-Command', 'wget', zip_source_path, '-outfile', zip_filename])
 		self.process_manager.dispatch_subprocess(['powershell', '-Command', '7z', 'x', zip_filename])

--- a/jenkins/catapult/requirements.txt
+++ b/jenkins/catapult/requirements.txt
@@ -1,1 +1,2 @@
 PyYAML==6.0.1
+node-semver==0.6.1 # use the same version as conan to avoid conflicts

--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -5,7 +5,7 @@ fedora = 36
 debian = 11.4
 windows = 2022
 
-boost = 80
+boost = 1.80.0
 cmake = 3.26.0
 gosu = 1.14
 

--- a/jenkins/shared-library/vars/codeCoverage.groovy
+++ b/jenkins/shared-library/vars/codeCoverage.groovy
@@ -7,7 +7,7 @@ void uploadCodeCoverage(String flag) {
 	final String repositoryName = helper.resolveRepositoryName()
 	withCredentials([string(credentialsId: "${repositoryName.toUpperCase()}_CODECOV_ID", variable: 'CODECOV_TOKEN')]) {
 		final String ownerName = helper.resolveOrganizationName()
-		final Boolean isPublicRepo = helper.isGitHubRepositoryPublic(ownerName, repositoryName)
+		final Boolean isPublicRepo = githubHelper.isGitHubRepositoryPublic(ownerName, repositoryName)
 		String codeCoverageCommand = "codecov --verbose --flags ${flag} --dir ."
 
 		if (isPublicRepo) {

--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -57,7 +57,6 @@ void call(Closure body) {
 			TEST_PYTHON_CREDENTIALS_ID = 'TEST_PYPI_TOKEN_ID'
 			DEV_BRANCH = 'dev'
 			RELEASE_BRANCH = 'main'
-			GITHUB_EMAIL = 'jenkins@symbol.dev'
 
 			LINT_SETUP_SCRIPT_FILEPATH = 'scripts/ci/setup_lint.sh'
 			LINT_SCRIPT_FILEPATH = 'scripts/ci/lint.sh'

--- a/jenkins/shared-library/vars/gitPullRequestPipeline.groovy
+++ b/jenkins/shared-library/vars/gitPullRequestPipeline.groovy
@@ -63,7 +63,7 @@ void call(Closure body) {
 				steps {
 					script {
 						helper.runStepAndRecordFailure {
-							sh("${jenkinsfileParams.srcriptCommand}")
+							sh("${jenkinsfileParams.scriptCommand}")
 						}
 					}
 				}

--- a/jenkins/shared-library/vars/gitPullRequestPipeline.groovy
+++ b/jenkins/shared-library/vars/gitPullRequestPipeline.groovy
@@ -1,0 +1,134 @@
+// groovylint-disable-next-line MethodSize
+void call(Closure body) {
+	Map jenkinsfileParams = [:]
+	body.resolveStrategy = Closure.DELEGATE_FIRST
+	body.delegate = jenkinsfileParams
+	body()
+
+	pipeline {
+		parameters {
+			gitParameter branchFilter: 'origin/(.*)', defaultValue: 'dev', name: 'MANUAL_GIT_BRANCH', type: 'PT_BRANCH'
+			booleanParam name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS', description: 'true to publish job status if failed', defaultValue: true
+		}
+
+		agent {
+			docker {
+				image "${jenkinsfileParams.dockerImageName}"
+
+				// using the same node and the same workspace mounted to the container
+				reuseNode true
+			}
+		}
+
+		options {
+			ansiColor('css')
+			timestamps()
+			timeout(time: 1, unit: 'HOURS')
+		}
+
+		stages {
+			stage('checkout') {
+				when {
+					expression { helper.isManualBuild(params.MANUAL_GIT_BRANCH) }
+				}
+				steps {
+					script {
+						helper.runStepAndRecordFailure {
+							baseBranchName = helper.resolveBranchName(params.MANUAL_GIT_BRANCH)
+							sh "git checkout -b ${baseBranchName} origin/${baseBranchName}"
+							sh "git reset --hard origin/${baseBranchName}"
+						}
+					}
+				}
+			}
+			stage('setup environment') {
+				steps {
+					script {
+						helper.runStepAndRecordFailure {
+							githubHelper.configureGitHub()
+							if (null != jenkinsfileParams.scriptSetupCommand) {
+								sh("${jenkinsfileParams.scriptSetupCommand}")
+							}
+						}
+					}
+				}
+			}
+			stage('print env') {
+				steps {
+					println("Jenkinsfile parameters: ${jenkinsfileParams}")
+					sh 'printenv'
+				}
+			}
+			stage('run script') {
+				steps {
+					script {
+						helper.runStepAndRecordFailure {
+							sh("${jenkinsfileParams.srcriptCommand}")
+						}
+					}
+				}
+			}
+			stage('create PR') {
+				when {
+					expression { hasAnyFileChanged(baseBranchName) }
+				}
+				stages {
+					stage('create branch') {
+						steps {
+							script {
+								helper.runStepAndRecordFailure {
+									sh("git checkout -b ${jenkinsfileParams.branchName}")
+								}
+							}
+						}
+					}
+					stage('commit and push code') {
+						steps {
+							script {
+								helper.runStepAndRecordFailure {
+									githubHelper.executeGitAuthenticatedCommand {
+										sh("git push origin ${jenkinsfileParams.branchName}")
+										final String prTitle = sh(script: 'git log -1 --pretty=%s', returnStdout: true).trim()
+										final String prBody = sh(script: 'git log -1 --pretty=%b', returnStdout: true).trim()
+										final String ownerName = helper.resolveOrganizationName()
+										final String repositoryName = helper.resolveRepositoryName()
+										githubHelper.createPullRequestWithReviewers(
+											"${GITHUB_ACCESS_TOKEN}",
+											ownerName,
+											repositoryName,
+											jenkinsfileParams.branchName,
+											baseBranchName,
+											prTitle,
+											prBody,
+											jenkinsfileParams.reviewers ?: []
+										)
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+		post {
+			unsuccessful {
+				script {
+					if (env.SHOULD_PUBLISH_FAIL_JOB_STATUS?.toBoolean()) {
+						helper.sendDiscordNotification(
+								jenkinsfileParams.discordWebHookUrlId,
+								"GitHub job failed for ${currentBuild.fullDisplayName}",
+								"GitHub job failed with result of ${currentBuild.currentResult} in"
+										+ " stage **${env.FAILED_STAGE_NAME}** with message: **${env.FAILURE_MESSAGE}**.",
+								env.BUILD_URL,
+								currentBuild.currentResult
+						)
+					}
+				}
+			}
+		}
+	}
+}
+
+boolean hasAnyFileChanged(String branchName) {
+	return runScript("git diff HEAD..origin/${branchName} --name-only | wc -l", true).trim().toInteger() > 0
+}

--- a/jenkins/shared-library/vars/gitPullRequestPipeline.groovy
+++ b/jenkins/shared-library/vars/gitPullRequestPipeline.groovy
@@ -77,7 +77,7 @@ void call(Closure body) {
 						steps {
 							script {
 								helper.runStepAndRecordFailure {
-									sh("git checkout -b ${jenkinsfileParams.branchName}")
+									sh("git checkout -b ${jenkinsfileParams.prBranchName}")
 								}
 							}
 						}
@@ -87,7 +87,7 @@ void call(Closure body) {
 							script {
 								helper.runStepAndRecordFailure {
 									githubHelper.executeGitAuthenticatedCommand {
-										sh("git push origin ${jenkinsfileParams.branchName}")
+										sh("git push origin ${jenkinsfileParams.prBranchName}")
 										final String prTitle = sh(script: 'git log -1 --pretty=%s', returnStdout: true).trim()
 										final String prBody = sh(script: 'git log -1 --pretty=%b', returnStdout: true).trim()
 										final String ownerName = helper.resolveOrganizationName()
@@ -96,7 +96,7 @@ void call(Closure body) {
 											"${GITHUB_ACCESS_TOKEN}",
 											ownerName,
 											repositoryName,
-											jenkinsfileParams.branchName,
+											jenkinsfileParams.prBranchName,
 											baseBranchName,
 											prTitle,
 											prBody,

--- a/jenkins/shared-library/vars/githubHelper.groovy
+++ b/jenkins/shared-library/vars/githubHelper.groovy
@@ -1,0 +1,104 @@
+import groovy.json.JsonOutput
+
+boolean isGitHubRepositoryPublic(String orgName, String repoName) {
+	try {
+		final URL url = "https://api.github.com/repos/${orgName}/${repoName}".toURL()
+		final Object repo = yamlHelper.readYamlFromText(url.text)
+
+		return repo.name == repoName && repo.visibility == 'public'
+	} catch (FileNotFoundException exception) {
+		println "Repository ${orgName}/${repoName} not found - ${exception}"
+		return false
+	}
+}
+
+String executeGithubApiRequest(String command) {
+	final String response = runScript(command, true)
+	if (response.contains('message')) {
+		println "GitHub API request failed: ${response}"
+		throw new IllegalArgumentException(response)
+	}
+
+	return response
+}
+
+// groovylint-disable-next-line FactoryMethodName
+Object createPullRequest(
+	String token,
+	String ownerName,
+	String repositoryName,
+	String branchName,
+	String baseBranchName,
+	String title,
+	String body
+) {
+	final String jsonBody = JsonOutput.toJson(body)
+	final String pullRequestCommand = """
+		curl -L \\
+  			-X POST \\
+  			-H "Accept: application/vnd.github+json" \\
+  			-H "Authorization: Bearer ${token}" \\
+  			-H "X-GitHub-Api-Version: 2022-11-28" \\
+  			https://api.github.com/repos/${ownerName}/${repositoryName}/pulls \\
+  			-d '{"title":"${title}","body":${jsonBody},"head":"${branchName}","base":"${baseBranchName}"}'
+	"""
+
+	final String pullRequestResponse = executeGithubApiRequest(pullRequestCommand)
+	final Object pullRequest = yamlHelper.readYamlFromText(pullRequestResponse)
+	println "Pull request created: ${pullRequest.number}"
+	return pullRequest
+}
+
+Object requestReviewersForPullRequest(String token, String ownerName, String repositoryName, int pullRequestNumber, List reviewers) {
+	final String reviewersCommand = """
+		curl -L \\
+  			-X POST \\
+  			-H "Accept: application/vnd.github+json" \\
+  			-H "Authorization: Bearer ${token}" \\
+  			-H "X-GitHub-Api-Version: 2022-11-28" \\
+  			https://api.github.com/repos/${ownerName}/${repositoryName}/pulls/${pullRequestNumber}/requested_reviewers \\
+  			-d '{"reviewers": ["${reviewers.join('", "')}"]}'
+	"""
+
+	String response = executeGithubApiRequest(reviewersCommand)
+	println "Reviewers requested: ${response}"
+	return yamlHelper.readYamlFromText(response)
+}
+
+// groovylint-disable-next-line FactoryMethodName
+Object createPullRequestWithReviewers(
+	String token,
+	String ownerName,
+	String repositoryName,
+	String branchName,
+	String baseBranchName,
+	String title,
+	String body,
+	List reviewers
+) {
+	Object pullRequest = createPullRequest(token, ownerName, repositoryName, branchName, baseBranchName, title, body)
+	if (!reviewers.isEmpty()) {
+		final int pullRequestNumber = pullRequest.number.toInteger()
+		pullRequest = requestReviewersForPullRequest(token, ownerName, repositoryName, pullRequestNumber, reviewers)
+	}
+
+	return pullRequest
+}
+
+void configureGitHub() {
+	runScript('git config --global user.name "symbol-bot"')
+	runScript('git config --global user.email "jenkins@symbol.dev"')
+}
+
+void executeGitAuthenticatedCommand(Closure command) {
+	withCredentials([usernamePassword(credentialsId: helper.resolveGitHubCredentialsId(),
+			usernameVariable: 'GITHUB_APP',
+			passwordVariable: 'GITHUB_ACCESS_TOKEN')]) {
+		final String ownerName = helper.resolveOrganizationName()
+		final String replaceUrl = "https://${GITHUB_APP}:${GITHUB_ACCESS_TOKEN}@github.com/${ownerName}.insteadOf" +
+			" 'https://github.com/${ownerName}'"
+		sh("git config --global url.${replaceUrl}")
+		configureGitHub()
+		command()
+	}
+}

--- a/jenkins/shared-library/vars/githubHelper.groovy
+++ b/jenkins/shared-library/vars/githubHelper.groovy
@@ -27,7 +27,7 @@ Object createPullRequest(
 	String token,
 	String ownerName,
 	String repositoryName,
-	String branchName,
+	String prBranchName,
 	String baseBranchName,
 	String title,
 	String body
@@ -40,7 +40,7 @@ Object createPullRequest(
 			-H "Authorization: Bearer ${token}" \\
 			-H "X-GitHub-Api-Version: 2022-11-28" \\
 			https://api.github.com/repos/${ownerName}/${repositoryName}/pulls \\
-			-d '{"title":"${title}","body":${jsonBody},"head":"${branchName}","base":"${baseBranchName}"}'
+			-d '{"title":"${title}","body":${jsonBody},"head":"${prBranchName}","base":"${baseBranchName}"}'
 	"""
 
 	final String pullRequestResponse = executeGithubApiRequest(pullRequestCommand)
@@ -70,13 +70,13 @@ Object createPullRequestWithReviewers(
 	String token,
 	String ownerName,
 	String repositoryName,
-	String branchName,
+	String prBranchName,
 	String baseBranchName,
 	String title,
 	String body,
 	List reviewers
 ) {
-	Object pullRequest = createPullRequest(token, ownerName, repositoryName, branchName, baseBranchName, title, body)
+	Object pullRequest = createPullRequest(token, ownerName, repositoryName, prBranchName, baseBranchName, title, body)
 	if (!reviewers.isEmpty()) {
 		final int pullRequestNumber = pullRequest.number.toInteger()
 		pullRequest = requestReviewersForPullRequest(token, ownerName, repositoryName, pullRequestNumber, reviewers)

--- a/jenkins/shared-library/vars/githubHelper.groovy
+++ b/jenkins/shared-library/vars/githubHelper.groovy
@@ -86,8 +86,8 @@ Object createPullRequestWithReviewers(
 }
 
 void configureGitHub() {
-	runScript('git config --global user.name "symbol-bot"')
-	runScript('git config --global user.email "jenkins@symbol.dev"')
+	runScript('git config user.name "symbol-bot"')
+	runScript('git config user.email "jenkins@symbol.dev"')
 }
 
 void executeGitAuthenticatedCommand(Closure command) {
@@ -97,7 +97,7 @@ void executeGitAuthenticatedCommand(Closure command) {
 		final String ownerName = helper.resolveOrganizationName()
 		final String replaceUrl = "https://${GITHUB_APP}:${GITHUB_ACCESS_TOKEN}@github.com/${ownerName}.insteadOf" +
 			" 'https://github.com/${ownerName}'"
-		sh("git config --global url.${replaceUrl}")
+		sh("git config url.${replaceUrl}")
 		configureGitHub()
 		command()
 	}

--- a/jenkins/shared-library/vars/githubHelper.groovy
+++ b/jenkins/shared-library/vars/githubHelper.groovy
@@ -35,12 +35,12 @@ Object createPullRequest(
 	final String jsonBody = JsonOutput.toJson(body)
 	final String pullRequestCommand = """
 		curl -L \\
-  			-X POST \\
-  			-H "Accept: application/vnd.github+json" \\
-  			-H "Authorization: Bearer ${token}" \\
-  			-H "X-GitHub-Api-Version: 2022-11-28" \\
-  			https://api.github.com/repos/${ownerName}/${repositoryName}/pulls \\
-  			-d '{"title":"${title}","body":${jsonBody},"head":"${branchName}","base":"${baseBranchName}"}'
+			-X POST \\
+			-H "Accept: application/vnd.github+json" \\
+			-H "Authorization: Bearer ${token}" \\
+			-H "X-GitHub-Api-Version: 2022-11-28" \\
+			https://api.github.com/repos/${ownerName}/${repositoryName}/pulls \\
+			-d '{"title":"${title}","body":${jsonBody},"head":"${branchName}","base":"${baseBranchName}"}'
 	"""
 
 	final String pullRequestResponse = executeGithubApiRequest(pullRequestCommand)
@@ -52,12 +52,12 @@ Object createPullRequest(
 Object requestReviewersForPullRequest(String token, String ownerName, String repositoryName, int pullRequestNumber, List reviewers) {
 	final String reviewersCommand = """
 		curl -L \\
-  			-X POST \\
-  			-H "Accept: application/vnd.github+json" \\
-  			-H "Authorization: Bearer ${token}" \\
-  			-H "X-GitHub-Api-Version: 2022-11-28" \\
-  			https://api.github.com/repos/${ownerName}/${repositoryName}/pulls/${pullRequestNumber}/requested_reviewers \\
-  			-d '{"reviewers": ["${reviewers.join('", "')}"]}'
+			-X POST \\
+			-H "Accept: application/vnd.github+json" \\
+			-H "Authorization: Bearer ${token}" \\
+			-H "X-GitHub-Api-Version: 2022-11-28" \\
+			https://api.github.com/repos/${ownerName}/${repositoryName}/pulls/${pullRequestNumber}/requested_reviewers \\
+			-d '{"reviewers": ["${reviewers.join('", "')}"]}'
 	"""
 
 	String response = executeGithubApiRequest(reviewersCommand)

--- a/jenkins/shared-library/vars/helper.groovy
+++ b/jenkins/shared-library/vars/helper.groovy
@@ -25,12 +25,6 @@ void runInitializeScriptIfPresent() {
 	}
 }
 
-void configureGitHub() {
-	runScript('git config user.name "symbol-bot"')
-	// groovylint-disable-next-line GStringExpressionWithinString
-	runScript('git config user.email "${GITHUB_EMAIL}"')
-}
-
 String resolveBuildConfigurationFile() {
 	return '.github/buildConfiguration.yaml'
 }
@@ -108,18 +102,6 @@ boolean tryRunCommand(Closure command) {
 
 String resolveWorkspacePath(String os) {
 	return 'windows' == os ? 'C:\\Users\\Administrator\\jenkins\\workspace\\' : '/home/ubuntu/jenkins/workspace/'
-}
-
-boolean isGitHubRepositoryPublic(String orgName, String repoName) {
-	try {
-		final URL url = "https://api.github.com/repos/${orgName}/${repoName}".toURL()
-		final Object repo = yamlHelper.readYamlFromText(url.text)
-
-		return repo.name == repoName && repo.visibility == 'public'
-	} catch (FileNotFoundException exception) {
-		println "Repository ${orgName}/${repoName} not found - ${exception}"
-		return false
-	}
 }
 
 String resolveGitHubCredentialsId() {

--- a/jenkins/shared-library/vars/publish.groovy
+++ b/jenkins/shared-library/vars/publish.groovy
@@ -135,11 +135,7 @@ void gitHubPagesPublisher(Map config, String phase) {
 		return
 	}
 
-	withCredentials([usernamePassword(credentialsId: config.gitHubId,
-		usernameVariable: 'GITHUB_APP',
-		passwordVariable: 'GITHUB_ACCESS_TOKEN')]) {
-		helper.configureGitHub()
-
+	githubHelper.executeGitAuthenticatedCommand {
 		withCredentials([usernamePassword(credentialsId: 'TRANSIFEX_LOGIN_ID',
 			usernameVariable: 'TRANSIFEX_USER',
 			passwordVariable: 'TRANSIFEX_PASSWORD')]) {


### PR DESCRIPTION
## What is the current behavior?
Catapult dependency are updated manually.

## What's the issue?
Manually checking for dependency is not scalable and requires someone to remember

## How have you changed the behavior?
Add a Jenkins job which will run once a month to check for new updates.
The version check is done against Conan since their is a dependency for Conan builds.

## How was this change tested?
Tested the updater script locally