### PR TITLE
[jenkins] fix: update docker images

### DIFF
--- a/jenkins/docker/fedora/javascript.Dockerfile
+++ b/jenkins/docker/fedora/javascript.Dockerfile
@@ -1,4 +1,4 @@
-ARG FROM_IMAGE='fedora:39'
+ARG FROM_IMAGE='fedora:40'
 
 FROM ${FROM_IMAGE}
 

--- a/jenkins/docker/fedora/python.Dockerfile
+++ b/jenkins/docker/fedora/python.Dockerfile
@@ -1,4 +1,4 @@
-ARG FROM_IMAGE='fedora:39'
+ARG FROM_IMAGE='fedora:40'
 
 FROM ${FROM_IMAGE}
 

--- a/jenkins/docker/ubuntu/java.Dockerfile
+++ b/jenkins/docker/ubuntu/java.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # install dependencies (install tzdata first to prevent 'geographic area' prompt)
 RUN apt-get update \

--- a/jenkins/docker/ubuntu/javascript.Dockerfile
+++ b/jenkins/docker/ubuntu/javascript.Dockerfile
@@ -1,11 +1,11 @@
-ARG FROM_IMAGE='ubuntu:22.04'
+ARG FROM_IMAGE='ubuntu:24.04'
 
 FROM ${FROM_IMAGE}
 
 # install tzdata first to prevent 'geographic area' prompt
 RUN apt-get update >/dev/null \
 	&& apt-get install -y tzdata \
-	&& apt-get install -y git curl
+	&& apt-get install -y git curl zip unzip
 
 # mongodb 6.0
 RUN apt-get install -y wget gnupg \
@@ -45,6 +45,12 @@ RUN ARCH=$([ "$(uname -m)" = "x86_64" ] && echo "linux" || echo "aarch64") \
 	&& curl -Os "https://uploader.codecov.io/latest/${ARCH}/codecov" \
 	&& chmod +x codecov \
 	&& mv codecov /usr/local/bin
+
+# install aws cli
+RUN ARCH=$([ "$(uname -m)" = "x86_64" ] && echo "x86_64" || echo "aarch64") \
+	&& curl "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip" -o "awscliv2.zip" \
+	&& unzip awscliv2.zip \
+	&& ./aws/install
 
 # add ubuntu user (used by jenkins)
 RUN id -u "ubuntu" || useradd --uid 1000 -ms /bin/bash ubuntu

--- a/jenkins/docker/ubuntu/linter.Dockerfile
+++ b/jenkins/docker/ubuntu/linter.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # install tzdata first to prevent 'geographic area' prompt
 RUN apt-get update >/dev/null \

--- a/jenkins/docker/ubuntu/python.Dockerfile
+++ b/jenkins/docker/ubuntu/python.Dockerfile
@@ -5,7 +5,7 @@ FROM ${FROM_IMAGE}
 # install tzdata first to prevent 'geographic area' prompt
 RUN apt-get update >/dev/null \
 	&& apt-get install -y tzdata \
-	&& apt-get install -y git curl
+	&& apt-get install -y git curl zip unzip
 
 # install python
 ARG FROM_IMAGE
@@ -32,6 +32,12 @@ RUN ARCH=$([ "$(uname -m)" = "x86_64" ] && echo "linux" || echo "aarch64") \
 	&& curl -Os "https://uploader.codecov.io/latest/${ARCH}/codecov" \
 	&& chmod +x codecov \
 	&& mv codecov /usr/local/bin
+
+# install aws cli
+RUN ARCH=$([ "$(uname -m)" = "x86_64" ] && echo "x86_64" || echo "aarch64") \
+	&& curl "https://awscli.amazonaws.com/awscli-exe-linux-${ARCH}.zip" -o "awscliv2.zip" \
+	&& unzip awscliv2.zip \
+	&& ./aws/install
 
 # add ubuntu user (used by jenkins)
 RUN id -u "ubuntu" || useradd --uid 1000 -ms /bin/bash ubuntu

--- a/jenkins/shared-library/resources/buildEnvironment/baseImages.yaml
+++ b/jenkins/shared-library/resources/buildEnvironment/baseImages.yaml
@@ -1,5 +1,5 @@
 fedora-lts:
-  image: fedora:39
+  image: fedora:40
 ubuntu-lts:
   image: ubuntu:22.04
   python: 3.11


### PR DESCRIPTION
problem: docker images are not using the latest OS
solution: upgrade the base images to the latest
          add zip and AWS CLI to the JS and Python images