### PR TITLE
[client/rest]: prevent hangs in failing db tests

### DIFF
--- a/client/rest/test/db/CatapultDb_spec.js
+++ b/client/rest/test/db/CatapultDb_spec.js
@@ -75,7 +75,7 @@ describe('catapult db', () => {
 			.then(() => deleteIds(dbEntities))
 			.then(() => issueDbCommand(db))
 			.then(assertDbCommandResult)
-			.then(() => db.close());
+			.finally(() => db.close());
 	};
 
 	const assertEqualDocuments = (expectedDocuments, actualDocuments) => {


### PR DESCRIPTION
 problem: db is not closed when a db test fails
solution: always close db
