### PR TITLE
[sdk/javascript]: fix package exports

### DIFF
--- a/sdk/javascript/README.md
+++ b/sdk/javascript/README.md
@@ -164,6 +164,20 @@ export default {
 
 If everything is set up correctly, the same syntax as the Node example can be used.
 
+### TypeScript Support
+
+JavaScript SDK uses [node subpath exports](https://nodejs.org/api/packages.html#subpath-exports) for cleaner imports and depends on ES2020 functionality.
+For TypeScript compatibility, the following minimum settings must be specified in `tsconfig.json`:
+
+```json
+	{
+		"compilerOptions": {
+			"target": "ES2020",
+			"module": "Node16",
+			"moduleResolution": "Node16"
+		}
+	}
+```
 
 ## NEM Cheat Sheet
 

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -7,16 +7,19 @@
   "types": "./ts/src/index.d.ts",
   "exports": {
     ".": {
-      "default": "./src/index.js",
-      "types": "./ts/src/index.d.ts"
+      "import": "./src/index.js",
+      "types": "./ts/src/index.d.ts",
+      "default": "./src/index.js"
     },
     "./nem": {
-      "default": "./src/nem/index.js",
-      "types": "./ts/src/nem/index.d.ts"
+      "import": "./src/nem/index.js",
+      "types": "./ts/src/nem/index.d.ts",
+      "default": "./src/nem/index.js"
     },
     "./symbol": {
-      "default": "./src/symbol/index.js",
-      "types": "./ts/src/symbol/index.d.ts"
+      "import": "./src/symbol/index.js",
+      "types": "./ts/src/symbol/index.d.ts",
+      "default": "./src/symbol/index.js"
     }
   },
   "scripts": {

--- a/sdk/javascript/scripts/run_catbuffer_generator.sh
+++ b/sdk/javascript/scripts/run_catbuffer_generator.sh
@@ -31,7 +31,7 @@ elif [[ "$1" = "dryrun" ]]; then
 	do
 		generate_code "${name}" "${name}2"
 		diff --strip-trailing-cr "./src/${name}/models.js" "./src/${name}2/models.js"
-		rm -rf "./src/${name}2/models.js"
+		rm -rf "./src/${name}2"
 	done
 else
 	echo "unknown options"


### PR DESCRIPTION
     problem: subpath exports are not working correctly with certain JS/TS environments
    solution: for max compatibility, add 'import' and move 'default' last
              add README for min TS requirements
