### PR TITLE
[jenkins] fix: add support to publish artifacts to Nexus public and private repo base on GitHub repo visibility

### DIFF
--- a/jenkins/shared-library/vars/configureArtifactRepository.groovy
+++ b/jenkins/shared-library/vars/configureArtifactRepository.groovy
@@ -1,8 +1,8 @@
-void call(String environment, Boolean isGitHubRepoPublic) {
+void call(String environment, Boolean publicGitHubRepo) {
 	final String ownerName = helper.resolveOrganizationName()
 	logger.logInfo("Configuring respository pull for ${environment}")
 
-	final String url = resolveRepositoryUrl(ownerName, resolveRepositoryName(environment, isGitHubRepoPublic))
+	final String url = resolveRepositoryUrl(ownerName, resolveRepositoryName(environment, publicGitHubRepo))
 
 	if (null != url) {
 		configure(environment, ownerName, url)
@@ -14,7 +14,7 @@ void call(String environment, Boolean isGitHubRepoPublic) {
 	}
 }
 
-String resolveRepositoryName(String environment, Boolean isGitHubRepoPublic) {
+String resolveRepositoryName(String environment, Boolean publicGitHubRepo) {
 	Map<String, List<Object>> environmentRepoNameMap = [
 		'javascript' : 'npm-group',
 		'python': 'pypi-group'
@@ -26,7 +26,7 @@ String resolveRepositoryName(String environment, Boolean isGitHubRepoPublic) {
 		return ''
 	}
 
-	return isGitHubRepoPublic ? repositoryName : "${repositoryName}-private"
+	return publicGitHubRepo ? repositoryName : "${repositoryName}-private"
 }
 
 String readNpmPackageScopeName() {

--- a/jenkins/shared-library/vars/configureArtifactRepository.groovy
+++ b/jenkins/shared-library/vars/configureArtifactRepository.groovy
@@ -31,6 +31,10 @@ String resolveRepositoryName(String environment, Boolean isGitHubRepoPublic) {
 
 String readNpmPackageScopeName() {
 	Object packageJson = readJSON file: 'package.json'
+	if (null == packageJson.name) {
+		return null
+	}
+
 	String[] nameParts = packageJson.name.tokenize('/')
 	return nameParts.length > 1 ? nameParts[0] : null
 }

--- a/jenkins/shared-library/vars/configureArtifactRepository.groovy
+++ b/jenkins/shared-library/vars/configureArtifactRepository.groovy
@@ -1,8 +1,8 @@
-void call(String environment, Boolean publicGitHubRepo) {
+void call(String environment, Boolean isPublicGitHubRepo) {
 	final String ownerName = helper.resolveOrganizationName()
 	logger.logInfo("Configuring respository pull for ${environment}")
 
-	final String url = resolveRepositoryUrl(ownerName, resolveRepositoryName(environment, publicGitHubRepo))
+	final String url = resolveRepositoryUrl(ownerName, resolveRepositoryName(environment, isPublicGitHubRepo))
 
 	if (null != url) {
 		configure(environment, ownerName, url)
@@ -14,7 +14,7 @@ void call(String environment, Boolean publicGitHubRepo) {
 	}
 }
 
-String resolveRepositoryName(String environment, Boolean publicGitHubRepo) {
+String resolveRepositoryName(String environment, Boolean isPublicGitHubRepo) {
 	Map<String, List<Object>> environmentRepoNameMap = [
 		'javascript' : 'npm-group',
 		'python': 'pypi-group'
@@ -26,7 +26,7 @@ String resolveRepositoryName(String environment, Boolean publicGitHubRepo) {
 		return ''
 	}
 
-	return publicGitHubRepo ? repositoryName : "${repositoryName}-private"
+	return isPublicGitHubRepo ? repositoryName : "${repositoryName}-private"
 }
 
 String readNpmPackageScopeName() {

--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -118,11 +118,11 @@ void call(Closure body) {
 									final String ownerName = helper.resolveOrganizationName()
 									final String gitHubRepositoryName = helper.resolveRepositoryName()
 
-									if (null == jenkinsfileParams.publicGitHubRepo) {
-										jenkinsfileParams.publicGitHubRepo = githubHelper.isGitHubRepositoryPublic(ownerName, gitHubRepositoryName)
+									if (null == jenkinsfileParams.isPublicGitHubRepo) {
+										jenkinsfileParams.isPublicGitHubRepo = githubHelper.isGitHubRepositoryPublic(ownerName, gitHubRepositoryName)
 									}
 
-									configureArtifactRepository(jobHelper.resolveCiEnvironmentName(jenkinsfileParams), jenkinsfileParams.publicGitHubRepo)
+									configureArtifactRepository(jobHelper.resolveCiEnvironmentName(jenkinsfileParams), jenkinsfileParams.isPublicGitHubRepo)
 								}
 							}
 						}

--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -117,9 +117,12 @@ void call(Closure body) {
 								runStepRelativeToPackageRoot packageRootPath, {
 									final String ownerName = helper.resolveOrganizationName()
 									final String gitHubRepositoryName = helper.resolveRepositoryName()
-									final Boolean isGitHubRepoPublic = githubHelper.isGitHubRepositoryPublic(ownerName, gitHubRepositoryName)
 
-									configureArtifactRepository(jobHelper.resolveCiEnvironmentName(jenkinsfileParams), isGitHubRepoPublic)
+									if (null == jenkinsfileParams.publicGitHubRepo) {
+										jenkinsfileParams.publicGitHubRepo = githubHelper.isGitHubRepositoryPublic(ownerName, gitHubRepositoryName)
+									}
+
+									configureArtifactRepository(jobHelper.resolveCiEnvironmentName(jenkinsfileParams), jenkinsfileParams.publicGitHubRepo)
 								}
 							}
 						}

--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -99,17 +99,6 @@ void call(Closure body) {
 							runScript(isUnix() ? 'printenv' : 'set')
 						}
 					}
-					stage('setup docker environment') {
-						steps {
-							script {
-								helper.runInitializeScriptIfPresent()
-							}
-
-							runStepRelativeToPackageRoot packageRootPath, {
-								configureArtifactRepository(jobHelper.resolveCiEnvironmentName(jenkinsfileParams))
-							}
-						}
-					}
 					stage('checkout') {
 						when {
 							triggeredBy 'UserIdCause'
@@ -118,6 +107,20 @@ void call(Closure body) {
 							script {
 								runScript("git reset --hard origin/${env.BRANCH_NAME}")
 								helper.runInitializeScriptIfPresent()
+							}
+						}
+					}
+					stage('setup docker environment') {
+						steps {
+							script {
+								helper.runInitializeScriptIfPresent()
+								runStepRelativeToPackageRoot packageRootPath, {
+									final String ownerName = helper.resolveOrganizationName()
+									final String gitHubRepositoryName = helper.resolveRepositoryName()
+									final Boolean isGitHubRepoPublic = githubHelper.isGitHubRepositoryPublic(ownerName, gitHubRepositoryName)
+
+									configureArtifactRepository(jobHelper.resolveCiEnvironmentName(jenkinsfileParams), isGitHubRepoPublic)
+								}
 							}
 						}
 					}

--- a/jenkins/shared-library/vars/helper.groovy
+++ b/jenkins/shared-library/vars/helper.groovy
@@ -109,7 +109,7 @@ String resolveGitHubCredentialsId() {
 }
 
 void withTempDir(Closure body) {
-	dir( pwd(tmp: true) ) {
+	dir(pwd(tmp: true)) {
 		try {
 			body()
 		} finally {

--- a/jenkins/shared-library/vars/helper.groovy
+++ b/jenkins/shared-library/vars/helper.groovy
@@ -107,3 +107,13 @@ String resolveWorkspacePath(String os) {
 String resolveGitHubCredentialsId() {
 	return scm.userRemoteConfigs[0].credentialsId
 }
+
+void withTempDir(Closure body) {
+	dir( pwd(tmp: true) ) {
+		try {
+			body()
+		} finally {
+			deleteDir()
+		}
+	}
+}

--- a/jenkins/shared-library/vars/publish.groovy
+++ b/jenkins/shared-library/vars/publish.groovy
@@ -30,13 +30,11 @@ void dockerPublisher(Map config, String phase) {
 		return
 	}
 
-	final String ownerName = helper.resolveOrganizationName()
-	final String gitHubRepositoryName = helper.resolveRepositoryName()
 	String dockerHost = 'registry.hub.docker.com'
 	String dockerCredentialsId = DOCKER_CREDENTIALS_ID
-	Boolean isGitHubRepoPublic = githubHelper.isGitHubRepositoryPublic(ownerName, gitHubRepositoryName)
-	if (isAlphaRelease(phase) || !isGitHubRepoPublic) {
-		String artifactRepositoryName = resolveArtifactRepositoryName('docker-hosted', isGitHubRepoPublic)
+	if (isAlphaRelease(phase) || !config.publicGitHubRepo) {
+		String artifactRepositoryName = resolveArtifactRepositoryName('docker-hosted', config.publicGitHubRepo)
+		final String ownerName = helper.resolveOrganizationName()
 		dockerCredentialsId = "${ownerName.toUpperCase()}_ARTIFACTORY_LOGIN_ID"
 		dockerHost = helper.resolveUrlHostName(configureArtifactRepository.resolveRepositoryUrl(ownerName, artifactRepositoryName))
 	}
@@ -70,11 +68,9 @@ void npmPublisher(Map config, String phase) {
 		npmPublishCommand.append(' --tag alpha')
 	}
 
-	final String ownerName = helper.resolveOrganizationName()
-	final String gitHubRepositoryName = helper.resolveRepositoryName()
-	final Boolean isGitHubRepoPublic = githubHelper.isGitHubRepositoryPublic(ownerName, gitHubRepositoryName)
-	if (isAlphaRelease(phase) || !isGitHubRepoPublic) {
-		final String artifactRepositoryName = resolveArtifactRepositoryName('npm-hosted', isGitHubRepoPublic)
+	if (isAlphaRelease(phase) || !config.publicGitHubRepo) {
+		final String artifactRepositoryName = resolveArtifactRepositoryName('npm-hosted', config.publicGitHubRepo)
+		final String ownerName = helper.resolveOrganizationName()
 		final String publishUrl = configureArtifactRepository.resolveRepositoryUrl(ownerName, artifactRepositoryName)
 		final String environment = jobHelper.resolveCiEnvironmentName(config)
 
@@ -102,15 +98,13 @@ void pythonPublisher(Map config, String phase) {
 		return
 	}
 
-	final String ownerName = helper.resolveOrganizationName()
-	final String gitHubRepositoryName = helper.resolveRepositoryName()
-	final Boolean isGitHubRepoPublic = githubHelper.isGitHubRepositoryPublic(ownerName, gitHubRepositoryName)
-	if (isAlphaRelease(phase) || !isGitHubRepoPublic) {
+	if (isAlphaRelease(phase) || !config.publicGitHubRepo) {
+		final String ownerName = helper.resolveOrganizationName()
 		withCredentials([usernamePassword(credentialsId: "${ownerName.toUpperCase()}_ARTIFACTORY_LOGIN_ID",
 			usernameVariable: 'USERNAME',
 			passwordVariable: 'PASSWORD')]) {
 			publishArtifact {
-				final String artifactRepositoryName = resolveArtifactRepositoryName('pypi-hosted', isGitHubRepoPublic)
+				final String artifactRepositoryName = resolveArtifactRepositoryName('pypi-hosted', config.publicGitHubRepo)
 				String publishUrl = configureArtifactRepository.resolveRepositoryUrl(ownerName, artifactRepositoryName)
 
 				poetryBuildPackage()


### PR DESCRIPTION
problem: currently, Jenkins publishes artifacts to a Nexus repo without knowing its visibility
solution: Jenkins will now publish private GitHub repos to a private Nexus repo