### PR TITLE
[client/catapult]: add configuration for managing RockDB log files

### DIFF
--- a/client/catapult/resources/config-node.properties
+++ b/client/catapult/resources/config-node.properties
@@ -60,6 +60,8 @@ listenInterface = 0.0.0.0
 
 enableStatistics = false
 maxOpenFiles = 0
+maxLogFiles = 0
+maxLogFileSize = 0MB
 maxBackgroundThreads = 0
 maxSubcompactionThreads = 0
 blockCacheSize = 0MB

--- a/client/catapult/src/catapult/cache_db/RocksDatabase.cpp
+++ b/client/catapult/src/catapult/cache_db/RocksDatabase.cpp
@@ -117,6 +117,12 @@ namespace catapult { namespace cache {
 			if (config.MaxOpenFiles > 0)
 				dbOptions.max_open_files = static_cast<int>(config.MaxOpenFiles);
 
+			if (config.MaxLogFiles > 0)
+				dbOptions.keep_log_file_num = config.MaxLogFiles;
+
+			if (utils::FileSize() != config.MaxLogFileSize)
+				dbOptions.max_log_file_size = config.MaxLogFileSize.bytes();
+
 			if (config.MaxBackgroundThreads > 0)
 				dbOptions.IncreaseParallelism(static_cast<int>(config.MaxBackgroundThreads));
 

--- a/client/catapult/src/catapult/config/NodeConfiguration.cpp
+++ b/client/catapult/src/catapult/config/NodeConfiguration.cpp
@@ -97,6 +97,8 @@ namespace catapult { namespace config {
 
 		LOAD_CACHE_DATABASE_PROPERTY(EnableStatistics);
 		LOAD_CACHE_DATABASE_PROPERTY(MaxOpenFiles);
+		LOAD_CACHE_DATABASE_PROPERTY(MaxLogFiles);
+		LOAD_CACHE_DATABASE_PROPERTY(MaxLogFileSize);
 		LOAD_CACHE_DATABASE_PROPERTY(MaxBackgroundThreads);
 		LOAD_CACHE_DATABASE_PROPERTY(MaxSubcompactionThreads);
 		LOAD_CACHE_DATABASE_PROPERTY(BlockCacheSize);
@@ -150,7 +152,7 @@ namespace catapult { namespace config {
 
 #undef LOAD_BANNING_PROPERTY
 
-		utils::VerifyBagSizeExact(bag, 40 + 7 + 4 + 4 + 5 + 9);
+		utils::VerifyBagSizeExact(bag, 40 + 9 + 4 + 4 + 5 + 9);
 		return config;
 	}
 

--- a/client/catapult/src/catapult/config/NodeConfiguration.h
+++ b/client/catapult/src/catapult/config/NodeConfiguration.h
@@ -167,6 +167,12 @@ namespace catapult { namespace config {
 			/// Maximum number of open files.
 			uint32_t MaxOpenFiles;
 
+			/// Maximum number of log files.
+			uint32_t MaxLogFiles;
+
+			/// Maximum log file size.
+			utils::FileSize MaxLogFileSize;
+
 			/// Maximum number of background threads.
 			uint32_t MaxBackgroundThreads;
 

--- a/client/catapult/tests/catapult/config/CatapultConfigurationTests.cpp
+++ b/client/catapult/tests/catapult/config/CatapultConfigurationTests.cpp
@@ -165,6 +165,8 @@ namespace catapult { namespace config {
 
 			EXPECT_FALSE(config.CacheDatabase.EnableStatistics);
 			EXPECT_EQ(0u, config.CacheDatabase.MaxOpenFiles);
+			EXPECT_EQ(0, config.CacheDatabase.MaxLogFiles);
+			EXPECT_EQ(utils::FileSize::FromMegabytes(0), config.CacheDatabase.MaxLogFileSize);
 			EXPECT_EQ(0u, config.CacheDatabase.MaxBackgroundThreads);
 			EXPECT_EQ(0u, config.CacheDatabase.MaxSubcompactionThreads);
 			EXPECT_EQ(utils::FileSize::FromMegabytes(0), config.CacheDatabase.BlockCacheSize);

--- a/client/catapult/tests/catapult/config/NodeConfigurationTests.cpp
+++ b/client/catapult/tests/catapult/config/NodeConfigurationTests.cpp
@@ -97,6 +97,8 @@ namespace catapult { namespace config {
 						{
 							{ "enableStatistics", "true" },
 							{ "maxOpenFiles", "1111" },
+							{ "maxLogFiles", "23" },
+							{ "maxLogFileSize", "12MB" },
 							{ "maxBackgroundThreads", "19" },
 							{ "maxSubcompactionThreads", "11" },
 							{ "blockCacheSize", "111MB" },
@@ -215,6 +217,8 @@ namespace catapult { namespace config {
 
 				EXPECT_FALSE(config.CacheDatabase.EnableStatistics);
 				EXPECT_EQ(0u, config.CacheDatabase.MaxOpenFiles);
+				EXPECT_EQ(0, config.CacheDatabase.MaxLogFiles);
+				EXPECT_EQ(utils::FileSize::FromMegabytes(0), config.CacheDatabase.MaxLogFileSize);
 				EXPECT_EQ(0u, config.CacheDatabase.MaxBackgroundThreads);
 				EXPECT_EQ(0u, config.CacheDatabase.MaxSubcompactionThreads);
 				EXPECT_EQ(utils::FileSize::FromMegabytes(0), config.CacheDatabase.BlockCacheSize);
@@ -310,6 +314,8 @@ namespace catapult { namespace config {
 
 				EXPECT_TRUE(config.CacheDatabase.EnableStatistics);
 				EXPECT_EQ(1111u, config.CacheDatabase.MaxOpenFiles);
+				EXPECT_EQ(23u, config.CacheDatabase.MaxLogFiles);
+				EXPECT_EQ(utils::FileSize::FromMegabytes(12), config.CacheDatabase.MaxLogFileSize);
 				EXPECT_EQ(19u, config.CacheDatabase.MaxBackgroundThreads);
 				EXPECT_EQ(11u, config.CacheDatabase.MaxSubcompactionThreads);
 				EXPECT_EQ(utils::FileSize::FromMegabytes(111), config.CacheDatabase.BlockCacheSize);


### PR DESCRIPTION
 problem: RocksDB logs files use a lot of disk space
solution: allow node operator to limit log resource use
