### PR TITLE
[sdk] fix: linting failure with use-yield-from

### DIFF
--- a/linters/python/lint_requirements.txt
+++ b/linters/python/lint_requirements.txt
@@ -1,3 +1,3 @@
 isort==5.13.2
 pycodestyle==2.11.1
-pylint==3.0.3
+pylint==3.1.0

--- a/sdk/javascript/generator/StructTypeFormatter.py
+++ b/sdk/javascript/generator/StructTypeFormatter.py
@@ -45,8 +45,7 @@ def filter_size_if_first(fields_iter):
 	else:
 		yield first_field
 
-	for field in fields_iter:
-		yield field
+	yield from fields_iter
 
 
 class DeserializerMode(Enum):

--- a/sdk/python/generator/StructTypeFormatter.py
+++ b/sdk/python/generator/StructTypeFormatter.py
@@ -38,8 +38,7 @@ def filter_size_if_first(fields_iter):
 	else:
 		yield first_field
 
-	for field in fields_iter:
-		yield field
+	yield from fields_iter
 
 
 class StructFormatter(AbstractTypeFormatter):


### PR DESCRIPTION
problem: Pylint 3.1.0 fails linting with ``use-yield-from`` for fields iterator
solution: update the generator function to use ``yield from`` instead of ``yield`` for the iterator