### PR TITLE
[sdk/javascript]: additional changes for ReactNative support

### DIFF
--- a/sdk/javascript/src/impl/ed25519_wasm.js
+++ b/sdk/javascript/src/impl/ed25519_wasm.js
@@ -1,8 +1,10 @@
 // this file contains implementation details and is not intended to be used directly
 
+/* eslint-disable import/no-extraneous-dependencies */
 import {
 	HashMode, crypto_private_sign, crypto_private_verify, crypto_sign_keypair
 } from 'symbol-crypto-wasm-node';
+/* eslint-enable import/no-extraneous-dependencies */
 
 const CRYPTO_SIGN_BYTES = 64;
 const CRYPTO_SIGN_PUBLICKEYBYTES = 32;


### PR DESCRIPTION
    [sdk/javascript]: disable instance of eslint warning 'import/no-extraneous-dependencies'
    
     problem: warning is raised when importing optional 'symbol-crypto-wasm-node'
    solution: disable warning
    
    [sdk/javascript]: update Cipher.js to support ReactNative environment
    
     problem: ReactNative Buffer polyfill only allows Buffers to be passed to Buffer.concat
    solution: all Uint8Arrays must be wrapped in Buffer when calling crypto cipher APIs
