### PR TITLE
[jenkins] fix: install common Python packages

### DIFF
--- a/jenkins/docker/fedora/javascript.Dockerfile
+++ b/jenkins/docker/fedora/javascript.Dockerfile
@@ -14,9 +14,8 @@ RUN dnf install --assumeyes make gcc g++ diffutils
 # install python
 RUN dnf install --assumeyes python3 python3-pip
 
-# install shellcheck and gitlint
-RUN dnf install --assumeyes shellcheck \
-	&& pip install gitlint
+# install shellcheck
+RUN dnf install --assumeyes shellcheck
 
 # rust dependencies - https://docs.rs/crate/openssl-sys/0.9.19
 RUN dnf install --assumeyes openssl openssl-devel pkg-config \
@@ -39,4 +38,13 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y \
 	&& curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | bash -s -- \
 	&& chown -R fedora:fedora /home/fedora/.cargo
 
+USER fedora
 WORKDIR /home/fedora
+
+# create a virtual environment
+ENV VIRTUAL_ENV=/home/fedora/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# install common python packages
+RUN python3 -m pip install --upgrade gitlint isort lark pycodestyle pylint PyYAML

--- a/jenkins/docker/fedora/python.Dockerfile
+++ b/jenkins/docker/fedora/python.Dockerfile
@@ -39,3 +39,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # install poetry and gitlint
 RUN python3 -m pip install poetry gitlint wheel setuptools
+
+# install common python packages
+RUN python3 -m pip install --upgrade aiohttp colorama coverage cryptography Jinja2 lark ply Pillow pynacl pytest PyYAML pyzbar requests \
+	ripemd-hash safe-pysha3 websockets zenlog

--- a/jenkins/docker/ubuntu/cpp.Dockerfile
+++ b/jenkins/docker/ubuntu/cpp.Dockerfile
@@ -26,4 +26,4 @@ USER ubuntu
 WORKDIR /home/ubuntu
 
 # installl all pip packages as ubuntu user
-RUN pip install gitlint
+RUN pip install --upgrade colorama gitlint isort pycodestyle ply pylint PyYAML

--- a/jenkins/docker/ubuntu/linter.Dockerfile
+++ b/jenkins/docker/ubuntu/linter.Dockerfile
@@ -18,18 +18,22 @@ RUN apt-get install -y default-jre ca-certificates curl gnupg \
 	&& npm install -g npm-groovy-lint@11.1.1
 
 # install python
-RUN apt-get install -y python3-pip
+RUN apt-get install -y python3-pip python3-venv
 
-# install shellcheck and gitlint
-RUN apt-get install -y shellcheck \
-	&& pip install gitlint
+# install shellcheck and ripgrep
+RUN apt-get install -y shellcheck ripgrep
 
-# install ripgrep and yamllint
-RUN apt-get install -y ripgrep \
-	&& pip install yamllint
 
 # add ubuntu user (used by jenkins)
-RUN useradd --uid 1000 -ms /bin/bash ubuntu
+RUN id -u "ubuntu" || useradd --uid 1000 -ms /bin/bash ubuntu
+USER ubuntu
+WORKDIR /home/ubuntu
 ENV PATH=$PATH:/home/ubuntu/.local/bin
 
-WORKDIR /home/ubuntu
+# create a virtual environment
+ENV VIRTUAL_ENV=/home/ubuntu/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# install common python packages
+RUN python3 -m pip install --upgrade gitlint isort lark pycodestyle pylint PyYAML yamllint

--- a/jenkins/docker/ubuntu/python.Dockerfile
+++ b/jenkins/docker/ubuntu/python.Dockerfile
@@ -45,3 +45,7 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # install poetry and gitlint
 RUN python3 -m pip install poetry gitlint wheel setuptools
+
+# install common python packages
+RUN python3 -m pip install --upgrade aiohttp colorama coverage cryptography Jinja2 lark ply Pillow pynacl pytest PyYAML pyzbar requests \
+	ripemd-hash safe-pysha3 websockets zenlog

--- a/jenkins/docker/windows/javascript.Dockerfile
+++ b/jenkins/docker/windows/javascript.Dockerfile
@@ -13,8 +13,7 @@ RUN Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser; `
 	iex $command; `
 	del c:\scoop.ps1; `
 	scoop install git shellcheck nodejs-lts cygwin rustup python; `
-	python3 -m pip install --upgrade pip; `
-	python3 -m pip install --upgrade gitlint wheel
+	python3 -m pip install --upgrade pip
 
 # Set VS tools first in the path so the correct link.exe is used.
 RUN Set-Content -Path c:\Users\ContainerAdministrator\.bash_profile  -Value 'export PATH=${VCToolsInstallDir}bin/Hostx64/x64:${PATH}'
@@ -30,3 +29,6 @@ ENV CARGO_HOME=C:\Users\ContainerAdministrator\scoop\apps\rustup\current\.cargo
 
 # Install wasm-pack
 RUN cargo install wasm-pack
+
+# install common python packages
+RUN python3 -m pip install --upgrade gitlint isort lark pycodestyle pylint PyYAML wheel

--- a/jenkins/docker/windows/python.Dockerfile
+++ b/jenkins/docker/windows/python.Dockerfile
@@ -17,8 +17,7 @@ RUN Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser; `
 	iex $command; `
 	del c:\scoop.ps1; `
 	scoop install git shellcheck openssl cmake cygwin python; `
-	python3 -m pip install --upgrade pip; `
-	python3 -m pip install --upgrade gitlint wheel setuptools
+	python3 -m pip install --upgrade pip
 
 # Set VS tools first in the path so the correct link.exe is used.
 RUN Set-Content -Path c:\Users\ContainerAdministrator\.bash_profile  -Value 'export PATH=${VCToolsInstallDir}bin/Hostx64/x64:${PATH}'
@@ -27,3 +26,7 @@ RUN Set-Content -Path c:\Users\ContainerAdministrator\.bash_profile  -Value 'exp
 RUN Invoke-WebRequest -Uri https://uploader.codecov.io/latest/windows/codecov.exe -Outfile c:\Windows\System32\codecov.exe
 
 ENV OPENSSL_ROOT_DIR='C:\Users\ContainerAdministrator\scoop\apps\openssl\current'
+
+# install common python packages
+RUN python3 -m pip install --upgrade aiohttp colorama coverage cryptography gitlint isort Jinja2 lark ply Pillow pycodestyle pylint pynacl pytest PyYAML pyzbar \
+    requests ripemd-hash safe-pysha3 setuptools websockets wheel zenlog


### PR DESCRIPTION
problem: each CI job installs common Python packages for linting, testing, etc.
solution: install common Python packages in the CI image.