### PR TITLE
[client/rest]: fix failing bootstrapper tests

### DIFF
--- a/client/rest/test/server/bootstrapper_spec.js
+++ b/client/rest/test/server/bootstrapper_spec.js
@@ -166,7 +166,8 @@ const makeWrappedRequest = (server, options = {}) => {
 		headers: {
 			'User-Agent': 'requestWrapper',
 			'Content-Type': 'application/json; charset=utf-8',
-			Accept: 'application/json'
+			Accept: 'application/json',
+			Connection: 'close'
 		}
 	};
 


### PR DESCRIPTION
 problem: tests are failing because requests are implicitly being sent with keep-alive
solution: explicitly send requests with `Connection: close` header