### PR TITLE
[sdk/javascript]: mm-snap requires default export to be last

### DIFF
--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -7,8 +7,8 @@
   "types": "./ts/src/index.d.ts",
   "exports": {
     ".": {
-      "default": "./src/index.js",
-      "types": "./ts/src/index.d.ts"
+      "types": "./ts/src/index.d.ts",
+      "default": "./src/index.js"
     }
   },
   "scripts": {


### PR DESCRIPTION
fix to support mm-snap