### PR TITLE
[sdk]: add now to facade to simplify timestamp creation 

### DIFF
--- a/sdk/javascript/src/NetworkTimestamp.js
+++ b/sdk/javascript/src/NetworkTimestamp.js
@@ -106,6 +106,6 @@ export class NetworkTimestampDatetimeConverter {
 			throw RangeError('timestamp cannot be before epoch');
 
 		const subtractDates = (lhs, rhs) => (lhs - rhs);
-		return subtractDates(referenceDatetime, this.epoch) / this.timeUnits;
+		return (subtractDates(referenceDatetime, this.epoch) / this.timeUnits) | 0;
 	}
 }

--- a/sdk/javascript/src/facade/NemFacade.js
+++ b/sdk/javascript/src/facade/NemFacade.js
@@ -12,7 +12,13 @@ import {
 } from '../CryptoTypes.js';
 import { NetworkLocator } from '../Network.js';
 import { KeyPair, Verifier } from '../nem/KeyPair.js';
-import { Address, Network as NemNetwork } from '../nem/Network.js';
+import {
+	Address,
+	Network,
+	/* eslint-disable no-unused-vars */
+	NetworkTimestamp
+	/* eslint-enable no-unused-vars */
+} from '../nem/Network.js';
 import { deriveSharedKey } from '../nem/SharedKey.js';
 import TransactionFactory from '../nem/TransactionFactory.js';
 /* eslint-disable no-unused-vars */
@@ -58,14 +64,14 @@ export default class NemFacade {
 
 	/**
 	 * Creates a NEM facade.
-	 * @param {string|NemNetwork} network NEM network or network name.
+	 * @param {string|Network} network NEM network or network name.
 	 */
 	constructor(network) {
 		/**
 		 * Underlying network.
-		 * @type {NemNetwork}
+		 * @type {Network}
 		 */
-		this.network = 'string' === typeof network ? NetworkLocator.findByName(NemNetwork.NETWORKS, network) : network;
+		this.network = 'string' === typeof network ? NetworkLocator.findByName(Network.NETWORKS, network) : network;
 
 		/**
 		 * Underlying transaction factory.
@@ -80,6 +86,14 @@ export default class NemFacade {
 	 */
 	get static() { // eslint-disable-line class-methods-use-this
 		return NemFacade;
+	}
+
+	/**
+	 * Creates a network timestamp representing the current time.
+	 * @returns {NetworkTimestamp} Network timestamp representing the current time
+	 */
+	now() {
+		return this.network.fromDatetime(new Date());
 	}
 
 	// the following three functions are NOT static in order for NemFacade and SymbolFacade to conform to the same interface

--- a/sdk/javascript/src/facade/SymbolFacade.js
+++ b/sdk/javascript/src/facade/SymbolFacade.js
@@ -12,7 +12,13 @@ import {
 } from '../CryptoTypes.js';
 import { NetworkLocator } from '../Network.js';
 import { KeyPair, Verifier } from '../symbol/KeyPair.js';
-import { Address, Network as SymbolNetwork } from '../symbol/Network.js';
+import {
+	Address,
+	Network,
+	/* eslint-disable no-unused-vars */
+	NetworkTimestamp
+	/* eslint-enable no-unused-vars */
+} from '../symbol/Network.js';
 import { deriveSharedKey } from '../symbol/SharedKey.js';
 import TransactionFactory from '../symbol/TransactionFactory.js';
 import { MerkleHashBuilder } from '../symbol/merkle.js';
@@ -88,14 +94,14 @@ export default class SymbolFacade {
 
 	/**
 	 * Creates a Symbol facade.
-	 * @param {string|SymbolNetwork} network Symbol network or network name.
+	 * @param {string|Network} network Symbol network or network name.
 	 */
 	constructor(network) {
 		/**
 		 * Underlying network.
-		 * @type {SymbolNetwork}
+		 * @type {Network}
 		 */
-		this.network = 'string' === typeof network ? NetworkLocator.findByName(SymbolNetwork.NETWORKS, network) : network;
+		this.network = 'string' === typeof network ? NetworkLocator.findByName(Network.NETWORKS, network) : network;
 
 		/**
 		 * Underlying transaction factory.
@@ -110,6 +116,14 @@ export default class SymbolFacade {
 	 */
 	get static() { // eslint-disable-line class-methods-use-this
 		return SymbolFacade;
+	}
+
+	/**
+	 * Creates a network timestamp representing the current time.
+	 * @returns {NetworkTimestamp} Network timestamp representing the current time
+	 */
+	now() {
+		return this.network.fromDatetime(new Date());
 	}
 
 	/**

--- a/sdk/javascript/test/NetworkTimestamp_spec.js
+++ b/sdk/javascript/test/NetworkTimestamp_spec.js
@@ -102,23 +102,23 @@ describe('NetworkTimestampDatetimeConverter', () => {
 		expect(() => { converter.toDifference(new Date(Date.UTC(2020, 1, 2, 2))); }).to.throw('timestamp cannot be before epoch');
 	});
 
-	it('cannot convert datetime to epochal timestamp', () => {
+	it('can convert datetime to epochal timestamp', () => {
 		// Arrange:
 		const converter = createConverter();
 
 		// Act:
-		const rawTimestamp = converter.toDifference(new Date(Date.UTC(2020, 1, 2, 3)));
+		const rawTimestamp = converter.toDifference(new Date(Date.UTC(2020, 1, 2, 3, 4)));
 
 		// Assert:
 		expect(rawTimestamp).to.equal(0);
 	});
 
-	it('cannot convert datetime to non epochal timestamp', () => {
+	it('can convert datetime to non epochal timestamp', () => {
 		// Arrange:
 		const converter = createConverter();
 
 		// Act:
-		const rawTimestamp = converter.toDifference(new Date(Date.UTC(2020, 1, 2, 3 + 5)));
+		const rawTimestamp = converter.toDifference(new Date(Date.UTC(2020, 1, 2, 3 + 5, 4)));
 
 		// Assert:
 		expect(rawTimestamp).to.equal(5);

--- a/sdk/javascript/test/facade/NemFacade_spec.js
+++ b/sdk/javascript/test/facade/NemFacade_spec.js
@@ -95,6 +95,30 @@ describe('NEM Facade', () => {
 
 	// endregion
 
+	// region now
+
+	it('can create current timestamp for network via now', () => {
+		for (;;) {
+			// Arrange: affinitize test to run so that whole test runs within the context of the same millisecond
+			const startTime = new Date().getTime();
+			const facade = new NemFacade('testnet');
+
+			// Act:
+			const nowFromFacade = facade.now();
+			const nowFromNetwork = facade.network.fromDatetime(new Date(Date.now()));
+
+			const endTime = new Date().getTime();
+			if (startTime !== endTime)
+				continue; // eslint-disable-line no-continue
+
+			// Assert:
+			expect(nowFromFacade).to.deep.equal(nowFromNetwork);
+			break;
+		}
+	});
+
+	// endregion
+
 	// region hash transaction / sign transaction
 
 	const createRealTransfer = () => {

--- a/sdk/javascript/test/facade/SymbolFacade_spec.js
+++ b/sdk/javascript/test/facade/SymbolFacade_spec.js
@@ -185,6 +185,30 @@ describe('Symbol Facade', () => {
 
 	// endregion
 
+	// region now
+
+	it('can create current timestamp for network via now', () => {
+		for (;;) {
+			// Arrange: affinitize test to run so that whole test runs within the context of the same millisecond
+			const startTime = new Date().getTime();
+			const facade = new SymbolFacade('testnet');
+
+			// Act:
+			const nowFromFacade = facade.now();
+			const nowFromNetwork = facade.network.fromDatetime(new Date(Date.now()));
+
+			const endTime = new Date().getTime();
+			if (startTime !== endTime)
+				continue; // eslint-disable-line no-continue
+
+			// Assert:
+			expect(nowFromFacade).to.deep.equal(nowFromNetwork);
+			break;
+		}
+	});
+
+	// endregion
+
 	// region hash transaction / sign transaction
 
 	const attachSignature = (facade, transaction, signature) => {

--- a/sdk/python/symbolchain/NetworkTimestamp.py
+++ b/sdk/python/symbolchain/NetworkTimestamp.py
@@ -50,4 +50,4 @@ class NetworkTimestampDatetimeConverter:
 		if reference_datetime < self.epoch:
 			raise ValueError('timestamp cannot be before epoch')
 
-		return (reference_datetime - self.epoch) / datetime.timedelta(**{self.time_units: 1})
+		return (reference_datetime - self.epoch) // datetime.timedelta(**{self.time_units: 1})

--- a/sdk/python/symbolchain/facade/NemFacade.py
+++ b/sdk/python/symbolchain/facade/NemFacade.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timezone
+
 import sha3
 
 from ..CryptoTypes import Hash256, PrivateKey, PublicKey
@@ -39,6 +41,10 @@ class NemFacade:
 			Address: 'address',
 			PublicKey: 'public_key'
 		}
+
+	def now(self):
+		"""Creates a network timestamp representing the current time."""
+		return self.network.from_datetime(datetime.now(timezone.utc))
 
 	@staticmethod
 	def hash_transaction(transaction):

--- a/sdk/python/symbolchain/facade/SymbolFacade.py
+++ b/sdk/python/symbolchain/facade/SymbolFacade.py
@@ -1,4 +1,5 @@
 import hashlib
+from datetime import datetime, timezone
 
 from .. import sc
 from ..CryptoTypes import Hash256, PublicKey, Signature
@@ -57,6 +58,10 @@ class SymbolFacade:
 			Address: 'address',
 			PublicKey: 'public_key',
 		}
+
+	def now(self):
+		"""Creates a network timestamp representing the current time."""
+		return self.network.from_datetime(datetime.now(timezone.utc))
 
 	def hash_transaction(self, transaction):
 		"""Hashes a Symbol transaction."""

--- a/sdk/python/tests/facade/test_NemFacade.py
+++ b/sdk/python/tests/facade/test_NemFacade.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import datetime, timezone
 
 from symbolchain.AccountDescriptorRepository import AccountDescriptorRepository
 from symbolchain.Bip32 import Bip32
@@ -108,6 +109,28 @@ class NemFacadeTest(unittest.TestCase):
 		self.assertEqual(
 			str(NemFacade.Address('TALIC33PNVKIMNXVOCOQGWLZK52K4XALZBNE2ISF')).encode('utf8'),
 			transaction.recipient_address.bytes)
+
+	# endregion
+
+	# region now
+
+	def test_can_create_current_timestamp_for_network_via_now(self):
+		while True:
+			# Arrange: affinitize test to run so that whole test runs within the context of the same millisecond
+			start_time = datetime.now()
+			facade = NemFacade('testnet')
+
+			# Act:
+			now_from_facade = facade.now()
+			now_from_network = facade.network.from_datetime(datetime.now(timezone.utc))
+
+			end_time = datetime.now()
+			if (start_time.microsecond // 1000) != (end_time.microsecond // 1000):
+				continue
+
+			# Assert:
+			self.assertEqual(now_from_network, now_from_facade)
+			break
 
 	# endregion
 

--- a/sdk/python/tests/facade/test_SymbolFacade.py
+++ b/sdk/python/tests/facade/test_SymbolFacade.py
@@ -1,4 +1,5 @@
 import unittest
+from datetime import datetime, timezone
 
 from symbolchain import sc
 from symbolchain.AccountDescriptorRepository import AccountDescriptorRepository
@@ -202,6 +203,28 @@ class SymbolFacadeTest(unittest.TestCase):
 			PublicKey('87DA603E7BE5656C45692D5FC7F6D0EF8F24BB7A5C10ED5FDA8C5CFBC49FCBC8').bytes,
 			transaction.signer_public_key.bytes)
 		self.assertEqual(SymbolFacade.Address('TASYMBOLLK6FSL7GSEMQEAWN7VW55ZSZU2Q2Q5Y').bytes, transaction.recipient_address.bytes)
+
+	# endregion
+
+	# region now
+
+	def test_can_create_current_timestamp_for_network_via_now(self):
+		while True:
+			# Arrange: affinitize test to run so that whole test runs within the context of the same millisecond
+			start_time = datetime.now()
+			facade = SymbolFacade('testnet')
+
+			# Act:
+			now_from_facade = facade.now()
+			now_from_network = facade.network.from_datetime(datetime.now(timezone.utc))
+
+			end_time = datetime.now()
+			if (start_time.microsecond // 1000) != (end_time.microsecond // 1000):
+				continue
+
+			# Assert:
+			self.assertEqual(now_from_network, now_from_facade)
+			break
 
 	# endregion
 

--- a/sdk/python/tests/test_NetworkTimestamp.py
+++ b/sdk/python/tests/test_NetworkTimestamp.py
@@ -101,7 +101,7 @@ class NetworkTimestampDatetimeConverterTest(unittest.TestCase):
 		converter = create_converter()
 
 		# Act:
-		raw_timestamp = converter.to_difference(datetime.datetime(2020, 1, 2, 3))
+		raw_timestamp = converter.to_difference(datetime.datetime(2020, 1, 2, 3, 4))
 
 		# Assert:
 		self.assertEqual(0, raw_timestamp)
@@ -111,7 +111,7 @@ class NetworkTimestampDatetimeConverterTest(unittest.TestCase):
 		converter = create_converter()
 
 		# Act:
-		raw_timestamp = converter.to_difference(datetime.datetime(2020, 1, 2, 3 + 5))
+		raw_timestamp = converter.to_difference(datetime.datetime(2020, 1, 2, 3 + 5, 4))
 
 		# Assert:
 		self.assertEqual(5, raw_timestamp)


### PR DESCRIPTION
     problem: calling network.fromDatetime is a bit verbose
    solution: add now
