### PR TITLE
[jenkins] fix: upgrade catapult os and mongodb version

### DIFF
--- a/client/catapult/docs/BUILD-docker.md
+++ b/client/catapult/docs/BUILD-docker.md
@@ -13,7 +13,7 @@ All scripts used in this guide can be found in the ``jenkins/catapult`` folder a
 - Python 3.
 - About 15 GB of free disk space.
 
-These instructions have been verified to work on Ubuntu 20.04 with 8 GB of RAM and 4 CPU cores. **The scripts used are not ready for Windows yet**.
+These instructions have been verified to work on Ubuntu 24.04 with 8 GB of RAM and 4 CPU cores. **The scripts used are not ready for Windows yet**.
 
 ## Step 1: Clone symbol repo
 
@@ -119,16 +119,16 @@ These images are built automatically via Docker Hub and are available in the [Do
 
 The process described next allows building several combinations of Operating Systems and compilers. The following is the list of combinations automatically built by Docker Hub:
 
-- Ubuntu (22.04)
-  - gcc-11
+- Ubuntu (24.04)
   - gcc-12
-  - clang-13
-  - clang-14
+  - gcc-13
+  - clang-17
+  - clang-18
   - clang + sanitizers (address + undefined behavior)
   - clang + sanitizers (threads)
-- Fedora (36)
-  - gcc-12
-- Debian (11.4)
+- Fedora (40)
+  - gcc-14
+- Debian (12)
   - gcc-10 (this is the newest gcc avail on Debian)
 
 ### Building your own base image

--- a/jenkins/catapult/compilers/fedora-gcc/Dockerfile
+++ b/jenkins/catapult/compilers/fedora-gcc/Dockerfile
@@ -1,4 +1,4 @@
-ARG FROM_IMAGE=fedora:39
+ARG FROM_IMAGE=fedora:40
 FROM ${FROM_IMAGE}
 
 RUN dnf update --assumeyes >/dev/null && \

--- a/jenkins/catapult/compilers/ubuntu-clang/Dockerfile
+++ b/jenkins/catapult/compilers/ubuntu-clang/Dockerfile
@@ -1,4 +1,4 @@
-ARG FROM_IMAGE=ubuntu:23.10
+ARG FROM_IMAGE=ubuntu:24.04
 FROM ${FROM_IMAGE}
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/jenkins/catapult/compilers/ubuntu-gcc/Dockerfile
+++ b/jenkins/catapult/compilers/ubuntu-gcc/Dockerfile
@@ -1,4 +1,4 @@
-ARG FROM_IMAGE=ubuntu:23.10
+ARG FROM_IMAGE=ubuntu:24.04
 FROM ${FROM_IMAGE}
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/jenkins/catapult/templates/RunTest.yaml
+++ b/jenkins/catapult/templates/RunTest.yaml
@@ -1,7 +1,7 @@
 version: '2.4'
 services:
   db:
-    image: mongo:6.0
+    image: mongo:7.0
     user: {{USER}}
     networks:
       test_net:

--- a/jenkins/catapult/templates/RunTestWindows.yaml
+++ b/jenkins/catapult/templates/RunTestWindows.yaml
@@ -1,7 +1,7 @@
 version: '2.1'
 services:
   db:
-    image: mongo:6.0
+    image: mongo:7.0
     command: mongod --bind_ip_all --dbpath=c:\mongo --logpath c:\mongo\mongod.log
     volumes:
       - ./mongo/{{BUILD_NUMBER}}:c:\mongo:rw

--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -1,7 +1,7 @@
 [versions]
 
 ubuntu = 24.04
-fedora = 39
+fedora = 40
 debian = 12
 windows = 2022
 

--- a/jenkins/docker/ubuntu/cpp.Dockerfile
+++ b/jenkins/docker/ubuntu/cpp.Dockerfile
@@ -6,11 +6,11 @@ RUN apt-get install -y shellcheck
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 
-# mongodb 6.0
+# mongodb 7.0
 RUN apt-get install -y wget gnupg \
-	&& wget -qO - https://www.mongodb.org/static/pgp/server-6.0.asc |  gpg --dearmor | tee /usr/share/keyrings/mongodb.gpg > /dev/null \
-	&& echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse"  \
-	| tee /etc/apt/sources.list.d/mongodb-org-6.0.list \
+	&& wget -qO - https://www.mongodb.org/static/pgp/server-7.0.asc |  gpg --dearmor | tee /usr/share/keyrings/mongodb.gpg > /dev/null \
+	&& echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse"  \
+	| tee /etc/apt/sources.list.d/mongodb-org-7.0.list \
 	&& apt-get update \
 	&& apt-get install -y mongodb-org
 


### PR DESCRIPTION
problem: catapult is not using the latest Fedora, Ubuntu and MongoDB versions
solution: update catapult docker images to use the latest.