### PR TITLE
[sdk]: add createAccount to facades

### DIFF
--- a/sdk/javascript/src/facade/NemFacade.js
+++ b/sdk/javascript/src/facade/NemFacade.js
@@ -97,6 +97,19 @@ export default class NemFacade {
 	}
 
 	/**
+	 * Creates a NEM account from a private key.
+	 * @param {PrivateKey} privateKey Account private key.
+	 * @returns {NemAccount} NEM account.
+	 */
+	createAccount(privateKey) {
+		const keyPair = new KeyPair(privateKey);
+		return {
+			address: this.network.publicKeyToAddress(keyPair.publicKey),
+			keyPair
+		};
+	}
+
+	/**
 	 * Creates a transaction from a (typed) transaction descriptor.
 	 * @param {object} typedDescriptor Transaction (typed) descriptor.
 	 * @param {PublicKey} signerPublicKey Signer public key.
@@ -173,3 +186,15 @@ export default class NemFacade {
 		return new KeyPair(new PrivateKey(reversedPrivateKeyBytes));
 	}
 }
+
+// region type declarations
+
+/**
+ * NEM account.
+ * @class
+ * @typedef {object} NemAccount
+ * @property {Address} address NEM account address.
+ * @property {KeyPair} keyPair NEM account key pair.
+ */
+
+// endregion

--- a/sdk/javascript/src/facade/SymbolFacade.js
+++ b/sdk/javascript/src/facade/SymbolFacade.js
@@ -127,6 +127,19 @@ export default class SymbolFacade {
 	}
 
 	/**
+	 * Creates a Symbol account from a private key.
+	 * @param {PrivateKey} privateKey Account private key.
+	 * @returns {SymbolAccount} Symbol account.
+	 */
+	createAccount(privateKey) {
+		const keyPair = new KeyPair(privateKey);
+		return {
+			address: this.network.publicKeyToAddress(keyPair.publicKey),
+			keyPair
+		};
+	}
+
+	/**
 	 * Creates a transaction from a (typed) transaction descriptor.
 	 * @param {object} typedDescriptor Transaction (typed) descriptor.
 	 * @param {PublicKey} signerPublicKey Signer public key.
@@ -274,3 +287,15 @@ export default class SymbolFacade {
 		return new KeyPair(new PrivateKey(bip32Node.privateKey.bytes));
 	}
 }
+
+// region type declarations
+
+/**
+ * Symbol account.
+ * @class
+ * @typedef {object} SymbolAccount
+ * @property {Address} address Symbol account address.
+ * @property {KeyPair} keyPair Symbol account key pair.
+ */
+
+// endregion

--- a/sdk/javascript/test/facade/NemFacade_spec.js
+++ b/sdk/javascript/test/facade/NemFacade_spec.js
@@ -122,6 +122,24 @@ describe('NEM Facade', () => {
 
 	// endregion
 
+	// region createAccount
+
+	it('can create account from private key', () => {
+		// Arrange:
+		const facade = new NemFacade('testnet');
+		const privateKey = new PrivateKey('ED4C70D78104EB11BCD73EBDC512FEBC8FBCEB36A370C957FF7E266230BB5D57');
+
+		// Act:
+		const account = facade.createAccount(privateKey);
+
+		// Assert:
+		expect(account.address).to.deep.equal(new Address('TCFGSLITSWMRROU2GO7FPMIUUDELUPSZUNUEZF33'));
+		expect(account.keyPair.publicKey).to.deep.equal(new PublicKey('D6C3845431236C5A5A907A9E45BD60DA0E12EFD350B970E7F58E3499E2E7A2F0'));
+		expect(account.keyPair.privateKey).to.deep.equal(privateKey);
+	});
+
+	// endregion
+
 	// region create from typed descriptor
 
 	it('can create transaction from typed descriptor', () => {

--- a/sdk/javascript/test/facade/SymbolFacade_spec.js
+++ b/sdk/javascript/test/facade/SymbolFacade_spec.js
@@ -211,6 +211,24 @@ describe('Symbol Facade', () => {
 
 	// endregion
 
+	// region createAccount
+
+	it('can create account from private key', () => {
+		// Arrange:
+		const facade = new SymbolFacade('testnet');
+		const privateKey = new PrivateKey('E88283CE35FE74C89FFCB2D8BFA0A2CF6108BDC0D07606DEE34D161C30AC2F1E');
+
+		// Act:
+		const account = facade.createAccount(privateKey);
+
+		// Assert:
+		expect(account.address).to.deep.equal(new Address('TABDOFVM2QYIMVNQII6UJWU7Y66GZI4LQTMN4PI'));
+		expect(account.keyPair.publicKey).to.deep.equal(new PublicKey('E29C5934F44482E7A9F50725C8681DE6CA63F49E5562DB7E5BC9EABA31356BAD'));
+		expect(account.keyPair.privateKey).to.deep.equal(privateKey);
+	});
+
+	// endregion
+
 	// region create from typed descriptor
 
 	it('can create transaction from typed descriptor', () => {

--- a/sdk/python/symbolchain/facade/NemFacade.py
+++ b/sdk/python/symbolchain/facade/NemFacade.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 from datetime import datetime, timezone
 
 import sha3
@@ -8,6 +9,8 @@ from ..nem.Network import Address, Network
 from ..nem.SharedKey import SharedKey
 from ..nem.TransactionFactory import TransactionFactory
 from ..Network import NetworkLocator
+
+NemAccount = namedtuple('NemAccount', ['address', 'key_pair'])
 
 
 class NemFacade:
@@ -45,6 +48,12 @@ class NemFacade:
 	def now(self):
 		"""Creates a network timestamp representing the current time."""
 		return self.network.from_datetime(datetime.now(timezone.utc))
+
+	def create_account(self, private_key):
+		"""Creates a NEM account from a private key."""
+		key_pair = KeyPair(private_key)
+		address = self.network.public_key_to_address(key_pair.public_key)
+		return NemAccount(address, key_pair)
 
 	@staticmethod
 	def hash_transaction(transaction):

--- a/sdk/python/symbolchain/facade/SymbolFacade.py
+++ b/sdk/python/symbolchain/facade/SymbolFacade.py
@@ -1,4 +1,5 @@
 import hashlib
+from collections import namedtuple
 from datetime import datetime, timezone
 
 from .. import sc
@@ -9,6 +10,8 @@ from ..symbol.Merkle import MerkleHashBuilder
 from ..symbol.Network import Address, Network
 from ..symbol.SharedKey import SharedKey
 from ..symbol.TransactionFactory import TransactionFactory
+
+SymbolAccount = namedtuple('SymbolAccount', ['address', 'key_pair'])
 
 TRANSACTION_HEADER_SIZE = sum(field[1] for field in [
 	('size', 4),
@@ -62,6 +65,12 @@ class SymbolFacade:
 	def now(self):
 		"""Creates a network timestamp representing the current time."""
 		return self.network.from_datetime(datetime.now(timezone.utc))
+
+	def create_account(self, private_key):
+		"""Creates a Symbol account from a private key."""
+		key_pair = KeyPair(private_key)
+		address = self.network.public_key_to_address(key_pair.public_key)
+		return SymbolAccount(address, key_pair)
 
 	def hash_transaction(self, transaction):
 		"""Hashes a Symbol transaction."""

--- a/sdk/python/tests/facade/test_NemFacade.py
+++ b/sdk/python/tests/facade/test_NemFacade.py
@@ -135,6 +135,23 @@ class NemFacadeTest(unittest.TestCase):
 
 	# endregion
 
+	# region create_account
+
+	def test_can_create_account_from_private_key(self):
+		# Arrange:
+		facade = NemFacade('testnet')
+		private_key = PrivateKey('ED4C70D78104EB11BCD73EBDC512FEBC8FBCEB36A370C957FF7E266230BB5D57')
+
+		# Act:
+		account = facade.create_account(private_key)
+
+		# Assert:
+		self.assertEqual(facade.Address('TCFGSLITSWMRROU2GO7FPMIUUDELUPSZUNUEZF33'), account.address)
+		self.assertEqual(PublicKey('D6C3845431236C5A5A907A9E45BD60DA0E12EFD350B970E7F58E3499E2E7A2F0'), account.key_pair.public_key)
+		self.assertEqual(private_key, account.key_pair.private_key)
+
+	# endregion
+
 	# region hash_transaction / sign_transaction
 
 	@staticmethod

--- a/sdk/python/tests/facade/test_SymbolFacade.py
+++ b/sdk/python/tests/facade/test_SymbolFacade.py
@@ -229,6 +229,23 @@ class SymbolFacadeTest(unittest.TestCase):
 
 	# endregion
 
+	# region create_account
+
+	def test_can_create_account_from_private_key(self):
+		# Arrange:
+		facade = SymbolFacade('testnet')
+		private_key = PrivateKey('E88283CE35FE74C89FFCB2D8BFA0A2CF6108BDC0D07606DEE34D161C30AC2F1E')
+
+		# Act:
+		account = facade.create_account(private_key)
+
+		# Assert:
+		self.assertEqual(facade.Address('TABDOFVM2QYIMVNQII6UJWU7Y66GZI4LQTMN4PI'), account.address)
+		self.assertEqual(PublicKey('E29C5934F44482E7A9F50725C8681DE6CA63F49E5562DB7E5BC9EABA31356BAD'), account.key_pair.public_key)
+		self.assertEqual(private_key, account.key_pair.private_key)
+
+	# endregion
+
 	# region hash_transaction / sign_transaction
 
 	def _assert_can_hash_transaction(self, transaction_factory, expected_hash):


### PR DESCRIPTION
    [sdk/python]: add create_account to facades
    
     problem: deriving an address from a private key is a multistep process
    solution: add facade function that will derive public key and address from private key


    [sdk/javascript]: add createAccount to facades
    
     problem: deriving an address from a private key is a multistep process
    solution: add facade function that will derive public key and address from private key
