### PR TITLE
[jenkins] fix: CFFI failing to install on Python 3.12

### DIFF
--- a/jenkins/docker/ubuntu/python.Dockerfile
+++ b/jenkins/docker/ubuntu/python.Dockerfile
@@ -44,4 +44,4 @@ RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # install poetry and gitlint
-RUN python3 -m pip install poetry gitlint wheel
+RUN python3 -m pip install poetry gitlint wheel setuptools

--- a/jenkins/docker/windows/python.Dockerfile
+++ b/jenkins/docker/windows/python.Dockerfile
@@ -18,7 +18,7 @@ RUN Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser; `
 	del c:\scoop.ps1; `
 	scoop install git shellcheck openssl cmake cygwin python; `
 	python3 -m pip install --upgrade pip; `
-	python3 -m pip install --upgrade gitlint wheel
+	python3 -m pip install --upgrade gitlint wheel setuptools
 
 # Set VS tools first in the path so the correct link.exe is used.
 RUN Set-Content -Path c:\Users\ContainerAdministrator\.bash_profile  -Value 'export PATH=${VCToolsInstallDir}bin/Hostx64/x64:${PATH}'


### PR DESCRIPTION
problem: CFFI requires setuptools to be installed with Python 3.12
solution: install setuptools by default in the Python CI image