### PR TITLE
[sdk/javascript]: run ts compiler over examples

### DIFF
--- a/sdk/javascript/README.md
+++ b/sdk/javascript/README.md
@@ -69,9 +69,9 @@ Third, sign the transaction and attach the signature:
 
 ```javascript
 const privateKey = new PrivateKey('EDB671EB741BD676969D8A035271D1EE5E75DF33278083D877F23615EB839FEC');
-const signature = facade.signTransaction(new facade.constructor.KeyPair(privateKey), transaction);
+const signature = facade.signTransaction(new facade.static.KeyPair(privateKey), transaction);
 
-const jsonPayload = facade.transactionFactory.constructor.attachSignature(transaction, signature);;
+const jsonPayload = facade.transactionFactory.static.attachSignature(transaction, signature);;
 ```
 
 Finally, send the payload to the desired network using the specified node endpoint:

--- a/sdk/javascript/examples/bip32_keypair.js
+++ b/sdk/javascript/examples/bip32_keypair.js
@@ -29,7 +29,7 @@ import { SymbolFacade } from '../src/symbol/index.js';
 
 	const facade = new SymbolFacade('testnet');
 
-	const bip = new Bip32(facade.BIP32_CURVE_NAME);
+	const bip = new Bip32(facade.static.BIP32_CURVE_NAME);
 	const rootNode = bip.fromMnemonic(
 		'cat swing flag economy stadium alone churn speed unique patch report train',
 		'correcthorsebatterystaple'

--- a/sdk/javascript/examples/readme/nem.js
+++ b/sdk/javascript/examples/readme/nem.js
@@ -16,9 +16,9 @@ console.log('created NEM transaction:');
 console.log(transaction.toString());
 
 const privateKey = new PrivateKey('EDB671EB741BD676969D8A035271D1EE5E75DF33278083D877F23615EB839FEC');
-const signature = facade.signTransaction(new facade.constructor.KeyPair(privateKey), transaction);
+const signature = facade.signTransaction(new facade.static.KeyPair(privateKey), transaction);
 
-const jsonPayload = facade.transactionFactory.constructor.attachSignature(transaction, signature);
+const jsonPayload = facade.transactionFactory.static.attachSignature(transaction, signature);
 
 console.log('prepared NEM JSON payload:');
 console.log(jsonPayload);

--- a/sdk/javascript/examples/readme/symbol.js
+++ b/sdk/javascript/examples/readme/symbol.js
@@ -17,9 +17,9 @@ console.log('created Symbol transaction:');
 console.log(transaction.toString());
 
 const privateKey = new PrivateKey('EDB671EB741BD676969D8A035271D1EE5E75DF33278083D877F23615EB839FEC');
-const signature = facade.signTransaction(new facade.constructor.KeyPair(privateKey), transaction);
+const signature = facade.signTransaction(new facade.static.KeyPair(privateKey), transaction);
 
-const jsonPayload = facade.transactionFactory.constructor.attachSignature(transaction, signature);
+const jsonPayload = facade.transactionFactory.static.attachSignature(transaction, signature);
 
 console.log('prepared Symbol JSON payload:');
 console.log(jsonPayload);

--- a/sdk/javascript/examples/transaction_aggregate.js
+++ b/sdk/javascript/examples/transaction_aggregate.js
@@ -42,13 +42,13 @@ import { fileURLToPath } from 'url';
 
 	const args = yargs(process.argv.slice(2))
 		.demandOption('private', 'path to file with private key')
-		.argv;
+		.parseSync();
 
 	const facade = new SymbolFacade('testnet');
 	const keyPair = readPrivateKey(args.private);
 
 	const embeddedTransactions = addEmbeddedTransfers(facade, keyPair.publicKey);
-	const merkleHash = facade.constructor.hashEmbeddedTransactions(embeddedTransactions);
+	const merkleHash = facade.static.hashEmbeddedTransactions(embeddedTransactions);
 
 	const aggregateTransaction = facade.transactionFactory.create({
 		type: 'aggregate_complete_transaction_v2',
@@ -60,7 +60,7 @@ import { fileURLToPath } from 'url';
 	});
 
 	const signature = facade.signTransaction(keyPair, aggregateTransaction);
-	facade.transactionFactory.constructor.attachSignature(aggregateTransaction, signature);
+	facade.transactionFactory.static.attachSignature(aggregateTransaction, signature);
 
 	console.log(`Hash: ${facade.hashTransaction(aggregateTransaction)}\n`);
 	console.log(aggregateTransaction.toString());

--- a/sdk/javascript/examples/transaction_multisig.js
+++ b/sdk/javascript/examples/transaction_multisig.js
@@ -27,7 +27,7 @@ import { KeyPair, SymbolFacade, models } from '../src/symbol/index.js';
 			const aggregateTransaction = this.createAggregateTransaction();
 
 			const signature = this.facade.signTransaction(this.multisigkeyPair, aggregateTransaction);
-			this.facade.transactionFactory.constructor.attachSignature(aggregateTransaction, signature);
+			this.facade.transactionFactory.static.attachSignature(aggregateTransaction, signature);
 
 			console.log(`Hash: ${this.facade.hashTransaction(aggregateTransaction)}`);
 
@@ -49,23 +49,26 @@ import { KeyPair, SymbolFacade, models } from '../src/symbol/index.js';
 				})
 			];
 
-			return this.facade.transactionFactory.create({
+			const aggregateTransaction = this.facade.transactionFactory.create({
 				type: 'aggregate_complete_transaction_v2',
 				signerPublicKey: this.multisigkeyPair.publicKey,
 				fee: 625n,
 				deadline: 12345n,
-				transactionsHash: this.facade.constructor.hashEmbeddedTransactions(embeddedTransactions).bytes,
+				transactionsHash: this.facade.static.hashEmbeddedTransactions(embeddedTransactions).bytes,
 				transactions: embeddedTransactions
 			});
+
+			// aggregateTransaction as models.AggregateCompleteTransactionV2
+			return (/** @type {models.AggregateCompleteTransactionV2} */ (/** @type {any} */ aggregateTransaction));
 		}
 
 		addCosignatures(aggregateTransaction) {
 			const transactionHash = this.facade.hashTransaction(aggregateTransaction).bytes;
 			aggregateTransaction.cosignatures = this.cosignatorykeyPairs.map(keyPair => {
 				const cosignature = new models.Cosignature();
-				cosignature.version = 0;
-				cosignature.signerPublicKey = keyPair.publicKey;
-				cosignature.signature = keyPair.sign(transactionHash);
+				cosignature.version = 0n;
+				cosignature.signerPublicKey = new models.PublicKey(keyPair.publicKey.bytes);
+				cosignature.signature = new models.Signature(keyPair.sign(transactionHash).bytes);
 				return cosignature;
 			});
 		}

--- a/sdk/javascript/examples/transaction_sign.js
+++ b/sdk/javascript/examples/transaction_sign.js
@@ -18,7 +18,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 			this.commonFields = commonFields;
 
 			const privateKey = new PrivateKey('11002233445566778899AABBCCDDEEFF11002233445566778899AABBCCDDEEFF');
-			this.keyPair = new this.facade.constructor.KeyPair(privateKey);
+			this.keyPair = new this.facade.static.KeyPair(privateKey);
 		}
 
 		processTransactionDescriptors(transactionDescriptors) {
@@ -38,7 +38,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 
 		signAndPrint(transaction) {
 			const signature = this.facade.signTransaction(this.keyPair, transaction);
-			this.facade.transactionFactory.constructor.attachSignature(transaction, signature);
+			this.facade.transactionFactory.static.attachSignature(transaction, signature);
 
 			console.log(`Hash: ${this.facade.hashTransaction(transaction)}`);
 			console.log(transaction.toString());
@@ -60,7 +60,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 			testsPending += 1;
 
 			const filepath = path.join(path.dirname(fileURLToPath(import.meta.url)), 'descriptors', `${factoryName}.js`);
-			import(pathToFileURL(filepath)).then(module => {
+			import(pathToFileURL(filepath).toString()).then(module => {
 				const transactionDescriptors = module.default();
 				sample.processTransactionDescriptors(transactionDescriptors);
 				totalDescriptorsCount += transactionDescriptors.length;
@@ -87,7 +87,7 @@ import { fileURLToPath, pathToFileURL } from 'url';
 			choices: ['nem', 'symbol'],
 			require: true
 		})
-		.argv;
+		.parseSync();
 
 	if ('nem' === args.blockchain) {
 		runAllTests(nemTransactionSample, [

--- a/sdk/javascript/scripts/ci/build.sh
+++ b/sdk/javascript/scripts/ci/build.sh
@@ -15,5 +15,6 @@ cd ..
 npm run bundle
 
 # build TS bindings
-npx tsc -p ./tsconfig-generate.json
-npx tsc
+npx tsc -p ./tsconfig/build-bindings.json
+npx tsc -p ./tsconfig/check-bindings.json
+npx tsc -p ./tsconfig/check-examples.json

--- a/sdk/javascript/src/facade/NemFacade.js
+++ b/sdk/javascript/src/facade/NemFacade.js
@@ -74,6 +74,13 @@ export default class NemFacade {
 		this.transactionFactory = new TransactionFactory(this.network);
 	}
 
+	/**
+	 * Gets class type.
+	 */
+	get static() { // eslint-disable-line class-methods-use-this
+		return NemFacade;
+	}
+
 	// the following three functions are NOT static in order for NemFacade and SymbolFacade to conform to the same interface
 
 	/**

--- a/sdk/javascript/src/facade/SymbolFacade.js
+++ b/sdk/javascript/src/facade/SymbolFacade.js
@@ -105,6 +105,13 @@ export default class SymbolFacade {
 	}
 
 	/**
+	 * Gets class type.
+	 */
+	get static() { // eslint-disable-line class-methods-use-this
+		return SymbolFacade;
+	}
+
+	/**
 	 * Hashes a Symbol transaction.
 	 * @param {sc.Transaction} transaction Transaction object.
 	 * @returns {Hash256} Transaction hash.

--- a/sdk/javascript/src/nem/TransactionFactory.js
+++ b/sdk/javascript/src/nem/TransactionFactory.js
@@ -37,6 +37,13 @@ export default class TransactionFactory {
 	}
 
 	/**
+	 * Gets class type.
+	 */
+	get static() { // eslint-disable-line class-methods-use-this
+		return TransactionFactory;
+	}
+
+	/**
 	 * Gets rule names with registered hints.
 	 */
 	get ruleNames() {

--- a/sdk/javascript/src/symbol/TransactionFactory.js
+++ b/sdk/javascript/src/symbol/TransactionFactory.js
@@ -38,6 +38,13 @@ export default class TransactionFactory {
 	}
 
 	/**
+	 * Gets class type.
+	 */
+	get static() { // eslint-disable-line class-methods-use-this
+		return TransactionFactory;
+	}
+
+	/**
 	 * Gets rule names with registered hints.
 	 */
 	get ruleNames() {

--- a/sdk/javascript/test/facade/NemFacade_spec.js
+++ b/sdk/javascript/test/facade/NemFacade_spec.js
@@ -15,6 +15,14 @@ describe('NEM Facade', () => {
 		expect(NemFacade.BIP32_CURVE_NAME).to.equal('ed25519-keccak');
 	});
 
+	it('has correct static accessor', () => {
+		// Arrange:
+		const facade = new NemFacade('testnet');
+
+		// Assert:
+		expect(NemFacade).to.deep.equal(facade.static);
+	});
+
 	it('has correct KeyPair', () => {
 		// Arrange:
 		const privateKey = new PrivateKey('ED4C70D78104EB11BCD73EBDC512FEBC8FBCEB36A370C957FF7E266230BB5D57'); // reversed

--- a/sdk/javascript/test/facade/SymbolFacade_spec.js
+++ b/sdk/javascript/test/facade/SymbolFacade_spec.js
@@ -105,6 +105,14 @@ describe('Symbol Facade', () => {
 		expect(SymbolFacade.BIP32_CURVE_NAME).to.equal('ed25519');
 	});
 
+	it('has correct static accessor', () => {
+		// Arrange:
+		const facade = new SymbolFacade('testnet');
+
+		// Assert:
+		expect(SymbolFacade).to.deep.equal(facade.static);
+	});
+
 	it('has correct KeyPair', () => {
 		// Arrange:
 		const privateKey = new PrivateKey('E88283CE35FE74C89FFCB2D8BFA0A2CF6108BDC0D07606DEE34D161C30AC2F1E');
@@ -180,7 +188,7 @@ describe('Symbol Facade', () => {
 	// region hash transaction / sign transaction
 
 	const attachSignature = (facade, transaction, signature) => {
-		(/** @type typeof TransactionFactory */(facade.transactionFactory.constructor)).attachSignature(transaction, signature);
+		facade.transactionFactory.static.attachSignature(transaction, signature);
 	};
 
 	const assertCanHashTransaction = (transactionFactory, expectedHash) => {

--- a/sdk/javascript/test/nem/TransactionFactory_spec.js
+++ b/sdk/javascript/test/nem/TransactionFactory_spec.js
@@ -32,7 +32,15 @@ describe('transaction factory (NEM)', () => {
 
 	runBasicTransactionFactoryTests(testDescriptor);
 
-	// region rules
+	// region constants + rules
+
+	it('has correct static accessor', () => {
+		// Arrange:
+		const factory = new TransactionFactory(Network.TESTNET);
+
+		// Assert:
+		expect(TransactionFactory).to.deep.equal(factory.static);
+	});
 
 	it('has rules with expected hints', () => {
 		// Act:

--- a/sdk/javascript/test/symbol/TransactionFactory_spec.js
+++ b/sdk/javascript/test/symbol/TransactionFactory_spec.js
@@ -17,7 +17,15 @@ describe('transaction factory (Symbol)', () => {
 		expect(transaction.network).to.deep.equal(sc.NetworkType.TESTNET);
 	};
 
-	// region rules
+	// region constants + rules
+
+	it('has correct static accessor', () => {
+		// Arrange:
+		const factory = new TransactionFactory(Network.TESTNET);
+
+		// Assert:
+		expect(TransactionFactory).to.deep.equal(factory.static);
+	});
 
 	it('has rules with expected hints', () => {
 		// Act:

--- a/sdk/javascript/tsconfig/build-bindings.json
+++ b/sdk/javascript/tsconfig/build-bindings.json
@@ -1,0 +1,23 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es2020",
+        "lib": ["es2020"],
+
+        "noImplicitAny": false,
+        "noImplicitThis": true,
+        "strictFunctionTypes": true,
+        "strictNullChecks": true,
+
+        "forceConsistentCasingInFileNames": true,
+
+        "allowJs": true,
+        "declaration": true,
+        "emitDeclarationOnly": true,
+        "declarationDir": "../ts",
+
+        "checkJs": true,
+        "esModuleInterop": true
+    },
+     "include": ["../src/**/*.js", "../test/**/*.js", "../vectors/**/*.js"]
+}

--- a/sdk/javascript/tsconfig/check-bindings.json
+++ b/sdk/javascript/tsconfig/check-bindings.json
@@ -11,5 +11,5 @@
         "noEmit": true,
         "forceConsistentCasingInFileNames": true
     },
-     "include": ["ts/src/**/*.ts", "ts/test/**/*.ts", "ts/vectors/**/*.ts"]
+     "include": ["../ts/src/**/*.ts", "../ts/test/**/*.ts", "../ts/vectors/**/*.ts"]
 }

--- a/sdk/javascript/tsconfig/check-examples.json
+++ b/sdk/javascript/tsconfig/check-examples.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "module": "commonjs",
+        "module": "nodenext",
         "target": "es2020",
         "lib": ["es2020"],
 
@@ -12,12 +12,10 @@
         "forceConsistentCasingInFileNames": true,
 
         "allowJs": true,
-        "declaration": true,
-        "emitDeclarationOnly": true,
-        "declarationDir": "ts",
+        "noEmit": true,
 
         "checkJs": true,
         "esModuleInterop": true
     },
-     "include": ["src/**/*.js", "test/**/*.js", "vectors/**/*.js"]
+     "include": ["../examples/**/*.js"]
 }


### PR DESCRIPTION
 problem: examples are not TS compliant
solution:
          - add static getter that can be used instead of constructor in TS
          - update examples