### PR TITLE
[jenkins] fix: move checkout to the first step

### DIFF
--- a/jenkins/catapult/jenkins/catapult-client-build-base-image.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-base-image.groovy
@@ -43,13 +43,13 @@ pipeline {
 
 	stages {
 		stage('prepare') {
-			stage('git checkout') {
-				steps {
-					sh "git checkout ${params.MANUAL_GIT_BRANCH}"
-					sh "git reset --hard origin/${params.MANUAL_GIT_BRANCH}"
-				}
-			}
 			stages {
+				stage('git checkout') {
+					steps {
+						sh "git checkout ${params.MANUAL_GIT_BRANCH}"
+						sh "git reset --hard origin/${params.MANUAL_GIT_BRANCH}"
+					}
+				}
 				stage('prepare variables') {
 					steps {
 						script {

--- a/jenkins/catapult/jenkins/catapult-client-build-base-image.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-base-image.groovy
@@ -43,6 +43,12 @@ pipeline {
 
 	stages {
 		stage('prepare') {
+			stage('git checkout') {
+				steps {
+					sh "git checkout ${params.MANUAL_GIT_BRANCH}"
+					sh "git reset --hard origin/${params.MANUAL_GIT_BRANCH}"
+				}
+			}
 			stages {
 				stage('prepare variables') {
 					steps {
@@ -71,12 +77,6 @@ pipeline {
 
 									 destImageName: ${destImageName}
 						"""
-					}
-				}
-				stage('git checkout') {
-					steps {
-						sh "git checkout ${params.MANUAL_GIT_BRANCH}"
-						sh "git reset --hard origin/${params.MANUAL_GIT_BRANCH}"
 					}
 				}
 			}

--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project.groovy
@@ -56,6 +56,22 @@ pipeline {
 	stages {
 		stage('prepare') {
 			stages {
+				stage('git checkout') {
+					when {
+						expression { isManualBuild() }
+					}
+					steps {
+						script {
+							helper.runStepAndRecordFailure {
+								dir('catapult-src') {
+									sh 'git config -l'
+									sh "git checkout ${resolveBranchName()}"
+									sh "git reset --hard origin/${resolveBranchName()}"
+								}
+							}
+						}
+					}
+				}
 				stage('prepare variables') {
 					steps {
 						script {
@@ -95,22 +111,6 @@ pipeline {
 								   buildImageLabel: ${buildImageLabel}
 								buildImageFullName: ${buildImageFullName}
 						"""
-					}
-				}
-				stage('git checkout') {
-					when {
-						expression { isManualBuild() }
-					}
-					steps {
-						script {
-							helper.runStepAndRecordFailure {
-								dir('catapult-src') {
-									sh 'git config -l'
-									sh "git checkout ${resolveBranchName()}"
-									sh "git reset --hard origin/${resolveBranchName()}"
-								}
-							}
-						}
 					}
 				}
 			}

--- a/jenkins/catapult/jenkins/catapult-client-build-compiler-image.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-compiler-image.groovy
@@ -28,6 +28,12 @@ pipeline {
 	}
 
 	stages {
+		stage('git checkout') {
+			steps {
+				sh "git checkout ${params.MANUAL_GIT_BRANCH}"
+				sh "git reset --hard origin/${params.MANUAL_GIT_BRANCH}"
+			}
+		}
 		stage('prepare') {
 			stages {
 				stage('prepare variables') {
@@ -66,12 +72,6 @@ pipeline {
 
 								     destImageName: ${destImageName}
 						"""
-					}
-				}
-				stage('git checkout') {
-					steps {
-						sh "git checkout ${params.MANUAL_GIT_BRANCH}"
-						sh "git reset --hard origin/${params.MANUAL_GIT_BRANCH}"
 					}
 				}
 			}

--- a/jenkins/catapult/jenkins/catapult-client-release-build.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-release-build.groovy
@@ -34,6 +34,17 @@ pipeline {
 	stages {
 		stage('prepare') {
 			stages {
+				stage('git checkout') {
+					when {
+						expression { isManualBuild() }
+					}
+					steps {
+						dir('symbol-mono') {
+							sh "git checkout ${resolveBranchName()}"
+							sh "git reset --hard origin/${resolveBranchName()}"
+						}
+					}
+				}
 				stage('prepare variables') {
 					steps {
 						script {
@@ -75,17 +86,6 @@ pipeline {
 										imageLabel: ${imageLabel}
 								buildImageFullName: ${buildImageFullName}
 						"""
-					}
-				}
-				stage('git checkout') {
-					when {
-						expression { isManualBuild() }
-					}
-					steps {
-						dir('symbol-mono') {
-							sh "git checkout ${resolveBranchName()}"
-							sh "git reset --hard origin/${resolveBranchName()}"
-						}
 					}
 				}
 			}


### PR DESCRIPTION
problem: in the prepare stage, the docker image names are created before the source code is checked out
         this causes the docker image name to always be based on code in dev and not the build branch.
solution: checkout source code before creating the docker image name