### PR TITLE
[jenkins] fix: add virtual python environment

### DIFF
--- a/jenkins/docker/ubuntu/cpp.Dockerfile
+++ b/jenkins/docker/ubuntu/cpp.Dockerfile
@@ -15,11 +15,18 @@ RUN apt-get install -y wget gnupg \
 	&& apt-get update \
 	&& apt-get install -y mongodb-org
 
+RUN apt-get install -y python3-pip python3-venv
+
 # add ubuntu user (used by jenkins)
 RUN useradd --uid 1000 -ms /bin/bash ubuntu
 
 # Create the MongoDB data directory
 RUN mkdir -p /data/db \
 	&& chown -R ubuntu:ubuntu /data
-
+USER ubuntu
 WORKDIR /home/ubuntu
+
+# create a virtual environment
+ENV VIRTUAL_ENV=/home/ubuntu/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"


### PR DESCRIPTION
## What is the current behavior?
The cpp image does not create a virtual environment for Python.

## What's the issue?
Without a virtual Python environment, there will be package conflicts on installation.

## How have you changed the behavior?
 Create a virtual python environment for the cpp image.

## How was this change tested?
It is tested locally on dev box.