### PR TITLE
[jenkins] fix: clang 18 remove the 'avx' options from ARM

### DIFF
--- a/jenkins/catapult/baseImageDockerfileGenerator.py
+++ b/jenkins/catapult/baseImageDockerfileGenerator.py
@@ -173,7 +173,7 @@ class OptionsManager:
 		descriptor = self._enable_thread_san_descriptor()
 		descriptor.options += get_dependency_flags('zeromq_libzmq')
 
-		if self.is_clang:
+		if not 'arm64' == self.architecture and self.is_clang:
 			# Xeon-based build machine, even with -mskylake seems to do miscompilation in libzmq,
 			# try to pass additional flags to disable faulty optimizations
 			descriptor.cxxflags += ['-mno-avx', '-mno-avx2']


### PR DESCRIPTION
problem: libzmq is failing to build on ARM due to 'avx' was removed in Clang 18
solution: only add the 'avx' options on intel architecture