### PR TITLE
[jenkins] fix: create a GitHub token for package install

### DIFF
--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -159,7 +159,9 @@ void call(Closure body) {
 						steps {
 							script {
 								helper.runStepRelativeToPackageRoot packageRootPath, {
-									setupBuild(env.LINT_SETUP_SCRIPT_FILEPATH)
+									githubHelper.executeGitAuthenticatedCommand {
+										setupBuild(env.LINT_SETUP_SCRIPT_FILEPATH)
+									}
 								}
 							}
 						}

--- a/jenkins/shared-library/vars/gitPullRequestPipeline.groovy
+++ b/jenkins/shared-library/vars/gitPullRequestPipeline.groovy
@@ -93,7 +93,7 @@ void call(Closure body) {
 										final String ownerName = helper.resolveOrganizationName()
 										final String repositoryName = helper.resolveRepositoryName()
 										githubHelper.createPullRequestWithReviewers(
-											"${GITHUB_ACCESS_TOKEN}",
+											"${GITHUB_TOKEN}",
 											ownerName,
 											repositoryName,
 											jenkinsfileParams.prBranchName,

--- a/jenkins/shared-library/vars/githubHelper.groovy
+++ b/jenkins/shared-library/vars/githubHelper.groovy
@@ -110,10 +110,10 @@ void configureGitHub() {
 
 void executeGitAuthenticatedCommand(Closure command) {
 	withCredentials([usernamePassword(credentialsId: helper.resolveGitHubCredentialsId(),
-			usernameVariable: 'GITHUB_APP',
+			usernameVariable: 'GITHUB_USER',
 			passwordVariable: 'GITHUB_TOKEN')]) {
 		final String ownerName = helper.resolveOrganizationName()
-		final String replaceUrl = "https://${GITHUB_APP}:${GITHUB_TOKEN}@github.com/${ownerName}.insteadOf" +
+		final String replaceUrl = "https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/${ownerName}.insteadOf" +
 			" 'https://github.com/${ownerName}'"
 		sh("git config url.${replaceUrl}")
 		configureGitHub()

--- a/jenkins/shared-library/vars/githubHelper.groovy
+++ b/jenkins/shared-library/vars/githubHelper.groovy
@@ -3,7 +3,7 @@ import groovy.json.JsonOutput
 boolean isGitHubRepositoryPublic(String orgName, String repoName) {
 	try {
 		executeGitAuthenticatedCommand {
-			final Object repo = getRepositoryInfo("${GITHUB_ACCESS_TOKEN}", orgName, repoName)
+			final Object repo = getRepositoryInfo("${GITHUB_TOKEN}", orgName, repoName)
 			return repo.name == repoName && repo.visibility == 'public'
 		}
 	} catch (FileNotFoundException exception) {
@@ -111,9 +111,9 @@ void configureGitHub() {
 void executeGitAuthenticatedCommand(Closure command) {
 	withCredentials([usernamePassword(credentialsId: helper.resolveGitHubCredentialsId(),
 			usernameVariable: 'GITHUB_APP',
-			passwordVariable: 'GITHUB_ACCESS_TOKEN')]) {
+			passwordVariable: 'GITHUB_TOKEN')]) {
 		final String ownerName = helper.resolveOrganizationName()
-		final String replaceUrl = "https://${GITHUB_APP}:${GITHUB_ACCESS_TOKEN}@github.com/${ownerName}.insteadOf" +
+		final String replaceUrl = "https://${GITHUB_APP}:${GITHUB_TOKEN}@github.com/${ownerName}.insteadOf" +
 			" 'https://github.com/${ownerName}'"
 		sh("git config url.${replaceUrl}")
 		configureGitHub()


### PR DESCRIPTION
problem: some projects install packages from GitHub directly and do not have access
solution: create a GitHub token during lint setup where most packages are installed