### PR TITLE
[monorepo] fix: update latest test image to use python 3.12

### DIFF
--- a/catbuffer/parser/catparser/CatsLarkParser.py
+++ b/catbuffer/parser/catparser/CatsLarkParser.py
@@ -27,7 +27,7 @@ def create_cats_lark_parser():
 		CLOSE_PAREN_types = []
 		INDENT_type = '_INDENT'
 		DEDENT_type = '_DEDENT'
-		tab_len = 4
+		tab_len = 4  # pylint: disable=invalid-name
 
 	class CatbufferTransformer(Transformer):
 		# pylint: disable=too-many-public-methods

--- a/jenkins/catapult/runDockerTestsInnerLint.py
+++ b/jenkins/catapult/runDockerTestsInnerLint.py
@@ -73,7 +73,6 @@ def run_python_linters(linter_runner, python_files, script_path):
 	linter_runner.run([
 		'pylint',
 		'--rcfile', str(LINTER_DIR.joinpath('python/.pylintrc').resolve()),
-		'--load-plugins', 'pylint_quotes',
 		'--output-format', 'parseable'
 	] + python_files)
 	linter_runner.fixup(lambda line: line if not pylint_warning_pattern.match(line) else f'{script_path}/{line}')

--- a/jenkins/catapult/templates/FedoraTestBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/FedoraTestBaseImage.Dockerfile
@@ -20,4 +20,4 @@ RUN dnf update --assumeyes && dnf install --assumeyes \
 	&& \
 	dnf clean all && \
 	rm -rf /var/cache/yum && \
-	pip3 install -U colorama cryptography gitpython pycodestyle "pylint<3.0.0" pylint-quotes PyYAML
+	pip3 install -U colorama cryptography gitpython pycodestyle pylint PyYAML

--- a/jenkins/catapult/templates/UbuntuTestBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuTestBaseImage.Dockerfile
@@ -29,7 +29,7 @@ ENV VIRTUAL_ENV=/home/ubuntu/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-RUN pip3 install -U colorama cryptography gitpython pycodestyle "pylint<3.0.0" pylint-quotes ply PyYAML
+RUN pip3 install -U colorama cryptography gitpython pycodestyle pylint ply PyYAML
 
 USER root
 RUN git clone https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git linux.git && \

--- a/jenkins/catapult/templates/UbuntuTestSanitizerBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuTestSanitizerBaseImage.Dockerfile
@@ -29,6 +29,6 @@ ENV VIRTUAL_ENV=/home/ubuntu/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-RUN pip3 install -U colorama cryptography gitpython pycodestyle "pylint<3.0.0" pylint-quotes ply PyYAML
+RUN pip3 install -U colorama cryptography gitpython pycodestyle pylint ply PyYAML
 
 USER root

--- a/jenkins/catapult/templates/WindowsTestBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/WindowsTestBaseImage.Dockerfile
@@ -14,7 +14,7 @@ RUN Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser; `
 	del c:\scoop.ps1; `
 	scoop install python git shellcheck; `
 	python3 -m pip install --upgrade pip; `
-	python3 -m pip install --upgrade colorama cryptography gitpython ply pycodestyle "pylint<3.0.0" pylint-quotes PyYAML
+	python3 -m pip install --upgrade colorama cryptography gitpython ply pycodestyle pylint PyYAML
 	
 RUN "'ACP', 'OEMCP', 'MACCP' | Set-ItemProperty 'HKLM:\SYSTEM\CurrentControlSet\Control\Nls\CodePage' -Name { $_ } 65001"; `
 	Get-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Nls\CodePage'

--- a/jenkins/docker/ubuntu/javascript.Dockerfile
+++ b/jenkins/docker/ubuntu/javascript.Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get install -y wget gnupg \
 
 # nodejs
 ENV NODE_OPTIONS="--dns-result-order=ipv4first"
-ARG NODEJS_VERSION=18
+ARG NODEJS_VERSION=20
 RUN apt-get install -y ca-certificates curl gnupg \
 	&& mkdir -p /etc/apt/keyrings \
 	&& curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \

--- a/jenkins/docker/ubuntu/javascript.Dockerfile
+++ b/jenkins/docker/ubuntu/javascript.Dockerfile
@@ -17,11 +17,11 @@ RUN apt-get install -y wget gnupg \
 
 # nodejs
 ENV NODE_OPTIONS="--dns-result-order=ipv4first"
-ARG NODE_MAJOR=18
+ARG NODEJS_VERSION=18
 RUN apt-get install -y ca-certificates curl gnupg \
 	&& mkdir -p /etc/apt/keyrings \
 	&& curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
-	&& echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" \
+	&& echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_${NODEJS_VERSION}.x nodistro main" \
 	| tee /etc/apt/sources.list.d/nodesource.list \
 	&& apt-get update \
 	&& apt-get install -y nodejs

--- a/jenkins/docker/ubuntu/python.Dockerfile
+++ b/jenkins/docker/ubuntu/python.Dockerfile
@@ -7,15 +7,11 @@ RUN apt-get update >/dev/null \
 	&& apt-get install -y tzdata \
 	&& apt-get install -y git curl
 
-# install python (python3.9 for ubuntu 20.04)
+# install python
 ARG FROM_IMAGE
-RUN if [ "${FROM_IMAGE}" = "ubuntu:20.04" ]; then \
-		apt-get install -y python3.9 python3-pip python3.9-venv python3.9-dev  \
-		&& update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 10; \
-	else \
-		apt-get install -y python3-pip python3-venv; \
-	fi
-
+ARG PYTHON_VERSION='3.11'
+RUN apt-get install -y python${PYTHON_VERSION} python3-pip python${PYTHON_VERSION}-venv python${PYTHON_VERSION}-dev  \
+		&& update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 10
 
 # install shellcheck
 RUN apt-get install -y shellcheck
@@ -48,4 +44,4 @@ RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # install poetry and gitlint
-RUN pip install poetry gitlint wheel
+RUN python3 -m pip install poetry gitlint wheel

--- a/jenkins/docker/windows/javascript.Dockerfile
+++ b/jenkins/docker/windows/javascript.Dockerfile
@@ -12,9 +12,7 @@ RUN Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser; `
 	$command='c:\scoop.ps1 -RunAsAdmin'; `
 	iex $command; `
 	del c:\scoop.ps1; `
-	scoop install git shellcheck nodejs-lts cygwin rustup; `
-	scoop bucket add versions; `
-	scoop install versions/python311; `
+	scoop install git shellcheck nodejs-lts cygwin rustup python3; `
 	python3 -m pip install --upgrade pip; `
 	python3 -m pip install --upgrade gitlint wheel
 

--- a/jenkins/docker/windows/javascript.Dockerfile
+++ b/jenkins/docker/windows/javascript.Dockerfile
@@ -12,7 +12,7 @@ RUN Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser; `
 	$command='c:\scoop.ps1 -RunAsAdmin'; `
 	iex $command; `
 	del c:\scoop.ps1; `
-	scoop install git shellcheck nodejs-lts cygwin rustup python3; `
+	scoop install git shellcheck nodejs-lts cygwin rustup python; `
 	python3 -m pip install --upgrade pip; `
 	python3 -m pip install --upgrade gitlint wheel
 

--- a/jenkins/docker/windows/python.Dockerfile
+++ b/jenkins/docker/windows/python.Dockerfile
@@ -16,9 +16,7 @@ RUN Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser; `
 	$command='c:\scoop.ps1 -RunAsAdmin'; `
 	iex $command; `
 	del c:\scoop.ps1; `
-	scoop install git shellcheck openssl cmake cygwin; `
-	scoop bucket add versions; `
-	scoop install versions/python311; `
+	scoop install git shellcheck openssl cmake cygwin python3; `
 	python3 -m pip install --upgrade pip; `
 	python3 -m pip install --upgrade gitlint wheel
 

--- a/jenkins/docker/windows/python.Dockerfile
+++ b/jenkins/docker/windows/python.Dockerfile
@@ -16,7 +16,7 @@ RUN Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser; `
 	$command='c:\scoop.ps1 -RunAsAdmin'; `
 	iex $command; `
 	del c:\scoop.ps1; `
-	scoop install git shellcheck openssl cmake cygwin python3; `
+	scoop install git shellcheck openssl cmake cygwin python; `
 	python3 -m pip install --upgrade pip; `
 	python3 -m pip install --upgrade gitlint wheel
 

--- a/jenkins/infra/jenkins/build-ci-image.groovy
+++ b/jenkins/infra/jenkins/build-ci-image.groovy
@@ -120,9 +120,6 @@ pipeline {
 String getVersionArg(String toolName, Object buildEnvironment) {
 	String name = 'javascript' == toolName ? 'nodejs' : toolName
 	String version = buildEnvironment[name]
-	if (version) {
-		return "${name.toUpperCase()}_VERSION=${version}"
-	}
 
-	return ''
+	return version ? "${name.toUpperCase()}_VERSION=${version}" : ''
 }

--- a/jenkins/infra/jenkins/build-ci-image.groovy
+++ b/jenkins/infra/jenkins/build-ci-image.groovy
@@ -66,9 +66,6 @@ pipeline {
 			}
 		}
 		stage('checkout') {
-			when {
-				triggeredBy 'UserIdCause'
-			}
 			steps {
 				script {
 					runScript "git reset --hard origin/${env.MANUAL_GIT_BRANCH}"
@@ -82,7 +79,7 @@ pipeline {
 						dir("jenkins/docker/${params.OPERATING_SYSTEM}")
 						{
 							String versionArg = getVersionArg(params.CI_IMAGE, buildEnvironment)
-							String buildArg = "-f ${CI_IMAGE}.Dockerfile --build-arg ${versionArg} --build-arg FROM_IMAGE=${dockerFromImage} ."
+							String buildArg = "-f ${CI_IMAGE}.Dockerfile ${versionArg} --build-arg FROM_IMAGE=${dockerFromImage} ."
 							docker.withRegistry(DOCKER_URL, DOCKER_CREDENTIALS_ID) {
 								docker.build(archImageName, buildArg).push()
 							}
@@ -121,5 +118,5 @@ String getVersionArg(String toolName, Object buildEnvironment) {
 	String name = 'javascript' == toolName ? 'nodejs' : toolName
 	String version = buildEnvironment[name]
 
-	return version ? "${name.toUpperCase()}_VERSION=${version}" : ''
+	return version ? "--build-arg ${name.toUpperCase()}_VERSION=${version}" : ''
 }

--- a/jenkins/shared-library/resources/buildEnvironment/baseImages.yaml
+++ b/jenkins/shared-library/resources/buildEnvironment/baseImages.yaml
@@ -1,4 +1,14 @@
-ubuntu-lts: ubuntu:22.04
-ubuntu-base: ubuntu:20.04
-ubuntu-latest: ubuntu:23.04
-windows-lts: symbolplatform/symbol-server-compiler:windows-msvc-17
+ubuntu-lts:
+  image: ubuntu:22.04
+  python: 3.11
+  nodejs: 20
+ubuntu-base:
+  image: ubuntu:20.04
+  python: 3.9
+  nodejs: 18
+ubuntu-latest:
+  image: ubuntu:24.04
+  python: 3.12
+  nodejs: 21
+windows-lts:
+  image: symbolplatform/symbol-server-compiler:windows-msvc-17

--- a/linters/python/.pylintrc
+++ b/linters/python/.pylintrc
@@ -276,7 +276,7 @@ missing-member-max-choices=1
 
 # List of additional names supposed to be defined in builtins. Remember that
 # you should avoid to define new builtins when possible.
-additional-builtins=
+additional-builtins=_
 
 # Tells whether unused global variables should be treated as a violation.
 allow-global-unused-variables=yes

--- a/linters/python/.pylintrc
+++ b/linters/python/.pylintrc
@@ -276,7 +276,7 @@ missing-member-max-choices=1
 
 # List of additional names supposed to be defined in builtins. Remember that
 # you should avoid to define new builtins when possible.
-additional-builtins=_
+additional-builtins=
 
 # Tells whether unused global variables should be treated as a violation.
 allow-global-unused-variables=yes
@@ -388,3 +388,9 @@ known-third-party=enchant
 # Exceptions that will emit a warning when being caught. Defaults to
 # "Exception"
 overgeneral-exceptions=builtins.Exception
+
+[STRING]
+
+# This flag controls whether inconsistent-quotes generates a warning when the
+# character used as a quote delimiter is used inconsistently within a module.
+check-quote-consistency=yes

--- a/linters/python/lint.sh
+++ b/linters/python/lint.sh
@@ -16,5 +16,4 @@ find . -type f -name "*.py" -print0 | PYTHONPATH=. xargs -0 python3 -m pycodesty
 	--config="$(git rev-parse --show-toplevel)/linters/python/.pycodestyle"
 find . -type f -name "*.py" -print0 | PYTHONPATH=. xargs -0 python3 -m pylint \
 	--rcfile "$(git rev-parse --show-toplevel)/linters/python/.pylintrc" \
-	--load-plugins pylint_quotes \
 	--disable "${PYLINT_DISABLE_COMMANDS}"

--- a/linters/python/lint_requirements.txt
+++ b/linters/python/lint_requirements.txt
@@ -1,4 +1,3 @@
 isort==5.13.2
 pycodestyle==2.11.1
-pylint==2.17.7
-pylint-quotes==0.2.3
+pylint==3.0.3

--- a/sdk/javascript/scripts/ci/lint_python.sh
+++ b/sdk/javascript/scripts/ci/lint_python.sh
@@ -14,5 +14,4 @@ find . -type f -name "*.py" -print0 | PYTHONPATH=. xargs -0 python3 -m pycodesty
 # Cygwin is install in our Windows images so pick the correct separator if Windows(Msys)
 SEPARATOR="$([ "$(uname -o)" = "Msys" ] && echo ";" || echo ":")"
 find . -type f -name "*.py" -print0 | PYTHONPATH=".${SEPARATOR}$(git rev-parse --show-toplevel)/catbuffer/parser" xargs -0 python3 -m pylint \
-	--rcfile "$(git rev-parse --show-toplevel)/linters/python/.pylintrc" \
-	--load-plugins pylint_quotes
+	--rcfile "$(git rev-parse --show-toplevel)/linters/python/.pylintrc"

--- a/sdk/python/scripts/ci/lint.sh
+++ b/sdk/python/scripts/ci/lint.sh
@@ -17,8 +17,7 @@ find . -name "nc" -prune -o -name "sc" -prune -o -type f -name "*.py" -print0 | 
 SEPARATOR="$([ "$(uname -o)" = "Msys" ] && echo ";" || echo ":")"
 find . -name "nc" -prune -o -name "sc" -prune -o -type f -name "*.py" -print0 | xargs -0 git check-ignore -nv | grep :: | cut -f2- | \
 	PYTHONPATH=".${SEPARATOR}$(git rev-parse --show-toplevel)/catbuffer/parser" xargs python3 -m pylint \
-	--rcfile "$(git rev-parse --show-toplevel)/linters/python/.pylintrc" \
-	--load-plugins pylint_quotes
+	--rcfile "$(git rev-parse --show-toplevel)/linters/python/.pylintrc"
 
 # generated code with some suppressions
 find . -name "nc" -o -name "sc" -o -type f -name "*.py" -print0 | xargs -0 git check-ignore -nv | grep :: | cut -f2- | \
@@ -28,5 +27,4 @@ find . -name "nc" -o -name "sc" -o -type f -name "*.py" -print0 | xargs -0 git c
 find . -name "nc" -o -name "sc" -o -type f -name "*.py" -print0 | xargs -0 git check-ignore -nv | grep :: | cut -f2- | \
 	PYTHONPATH=".${SEPARATOR}$(git rev-parse --show-toplevel)/catbuffer/parser" xargs python3 -m pylint \
 	--rcfile "$(git rev-parse --show-toplevel)/linters/python/.pylintrc" \
-	--load-plugins pylint_quotes \
 	--disable=duplicate-code

--- a/sdk/python/testvectors/__main__.py
+++ b/sdk/python/testvectors/__main__.py
@@ -77,11 +77,11 @@ class SymbolHelper:
 	@staticmethod
 	def get_test_name(object_name, test_prefix, index):
 		name_mapping = {
-			'transaction': lambda test_prefix, index: f'{test_prefix}_single_{index+1}',
-			'aggregate': lambda test_prefix, index: f'{test_prefix}_aggregate_{index+1}',
-			'receipt': lambda test_prefix, index: f'{test_prefix}_{index+1}',
-			'block': lambda test_prefix, index: f'{test_prefix}_{index+1}',
-			'other': lambda test_prefix, index: f'{test_prefix}_other_{index+1}'
+			'transaction': lambda test_prefix, index: f'{test_prefix}_single_{index + 1}',
+			'aggregate': lambda test_prefix, index: f'{test_prefix}_aggregate_{index + 1}',
+			'receipt': lambda test_prefix, index: f'{test_prefix}_{index + 1}',
+			'block': lambda test_prefix, index: f'{test_prefix}_{index + 1}',
+			'other': lambda test_prefix, index: f'{test_prefix}_other_{index + 1}'
 		}
 
 		return name_mapping[object_name](test_prefix, index)
@@ -115,7 +115,7 @@ class SymbolHelper:
 
 	@staticmethod
 	def create_cosignature_descriptor(test_name, index):
-		name = f'{test_name}_cosig_{index+1}'
+		name = f'{test_name}_cosig_{index + 1}'
 		return {
 			'signer_public_key': hashlib.sha3_256(name.encode('utf8')).hexdigest(),
 			'signature': hashlib.sha3_512(name.encode('utf8')).hexdigest()
@@ -213,8 +213,8 @@ class NemHelper:
 	@staticmethod
 	def get_test_name(object_name, test_prefix, index):
 		name_mapping = {
-			'transaction': lambda test_prefix, index: f'{test_prefix}_single_{index+1}',
-			'aggregate': lambda test_prefix, index: f'{test_prefix}_aggregate_{index+1}'
+			'transaction': lambda test_prefix, index: f'{test_prefix}_single_{index + 1}',
+			'aggregate': lambda test_prefix, index: f'{test_prefix}_aggregate_{index + 1}'
 		}
 
 		return name_mapping[object_name](test_prefix, index)
@@ -260,7 +260,7 @@ class NemHelper:
 		return self.facade.transaction_factory.create(descriptor), printable_descriptor
 
 	def create_cosignature(self, test_name, index):
-		name = f'{test_name}_cosig_{index+1}'
+		name = f'{test_name}_cosig_{index + 1}'
 		descriptor = {
 			# note: `type: cosignature`` is not present, it's handled by TransactionDescriptorProcessor
 			'multisig_transaction_hash': hashlib.sha3_256(test_name.encode('utf8')).hexdigest(),
@@ -340,7 +340,7 @@ class VectorGenerator:
 				continue
 
 			test_prefix = f'{recipe["schema_name"]}_{module_descriptor[0]}'
-			test_name = f'{test_prefix}_aggregate_{index+1}'
+			test_name = f'{test_prefix}_aggregate_{index + 1}'
 
 			handler = self.helper.create_aggregate_from_single
 			test_cases.append(self.create_entry(self.helper.AGGREGATE_SCHEMA_NAME, test_name, handler, recipe['descriptor']))


### PR DESCRIPTION
## What is the current behavior?
Tests are currently not run with Python 3.12

## What's the issue?
Python 3.12 is now the default version on some Linux distributions.

## How have you changed the behavior?
Use Python 3.12 for testing in the latest image.
Move to Pylint 3, which supports Python 3.12
Remove Pylint-Quotes since does not support Pylint 3

## How was this change tested?
Will run tests in Jenkins.