### PR TITLE
[jenkins] fix: linting failure due to rmtree onerror deprecation

### DIFF
--- a/jenkins/catapult/environment.py
+++ b/jenkins/catapult/environment.py
@@ -4,11 +4,15 @@ import sys
 from pathlib import Path
 
 
-def rm_failure_handler(func, path, excinfo):
+def rm_onerror_handler(func, path, excinfo):
+	rm_onexc_handler(func, path, excinfo[1])
+
+
+def rm_onexc_handler(func, path, exception):
 	del func
 	del path
-	if excinfo[0] != FileNotFoundError:
-		raise excinfo[1]
+	if not isinstance(exception, FileNotFoundError):
+		raise exception
 
 
 class EnvironmentManager:
@@ -71,7 +75,7 @@ class EnvironmentManager:
 		if self.dry_run:
 			return
 
-		kwargs = {'onexc' if sys.version_info >= (3, 12) else 'onerror': rm_failure_handler}
+		kwargs = {'onexc': rm_onexc_handler} if sys.version_info >= (3, 12) else {'onerror': rm_onerror_handler}
 		shutil.rmtree(path, **kwargs)
 
 	# endregion

--- a/jenkins/catapult/environment.py
+++ b/jenkins/catapult/environment.py
@@ -71,7 +71,8 @@ class EnvironmentManager:
 		if self.dry_run:
 			return
 
-		shutil.rmtree(path, onerror=rm_failure_handler)
+		kwargs = {'onexc' if sys.version_info >= (3, 12) else 'onerror': rm_failure_handler}
+		shutil.rmtree(path, **kwargs)
 
 	# endregion
 

--- a/jenkins/docker/ubuntu/java.Dockerfile
+++ b/jenkins/docker/ubuntu/java.Dockerfile
@@ -7,11 +7,10 @@ RUN apt-get update \
 	&& update-ca-certificates
 
 # install python
-RUN apt-get install -y python3-pip
+RUN apt-get install -y python3-pip python3-venv
 
-# install shellcheck and gitlint
-RUN apt-get install -y shellcheck \
-	&& pip install gitlint
+# install shellcheck
+RUN apt-get install -y shellcheck
 
 # codecov uploader
 RUN ARCH=$([ "$(uname -m)" = "x86_64" ] && echo "linux" || echo "aarch64") \
@@ -20,6 +19,17 @@ RUN ARCH=$([ "$(uname -m)" = "x86_64" ] && echo "linux" || echo "aarch64") \
 	&& mv codecov /usr/local/bin
 
 # add ubuntu user (used by jenkins)
-RUN useradd --uid 1000 -ms /bin/bash ubuntu
+RUN id -u "ubuntu" || useradd --uid 1000 -ms /bin/bash ubuntu
+USER ubuntu
+WORKDIR /home/ubuntu
+ENV PATH=$PATH:/home/ubuntu/.local/bin
+
+# create a virtual environment
+ENV VIRTUAL_ENV=/home/ubuntu/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# install gitlint
+RUN pip install gitlint
 
 WORKDIR /home/ubuntu

--- a/jenkins/docker/ubuntu/linter.Dockerfile
+++ b/jenkins/docker/ubuntu/linter.Dockerfile
@@ -5,17 +5,17 @@ RUN apt-get update >/dev/null \
 	&& apt-get install -y tzdata \
 	&& apt-get install -y git curl
 
-# install npm-groovy-lint
+# install npm-groovy-lint which requires java 17
 ENV NODE_OPTIONS="--dns-result-order=ipv4first"
 ARG NODE_MAJOR=18
-RUN apt-get install -y default-jre ca-certificates curl gnupg \
+RUN apt-get install -y openjdk-17-jre ca-certificates curl gnupg \
 	&& mkdir -p /etc/apt/keyrings \
 	&& curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
 	&& echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" \
 	| tee /etc/apt/sources.list.d/nodesource.list \
 	&& apt-get update \
 	&& apt-get install -y nodejs \
-	&& npm install -g npm-groovy-lint@11.1.1
+	&& npm install -g npm-groovy-lint
 
 # install python
 RUN apt-get install -y python3-pip python3-venv


### PR DESCRIPTION
problem: in Python 3.12, shutil.rmtree onerror parameter is deprecated
solution: in Python 3.12 use onexc parameter instead of onerror