### PR TITLE
[sdk/javascript]: split single entry point into default, nem and symbol

### DIFF
--- a/sdk/javascript/README.md
+++ b/sdk/javascript/README.md
@@ -21,16 +21,18 @@ To send a transaction, first create a facade for the desired network:
 
 _Symbol_
 ```javascript
-import symbolSdk from 'symbol-sdk';
+import { PrivateKey } from 'symbol-sdk';
+import { SymbolFacade } from 'symbol-sdk/symbol';
 
-const facade = new symbolSdk.facade.SymbolFacade('testnet');
+const facade = new SymbolFacade('testnet');
 ```
 
 _NEM_
 ```javascript
-import symbolSdk from 'symbol-sdk';
+import { PrivateKey } from 'symbol-sdk';
+import { NemFacade } from 'symbol-sdk/nem';
 
-const facade = new symbolSdk.facade.NemFacade('testnet');
+const facade = new NemFacade('testnet');
 ````
 
 Second, describe the transaction using JavaScript object syntax. For example, a transfer transaction can be described as follows:
@@ -66,7 +68,7 @@ Third, sign the transaction and attach the signature:
 
 
 ```javascript
-const privateKey = new symbolSdk.PrivateKey('EDB671EB741BD676969D8A035271D1EE5E75DF33278083D877F23615EB839FEC');
+const privateKey = new PrivateKey('EDB671EB741BD676969D8A035271D1EE5E75DF33278083D877F23615EB839FEC');
 const signature = facade.signTransaction(new facade.constructor.KeyPair(privateKey), transaction);
 
 const jsonPayload = facade.transactionFactory.constructor.attachSignature(transaction, signature);;
@@ -90,12 +92,13 @@ npm install symbol-sdk
 ```
 
 ```js
-import symbolSdk from 'symbol-sdk';
+import { PrivateKey } from 'symbol-sdk';
+import { KeyPair } from 'symbol-sdk/symbol';
 
-const privateKey = new symbolSdk.PrivateKey('EDB671EB741BD676969D8A035271D1EE5E75DF33278083D877F23615EB839FEC');
+const privateKey = new PrivateKey('EDB671EB741BD676969D8A035271D1EE5E75DF33278083D877F23615EB839FEC');
 console.log(`Private Key: ${privateKey.toString()}`);
 
-const keyPair = new symbolSdk.symbol.KeyPair(privateKey);
+const keyPair = new KeyPair(privateKey);
 console.log(`Public Key: ${keyPair.publicKey.toString()}`);
 ```
 
@@ -105,12 +108,15 @@ Symbol-sdk is alternatively published as a bundled file, which can be imported d
 
 ```html
 <script type="module">
-	import symbolSdk from './node_modules/symbol-sdk/dist/bundle.web.js';
+	import { core, /* nem, */ symbol } from './node_modules/symbol-sdk/dist/bundle.web.js';
 
-	const privateKey = new symbolSdk.PrivateKey('EDB671EB741BD676969D8A035271D1EE5E75DF33278083D877F23615EB839FEC');
+	const { PrivateKey } = core;
+	const { KeyPair } = symbol;
+
+	const privateKey = new PrivateKey('EDB671EB741BD676969D8A035271D1EE5E75DF33278083D877F23615EB839FEC');
 	console.log(`Private Key: ${privateKey.toString()}`);
 
-	const keyPair = new symbolSdk.symbol.KeyPair(privateKey);
+	const keyPair = new KeyPair(privateKey);
 	console.log(`Public Key: ${keyPair.publicKey.toString()}`);
 </script>
 ```

--- a/sdk/javascript/examples/bip32_keypair.js
+++ b/sdk/javascript/examples/bip32_keypair.js
@@ -6,7 +6,8 @@
 // note: this example is *not* generating keys compatible with wallet
 //
 
-import symbolSdk from '../src/index.js';
+import { Bip32 } from '../src/index.js';
+import { SymbolFacade } from '../src/symbol/index.js';
 
 (() => {
 	const deriveKey = (rootNode, facade, change, index) => {
@@ -26,9 +27,9 @@ import symbolSdk from '../src/index.js';
 		console.log('');
 	};
 
-	const facade = new symbolSdk.facade.SymbolFacade('testnet');
+	const facade = new SymbolFacade('testnet');
 
-	const bip = new symbolSdk.Bip32(facade.BIP32_CURVE_NAME);
+	const bip = new Bip32(facade.BIP32_CURVE_NAME);
 	const rootNode = bip.fromMnemonic(
 		'cat swing flag economy stadium alone churn speed unique patch report train',
 		'correcthorsebatterystaple'

--- a/sdk/javascript/examples/descriptors/nem_mosaic.js
+++ b/sdk/javascript/examples/descriptors/nem_mosaic.js
@@ -1,6 +1,4 @@
-import symbolSdk from '../../src/index.js';
-
-const { nem } = symbolSdk;
+import { Address, models as nem } from '../../src/nem/index.js';
 
 export default () => {
 	const sampleAddress = 'TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C';
@@ -9,7 +7,7 @@ export default () => {
 	// HACK: until fixed
 	const levy = new nem.MosaicLevy();
 	levy.transferFeeType = nem.MosaicTransferFeeType.ABSOLUTE;
-	levy.recipientAddress.bytes = (new nem.Address(sampleAddress)).bytes;
+	levy.recipientAddress.bytes = (new Address(sampleAddress)).bytes;
 	levy.mosaicId = new nem.MosaicId();
 	levy.mosaicId.namespaceId = new nem.NamespaceId();
 	levy.mosaicId.namespaceId.name = textEncoder.encode('lieutenant');

--- a/sdk/javascript/examples/descriptors/symbol_lock.js
+++ b/sdk/javascript/examples/descriptors/symbol_lock.js
@@ -1,4 +1,4 @@
-import symbolSdk from '../../src/index.js';
+import { ByteArray, Hash256 } from '../../src/index.js';
 
 export default () => {
 	const sampleAddress = 'TASYMBOLLK6FSL7GSEMQEAWN7VW55ZSZU2Q2Q5Y';
@@ -11,7 +11,7 @@ export default () => {
 			type: 'hash_lock_transaction_v1',
 			mosaic: { mosaicId: sampleMosaicId, amount: 123_000000n },
 			duration: 123n,
-			hash: symbolSdk.Hash256.zero()
+			hash: Hash256.zero()
 		},
 
 		{
@@ -28,7 +28,7 @@ export default () => {
 			recipientAddress: sampleAddress,
 			secret,
 			hashAlgorithm: 'hash_160',
-			proof: (new symbolSdk.ByteArray(4, 'C1ECFDFC')).bytes
+			proof: (new ByteArray(4, 'C1ECFDFC')).bytes
 		}
 	];
 };

--- a/sdk/javascript/examples/descriptors/symbol_mosaic.js
+++ b/sdk/javascript/examples/descriptors/symbol_mosaic.js
@@ -1,9 +1,7 @@
-import symbolSdk from '../../src/index.js';
-
-const { symbol } = symbolSdk;
+import { Address, generateMosaicId } from '../../src/symbol/index.js';
 
 export default () => {
-	const sampleAddress = new symbol.Address('TASYMBOLLK6FSL7GSEMQEAWN7VW55ZSZU2Q2Q5Y');
+	const sampleAddress = new Address('TASYMBOLLK6FSL7GSEMQEAWN7VW55ZSZU2Q2Q5Y');
 
 	return [
 		{
@@ -16,7 +14,7 @@ export default () => {
 
 		{
 			type: 'mosaic_supply_change_transaction_v1',
-			mosaicId: symbol.generateMosaicId(sampleAddress, 123),
+			mosaicId: generateMosaicId(sampleAddress, 123),
 			delta: 1000n * 100n, // assuming divisibility = 2
 			action: 'increase'
 		}

--- a/sdk/javascript/examples/descriptors/symbol_namespace.js
+++ b/sdk/javascript/examples/descriptors/symbol_namespace.js
@@ -1,6 +1,4 @@
-import symbolSdk from '../../src/index.js';
-
-const { symbol } = symbolSdk;
+import { generateNamespaceId } from '../../src/symbol/index.js';
 
 export default () => ([
 	{
@@ -13,7 +11,7 @@ export default () => ([
 	{
 		type: 'namespace_registration_transaction_v1',
 		registrationType: 'child',
-		parentId: symbol.generateNamespaceId('roger'),
+		parentId: generateNamespaceId('roger'),
 		name: 'charlie'
 	}
 ]);

--- a/sdk/javascript/examples/examples_utils.js
+++ b/sdk/javascript/examples/examples_utils.js
@@ -1,5 +1,6 @@
-import symbolSdk from '../src/index.js';
+import { PrivateKey } from '../src/index.js';
+import { KeyPair } from '../src/symbol/index.js';
 import fs from 'fs';
 
 export const readContents = filepath => fs.readFileSync(filepath, { encoding: 'utf8', flag: 'r' });
-export const readPrivateKey = filepath => new symbolSdk.symbol.KeyPair(new symbolSdk.PrivateKey(readContents(filepath).trim()));
+export const readPrivateKey = filepath => new KeyPair(new PrivateKey(readContents(filepath).trim()));

--- a/sdk/javascript/examples/readme/nem.js
+++ b/sdk/javascript/examples/readme/nem.js
@@ -1,6 +1,7 @@
-import symbolSdk from '../../src/index.js';
+import { PrivateKey } from '../../src/index.js';
+import { NemFacade } from '../../src/nem/index.js';
 
-const facade = new symbolSdk.facade.NemFacade('testnet');
+const facade = new NemFacade('testnet');
 const transaction = facade.transactionFactory.create({
 	type: 'transfer_transaction_v1',
 	signerPublicKey: 'A59277D56E9F4FA46854F5EFAAA253B09F8AE69A473565E01FD9E6A738E4AB74',
@@ -14,7 +15,7 @@ const transaction = facade.transactionFactory.create({
 console.log('created NEM transaction:');
 console.log(transaction.toString());
 
-const privateKey = new symbolSdk.PrivateKey('EDB671EB741BD676969D8A035271D1EE5E75DF33278083D877F23615EB839FEC');
+const privateKey = new PrivateKey('EDB671EB741BD676969D8A035271D1EE5E75DF33278083D877F23615EB839FEC');
 const signature = facade.signTransaction(new facade.constructor.KeyPair(privateKey), transaction);
 
 const jsonPayload = facade.transactionFactory.constructor.attachSignature(transaction, signature);

--- a/sdk/javascript/examples/readme/symbol.js
+++ b/sdk/javascript/examples/readme/symbol.js
@@ -1,6 +1,7 @@
-import symbolSdk from '../../src/index.js';
+import { PrivateKey } from '../../src/index.js';
+import { SymbolFacade } from '../../src/symbol/index.js';
 
-const facade = new symbolSdk.facade.SymbolFacade('testnet');
+const facade = new SymbolFacade('testnet');
 const transaction = facade.transactionFactory.create({
 	type: 'transfer_transaction_v1',
 	signerPublicKey: '87DA603E7BE5656C45692D5FC7F6D0EF8F24BB7A5C10ED5FDA8C5CFBC49FCBC8',
@@ -15,7 +16,7 @@ const transaction = facade.transactionFactory.create({
 console.log('created Symbol transaction:');
 console.log(transaction.toString());
 
-const privateKey = new symbolSdk.PrivateKey('EDB671EB741BD676969D8A035271D1EE5E75DF33278083D877F23615EB839FEC');
+const privateKey = new PrivateKey('EDB671EB741BD676969D8A035271D1EE5E75DF33278083D877F23615EB839FEC');
 const signature = facade.signTransaction(new facade.constructor.KeyPair(privateKey), transaction);
 
 const jsonPayload = facade.transactionFactory.constructor.attachSignature(transaction, signature);

--- a/sdk/javascript/examples/transaction_aggregate.js
+++ b/sdk/javascript/examples/transaction_aggregate.js
@@ -7,15 +7,13 @@
 //
 
 import { readContents, readPrivateKey } from './examples_utils.js';
-import symbolSdk from '../src/index.js';
+import { SymbolFacade } from '../src/symbol/index.js';
 import yargs from 'yargs';
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
 (() => {
-	const { SymbolFacade } = symbolSdk.facade;
-
 	const addEmbeddedTransfers = (facade, publicKey) => {
 		const textEncoder = new TextEncoder();
 

--- a/sdk/javascript/examples/transaction_multisig.js
+++ b/sdk/javascript/examples/transaction_multisig.js
@@ -4,15 +4,16 @@
 // Shows how to create multisig account.
 //
 
-import symbolSdk from '../src/index.js';
+import { PrivateKey } from '../src/index.js';
+import { KeyPair, SymbolFacade, models } from '../src/symbol/index.js';
 
 (() => {
 	const createKeyPairFromPrivateKey = privateKeyString =>
-		new symbolSdk.symbol.KeyPair(new symbolSdk.PrivateKey(privateKeyString));
+		new KeyPair(new PrivateKey(privateKeyString));
 
 	class MultisigAccountModificationSample {
 		constructor() {
-			this.facade = new symbolSdk.facade.SymbolFacade('testnet');
+			this.facade = new SymbolFacade('testnet');
 			this.multisigkeyPair = createKeyPairFromPrivateKey('11002233445566778899AABBCCDDEEFF11002233445566778899AABBCCDDEEFF');
 			this.cosignatorykeyPairs = [
 				createKeyPairFromPrivateKey('AABBCCDDEEFF11002233445566778899AABBCCDDEEFF11002233445566778899'),
@@ -61,7 +62,7 @@ import symbolSdk from '../src/index.js';
 		addCosignatures(aggregateTransaction) {
 			const transactionHash = this.facade.hashTransaction(aggregateTransaction).bytes;
 			aggregateTransaction.cosignatures = this.cosignatorykeyPairs.map(keyPair => {
-				const cosignature = new symbolSdk.symbol.Cosignature();
+				const cosignature = new models.Cosignature();
 				cosignature.version = 0;
 				cosignature.signerPublicKey = keyPair.publicKey;
 				cosignature.signature = keyPair.sign(transactionHash);

--- a/sdk/javascript/examples/transaction_sign.js
+++ b/sdk/javascript/examples/transaction_sign.js
@@ -4,7 +4,9 @@
 // Shows how to create all transactions manually using TransactionFactory.
 //
 
-import symbolSdk from '../src/index.js';
+import { PrivateKey } from '../src/index.js';
+import { NemFacade } from '../src/nem/index.js';
+import { SymbolFacade } from '../src/symbol/index.js';
 import yargs from 'yargs';
 import path from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
@@ -15,7 +17,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 			this.facade = facade;
 			this.commonFields = commonFields;
 
-			const privateKey = new symbolSdk.PrivateKey('11002233445566778899AABBCCDDEEFF11002233445566778899AABBCCDDEEFF');
+			const privateKey = new PrivateKey('11002233445566778899AABBCCDDEEFF11002233445566778899AABBCCDDEEFF');
 			this.keyPair = new this.facade.constructor.KeyPair(privateKey);
 		}
 
@@ -70,11 +72,11 @@ import { fileURLToPath, pathToFileURL } from 'url';
 		decrementTestsPending();
 	};
 
-	const nemTransactionSample = new TransactionSample(new symbolSdk.facade.NemFacade('testnet'), {
+	const nemTransactionSample = new TransactionSample(new NemFacade('testnet'), {
 		deadline: 12345
 	});
 
-	const symbolTransactionSample = new TransactionSample(new symbolSdk.facade.SymbolFacade('testnet'), {
+	const symbolTransactionSample = new TransactionSample(new SymbolFacade('testnet'), {
 		fee: 625n,
 		deadline: 12345n
 	});

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -7,8 +7,16 @@
   "types": "./ts/src/index.d.ts",
   "exports": {
     ".": {
-      "types": "./ts/src/index.d.ts",
-      "default": "./src/index.js"
+      "default": "./src/index.js",
+      "types": "./ts/src/index.d.ts"
+    },
+    "./nem": {
+      "default": "./src/nem/index.js",
+      "types": "./ts/src/nem/index.d.ts"
+    },
+    "./symbol": {
+      "default": "./src/symbol/index.js",
+      "types": "./ts/src/symbol/index.d.ts"
     }
   },
   "scripts": {

--- a/sdk/javascript/src/index.js
+++ b/sdk/javascript/src/index.js
@@ -1,27 +1,19 @@
 import BaseValue from './BaseValue.js';
 import { Bip32 } from './Bip32.js';
 import ByteArray from './ByteArray.js';
-import * as CryptoTypes from './CryptoTypes.js';
+import {
+	Hash256,
+	PrivateKey,
+	PublicKey,
+	SharedKey256,
+	Signature
+} from './CryptoTypes.js';
 import { NetworkLocator } from './Network.js';
-import NemFacade from './facade/NemFacade.js';
-import SymbolFacade from './facade/SymbolFacade.js';
-import * as NemKeyPair from './nem/KeyPair.js';
-import NemMessageEncoder from './nem/MessageEncoder.js';
-import * as NemNetwork from './nem/Network.js';
-import NemTransactionFactory from './nem/TransactionFactory.js';
-import * as NemModels from './nem/models.js';
-import * as SymbolKeyPair from './symbol/KeyPair.js';
-import SymbolMessageEncoder from './symbol/MessageEncoder.js';
-import * as SymbolNetwork from './symbol/Network.js';
-import SymbolTransactionFactory from './symbol/TransactionFactory.js';
-import VotingKeysGenerator from './symbol/VotingKeysGenerator.js';
-import * as SymbolIdGenerator from './symbol/idGenerator.js';
-import * as SymbolMerkle from './symbol/merkle.js';
-import * as SymbolMetadata from './symbol/metadata.js';
-import * as SymbolModels from './symbol/models.js';
 import { hexToUint8, uint8ToHex } from './utils/converter.js';
 
-const sdk = {
+const utils = { hexToUint8, uint8ToHex };
+
+export {
 	/**
 	 * Represents a base integer.
 	 * @type {typeof BaseValue}
@@ -46,33 +38,31 @@ const sdk = {
 	 * Represents a 256-bit hash.
 	 * @type {typeof CryptoTypes.Hash256}
 	 */
-	Hash256: CryptoTypes.Hash256,
+	Hash256,
 
 	/**
 	 * Represents a private key.
 	 * @type {typeof CryptoTypes.PrivateKey}
 	 */
-	PrivateKey: CryptoTypes.PrivateKey,
+	PrivateKey,
 
 	/**
 	 * Represents a public key.
 	 * @type {typeof CryptoTypes.PublicKey}
 	 */
-	PublicKey: CryptoTypes.PublicKey,
+	PublicKey,
 
 	/**
 	 * Represents a 256-bit symmetric encryption key.
 	 * @type {typeof CryptoTypes.SharedKey256}
 	 */
-	SharedKey256: CryptoTypes.SharedKey256,
+	SharedKey256,
 
 	/**
 	 * Represents a signature.
 	 * @type {typeof CryptoTypes.Signature}
 	 */
-	Signature: CryptoTypes.Signature,
-
-	// endregion
+	Signature,
 
 	/**
 	 * Provides utility functions for finding a network.
@@ -80,154 +70,8 @@ const sdk = {
 	 */
 	NetworkLocator,
 
-	// region facade
-
-	/**
-	 * Network facades.
-	 */
-	facade: {
-		/**
-		 * Facade used to interact with NEM blockchain.
-		 * @type {typeof NemFacade}
-		 */
-		NemFacade,
-
-		/**
-		 * Facade used to interact with Symbol blockchain.
-		 * @type {typeof SymbolFacade}
-		 */
-		SymbolFacade
-	},
-
-	// endregion
-
-	/**
-	 * NEM blockchain accessors.
-	 */
-	nem: {
-		...NemModels, // must be before Network to promote Address from Network
-
-		// region common
-
-		/**
-		 * Factory for creating NEM transactions.
-		 * @type {typeof NemTransactionFactory}
-		 */
-		NemTransactionFactory,
-
-		/**
-		 * Represents a NEM network timestamp with second resolution.
-		 * @type {typeof NemNetwork.NetworkTimestamp}
-		 */
-		NetworkTimestamp: NemNetwork.NetworkTimestamp,
-
-		/**
-		 * Represents a NEM address.
-		 * @type {typeof NemNetwork.Address}
-		 */
-		Address: NemNetwork.Address,
-
-		/**
-		 * Represents a NEM network.
-		 * @type {typeof NemNetwork.Network}
-		 */
-		Network: NemNetwork.Network,
-
-		/**
-		 * Encrypts and encodes messages between two parties.
-		 * @type {typeof NemMessageEncoder}
-		 */
-		MessageEncoder: NemMessageEncoder,
-
-		/**
-		 * Encrypts and encodes messages between two parties.
-		 * @type {typeof NemKeyPair.KeyPair}
-		 */
-		KeyPair: NemKeyPair.KeyPair,
-
-		/**
-		 * Encrypts and encodes messages between two parties.
-		 * @type {typeof NemKeyPair.Verifier}
-		 */
-		Verifier: NemKeyPair.Verifier
-
-		// endregion
-	},
-
-	/**
-	 * Symbol blockchain accessors.
-	 */
-	symbol: {
-		...SymbolModels, // must be before Network to promote Address from Network
-
-		// region common
-
-		/**
-		 * Factory for creating Symbol transactions.
-		 * @type {typeof SymbolTransactionFactory}
-		 */
-		SymbolTransactionFactory,
-
-		/**
-		 * Represents a Symbol network timestamp with second resolution.
-		 * @type {typeof SymbolNetwork.NetworkTimestamp}
-		 */
-		NetworkTimestamp: SymbolNetwork.NetworkTimestamp,
-
-		/**
-		 * Represents a Symbol address.
-		 * @type {typeof SymbolNetwork.Address}
-		 */
-		Address: SymbolNetwork.Address,
-
-		/**
-		 * Represents a Symbol network.
-		 * @type {typeof SymbolNetwork.Network}
-		 */
-		Network: SymbolNetwork.Network,
-
-		/**
-		 * Encrypts and encodes messages between two parties.
-		 * @type {typeof SymbolMessageEncoder}
-		 */
-		MessageEncoder: SymbolMessageEncoder,
-
-		/**
-		 * Encrypts and encodes messages between two parties.
-		 * @type {typeof SymbolKeyPair.KeyPair}
-		 */
-		KeyPair: SymbolKeyPair.KeyPair,
-
-		/**
-		 * Encrypts and encodes messages between two parties.
-		 * @type {typeof SymbolKeyPair.Verifier}
-		 */
-		Verifier: SymbolKeyPair.Verifier,
-
-		// endregion
-
-		// region Symbol extensions
-
-		...SymbolIdGenerator,
-		...SymbolMerkle,
-		...SymbolMetadata,
-
-		/**
-		 * Generates symbol voting keys.
-		 * @type {typeof VotingKeysGenerator}
-		 */
-		VotingKeysGenerator
-
-		// endregion
-	},
-
 	/**
 	 * Network independent utilities.
 	 */
-	utils: {
-		hexToUint8,
-		uint8ToHex
-	}
+	utils
 };
-
-export default sdk;

--- a/sdk/javascript/src/index.web.js
+++ b/sdk/javascript/src/index.web.js
@@ -1,0 +1,5 @@
+import * as core from './index.js';
+import * as nem from './nem/index.js';
+import * as symbol from './symbol/index.js';
+
+export { core, nem, symbol };

--- a/sdk/javascript/src/nem/index.js
+++ b/sdk/javascript/src/nem/index.js
@@ -1,0 +1,67 @@
+import { KeyPair, Verifier } from './KeyPair.js';
+import MessageEncoder from './MessageEncoder.js';
+import { Address, Network, NetworkTimestamp } from './Network.js';
+import TransactionFactory from './TransactionFactory.js';
+import * as models from './models.js';
+import NemFacade from '../facade/NemFacade.js';
+
+export {
+	/**
+	 * Facade used to interact with NEM blockchain.
+	 * @type {typeof NemFacade}
+	 */
+	NemFacade,
+
+	// region common
+
+	/**
+	 * Factory for creating NEM transactions.
+	 * @type {typeof NemTransactionFactory}
+	 */
+	TransactionFactory,
+
+	/**
+	 * Represents a NEM network timestamp with second resolution.
+	 * @type {typeof NemNetwork.NetworkTimestamp}
+	 */
+	NetworkTimestamp,
+
+	/**
+	 * Represents a NEM address.
+	 * @type {typeof NemNetwork.Address}
+	 */
+	Address,
+
+	/**
+	 * Represents a NEM network.
+	 * @type {typeof NemNetwork.Network}
+	 */
+	Network,
+
+	/**
+	 * Encrypts and encodes messages between two parties.
+	 * @type {typeof NemMessageEncoder}
+	 */
+	MessageEncoder,
+
+	/**
+	 * Encrypts and encodes messages between two parties.
+	 * @type {typeof NemKeyPair.KeyPair}
+	 */
+	KeyPair,
+
+	/**
+	 * Encrypts and encodes messages between two parties.
+	 * @type {typeof NemKeyPair.Verifier}
+	 */
+	Verifier,
+
+	// region NEM extensions
+
+	/**
+	 * Raw models generated from catbuffer schemas.
+	 */
+	models
+
+	// endregion
+};

--- a/sdk/javascript/src/symbol/index.js
+++ b/sdk/javascript/src/symbol/index.js
@@ -1,0 +1,101 @@
+import { KeyPair, Verifier } from './KeyPair.js';
+import MessageEncoder from './MessageEncoder.js';
+import { Address, Network, NetworkTimestamp } from './Network.js';
+import SymbolTransactionFactory from './TransactionFactory.js';
+import VotingKeysGenerator from './VotingKeysGenerator.js';
+import {
+	generateMosaicAliasId,
+	generateMosaicId,
+	generateNamespaceId,
+	generateNamespacePath,
+	isValidNamespaceName
+} from './idGenerator.js';
+import {
+	deserializePatriciaTreeNodes,
+	proveMerkle,
+	provePatriciaMerkle
+} from './merkle.js';
+import { metadataUpdateValue } from './metadata.js';
+import * as models from './models.js';
+import SymbolFacade from '../facade/SymbolFacade.js';
+
+export {
+	/**
+	 * Facade used to interact with Symbol blockchain.
+	 * @type {typeof SymbolFacade}
+	 */
+	SymbolFacade,
+
+	// region common
+
+	/**
+	 * Factory for creating Symbol transactions.
+	 * @type {typeof SymbolTransactionFactory}
+	 */
+	SymbolTransactionFactory,
+
+	/**
+	 * Represents a Symbol network timestamp with second resolution.
+	 * @type {typeof SymbolNetwork.NetworkTimestamp}
+	 */
+	NetworkTimestamp,
+
+	/**
+	 * Represents a Symbol address.
+	 * @type {typeof SymbolNetwork.Address}
+	 */
+	Address,
+
+	/**
+	 * Represents a Symbol network.
+	 * @type {typeof SymbolNetwork.Network}
+	 */
+	Network,
+
+	/**
+	 * Encrypts and encodes messages between two parties.
+	 * @type {typeof SymbolMessageEncoder}
+	 */
+	MessageEncoder,
+
+	/**
+	 * Encrypts and encodes messages between two parties.
+	 * @type {typeof SymbolKeyPair.KeyPair}
+	 */
+	KeyPair,
+
+	/**
+	 * Encrypts and encodes messages between two parties.
+	 * @type {typeof SymbolKeyPair.Verifier}
+	 */
+	Verifier,
+
+	// endregion
+
+	// region Symbol extensions
+
+	generateMosaicId,
+	generateNamespaceId,
+	isValidNamespaceName,
+	generateNamespacePath,
+	generateMosaicAliasId,
+
+	proveMerkle,
+	deserializePatriciaTreeNodes,
+	provePatriciaMerkle,
+
+	metadataUpdateValue,
+
+	/**
+	 * Generates symbol voting keys.
+	 * @type {typeof VotingKeysGenerator}
+	 */
+	VotingKeysGenerator,
+
+	/**
+	 * Raw models generated from catbuffer schemas.
+	 */
+	models
+
+	// endregion
+};

--- a/sdk/javascript/webpack.config.js
+++ b/sdk/javascript/webpack.config.js
@@ -8,7 +8,10 @@ const buildDirectory = path.resolve(path.dirname(URL.fileURLToPath(import.meta.u
 const distDirectory = path.resolve(path.dirname(URL.fileURLToPath(import.meta.url)), 'dist');
 
 export default {
-	entry: './src/index.js',
+	entry: {
+		main: './src/index.web.js'
+	},
+
 	mode: process.env.NODE_ENV || 'development',
 	target,
 	devtool: 'source-map',


### PR DESCRIPTION
     problem: sdk does not support named imports
    solution: restructure and split up module entry points
    
    allow usage like:
    ```js
    import { PrivateKey } from 'symbol-sdk';
    import { SymbolFacade } from 'symbol-sdk/symbol';
    ```