### PR TITLE
[jenkins] fix: the latest docker requires subnet for static ip

### DIFF
--- a/client/catapult/Jenkinsfile
+++ b/client/catapult/Jenkinsfile
@@ -9,7 +9,8 @@ defaultCiPipeline {
 		--volume="/jenkins_cache/ccache/$ARCHITECTURE/ci:/ccache:rw" \
 		--volume="/jenkins_cache/conan/$ARCHITECTURE/gcc:/conan" \
 		--add-host=db:127.0.0.1 \
-		--ip6 2001:db8:1::20'
+		--ip6 2001:db8:85a3::8a2e:370:7334 \
+		--network=my-network'
 
 	packageId = 'client-catapult'
 }


### PR DESCRIPTION
problem: the latest docker version requires a subnetwork when a static IP address is used.
solution: specify the network that has the static IP address