### PR TITLE
[catapult/client]: upgrade boost to 1.83

### DIFF
--- a/client/catapult/CMakeGlobalSettings.cmake
+++ b/client/catapult/CMakeGlobalSettings.cmake
@@ -40,6 +40,12 @@ endif()
 ### set boost settings
 add_definitions(-DBOOST_ALL_DYN_LINK)
 add_definitions(-DBOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT)
+
+if(Boost_VERSION VERSION_LESS 1.84)
+	# workaround for https://github.com/boostorg/phoenix/issues/111
+	add_definitions(-DBOOST_PHOENIX_STL_TUPLE_H_)
+endif()
+
 set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)

--- a/client/catapult/CMakeGlobalSettings.cmake
+++ b/client/catapult/CMakeGlobalSettings.cmake
@@ -440,8 +440,6 @@ endfunction()
 function(catapult_test_executable TARGET_NAME)
 	catapult_executable(${TARGET_NAME} ${ARGN})
 	add_test(NAME ${TARGET_NAME} WORKING_DIRECTORY ${CMAKE_BINARY_DIR} COMMAND ${TARGET_NAME})
-
-	target_link_libraries(${TARGET_NAME} ${GTEST_LIBRARIES})
 endfunction()
 
 # used to define a catapult test executable for a catapult library by combining catapult_test_executable and
@@ -458,13 +456,14 @@ function(catapult_test_executable_target TARGET_NAME TEST_DEPENDENCY_NAME)
 	MATH(EXPR TEST_END_INDEX "${TEST_END_INDEX}+1")
 	string(SUBSTRING ${TARGET_NAME} ${TEST_END_INDEX} -1 LIBRARY_UNDER_TEST)
 
-	target_link_libraries(${TARGET_NAME} tests.catapult.test.${TEST_DEPENDENCY_NAME} ${LIBRARY_UNDER_TEST} ${GTEST_LIBRARIES})
+	target_link_libraries(${TARGET_NAME} tests.catapult.test.${TEST_DEPENDENCY_NAME} ${LIBRARY_UNDER_TEST})
 	catapult_target(${TARGET_NAME})
 endfunction()
 
 # used to define a catapult test executable for a header only catapult library by combining catapult_test_executable and
 # catapult_target and adding some library dependencies
-function(catapult_test_executable_target_header_only TARGET_NAME TEST_DEPENDENCY_NAME)
+# also used when the library under test should not be automatically added because it's included by the test dependency library
+function(catapult_test_executable_target_no_lib TARGET_NAME TEST_DEPENDENCY_NAME)
 	catapult_test_executable(${TARGET_NAME} ${ARGN})
 
 	# customize and export compiler options for gtest

--- a/client/catapult/CMakeLists.txt
+++ b/client/catapult/CMakeLists.txt
@@ -33,7 +33,7 @@ endfunction()
 
 ### setup boost
 message("--- locating boost dependencies ---")
-find_package(Boost 1.80.0 EXACT COMPONENTS ${CATAPULT_BOOST_COMPONENTS} REQUIRED)
+find_package(Boost 1.83.0 EXACT COMPONENTS ${CATAPULT_BOOST_COMPONENTS} REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIR})
 
 message("boost     ver: ${Boost_VERSION}")

--- a/client/catapult/conanfile.txt
+++ b/client/catapult/conanfile.txt
@@ -1,6 +1,6 @@
 [requires]
 # release dependencies
-boost/1.80.0
+boost/1.83.0
 openssl/3.2.0
 
 cppzmq/4.10.0@nemtech/stable

--- a/client/catapult/extensions/harvesting/tests/CMakeLists.txt
+++ b/client/catapult/extensions/harvesting/tests/CMakeLists.txt
@@ -1,4 +1,3 @@
 cmake_minimum_required(VERSION 3.14)
 
 catapult_define_extension_test(harvesting test)
-target_link_libraries(tests.catapult.harvesting tests.catapult.test.crypto)

--- a/client/catapult/extensions/mongo/plugins/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/CMakeLists.txt
@@ -36,7 +36,6 @@ function(catapult_mongo_plugin_tests_with_header_only_deps TARGET_NAME)
 
 	catapult_test_executable_target(${TARGET_NAME} mongo "${ARGN}")
 	catapult_add_mongo_dependencies(${TARGET_NAME})
-	target_link_libraries(${TARGET_NAME} catapult.plugins.${PLUGIN_NAME}.deps)
 	target_link_libraries(${TARGET_NAME} catapult.mongo.plugins.${PLUGIN_NAME}.deps)
 
 	if(TARGET "tests.catapult.test.plugins.${PLUGIN_NAME}")

--- a/client/catapult/extensions/mongo/plugins/metadata/tests/int/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/metadata/tests/int/CMakeLists.txt
@@ -9,5 +9,4 @@ target_link_libraries(${TARGET_NAME}
 	tests.catapult.test.plugins.metadata
 	tests.catapult.test.cache
 	tests.catapult.test.mongo
-	catapult.mongo.plugins.metadata
-	catapult.plugins.metadata.deps)
+	catapult.mongo.plugins.metadata)

--- a/client/catapult/extensions/mongo/plugins/mosaic/tests/int/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/mosaic/tests/int/CMakeLists.txt
@@ -9,5 +9,4 @@ target_link_libraries(${TARGET_NAME}
 	tests.catapult.test.plugins.mosaic
 	tests.catapult.test.cache
 	tests.catapult.test.mongo
-	catapult.mongo.plugins.mosaic
-	catapult.plugins.mosaic.deps)
+	catapult.mongo.plugins.mosaic)

--- a/client/catapult/extensions/mongo/plugins/namespace/tests/int/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/namespace/tests/int/CMakeLists.txt
@@ -9,5 +9,4 @@ target_link_libraries(${TARGET_NAME}
 	tests.catapult.test.plugins.namespace
 	tests.catapult.test.cache
 	tests.catapult.test.mongo
-	catapult.mongo.plugins.namespace
-	catapult.plugins.namespace.deps)
+	catapult.mongo.plugins.namespace)

--- a/client/catapult/extensions/mongo/plugins/restriction_account/tests/int/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/restriction_account/tests/int/CMakeLists.txt
@@ -8,5 +8,4 @@ target_link_libraries(${TARGET_NAME}
 	tests.catapult.test.cache
 	tests.catapult.test.mongo
 	tests.catapult.test.mongo.plugins.restrictionaccount
-	catapult.mongo.plugins.restrictionaccount
-	catapult.plugins.restrictionaccount.deps)
+	catapult.mongo.plugins.restrictionaccount)

--- a/client/catapult/extensions/mongo/plugins/restriction_mosaic/tests/int/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/restriction_mosaic/tests/int/CMakeLists.txt
@@ -8,5 +8,4 @@ target_link_libraries(${TARGET_NAME}
 	tests.catapult.test.cache
 	tests.catapult.test.mongo
 	tests.catapult.test.mongo.plugins.restrictionmosaic
-	catapult.mongo.plugins.restrictionmosaic
-	catapult.plugins.restrictionmosaic.deps)
+	catapult.mongo.plugins.restrictionmosaic)

--- a/client/catapult/extensions/mongo/tests/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ set(TARGET_NAME tests.catapult.mongo)
 add_subdirectory(int)
 add_subdirectory(test)
 
-catapult_test_executable_target(${TARGET_NAME} mongo mappers)
+catapult_test_executable_target_no_lib(${TARGET_NAME} mongo mappers)
 catapult_add_mongo_dependencies(${TARGET_NAME})
 target_link_libraries(${TARGET_NAME} tests.catapult.test.cache)
 target_link_libraries(${TARGET_NAME} catapult.mongo.plugins.transfer) # allow transfer to be loaded implicitly

--- a/client/catapult/plugins/txes/CMakeLists.txt
+++ b/client/catapult/plugins/txes/CMakeLists.txt
@@ -19,7 +19,6 @@ function(catapult_tx_plugin_src PLUGIN_BASE_NAME)
 
 	# create a plugin dll
 	catapult_shared_library_target(${PLUGIN_BASE_NAME} plugins)
-	target_link_libraries(${PLUGIN_BASE_NAME} ${PLUGIN_CATAPULT_LIBS})
 
 	if(DEFINED PLUGIN_DEPS_FOLDERS)
 		target_link_libraries(${PLUGIN_BASE_NAME} ${PLUGIN_BASE_NAME}.deps)

--- a/client/catapult/tests/bench/CMakeLists.txt
+++ b/client/catapult/tests/bench/CMakeLists.txt
@@ -5,19 +5,10 @@ message("--- locating bench dependencies ---")
 find_package(benchmark 1.8.3 EXACT REQUIRED)
 message("bench     ver: ${benchmark_VERSION}")
 
-# add benchmark dependencies
-function(catapult_add_benchmark_dependencies TARGET_NAME)
-	add_definitions(-DBENCHMARK_STATIC_DEFINE)
-
-	# this should both link and add proper include path
-	target_link_libraries(${TARGET_NAME} benchmark::benchmark)
-endfunction()
-
 # used to define a catapult bench executable
 function(catapult_bench_executable_target TARGET_NAME)
 	catapult_executable(${TARGET_NAME} ${ARGN})
 
-	catapult_add_benchmark_dependencies(${TARGET_NAME})
 	catapult_set_test_compiler_options()
 
 	catapult_target(${TARGET_NAME})

--- a/client/catapult/tests/bench/nodeps/CMakeLists.txt
+++ b/client/catapult/tests/bench/nodeps/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
 
 catapult_library_target(bench.catapult.bench.nodeps)
-catapult_add_benchmark_dependencies(bench.catapult.bench.nodeps)
+target_link_libraries(bench.catapult.bench.nodeps benchmark::benchmark)  # this also sets up benchmark include directories
 target_link_libraries(bench.catapult.bench.nodeps catapult.utils catapult.version)

--- a/client/catapult/tests/catapult/cache/CMakeLists.txt
+++ b/client/catapult/tests/catapult/cache/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.14)
 
-catapult_test_executable_target(tests.catapult.cache cache test)
-target_link_libraries(tests.catapult.cache catapult.crypto)
+catapult_test_executable_target_no_lib(tests.catapult.cache cache test)
 catapult_add_rocksdb_dependencies(tests.catapult.cache)

--- a/client/catapult/tests/catapult/config/CMakeLists.txt
+++ b/client/catapult/tests/catapult/config/CMakeLists.txt
@@ -1,3 +1,3 @@
 cmake_minimum_required(VERSION 3.14)
 
-catapult_test_executable_target(tests.catapult.config net)
+catapult_test_executable_target_no_lib(tests.catapult.config net)

--- a/client/catapult/tests/catapult/crypto/CMakeLists.txt
+++ b/client/catapult/tests/catapult/crypto/CMakeLists.txt
@@ -2,6 +2,5 @@ cmake_minimum_required(VERSION 3.14)
 
 include_directories(../../../external)
 
-catapult_test_executable_target(tests.catapult.crypto crypto)
-target_link_libraries(tests.catapult.crypto external)
+catapult_test_executable_target_no_lib(tests.catapult.crypto crypto)
 catapult_add_openssl_dependencies(tests.catapult.crypto)

--- a/client/catapult/tests/catapult/deltaset/CMakeLists.txt
+++ b/client/catapult/tests/catapult/deltaset/CMakeLists.txt
@@ -4,4 +4,4 @@ if(MSVC)
 	set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /bigobj")
 endif()
 
-catapult_test_executable_target_header_only(tests.catapult.deltaset nodeps test)
+catapult_test_executable_target_no_lib(tests.catapult.deltaset nodeps test)

--- a/client/catapult/tests/catapult/extensions/CMakeLists.txt
+++ b/client/catapult/tests/catapult/extensions/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
 
-catapult_test_executable_target(tests.catapult.extensions local)
-target_link_libraries(tests.catapult.extensions catapult.plugins.coresystem.deps tests.catapult.test.nemesis)
+catapult_test_executable_target_no_lib(tests.catapult.extensions nemesis)
+target_link_libraries(tests.catapult.extensions catapult.plugins.coresystem.deps)
 catapult_add_openssl_dependencies(tests.catapult.extensions)

--- a/client/catapult/tests/catapult/ionet/CMakeLists.txt
+++ b/client/catapult/tests/catapult/ionet/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required(VERSION 3.14)
 
-catapult_test_executable_target(tests.catapult.ionet net)
+catapult_test_executable_target_no_lib(tests.catapult.ionet net)
 catapult_add_openssl_dependencies(tests.catapult.ionet)

--- a/client/catapult/tests/catapult/keylink/CMakeLists.txt
+++ b/client/catapult/tests/catapult/keylink/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required(VERSION 3.14)
 
-catapult_test_executable_target_header_only(tests.catapult.keylink cache)
+catapult_test_executable_target_no_lib(tests.catapult.keylink cache)
 target_link_libraries(tests.catapult.keylink catapult.observers catapult.validators)

--- a/client/catapult/tests/catapult/local/importer/CMakeLists.txt
+++ b/client/catapult/tests/catapult/local/importer/CMakeLists.txt
@@ -1,4 +1,3 @@
 cmake_minimum_required(VERSION 3.14)
 
-catapult_test_executable_target(tests.catapult.local.importer local)
-target_link_libraries(tests.catapult.local.importer tests.catapult.test.nemesis)
+catapult_test_executable_target(tests.catapult.local.importer nemesis)

--- a/client/catapult/tests/catapult/local/recovery/CMakeLists.txt
+++ b/client/catapult/tests/catapult/local/recovery/CMakeLists.txt
@@ -1,4 +1,3 @@
 cmake_minimum_required(VERSION 3.14)
 
-catapult_test_executable_target(tests.catapult.local.recovery local)
-target_link_libraries(tests.catapult.local.recovery tests.catapult.test.nemesis)
+catapult_test_executable_target(tests.catapult.local.recovery nemesis)

--- a/client/catapult/tests/catapult/local/server/CMakeLists.txt
+++ b/client/catapult/tests/catapult/local/server/CMakeLists.txt
@@ -1,4 +1,3 @@
 cmake_minimum_required(VERSION 3.14)
 
-catapult_test_executable_target(tests.catapult.local.server local)
-target_link_libraries(tests.catapult.local.server tests.catapult.test.nemesis)
+catapult_test_executable_target_no_lib(tests.catapult.local.server nemesis)

--- a/client/catapult/tests/catapult/model/CMakeLists.txt
+++ b/client/catapult/tests/catapult/model/CMakeLists.txt
@@ -1,4 +1,3 @@
 cmake_minimum_required(VERSION 3.14)
 
-catapult_test_executable_target(tests.catapult.model core)
-target_link_libraries(tests.catapult.model external)
+catapult_test_executable_target_no_lib(tests.catapult.model core)

--- a/client/catapult/tests/catapult/plugins/CMakeLists.txt
+++ b/client/catapult/tests/catapult/plugins/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required(VERSION 3.14)
 
-catapult_test_executable_target(tests.catapult.plugins core)
+catapult_test_executable_target_no_lib(tests.catapult.plugins core)
 target_link_libraries(tests.catapult.plugins catapult.plugins.transfer) # allow transfer to be loaded implicitly

--- a/client/catapult/tests/catapult/state/CMakeLists.txt
+++ b/client/catapult/tests/catapult/state/CMakeLists.txt
@@ -1,3 +1,3 @@
 cmake_minimum_required(VERSION 3.14)
 
-catapult_test_executable_target(tests.catapult.state core)
+catapult_test_executable_target_no_lib(tests.catapult.state core)

--- a/client/catapult/tests/catapult/subscribers/CMakeLists.txt
+++ b/client/catapult/tests/catapult/subscribers/CMakeLists.txt
@@ -1,4 +1,3 @@
 cmake_minimum_required(VERSION 3.14)
 
 catapult_test_executable_target(tests.catapult.subscribers cache test)
-target_link_libraries(tests.catapult.subscribers catapult.config)

--- a/client/catapult/tests/catapult/thread/CMakeLists.txt
+++ b/client/catapult/tests/catapult/thread/CMakeLists.txt
@@ -1,3 +1,3 @@
 cmake_minimum_required(VERSION 3.14)
 
-catapult_test_executable_target(tests.catapult.thread core)
+catapult_test_executable_target_no_lib(tests.catapult.thread core)

--- a/client/catapult/tests/catapult/utils/CMakeLists.txt
+++ b/client/catapult/tests/catapult/utils/CMakeLists.txt
@@ -1,3 +1,3 @@
 cmake_minimum_required(VERSION 3.14)
 
-catapult_test_executable_target(tests.catapult.utils nodeps test)
+catapult_test_executable_target_no_lib(tests.catapult.utils nodeps test)

--- a/client/catapult/tests/int/node/basic/CMakeLists.txt
+++ b/client/catapult/tests/int/node/basic/CMakeLists.txt
@@ -3,4 +3,4 @@ cmake_minimum_required(VERSION 3.14)
 set(TARGET_NAME tests.catapult.int.node)
 
 catapult_int_test_executable_target(${TARGET_NAME})
-target_link_libraries(${TARGET_NAME} tests.catapult.int.node.test tests.catapult.test.nemesis catapult.local.server)
+target_link_libraries(${TARGET_NAME} tests.catapult.int.node.test tests.catapult.test.nemesis)

--- a/client/catapult/tests/int/node/stress/CMakeLists.txt
+++ b/client/catapult/tests/int/node/stress/CMakeLists.txt
@@ -3,6 +3,6 @@ cmake_minimum_required(VERSION 3.14)
 set(TARGET_NAME tests.catapult.int.node.stress)
 
 catapult_int_test_executable_target(${TARGET_NAME} test)
-target_link_libraries(${TARGET_NAME} tests.catapult.int.node.test tests.catapult.test.nemesis catapult.local.server)
+target_link_libraries(${TARGET_NAME} tests.catapult.int.node.test tests.catapult.test.nemesis)
 
 set_property(TEST ${TARGET_NAME} PROPERTY LABELS Stress)

--- a/client/catapult/tests/int/stress/CMakeLists.txt
+++ b/client/catapult/tests/int/stress/CMakeLists.txt
@@ -4,11 +4,8 @@ set(TARGET_NAME tests.catapult.int.stress)
 
 catapult_int_test_executable_target(${TARGET_NAME} test)
 target_link_libraries(${TARGET_NAME}
-	catapult.cache_db
 	catapult.harvesting
 	catapult.plugins.hashcache
-	catapult.plugins.hashcache.cache
-	tests.catapult.test.local
 	tests.catapult.test.nemesis)
 
 set_property(TEST ${TARGET_NAME} PROPERTY LABELS Stress)

--- a/client/catapult/tests/test/local/CMakeLists.txt
+++ b/client/catapult/tests/test/local/CMakeLists.txt
@@ -3,6 +3,5 @@ cmake_minimum_required(VERSION 3.14)
 catapult_library_target(tests.catapult.test.local)
 target_link_libraries(tests.catapult.test.local
 	tests.catapult.test.cache
-	tests.catapult.test.nemesis
 	tests.catapult.test.net
 	catapult.local.server)

--- a/client/catapult/tests/test/local/FilechainTestUtils.cpp
+++ b/client/catapult/tests/test/local/FilechainTestUtils.cpp
@@ -23,7 +23,6 @@
 #include "RealTransactionFactory.h"
 #include "sdk/src/extensions/ConversionExtensions.h"
 #include "tests/test/core/BlockTestUtils.h"
-#include "tests/test/nemesis/NemesisCompatibleConfiguration.h"
 #include "tests/test/nodeps/TestNetworkConstants.h"
 
 namespace catapult { namespace test {

--- a/client/catapult/tools/votingkey/CMakeLists.txt
+++ b/client/catapult/tools/votingkey/CMakeLists.txt
@@ -1,4 +1,4 @@
 cmake_minimum_required(VERSION 3.14)
 
 catapult_define_tool(votingkey)
-target_link_libraries(catapult.tools.votingkey catapult.crypto_voting catapult.finalization)
+target_link_libraries(catapult.tools.votingkey catapult.finalization)

--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -5,7 +5,7 @@ fedora = 39
 debian = 12
 windows = 2022
 
-boost = 1.80.0
+boost = 1.83.0
 cmake = 3.28.1
 gosu = 1.17
 


### PR DESCRIPTION
- fix duplicate libraries linker warning
- workaround boost versions 1.81-1.83
- increment boost target