### PR TITLE
[sdk/javascript]: fix failing test vectors after constructor.name change

### DIFF
--- a/sdk/javascript/src/RuleBasedTransactionFactory.js
+++ b/sdk/javascript/src/RuleBasedTransactionFactory.js
@@ -43,7 +43,11 @@ const typeConverterFactory = (module, customTypeConverter, value) => {
 	if (value instanceof ByteArray) {
 		/** @type object */
 		const ByteArrayClass = value.constructor;
-		return new module[ByteArrayClass.NAME](value.bytes);
+
+		if (ByteArrayClass.NAME in module)
+			return new module[ByteArrayClass.NAME](value.bytes);
+
+		return new ByteArrayClass(value.bytes);
 	}
 
 	return value;

--- a/sdk/javascript/src/nem/Network.js
+++ b/sdk/javascript/src/nem/Network.js
@@ -36,6 +36,12 @@ export class Address extends ByteArray {
 	static ENCODED_SIZE = 40;
 
 	/**
+	 * Byte array name (required because `constructor.name` is dropped during minification).
+	 * @type string
+	 */
+	static NAME = 'Address';
+
+	/**
 	 * Creates a NEM address.
 	 * @param {Uint8Array|string|Address} addressInput Input string, byte array or address.
 	 */

--- a/sdk/javascript/src/symbol/Network.js
+++ b/sdk/javascript/src/symbol/Network.js
@@ -46,6 +46,12 @@ export class Address extends ByteArray {
 	static ENCODED_SIZE = 39;
 
 	/**
+	 * Byte array name (required because `constructor.name` is dropped during minification).
+	 * @type string
+	 */
+	static NAME = 'Address';
+
+	/**
 	 * Creates a Symbol address.
 	 * @param {Uint8Array|string|Address} addressInput Input string, byte array or address.
 	 */

--- a/sdk/javascript/test/RuleBasedTransactionFactory_spec.js
+++ b/sdk/javascript/test/RuleBasedTransactionFactory_spec.js
@@ -403,7 +403,7 @@ describe('RuleBasedTransactionFactory', () => {
 			expect(parsed.mosaicId instanceof Module.UnresolvedMosaicId).to.equal(true);
 		});
 
-		it('can parse with type converter and autodetect byte arrays', () => {
+		const assertCanParseWithTypeConverterAndAutodetectByteArrays = ByteArrayClass => {
 			// Arrange:
 			const factory = new RuleBasedTransactionFactory(Module);
 			factory.addPodParser('Hash256', Module.Hash256);
@@ -412,13 +412,21 @@ describe('RuleBasedTransactionFactory', () => {
 
 			// Act:
 			const parsed = rule({
-				hash: new Hash256('E9B3AEDE9A57C2B8C3D78DB9805D12AB0D983B63CE8F89D8DFE108D0FF08D23C')
+				hash: new ByteArrayClass('E9B3AEDE9A57C2B8C3D78DB9805D12AB0D983B63CE8F89D8DFE108D0FF08D23C')
 			});
 
 			// Assert:
 			expect(parsed.hash).to.deep.equal(new Module.Hash256('E9B3AEDE9A57C2B8C3D78DB9805D12AB0D983B63CE8F89D8DFE108D0FF08D23C'));
 
 			expect(parsed.hash instanceof Module.Hash256).to.equal(true);
+		};
+
+		it('can parse with type converter and autodetect byte arrays (from public type)', () => {
+			assertCanParseWithTypeConverterAndAutodetectByteArrays(Hash256);
+		});
+
+		it('can parse with type converter and autodetect byte arrays (from model type)', () => {
+			assertCanParseWithTypeConverterAndAutodetectByteArrays(Module.Hash256);
 		});
 	});
 

--- a/sdk/javascript/test/nem/Network_spec.js
+++ b/sdk/javascript/test/nem/Network_spec.js
@@ -30,6 +30,12 @@ describe('Address (NEM)', () => {
 		encodedAddress: 'TCFGSLITSWMRROU2GO7FPMIUUDELUPSZUNUEZF33',
 		decodedAddress: hexToUint8('988A692D13959918BA9A33BE57B114A0C8BA3E59A3684C977B')
 	});
+
+	it('has correct constants', () => {
+		expect(Address.NAME).to.deep.equal('Address');
+		expect(Address.SIZE).to.deep.equal(25);
+		expect(Address.ENCODED_SIZE).to.deep.equal(40);
+	});
 });
 
 describe('Network (NEM)', () => {

--- a/sdk/javascript/test/symbol/Network_spec.js
+++ b/sdk/javascript/test/symbol/Network_spec.js
@@ -45,6 +45,12 @@ describe('Address (Symbol)', () => {
 		encodedAddress: 'TBLYH55IHPS5QCCMNWR3GZWKV6WMCKPTNI7KSDA',
 		decodedAddress: hexToUint8('985783F7A83BE5D8084C6DA3B366CAAFACC129F36A3EA90C')
 	});
+
+	it('has correct constants', () => {
+		expect(Address.NAME).to.deep.equal('Address');
+		expect(Address.SIZE).to.deep.equal(24);
+		expect(Address.ENCODED_SIZE).to.deep.equal(39);
+	});
 });
 
 describe('Network (Symbol)', () => {

--- a/sdk/javascript/vectors/BlockFactory.js
+++ b/sdk/javascript/vectors/BlockFactory.js
@@ -15,6 +15,8 @@ import * as sc from '../src/symbol/models.js';
 class ProofGamma extends ByteArray {
 	static SIZE = 32;
 
+	static NAME = 'ProofGamma';
+
 	/**
 	 * Creates a vrf proof gamma from bytes or a hex string.
 	 * @param {Uint8Array|string} proofGamma Input string or byte array.
@@ -30,6 +32,8 @@ class ProofGamma extends ByteArray {
 class ProofVerificationHash extends ByteArray {
 	static SIZE = 16;
 
+	static NAME = 'ProofVerificationHash';
+
 	/**
 	 * Creates a proof verification hash from bytes or a hex string.
 	 * @param {Uint8Array|string} proofVerificationHash Input string or byte array.
@@ -44,6 +48,8 @@ class ProofVerificationHash extends ByteArray {
  */
 class ProofScalar extends ByteArray {
 	static SIZE = 32;
+
+	static NAME = 'ProofScalar';
 
 	/**
 	 * Creates a vrf proof scalar from bytes or a hex string.


### PR DESCRIPTION
 problem: NAME is not added to generated model classes, so they can not be used in descriptors
solution: add fallback logic when NAME is not provided