### PR TITLE
[sdk]:  add deserialize function to TransactionFactory in sdk

### DIFF
--- a/sdk/javascript/src/nem/TransactionFactory.js
+++ b/sdk/javascript/src/nem/TransactionFactory.js
@@ -85,6 +85,15 @@ export default class TransactionFactory {
 	}
 
 	/**
+	 * Deserializes a transaction from a binary payload.
+	 * @param {Uint8Array} payload Binary payload.
+	 * @returns {nc.Transaction} Deserialized transaction.
+	 */
+	static deserialize(payload) {
+		return nc.TransactionFactory.deserialize(payload);
+	}
+
+	/**
 	 * Converts a transaction to a non-verifiable transaction.
 	 * @param {nc.Transaction|nc.NonVerifiableTransaction} transaction Transaction object.
 	 * @returns {nc.NonVerifiableTransaction} Non-verifiable transaction object.

--- a/sdk/javascript/src/symbol/TransactionFactory.js
+++ b/sdk/javascript/src/symbol/TransactionFactory.js
@@ -117,6 +117,24 @@ export default class TransactionFactory {
 	}
 
 	/**
+	 * Deserializes a transaction from a binary payload.
+	 * @param {Uint8Array} payload Binary payload.
+	 * @returns {sc.Transaction} Deserialized transaction.
+	 */
+	static deserialize(payload) {
+		return sc.TransactionFactory.deserialize(payload);
+	}
+
+	/**
+	 * Deserializes an embedded transaction from a binary payload.
+	 * @param {Uint8Array} payload Binary payload.
+	 * @returns {sc.EmbeddedTransaction} Deserialized embedded transaction.
+	 */
+	static deserializeEmbedded(payload) {
+		return sc.EmbeddedTransactionFactory.deserialize(payload);
+	}
+
+	/**
 	 * Attaches a signature to a transaction.
 	 * @param {sc.Transaction} transaction Transaction object.
 	 * @param {Signature} signature Signature to attach.

--- a/sdk/javascript/test/nem/TransactionFactory_spec.js
+++ b/sdk/javascript/test/nem/TransactionFactory_spec.js
@@ -21,6 +21,7 @@ describe('transaction factory (NEM)', () => {
 		transactionTypeName: 'transfer_transaction_v2',
 		createFactory: typeRuleOverrides => new TransactionFactory(Network.TESTNET, typeRuleOverrides),
 		createTransaction: factory => ((descriptor, autosort = true) => factory.create(descriptor, autosort)),
+		deserializeTransaction: TransactionFactory.deserialize,
 		assertTransaction: assertTransfer,
 		assertSignature: (transaction, signature, signedTransactionPayload) => {
 			const transactionHex = uint8ToHex(TransactionFactory.toNonVerifiableTransaction(transaction).serialize());

--- a/sdk/javascript/test/symbol/TransactionFactory_spec.js
+++ b/sdk/javascript/test/symbol/TransactionFactory_spec.js
@@ -238,6 +238,7 @@ describe('transaction factory (Symbol)', () => {
 			name: 'Transaction',
 			createFactory: typeRuleOverrides => new TransactionFactory(Network.TESTNET, typeRuleOverrides),
 			createTransaction: factory => ((descriptor, autosort = true) => factory.create(descriptor, autosort)),
+			deserializeTransaction: TransactionFactory.deserialize,
 			assertTransaction: assertTransfer,
 			assertSignature: (transaction, signature, signedTransactionPayload) => {
 				const transactionHex = uint8ToHex(transaction.serialize());
@@ -254,6 +255,7 @@ describe('transaction factory (Symbol)', () => {
 			name: 'EmbeddedTransaction',
 			createFactory: typeRuleOverrides => new TransactionFactory(Network.TESTNET, typeRuleOverrides),
 			createTransaction: factory => ((descriptor, autosort = true) => factory.createEmbedded(descriptor, autosort)),
+			deserializeTransaction: TransactionFactory.deserializeEmbedded,
 			assertTransaction: assertTransfer
 		};
 		runBasicTransactionFactoryTests(testDescriptor, false);

--- a/sdk/javascript/test/test/basicTransactionFactoryTests.js
+++ b/sdk/javascript/test/test/basicTransactionFactoryTests.js
@@ -41,6 +41,27 @@ export const runBasicTransactionFactoryTests = ( // eslint-disable-line import/p
 
 	// endregion
 
+	// region deserialize
+
+	it('can deserialize transaction from buffer', () => {
+		// Arrange: create a transaction and serialize it to a buffer
+		const factory = testDescriptor.createFactory();
+
+		const transaction = testDescriptor.createTransaction(factory)({
+			type: transactionTypeName,
+			signerPublicKey: TEST_SIGNER_PUBLIC_KEY
+		});
+		const payload = transaction.serialize();
+
+		// Act: deserialize a transaction from the buffer
+		const transactionDeserialized = testDescriptor.deserializeTransaction(payload);
+
+		// Assert: the two transactions are equal
+		expect(transactionDeserialized).to.deep.equal(transaction);
+	});
+
+	// endregion
+
 	if (includeAttachSignatureTests) {
 		// region attachSignature
 

--- a/sdk/python/symbolchain/nem/TransactionFactory.py
+++ b/sdk/python/symbolchain/nem/TransactionFactory.py
@@ -40,6 +40,11 @@ class TransactionFactory:
 		return transaction
 
 	@staticmethod
+	def deserialize(payload):
+		"""Deserializes a transaction from a binary payload."""
+		return nc.TransactionFactory.deserialize(payload)
+
+	@staticmethod
 	def to_non_verifiable_transaction(transaction):
 		"""Converts a transaction to a non-verifiable transaction."""
 		non_verifiable_class_name = type(transaction).__name__

--- a/sdk/python/symbolchain/symbol/TransactionFactory.py
+++ b/sdk/python/symbolchain/symbol/TransactionFactory.py
@@ -56,6 +56,16 @@ class TransactionFactory:
 		return self._create_and_extend(transaction_descriptor, autosort, sc.EmbeddedTransactionFactory)
 
 	@staticmethod
+	def deserialize(payload):
+		"""Deserializes a transaction from a binary payload."""
+		return sc.TransactionFactory.deserialize(payload)
+
+	@staticmethod
+	def deserialize_embedded(payload):
+		"""Deserializes an embedded transaction from a binary payload."""
+		return sc.EmbeddedTransactionFactory.deserialize(payload)
+
+	@staticmethod
 	def attach_signature(transaction, signature):
 		"""Attaches a signature to a transaction."""
 		transaction.signature = sc.Signature(signature.bytes)

--- a/sdk/python/tests/symbol/test_TransactionFactory.py
+++ b/sdk/python/tests/symbol/test_TransactionFactory.py
@@ -209,6 +209,10 @@ class EmbeddedTransactionFactoryTest(BasicTransactionFactoryExSignatureTest, Sym
 	def create_transaction(factory):
 		return factory.create_embedded
 
+	@staticmethod
+	def deserialize_transaction(factory):
+		return factory.deserialize_embedded
+
 
 class TransactionFactoryTest(BasicTransactionFactoryTest, SymbolTransactionFactoryTest, unittest.TestCase):
 	def assert_transaction(self, transaction):

--- a/sdk/python/tests/test/BasicTransactionFactoryTest.py
+++ b/sdk/python/tests/test/BasicTransactionFactoryTest.py
@@ -24,6 +24,10 @@ class AbstractBasicTransactionFactoryExSignatureTest:
 	def create_transaction(factory):
 		return factory.create
 
+	@staticmethod
+	def deserialize_transaction(factory):
+		return factory.deserialize
+
 
 class BasicTransactionFactoryExSignatureTest(AbstractBasicTransactionFactoryExSignatureTest):
 	# pylint: disable=abstract-method, no-member
@@ -54,6 +58,26 @@ class BasicTransactionFactoryExSignatureTest(AbstractBasicTransactionFactoryExSi
 				'type': f'x{self.transaction_type_name()}',
 				'signer_public_key': TEST_SIGNER_PUBLIC_KEY
 			})
+
+	# endregion
+
+	# region deserialize
+
+	def test_can_deserialize_transaction_from_buffer(self):
+		# Arrange: create a transaction and serialize it to a buffer
+		factory = self.create_factory()
+
+		transaction = self.create_transaction(factory)({
+			'type': self.transaction_type_name(),
+			'signer_public_key': TEST_SIGNER_PUBLIC_KEY
+		})
+		payload = transaction.serialize()
+
+		# Act: deserialize a transaction from the buffer
+		transaction_deserialized = self.deserialize_transaction(factory)(payload)
+
+		# Assert: the two transactions are equal
+		self.assertEqual(transaction.__dict__, transaction_deserialized.__dict__)
 
 	# endregion
 


### PR DESCRIPTION
    [sdk/python]: add deserialize function to TransactionFactory in sdk
    
     problem: deserialize is difficult to discover because it is only on model factory
    solution: expose deserialize on sdk TransactionFactory too

    [sdk/javascript]: add deserialize function to TransactionFactory in sdk
    
     problem: deserialize is difficult to discover because it is only on model factory
    solution: expose deserialize on sdk TransactionFactory too

