### PR TITLE
[jenkins] fix: add coverage to JavaScript image

### DIFF
--- a/jenkins/docker/fedora/javascript.Dockerfile
+++ b/jenkins/docker/fedora/javascript.Dockerfile
@@ -47,4 +47,4 @@ RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # install common python packages
-RUN python3 -m pip install --upgrade gitlint isort lark pycodestyle pylint PyYAML
+RUN python3 -m pip install --upgrade gitlint isort lark pycodestyle pylint PyYAML coverage

--- a/jenkins/docker/ubuntu/javascript.Dockerfile
+++ b/jenkins/docker/ubuntu/javascript.Dockerfile
@@ -76,4 +76,4 @@ RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # install common python packages
-RUN python3 -m pip install --upgrade gitlint isort lark pycodestyle pylint PyYAML
+RUN python3 -m pip install --upgrade gitlint isort lark pycodestyle pylint PyYAML coverage

--- a/jenkins/docker/windows/javascript.Dockerfile
+++ b/jenkins/docker/windows/javascript.Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-
+ht
 ARG FROM_IMAGE=symbolplatform/symbol-server-compiler:windows-msvc-17
 
 FROM ${FROM_IMAGE}
@@ -31,4 +31,4 @@ ENV CARGO_HOME=C:\Users\ContainerAdministrator\scoop\apps\rustup\current\.cargo
 RUN cargo install wasm-pack
 
 # install common python packages
-RUN python3 -m pip install --upgrade gitlint isort lark pycodestyle pylint PyYAML wheel
+RUN python3 -m pip install --upgrade gitlint isort lark pycodestyle pylint PyYAML wheel coverage


### PR DESCRIPTION
problem: some Python projects use Javascript image since npm is required
solution: add coverage tool to Javascript image to allow Python projects to create code coverage