### PR TITLE
block_filterd_timestamp

### DIFF
--- a/client/rest/src/db/CatapultDb.js
+++ b/client/rest/src/db/CatapultDb.js
@@ -204,11 +204,13 @@ class CatapultDb {
 	 * Retrieves filtered and paginated blocks.
 	 * @param {Uint8Array} signerPublicKey Filters by signer public key
 	 * @param {Uint8Array} beneficiaryAddress Filters by beneficiary address
+	 * @param {uint64} fromTimestamp Filters by fromTimestamp
+	 * @param {uint64} toTimestamp Filters by toTimestamp
 	 * @param {object} options Options for ordering and pagination. Can have an `offset`, and must contain the `sortField`, `sortDirection`,
 	 * `pageSize` and `pageNumber`. 'sortField' must be within allowed 'sortingOptions'.
 	 * @returns {Promise.<object>} Blocks page.
 	 */
-	blocks(signerPublicKey, beneficiaryAddress, options) {
+	blocks(signerPublicKey, beneficiaryAddress, fromTimestamp, toTimestamp, options) {
 		const sortingOptions = {
 			id: '_id',
 			height: 'block.height'
@@ -226,6 +228,13 @@ class CatapultDb {
 		if (undefined !== beneficiaryAddress)
 			conditions['block.beneficiaryAddress'] = Buffer.from(beneficiaryAddress);
 
+		if (undefined !== fromTimestamp || undefined !== toTimestamp) {
+			conditions['block.timestamp'] = {};
+			if (undefined !== fromTimestamp)
+				conditions['block.timestamp'].$gte = convertToLong(fromTimestamp);
+			if (undefined !== toTimestamp)
+				conditions['block.timestamp'].$lte = convertToLong(toTimestamp);
+		}
 		const removeFields = ['meta.transactionMerkleTree', 'meta.statementMerkleTree'];
 
 		const sortConditions = { [sortingOptions[options.sortField]]: options.sortDirection };

--- a/client/rest/src/db/CatapultDb.js
+++ b/client/rest/src/db/CatapultDb.js
@@ -204,8 +204,8 @@ class CatapultDb {
 	 * Retrieves filtered and paginated blocks.
 	 * @param {Uint8Array} signerPublicKey Filters by signer public key
 	 * @param {Uint8Array} beneficiaryAddress Filters by beneficiary address
-	 * @param {uint64} fromTimestamp Filters by fromTimestamp
-	 * @param {uint64} toTimestamp Filters by toTimestamp
+	 * @param {uint64} fromTimestamp Filters blocks by only including blocks with a timestamp greater than or equal to provided value
+	 * @param {uint64} toTimestamp Filters blocks by only including blocks with a timestamp less than or equal to provided value
 	 * @param {object} options Options for ordering and pagination. Can have an `offset`, and must contain the `sortField`, `sortDirection`,
 	 * `pageSize` and `pageNumber`. 'sortField' must be within allowed 'sortingOptions'.
 	 * @returns {Promise.<object>} Blocks page.

--- a/client/rest/src/routes/blockRoutes.js
+++ b/client/rest/src/routes/blockRoutes.js
@@ -36,13 +36,16 @@ module.exports = {
 				? routeUtils.parseArgument(params, 'beneficiaryAddress', 'address')
 				: undefined;
 
+			const fromTimestamp = params.fromTimestamp ? routeUtils.parseArgument(params, 'fromTimestamp', 'uint64') : undefined;
+			const toTimestamp = params.toTimestamp ? routeUtils.parseArgument(params, 'toTimestamp', 'uint64') : undefined;
+
 			const offsetParsers = {
 				id: 'objectId',
 				height: 'uint64'
 			};
 			const options = routeUtils.parsePaginationArguments(params, services.config.pageSize, offsetParsers);
 
-			return db.blocks(signerPublicKey, beneficiaryAddress, options)
+			return db.blocks(signerPublicKey, beneficiaryAddress, fromTimestamp, toTimestamp, options)
 				.then(result => routeUtils.createSender(routeResultTypes.block).sendPage(res, next)(result));
 		});
 

--- a/client/rest/test/db/CatapultDb_spec.js
+++ b/client/rest/test/db/CatapultDb_spec.js
@@ -418,28 +418,17 @@ describe('catapult db', () => {
 			it('fromTimestamp', () => {
 				// Arrange:
 				const dbBlocks = [
-					createBlock(10, 1, account1.publicKey, account1.address, 23456),
-					createBlock(20, 1, account1.publicKey, account1.address, 12345)
+					createBlock(10, 1, account1.publicKey, account1.address, 12345),
+					createBlock(20, 1, account1.publicKey, account1.address, 23456),
+					createBlock(30, 1, account1.publicKey, account1.address, 34567)
 				];
 
 				// Act + Assert:
 				return runTestAndVerifyIds(dbBlocks, db =>
-					db.blocks(undefined, undefined, 23456, undefined, paginationOptions), [10]);
+					db.blocks(undefined, undefined, 23456, undefined, paginationOptions), [20, 30]);
 			});
 
 			it('toTimestamp', () => {
-				// Arrange:
-				const dbBlocks = [
-					createBlock(10, 1, account1.publicKey, account1.address, 12345),
-					createBlock(20, 1, account1.publicKey, account1.address, 23456)
-				];
-
-				// Act + Assert:
-				return runTestAndVerifyIds(dbBlocks, db =>
-					db.blocks(undefined, undefined, undefined, 12345, paginationOptions), [10]);
-			});
-
-			it('fromTimestamp && toTimestamp', () => {
 				// Arrange:
 				const dbBlocks = [
 					createBlock(10, 1, account1.publicKey, account1.address, 12345),
@@ -449,7 +438,22 @@ describe('catapult db', () => {
 
 				// Act + Assert:
 				return runTestAndVerifyIds(dbBlocks, db =>
-					db.blocks(undefined, undefined, 23456, 34566, paginationOptions), [20]);
+					db.blocks(undefined, undefined, undefined, 23456, paginationOptions), [10, 20]);
+			});
+
+			it('fromTimestamp && toTimestamp', () => {
+				// Arrange:
+				const dbBlocks = [
+					createBlock(10, 1, account1.publicKey, account1.address, 12345),
+					createBlock(20, 1, account1.publicKey, account1.address, 23456),
+					createBlock(30, 1, account1.publicKey, account1.address, 34567),
+					createBlock(40, 1, account1.publicKey, account1.address, 45678),
+					createBlock(50, 1, account1.publicKey, account1.address, 56789)
+				];
+
+				// Act + Assert:
+				return runTestAndVerifyIds(dbBlocks, db =>
+					db.blocks(undefined, undefined, 23456, 45678, paginationOptions), [20, 30, 40]);
 			});
 		});
 	});

--- a/client/rest/test/db/utils/dbTestUtils.js
+++ b/client/rest/test/db/utils/dbTestUtils.js
@@ -162,7 +162,7 @@ const createDbTransaction = (id, signerPublicKey, recipientAddress, options) => 
 		message: { size: 12, payload: new Binary(test.random.bytes(12)) },
 		mosaics: []
 	};
-	for (let j = 0; 3 < j; ++j)
+	for (let j = 0; 3 > j; ++j)
 		transaction.mosaics.push({ id: Long.fromNumber(j), amount: Long.fromNumber(j * j) });
 
 	return { _id: id, meta, transaction };

--- a/client/rest/test/db/utils/dbTestUtils.js
+++ b/client/rest/test/db/utils/dbTestUtils.js
@@ -162,7 +162,7 @@ const createDbTransaction = (id, signerPublicKey, recipientAddress, options) => 
 		message: { size: 12, payload: new Binary(test.random.bytes(12)) },
 		mosaics: []
 	};
-	for (let j = 0; 3 > j; ++j)
+	for (let j = 0; 3 < j; ++j)
 		transaction.mosaics.push({ id: Long.fromNumber(j), amount: Long.fromNumber(j * j) });
 
 	return { _id: id, meta, transaction };

--- a/client/rest/test/routes/blockRoutes_spec.js
+++ b/client/rest/test/routes/blockRoutes_spec.js
@@ -92,12 +92,32 @@ describe('block routes', () => {
 				mockServer.callRoute(route, { params: { signerPublicKey: testPublickeyString } }).then(() => {
 					expect(dbBlocksFake.firstCall.args[0]).to.deep.equal(testPublickey);
 					expect(dbBlocksFake.firstCall.args[1]).to.deep.equal(undefined);
+					expect(dbBlocksFake.firstCall.args[2]).to.deep.equal(undefined);
+					expect(dbBlocksFake.firstCall.args[3]).to.deep.equal(undefined);
 				}));
 
 			it('forwards beneficiaryAddress filter', () =>
 				mockServer.callRoute(route, { params: { beneficiaryAddress: testAddressString } }).then(() => {
 					expect(dbBlocksFake.firstCall.args[0]).to.deep.equal(undefined);
 					expect(dbBlocksFake.firstCall.args[1]).to.deep.equal(testAddress);
+					expect(dbBlocksFake.firstCall.args[2]).to.deep.equal(undefined);
+					expect(dbBlocksFake.firstCall.args[3]).to.deep.equal(undefined);
+				}));
+
+			it('forwards fromTimestamp filter', () =>
+				mockServer.callRoute(route, { params: { fromTimestamp: '123456' } }).then(() => {
+					expect(dbBlocksFake.firstCall.args[0]).to.deep.equal(undefined);
+					expect(dbBlocksFake.firstCall.args[1]).to.deep.equal(undefined);
+					expect(dbBlocksFake.firstCall.args[2]).to.deep.equal([123456, 0]);
+					expect(dbBlocksFake.firstCall.args[3]).to.deep.equal(undefined);
+				}));
+
+			it('forwards toTimestamp filter', () =>
+				mockServer.callRoute(route, { params: { toTimestamp: '123456' } }).then(() => {
+					expect(dbBlocksFake.firstCall.args[0]).to.deep.equal(undefined);
+					expect(dbBlocksFake.firstCall.args[1]).to.deep.equal(undefined);
+					expect(dbBlocksFake.firstCall.args[2]).to.deep.equal(undefined);
+					expect(dbBlocksFake.firstCall.args[3]).to.deep.equal([123456, 0]);
 				}));
 
 			describe('parses paging', () => {
@@ -114,7 +134,7 @@ describe('block routes', () => {
 						expect(paginationParser.firstCall.args[2]).to.deep.equal({ id: 'objectId', height: 'uint64' });
 
 						expect(dbBlocksFake.calledOnce).to.equal(true);
-						expect(dbBlocksFake.firstCall.args[2]).to.deep.equal(pagingBag);
+						expect(dbBlocksFake.firstCall.args[4]).to.deep.equal(pagingBag);
 						paginationParser.restore();
 					});
 				});


### PR DESCRIPTION
## What is the current behavior?
Could not filter blocks by timestamp

## How have you changed the behavior?
Blocks can be filtered by timestamp