### PR TITLE
[sdk]: add metadata-generate-key

### DIFF
--- a/sdk/javascript/src/symbol/index.js
+++ b/sdk/javascript/src/symbol/index.js
@@ -15,7 +15,7 @@ import {
 	proveMerkle,
 	provePatriciaMerkle
 } from './merkle.js';
-import { metadataUpdateValue } from './metadata.js';
+import { metadataGenerateKey, metadataUpdateValue } from './metadata.js';
 import * as models from './models.js';
 import * as descriptors from './models_ts.js';
 import { SymbolAccount, SymbolFacade, SymbolPublicAccount } from '../facade/SymbolFacade.js';
@@ -101,6 +101,7 @@ export {
 	deserializePatriciaTreeNodes,
 	provePatriciaMerkle,
 
+	metadataGenerateKey,
 	metadataUpdateValue,
 
 	/**

--- a/sdk/javascript/src/symbol/metadata.js
+++ b/sdk/javascript/src/symbol/metadata.js
@@ -1,3 +1,20 @@
+import { sha3_256 } from '@noble/hashes/sha3';
+
+/**
+ * Generates a metadata key from a string.
+ * @param {string} seed Metadata key seed.
+ * @returns {bigint} Metadata key.
+ */
+const metadataGenerateKey = seed => {
+	const hashResult = sha3_256(seed);
+
+	const keyBytes = hashResult.subarray(0, 8);
+	keyBytes[7] |= 0x80; // set high bit to match SDK V2 implementation
+
+	const keys = new BigUint64Array(keyBytes.buffer);
+	return keys[0];
+};
+
 /**
  * Creates a metadata payload for updating old value to new value.
  * @param {Uint8Array|undefined} oldValue Old metadata value.
@@ -24,4 +41,4 @@ const metadataUpdateValue = (oldValue, newValue) => {
 	return result;
 };
 
-export { metadataUpdateValue }; // eslint-disable-line import/prefer-default-export
+export { metadataGenerateKey, metadataUpdateValue };

--- a/sdk/javascript/test/symbol/metadata_spec.js
+++ b/sdk/javascript/test/symbol/metadata_spec.js
@@ -1,7 +1,23 @@
-import { metadataUpdateValue } from '../../src/symbol/metadata.js';
+import { metadataGenerateKey, metadataUpdateValue } from '../../src/symbol/metadata.js';
 import { expect } from 'chai';
 
 describe('metadata', () => {
+	describe('metadataGenerateKey', () => {
+		const assertKeyGeneration = (seed, expectedKey) => {
+			// Act:
+			const key = metadataGenerateKey(seed);
+
+			// Assert:
+			expect(key).to.equal(expectedKey);
+		};
+
+		it('can generate expected keys from seeds', () => {
+			assertKeyGeneration('a', 0xF524A0FBF24B0880n);
+			assertKeyGeneration('abc', 0xB225E24FA75D983An);
+			assertKeyGeneration('def', 0xB0AC5222678F0D8En);
+		});
+	});
+
 	describe('metadataUpdateValue', () => {
 		it('can set new value without old value', () => {
 			// Arrange:

--- a/sdk/python/symbolchain/symbol/Metadata.py
+++ b/sdk/python/symbolchain/symbol/Metadata.py
@@ -1,3 +1,17 @@
+import hashlib
+
+
+def metadata_generate_key(seed):
+	"""Generates a metadata key from a string."""
+
+	hash_result = hashlib.sha3_256(seed.encode('utf8')).digest()
+
+	key_bytes = bytearray(hash_result[:8])
+	key_bytes[7] |= 0x80  # set high bit to match SDK V2 implementation
+
+	return int.from_bytes(key_bytes, 'little')
+
+
 def metadata_update_value(old_value, new_value):
 	"""Creates a metadata payload for updating old value to new value."""
 

--- a/sdk/python/tests/symbol/test_Metadata.py
+++ b/sdk/python/tests/symbol/test_Metadata.py
@@ -1,9 +1,21 @@
 import unittest
 
-from symbolchain.symbol.Metadata import metadata_update_value
+from symbolchain.symbol.Metadata import metadata_generate_key, metadata_update_value
 
 
 class MetadataTest(unittest.TestCase):
+	def _assert_key_generation(self, seed, expected_key):
+		# Act:
+		key = metadata_generate_key(seed)
+
+		# Assert:
+		self.assertEqual(expected_key, key)
+
+	def test_can_generate_expected_keys_from_seeds(self):
+		self._assert_key_generation('a', 0xF524A0FBF24B0880)
+		self._assert_key_generation('abc', 0xB225E24FA75D983A)
+		self._assert_key_generation('def', 0xB0AC5222678F0D8E)
+
 	def test_can_set_new_value_without_old_value(self):
 		# Arrange:
 		new_value = [0x9A, 0xC7, 0x33, 0x18, 0xA7, 0xB0, 0x36]


### PR DESCRIPTION
    [sdk/python]: add metadata_generate_key
    
     problem: there is no built in way to convert a string to a metadata key
    solution: add metadata_generate_key and make it compatible with SDK V2 implementation

    [sdk/javascript]: add metadataGenerateKey
    
     problem: there is no built in way to convert a string to a metadata key
    solution: add metadataGenerateKey and make it compatible with SDK V2 implementation
