### PR TITLE
[jenkins] fix: add support for untrusted repo

### DIFF
--- a/jenkins/shared-library/vars/createMultibranchJob.groovy
+++ b/jenkins/shared-library/vars/createMultibranchJob.groovy
@@ -55,7 +55,9 @@ void call(Map jobConfiguration, Boolean manualTrigger = true) {
 
 									gitHubForkDiscovery {
 										strategyId(USE_CURRENT_SOURCE_STRATEGY_ID)
-										// One of the great powers of pull requests is that anyone with read access to a repository can fork it, commit some changes to their fork and then create a pull request against the original repository with their changes.
+										// One of the great powers of pull requests is that anyone with read access
+										// to a repository can fork it, commit some changes to their fork and then
+										// create a pull request against the original repository with their changes.
 										trust {
 											gitHubTrustPermissions()
 										}

--- a/jenkins/shared-library/vars/createMultibranchJob.groovy
+++ b/jenkins/shared-library/vars/createMultibranchJob.groovy
@@ -53,6 +53,14 @@ void call(Map jobConfiguration, Boolean manualTrigger = true) {
 										strategyId(USE_CURRENT_SOURCE_STRATEGY_ID)
 									}
 
+									gitHubForkDiscovery {
+										strategyId(USE_CURRENT_SOURCE_STRATEGY_ID)
+										// One of the great powers of pull requests is that anyone with read access to a repository can fork it, commit some changes to their fork and then create a pull request against the original repository with their changes.
+										trust {
+											gitHubTrustPermissions()
+										}
+									}
+
 									// By default, Jenkins notifies GitHub with a constant context, i.e. a string that
 									// identifies the check. We want each individual build result to have its own context so
 									// they do not conflict. Requires the github-scm-trait-notification-context-plugin to be

--- a/jenkins/shared-library/vars/createMultibranchJob.groovy
+++ b/jenkins/shared-library/vars/createMultibranchJob.groovy
@@ -55,9 +55,11 @@ void call(Map jobConfiguration, Boolean manualTrigger = true) {
 
 									gitHubForkDiscovery {
 										strategyId(USE_CURRENT_SOURCE_STRATEGY_ID)
+
 										// One of the great powers of pull requests is that anyone with read access
 										// to a repository can fork it, commit some changes to their fork and then
 										// create a pull request against the original repository with their changes.
+										// Since this can be abused, we don't want to run jenkins jobs for every PR.
 										trust {
 											gitHubTrustPermissions()
 										}

--- a/jenkins/shared-library/vars/jobHelper.groovy
+++ b/jenkins/shared-library/vars/jobHelper.groovy
@@ -57,8 +57,7 @@ String resolveJobName(String jobFolder, String branchName) {
 	List<Item> jobs = Jenkins.get().getItemByFullName(jobFolder).items
 	for (Item item in jobs) {
 		if (item.name.startsWith('PR-') && item.isBuildable()) {
-			String changeBranch = item.lastBuild.environment.get('CHANGE_BRANCH', '')
-			if (changeBranch == branchName) {
+			if (env.CHANGE_BRANCH == branchName) {
 				echo "found PR: ${item.name}"
 				return item.name
 			}
@@ -69,7 +68,8 @@ String resolveJobName(String jobFolder, String branchName) {
 }
 
 Object loadBuildConfigurationfile() {
-	return yamlHelper.readYamlFromFile(helper.resolveBuildConfigurationFile())
+	String buildConfiguration = readTrusted(helper.resolveBuildConfigurationFile())
+	return yamlHelper.readYamlFromText(buildConfiguration)
 }
 
 Map <String, String> loadJenkinsfileMap(Object buildConfiguration = loadBuildConfigurationfile()) {


### PR DESCRIPTION
## What is the current behavior?
Jenkins jobs are not configured to run for PRs from the forked repo

## What's the issue?
Not able to manually run Jenkins job for outside contributor 

## How have you changed the behavior?
Allow an admin to run Jenkins job for outside contributors manually 
Added ``readTrusted`` for the build configuration file to prevent an outside contributor from modifying it.

## How was this change tested?
Tested in Jenkins