### PR TITLE
[jenkins] fix: catapult project fails on initial create

### DIFF
--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project-daily.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project-daily.groovy
@@ -18,7 +18,7 @@ pipeline {
 	}
 
 	stages {
-		stage('override architecture') {
+		stage('override variables') {
 			when {
 				triggeredBy 'TimerTrigger'
 			}
@@ -26,6 +26,8 @@ pipeline {
 				script {
 					// even days are amd64, odd days are arm64
 					env.ARCHITECTURE = helper.determineArchitecture()
+					env.MANUAL_GIT_BRANCH = env.MANUAL_GIT_BRANCH ?: 'dev'
+					env.SHOULD_PUBLISH_JOB_STATUS = env.SHOULD_PUBLISH_JOB_STATUS ?: 'true'
 				}
 			}
 		}
@@ -159,9 +161,13 @@ void dispatchBuildJob(String compilerConfiguration, String buildConfiguration, S
 		string(name: 'OPERATING_SYSTEM', value: "${operatingSystem}"),
 		string(name: 'MANUAL_GIT_BRANCH', value: "${params.MANUAL_GIT_BRANCH}"),
 		string(name: 'ARCHITECTURE', value: "${architecture}"),
+		string(name: 'TEST_IMAGE_LABEL', value: ''),
+		string(name: 'TEST_MODE', value: 'test'),
+		string(name: 'TEST_VERBOSITY', value: 'suite'),
+		booleanParam(name: 'SHOULD_PUBLISH_BUILD_IMAGE', value: false),
 		booleanParam(
 			name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS',
-			value: "${!env.SHOULD_PUBLISH_JOB_STATUS || env.SHOULD_PUBLISH_JOB_STATUS.toBoolean()}"
+			value: !env.SHOULD_PUBLISH_JOB_STATUS || env.SHOULD_PUBLISH_JOB_STATUS.toBoolean()
 		)
 	]
 }

--- a/jenkins/catapult/jenkins/catapult-client-build-catapult-project-weekly.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-catapult-project-weekly.groovy
@@ -18,6 +18,17 @@ pipeline {
 	}
 
 	stages {
+		stage('override variables') {
+			when {
+				triggeredBy 'TimerTrigger'
+			}
+			steps {
+				script {
+					env.MANUAL_GIT_BRANCH = env.MANUAL_GIT_BRANCH ?: 'dev'
+					env.SHOULD_PUBLISH_JOB_STATUS = env.SHOULD_PUBLISH_JOB_STATUS ?: 'true'
+				}
+			}
+		}
 		stage('print env') {
 			steps {
 				echo """
@@ -141,9 +152,13 @@ void dispatchBuildJob(String compilerConfiguration, String buildConfiguration, S
 		string(name: 'OPERATING_SYSTEM', value: "${operatingSystem}"),
 		string(name: 'MANUAL_GIT_BRANCH', value: "${params.MANUAL_GIT_BRANCH}"),
 		string(name: 'ARCHITECTURE', value: "${architecture}"),
+		string(name: 'TEST_IMAGE_LABEL', value: ''),
+		string(name: 'TEST_MODE', value: 'test'),
+		string(name: 'TEST_VERBOSITY', value: 'suite'),
+		booleanParam(name: 'SHOULD_PUBLISH_BUILD_IMAGE', value: false),
 		booleanParam(
 			name: 'SHOULD_PUBLISH_FAIL_JOB_STATUS',
-			value: "${!env.SHOULD_PUBLISH_JOB_STATUS || env.SHOULD_PUBLISH_JOB_STATUS.toBoolean()}"
+			value: !env.SHOULD_PUBLISH_JOB_STATUS || env.SHOULD_PUBLISH_JOB_STATUS.toBoolean()
 		)
 	]
 }


### PR DESCRIPTION
problem: catapult jobs will get updated when build configuration changes.
         this causes catapult project jobs to fail due to defaults values are not set.
solution: set the default values for each parameter for the catapult project.