### PR TITLE
[linters] fix: disable no-unresolved for symbol-sdk imports

### DIFF
--- a/linters/javascript/default.eslintrc
+++ b/linters/javascript/default.eslintrc
@@ -113,7 +113,7 @@ rules:
   - error
   import/no-unresolved:
   - 2
-// disable for symbol-sdk until https://github.com/import-js/eslint-plugin-import/issues/1810 is resolved
+  # disable for symbol-sdk until https://github.com/import-js/eslint-plugin-import/issues/1810 is resolved
   - ignore:
     - '^symbol-sdk/'
   import/no-deprecated:

--- a/linters/javascript/default.eslintrc
+++ b/linters/javascript/default.eslintrc
@@ -113,6 +113,9 @@ rules:
   - error
   import/no-unresolved:
   - 2
+// disable for symbol-sdk until https://github.com/import-js/eslint-plugin-import/issues/1810 is resolved
+  - ignore:
+    - '^symbol-sdk/'
   import/no-deprecated:
   - error
   import/named:


### PR DESCRIPTION
problem: no-resolved does not support subpath exports
solution: disable  no-resolved for symbol-sdk imports 
               until ``https://github.com/import-js/eslint-plugin-import/issues/1810`` is resolved