### PR TITLE
[client/catapult] fix: update OpenSSL to 3.2.1

### DIFF
--- a/client/catapult/CMakeLists.txt
+++ b/client/catapult/CMakeLists.txt
@@ -54,7 +54,7 @@ endif()
 ### setup openssl
 message("--- locating openssl dependencies ---")
 
-find_package(OpenSSL 3.2.0 EXACT REQUIRED)
+find_package(OpenSSL 3.2.1 EXACT REQUIRED)
 message("OpenSSL   ver: ${OPENSSL_VERSION}")
 message("OpenSSL  root: ${OPENSSL_ROOT_DIR}")
 message("OpenSSL   inc: ${OPENSSL_INCLUDE_DIR}")

--- a/client/catapult/conanfile.txt
+++ b/client/catapult/conanfile.txt
@@ -1,7 +1,7 @@
 [requires]
 # release dependencies
 boost/1.83.0
-openssl/3.2.0
+openssl/3.2.1
 
 cppzmq/4.10.0@nemtech/stable
 mongo-cxx-driver/3.9.0@nemtech/stable

--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -17,7 +17,7 @@ google_benchmark = v1.8.3
 mongodb_mongo-c-driver = 1.25.4
 mongodb_mongo-cxx-driver = r3.9.0
 
-openssl_openssl = openssl-3.2.0
+openssl_openssl = openssl-3.2.1
 
 zeromq_libzmq = v4.3.5
 zeromq_cppzmq = v4.10.0


### PR DESCRIPTION
problem: catapult is not using the latest OpenSSL version
solution: update OpenSSL to version 3.2.1