### PR TITLE
[client/catapult] fix: update _FORTIFY_SOURCE=3 for gcc on Ubuntu 24.04

### DIFF
--- a/client/catapult/CMakeGlobalSettings.cmake
+++ b/client/catapult/CMakeGlobalSettings.cmake
@@ -184,7 +184,7 @@ endif()
 if("${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
 	# set hardening flags
 	if(ENABLE_HARDENING)
-		set(HARDENING_FLAGS "-fstack-protector-all -D_FORTIFY_SOURCE=2")
+		set(HARDENING_FLAGS "-fstack-protector-all -D_FORTIFY_SOURCE=3")
 		if("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
 			set(HARDENING_FLAGS "${HARDENING_FLAGS} -fstack-clash-protection")
 		else()


### PR DESCRIPTION
problem: GCC on Ubuntu 24.04 updated the default _FORTIFY_SOURCE to 3
         This causes refined warning when building catapult release
solution: update the _FORTIFY_SOURCE=3