### PR TITLE
[sdk]: add message-encoder to account class 

### DIFF
--- a/sdk/javascript/src/facade/NemFacade.js
+++ b/sdk/javascript/src/facade/NemFacade.js
@@ -152,7 +152,7 @@ export class NemFacade {
 
 	/**
 	 * Creates a network timestamp representing the current time.
-	 * @returns {NetworkTimestamp} Network timestamp representing the current time
+	 * @returns {NetworkTimestamp} Network timestamp representing the current time.
 	 */
 	now() {
 		return this.network.fromDatetime(new Date());

--- a/sdk/javascript/src/facade/NemFacade.js
+++ b/sdk/javascript/src/facade/NemFacade.js
@@ -12,6 +12,7 @@ import {
 } from '../CryptoTypes.js';
 import { NetworkLocator } from '../Network.js';
 import { KeyPair, Verifier } from '../nem/KeyPair.js';
+import MessageEncoder from '../nem/MessageEncoder.js';
 import {
 	Address,
 	Network,
@@ -74,6 +75,14 @@ export class NemAccount extends NemPublicAccount {
 		 * @type {KeyPair}
 		 */
 		this.keyPair = keyPair;
+	}
+
+	/**
+	 * Creates a message encoder that can be used for encrypting and encoding messages between two parties.
+	 * @returns {MessageEncoder} Message encoder using this account as one party.
+	 */
+	messageEncoder() {
+		return new MessageEncoder(this.keyPair);
 	}
 
 	/**

--- a/sdk/javascript/src/facade/SymbolFacade.js
+++ b/sdk/javascript/src/facade/SymbolFacade.js
@@ -12,6 +12,7 @@ import {
 } from '../CryptoTypes.js';
 import { NetworkLocator } from '../Network.js';
 import { KeyPair, Verifier } from '../symbol/KeyPair.js';
+import MessageEncoder from '../symbol/MessageEncoder.js';
 import {
 	Address,
 	Network,
@@ -104,6 +105,14 @@ export class SymbolAccount extends SymbolPublicAccount {
 		 * @type {KeyPair}
 		 */
 		this.keyPair = keyPair;
+	}
+
+	/**
+	 * Creates a message encoder that can be used for encrypting and encoding messages between two parties.
+	 * @returns {MessageEncoder} Message encoder using this account as one party.
+	 */
+	messageEncoder() {
+		return new MessageEncoder(this.keyPair);
 	}
 
 	/**

--- a/sdk/javascript/src/facade/SymbolFacade.js
+++ b/sdk/javascript/src/facade/SymbolFacade.js
@@ -193,7 +193,7 @@ export class SymbolFacade {
 
 	/**
 	 * Creates a network timestamp representing the current time.
-	 * @returns {NetworkTimestamp} Network timestamp representing the current time
+	 * @returns {NetworkTimestamp} Network timestamp representing the current time.
 	 */
 	now() {
 		return this.network.fromDatetime(new Date());

--- a/sdk/javascript/test/facade/NemFacade_spec.js
+++ b/sdk/javascript/test/facade/NemFacade_spec.js
@@ -192,6 +192,18 @@ describe('NEM Facade', () => {
 			expect(account.keyPair.privateKey).to.deep.equal(privateKey);
 		});
 
+		it('can create message encoder', () => {
+			// Arrange:
+			const facade = new NemFacade('testnet');
+			const account = facade.createAccount(new PrivateKey('EDB671EB741BD676969D8A035271D1EE5E75DF33278083D877F23615EB839FEC'));
+
+			// Act:
+			const encoder = account.messageEncoder();
+
+			// Assert: message encoder matches the account
+			expect(encoder.publicKey).to.deep.equal(account.publicKey);
+		});
+
 		it('can sign and verify transaction', () => {
 			// Arrange:
 			const facade = new NemFacade('testnet');

--- a/sdk/javascript/test/facade/SymbolFacade_spec.js
+++ b/sdk/javascript/test/facade/SymbolFacade_spec.js
@@ -298,6 +298,18 @@ describe('Symbol Facade', () => {
 			expect(account.keyPair.privateKey).to.deep.equal(privateKey);
 		});
 
+		it('can create message encoder', () => {
+			// Arrange:
+			const facade = new SymbolFacade('testnet');
+			const account = facade.createAccount(new PrivateKey('EDB671EB741BD676969D8A035271D1EE5E75DF33278083D877F23615EB839FEC'));
+
+			// Act:
+			const encoder = account.messageEncoder();
+
+			// Assert: message encoder matches the account
+			expect(encoder.publicKey).to.deep.equal(account.publicKey);
+		});
+
 		it('can sign transaction', () => {
 			// Arrange:
 			const facade = new SymbolFacade('testnet');

--- a/sdk/javascript/test/nem/MessageEncoder_spec.js
+++ b/sdk/javascript/test/nem/MessageEncoder_spec.js
@@ -6,17 +6,6 @@ import { runBasicMessageEncoderTests } from '../test/messageEncoderTests.js';
 import { expect } from 'chai';
 
 describe('MessageEncoder (NEM)', () => {
-	it('can create encoder', () => {
-		// Arrange:
-		const keyPair = new KeyPair(PrivateKey.random());
-
-		// Act:
-		const encoder = new MessageEncoder(keyPair);
-
-		// Assert:
-		expect(encoder.publicKey).to.deep.equal(keyPair.publicKey);
-	});
-
 	runBasicMessageEncoderTests({
 		KeyPair,
 		MessageEncoder,

--- a/sdk/javascript/test/symbol/MessageEncoder_spec.js
+++ b/sdk/javascript/test/symbol/MessageEncoder_spec.js
@@ -6,17 +6,6 @@ import { runBasicMessageEncoderTests, runMessageEncoderDecodeFailureTests } from
 import { expect } from 'chai';
 
 describe('MessageEncoder (Symbol)', () => {
-	it('can create encoder', () => {
-		// Arrange:
-		const keyPair = new KeyPair(PrivateKey.random());
-
-		// Act:
-		const encoder = new MessageEncoder(keyPair);
-
-		// Assert:
-		expect(encoder.publicKey).to.deep.equal(keyPair.publicKey);
-	});
-
 	const malformEncoded = encoded => {
 		encoded[encoded.length - 1] ^= 0xFF;
 	};

--- a/sdk/javascript/test/test/messageEncoderTests.js
+++ b/sdk/javascript/test/test/messageEncoderTests.js
@@ -11,6 +11,17 @@ const tryDecode = (testDescriptor, decoder) => (
 const runMessageEncoderDecodeSuccessTests = testDescriptor => {
 	const testSuffix = testDescriptor.name ? ` (${testDescriptor.name})` : '';
 
+	it(`can create encoder${testSuffix}`, () => {
+		// Arrange:
+		const keyPair = new testDescriptor.KeyPair(PrivateKey.random());
+
+		// Act:
+		const encoder = new testDescriptor.MessageEncoder(keyPair);
+
+		// Assert:
+		expect(encoder.publicKey).to.deep.equal(keyPair.publicKey);
+	});
+
 	it(`sender can decode encoded message${testSuffix}`, () => {
 		// Arrange:
 		const keyPair = new testDescriptor.KeyPair(PrivateKey.random());

--- a/sdk/python/symbolchain/facade/NemFacade.py
+++ b/sdk/python/symbolchain/facade/NemFacade.py
@@ -4,6 +4,7 @@ import sha3
 
 from ..CryptoTypes import Hash256, PrivateKey, PublicKey
 from ..nem.KeyPair import KeyPair, Verifier
+from ..nem.MessageEncoder import MessageEncoder
 from ..nem.Network import Address, Network
 from ..nem.SharedKey import SharedKey
 from ..nem.TransactionFactory import TransactionFactory
@@ -29,6 +30,10 @@ class NemAccount(NemPublicAccount):
 		"""Creates a NEM account."""
 		super().__init__(facade, key_pair.public_key)
 		self.key_pair = key_pair
+
+	def message_encoder(self):
+		"""Creates a message encoder that can be used for encrypting and encoding messages between two parties."""
+		return MessageEncoder(self.key_pair)
 
 	def sign_transaction(self, transaction):
 		"""Signs a NEM transaction."""

--- a/sdk/python/symbolchain/facade/SymbolFacade.py
+++ b/sdk/python/symbolchain/facade/SymbolFacade.py
@@ -6,6 +6,7 @@ from ..CryptoTypes import Hash256, PublicKey, Signature
 from ..Network import NetworkLocator
 from ..symbol.KeyPair import KeyPair, Verifier
 from ..symbol.Merkle import MerkleHashBuilder
+from ..symbol.MessageEncoder import MessageEncoder
 from ..symbol.Network import Address, Network
 from ..symbol.SharedKey import SharedKey
 from ..symbol.TransactionFactory import TransactionFactory
@@ -45,6 +46,10 @@ class SymbolAccount(SymbolPublicAccount):
 		"""Creates a Symbol account."""
 		super().__init__(facade, key_pair.public_key)
 		self.key_pair = key_pair
+
+	def message_encoder(self):
+		"""Creates a message encoder that can be used for encrypting and encoding messages between two parties."""
+		return MessageEncoder(self.key_pair)
 
 	def sign_transaction(self, transaction):
 		"""Signs a Symbol transaction."""

--- a/sdk/python/symbolchain/nem/MessageEncoder.py
+++ b/sdk/python/symbolchain/nem/MessageEncoder.py
@@ -17,6 +17,12 @@ class MessageEncoder:
 
 		self.key_pair = key_pair
 
+	@property
+	def public_key(self):
+		"""Public key used for message encoding."""
+
+		return self.key_pair.public_key
+
 	def try_decode(self, recipient_public_key, encoded_message: Message):
 		"""Tries to decode encoded message, returns tuple:
 		* True, message - if message has been decoded and decrypted

--- a/sdk/python/symbolchain/symbol/MessageEncoder.py
+++ b/sdk/python/symbolchain/symbol/MessageEncoder.py
@@ -20,6 +20,12 @@ class MessageEncoder:
 
 		self.key_pair = key_pair
 
+	@property
+	def public_key(self):
+		"""Public key used for message encoding."""
+
+		return self.key_pair.public_key
+
 	def try_decode(self, recipient_public_key, encoded_message):
 		"""Tries to decode encoded message, returns tuple:
 		* True, message - if message has been decoded and decrypted

--- a/sdk/python/tests/facade/test_NemFacade.py
+++ b/sdk/python/tests/facade/test_NemFacade.py
@@ -205,6 +205,17 @@ class NemFacadeTest(unittest.TestCase):
 		self.assertEqual(public_key, account.key_pair.public_key)
 		self.assertEqual(private_key, account.key_pair.private_key)
 
+	def test_can_create_message_encoder_from_account(self):
+		# Arrange:
+		facade = NemFacade('testnet')
+		account = facade.create_account(PrivateKey('EDB671EB741BD676969D8A035271D1EE5E75DF33278083D877F23615EB839FEC'))
+
+		# Act:
+		encoder = account.message_encoder()
+
+		# Assert: message encoder matches the account
+		self.assertEqual(account.public_key, encoder.public_key)
+
 	def test_can_sign_transaction_with_account_wrappers(self):
 		# Arrange:
 		facade = NemFacade('testnet', AccountDescriptorRepository(YAML_INPUT))

--- a/sdk/python/tests/facade/test_SymbolFacade.py
+++ b/sdk/python/tests/facade/test_SymbolFacade.py
@@ -304,6 +304,17 @@ class SymbolFacadeTest(unittest.TestCase):
 		self.assertEqual(public_key, account.key_pair.public_key)
 		self.assertEqual(private_key, account.key_pair.private_key)
 
+	def test_can_create_message_encoder_from_account(self):
+		# Arrange:
+		facade = SymbolFacade('testnet')
+		account = facade.create_account(PrivateKey('EDB671EB741BD676969D8A035271D1EE5E75DF33278083D877F23615EB839FEC'))
+
+		# Act:
+		encoder = account.message_encoder()
+
+		# Assert: message encoder matches the account
+		self.assertEqual(account.public_key, encoder.public_key)
+
 	def test_can_sign_transaction_with_account_wrappers(self):
 		# Arrange:
 		facade = SymbolFacade('testnet', AccountDescriptorRepository(YAML_INPUT))

--- a/sdk/python/tests/test/BasicMessageEncoderTest.py
+++ b/sdk/python/tests/test/BasicMessageEncoderTest.py
@@ -49,6 +49,17 @@ class MessageEncoderDecodeFailureTest:
 class BasicMessageEncoderTest(MessageEncoderDecodeFailureTest):
 	# pylint: disable=no-member
 
+	def test_can_create_encoder(self):
+		# Arrange:
+		interface = self.get_basic_test_interface()
+		key_pair = interface.key_pair_class(PrivateKey.random())
+
+		# Act:
+		encoder = interface.encoder_class(key_pair)
+
+		# Assert:
+		self.assertEqual(key_pair.public_key, encoder.public_key)
+
 	def test_sender_can_decode_encoded_message(self):
 		# Arrange:
 		interface = self.get_basic_test_interface()


### PR DESCRIPTION
    [sdk/python]: add message_encoder to account classes
    
     problem: user needs to know about MessageEncoder to encrypt/encode messages
    solution: add a helper function to accounts to create it to improve discoverability

    [sdk/javascript]: add messageEncoder to account classes
    
     problem: user needs to know about MessageEncoder to encrypt/encode messages
    solution: add a helper function to accounts to create it to improve discoverability
