### PR TITLE
[jenkins] fix: upgrade to clang 18

### DIFF
--- a/client/catapult/CMakeGlobalSettings.cmake
+++ b/client/catapult/CMakeGlobalSettings.cmake
@@ -166,7 +166,8 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 		-Wno-switch-enum \
 		-Wno-weak-vtables \
 		-Wno-unsafe-buffer-usage \
-		-Wno-shadow-uncaptured-local")
+		-Wno-shadow-uncaptured-local \
+		-Wno-switch-default")
 
 	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -g1")
 endif()

--- a/jenkins/catapult/compilers/clang-latest.yaml
+++ b/jenkins/catapult/compilers/clang-latest.yaml
@@ -1,15 +1,15 @@
 c: clang
 cpp: clang++
-version: 17
+version: 18
 
 stl:
   version: c++1y
   lib: libc++
 
 deps:
-  - /usr/lib/llvm-17/lib/libc++.so.*
-  - /usr/lib/llvm-17/lib/libc++abi.so.*
-  - /usr/lib/llvm-17/lib/libunwind.*
+  - /usr/lib/llvm-18/lib/libc++.so.*
+  - /usr/lib/llvm-18/lib/libc++abi.so.*
+  - /usr/lib/llvm-18/lib/libunwind.*
 
-  - /usr/lib/llvm-17/bin/llvm-symbolizer
-  - /usr/lib/x86_64-linux-gnu/libLLVM-17.*
+  - /usr/lib/llvm-18/bin/llvm-symbolizer
+  - /usr/lib/x86_64-linux-gnu/libLLVM-18.*

--- a/jenkins/catapult/compilers/clang-prior.yaml
+++ b/jenkins/catapult/compilers/clang-prior.yaml
@@ -1,15 +1,15 @@
 c: clang
 cpp: clang++
-version: 16
+version: 17
 
 stl:
   version: c++1y
   lib: libc++
 
 deps:
-  - /usr/lib/llvm-16/lib/libc++.so.*
-  - /usr/lib/llvm-16/lib/libc++abi.so.*
-  - /usr/lib/llvm-16/lib/libunwind.*
+  - /usr/lib/llvm-17/lib/libc++.so.*
+  - /usr/lib/llvm-17/lib/libc++abi.so.*
+  - /usr/lib/llvm-17/lib/libunwind.*
 
-  - /usr/lib/llvm-16/bin/llvm-symbolizer
-  - /usr/lib/x86_64-linux-gnu/libLLVM-16.*
+  - /usr/lib/llvm-17/bin/llvm-symbolizer
+  - /usr/lib/x86_64-linux-gnu/libLLVM-17.*

--- a/jenkins/catapult/compilers/ubuntu-clang/Dockerfile
+++ b/jenkins/catapult/compilers/ubuntu-clang/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update >/dev/null && \
 	wget 
 
 # Use the latest Clang version.
-ARG COMPILER_VERSION=17
+ARG COMPILER_VERSION=18
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /etc/apt/trusted.gpg.d/clang.gpg  && \
 	echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${COMPILER_VERSION} main" > /etc/apt/sources.list.d/clang.list && \
 	apt-get update >/dev/null && \


### PR DESCRIPTION
problem: tsan run is failing 'unexpected memory mapping'
         this is due to a change in the latest Linux kernel.
solution: upgrade to the latest clang 18, which should have the fix
``https://github.com/google/sanitizers/issues/1716#issuecomment-2010399341``
