### PR TITLE
[sdk/javascript]: '| 0' truncation trick doesn't work with large integers

### DIFF
--- a/sdk/javascript/src/NetworkTimestamp.js
+++ b/sdk/javascript/src/NetworkTimestamp.js
@@ -105,7 +105,7 @@ export class NetworkTimestampDatetimeConverter {
 		if (referenceDatetime < this.epoch)
 			throw RangeError('timestamp cannot be before epoch');
 
-		const subtractDates = (lhs, rhs) => (lhs - rhs);
-		return (subtractDates(referenceDatetime, this.epoch) / this.timeUnits) | 0;
+		const differenceMilliseconds = referenceDatetime.getTime() - this.epoch.getTime();
+		return Math.trunc(differenceMilliseconds / this.timeUnits);
 	}
 }

--- a/sdk/javascript/test/NetworkTimestamp_spec.js
+++ b/sdk/javascript/test/NetworkTimestamp_spec.js
@@ -123,4 +123,16 @@ describe('NetworkTimestampDatetimeConverter', () => {
 		// Assert:
 		expect(rawTimestamp).to.equal(5);
 	});
+
+	it('can convert datetime to non epochal timestamp (large)', () => {
+		// Arrange:
+		const converter = new NetworkTimestampDatetimeConverter(new Date(Date.UTC(2020, 1, 2, 3)), 'milliseconds');
+
+		// Act:
+		const rawTimestamp = converter.toDifference(new Date(Date.UTC(2025, 1, 2, 3)));
+
+		// Assert:
+		expect(rawTimestamp).to.equal(((5 * 365) + 2) * 24 * 60 * 60 * 1000);
+		expect(rawTimestamp).to.be.above(2 ** 31);
+	});
 });

--- a/sdk/javascript/test/facade/NemFacade_spec.js
+++ b/sdk/javascript/test/facade/NemFacade_spec.js
@@ -113,6 +113,7 @@ describe('NEM Facade', () => {
 
 			// Assert:
 			expect(nowFromFacade).to.deep.equal(nowFromNetwork);
+			expect(0n < nowFromFacade.timestamp).to.equal(true);
 			break;
 		}
 	});

--- a/sdk/javascript/test/facade/SymbolFacade_spec.js
+++ b/sdk/javascript/test/facade/SymbolFacade_spec.js
@@ -203,6 +203,7 @@ describe('Symbol Facade', () => {
 
 			// Assert:
 			expect(nowFromFacade).to.deep.equal(nowFromNetwork);
+			expect(0n < nowFromFacade.timestamp).to.equal(true);
 			break;
 		}
 	});

--- a/sdk/python/tests/facade/test_NemFacade.py
+++ b/sdk/python/tests/facade/test_NemFacade.py
@@ -130,6 +130,7 @@ class NemFacadeTest(unittest.TestCase):
 
 			# Assert:
 			self.assertEqual(now_from_network, now_from_facade)
+			self.assertGreater(now_from_facade.timestamp, 0)
 			break
 
 	# endregion

--- a/sdk/python/tests/facade/test_SymbolFacade.py
+++ b/sdk/python/tests/facade/test_SymbolFacade.py
@@ -224,6 +224,7 @@ class SymbolFacadeTest(unittest.TestCase):
 
 			# Assert:
 			self.assertEqual(now_from_network, now_from_facade)
+			self.assertGreater(now_from_facade.timestamp, 0)
 			break
 
 	# endregion

--- a/sdk/python/tests/test_NetworkTimestamp.py
+++ b/sdk/python/tests/test_NetworkTimestamp.py
@@ -115,3 +115,13 @@ class NetworkTimestampDatetimeConverterTest(unittest.TestCase):
 
 		# Assert:
 		self.assertEqual(5, raw_timestamp)
+
+	def test_can_convert_datetime_to_non_epochal_timestamp_large(self):
+		# Arrange:
+		converter = NetworkTimestampDatetimeConverter(datetime.datetime(2020, 1, 2, 3), 'milliseconds')
+
+		# Act:
+		raw_timestamp = converter.to_difference(datetime.datetime(2025, 1, 2, 3))
+
+		# Assert:
+		self.assertEqual(((5 * 365) + 2) * 24 * 60 * 60 * 1000, raw_timestamp)


### PR DESCRIPTION
 problem: '| 0' is a bitwise operation that only works with signed 32-bit integers
          since DateTime timestamps are larger, it is inappropriate for these numbers
solution: use Math.trunc instead, which properly handles larger numbers
