### PR TITLE
[jenkins] fix: always call init script

### DIFF
--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -102,6 +102,10 @@ void call(Closure body) {
 					}
 					stage('setup docker environment') {
 						steps {
+							script {
+								helper.runInitializeScriptIfPresent()
+							}
+
 							runStepRelativeToPackageRoot packageRootPath, {
 								configureArtifactRepository(jobHelper.resolveCiEnvironmentName(jenkinsfileParams))
 							}


### PR DESCRIPTION
# What is the current behavior?
On Windows links to the submodule are not created correctly.

## What's the issue?
The links are created before the submodule file/directory is present.
Windows does not handle this correctly.

## How have you changed the behavior?
Call the init scripts which will re-create links.

## How was this change tested?
Tested with Jenkins.