### PR TITLE
[sdk]: add additional Symbol address utilities

### DIFF
--- a/sdk/javascript/test/symbol/Network_spec.js
+++ b/sdk/javascript/test/symbol/Network_spec.js
@@ -1,5 +1,6 @@
 import { Hash256, PublicKey } from '../../src/CryptoTypes.js';
 import { Address, Network, NetworkTimestamp } from '../../src/symbol/Network.js';
+import { NamespaceId } from '../../src/symbol/models.js';
 import { hexToUint8 } from '../../src/utils/converter.js';
 import { runBasicAddressTests } from '../test/addressTests.js';
 import { runBasicNetworkTests } from '../test/networkTests.js';
@@ -50,6 +51,44 @@ describe('Address (Symbol)', () => {
 		expect(Address.NAME).to.deep.equal('Address');
 		expect(Address.SIZE).to.deep.equal(24);
 		expect(Address.ENCODED_SIZE).to.deep.equal(39);
+	});
+
+	it('cannot extract namespace id from non-alias address', () => {
+		// Arrange:
+		const address = new Address('TBLYH55IHPS5QCCMNWR3GZWKV6WMCKPTNI7KSDA');
+
+		// Act:
+		const namespaceId = address.toNamespaceId();
+
+		// Assert:
+		expect(namespaceId).to.equal(undefined);
+	});
+
+	it('can extract namespace id from alias address', () => {
+		// Arrange:
+		const address = new Address('THBIMC3THGH5RUYAAAAAAAAAAAAAAAAAAAAAAAA');
+
+		// Act:
+		const namespaceId = address.toNamespaceId();
+
+		// Assert:
+		expect(namespaceId).to.deep.equal(new NamespaceId(0xD3D88F39730B86C2n));
+	});
+
+	it('can be created from decoded address hex string', () => {
+		// Act:
+		const address = Address.fromDecodedAddressHexString('980E356BFE40284E4C9C532CB2D5260F6D5FC029D35D2D62');
+
+		// Assert:
+		expect(address.toString()).to.equal('TAHDK276IAUE4TE4KMWLFVJGB5WV7QBJ2NOS2YQ');
+	});
+
+	it('can be created from namespace id', () => {
+		// Act:
+		const address = Address.fromNamespaceId(new NamespaceId(0xD3D88F39730B86C2n), 152);
+
+		// Assert:
+		expect(address.toString()).to.equal('THBIMC3THGH5RUYAAAAAAAAAAAAAAAAAAAAAAAA');
 	});
 });
 

--- a/sdk/python/symbolchain/symbol/Network.py
+++ b/sdk/python/symbolchain/symbol/Network.py
@@ -1,12 +1,14 @@
 import base64
 import datetime
 import hashlib
+from binascii import unhexlify
 
 from ..ByteArray import ByteArray
 from ..CryptoTypes import Hash256
 from ..Network import Network as BasicNetwork
 from ..NetworkTimestamp import NetworkTimestamp as BasicNetworkTimestamp
 from ..NetworkTimestamp import NetworkTimestampDatetimeConverter
+from ..sc import NamespaceId
 
 
 class NetworkTimestamp(BasicNetworkTimestamp):
@@ -36,11 +38,31 @@ class Address(ByteArray):
 
 		super().__init__(self.SIZE, raw_bytes, Address)
 
+	def to_namespace_id(self):
+		"""Attempts to convert this address into a namespace id."""
+
+		if not self.bytes[0] & 0x01:
+			return None
+
+		return NamespaceId(int.from_bytes(self.bytes[1:9], 'little'))
+
 	def __str__(self):
 		return base64.b32encode(self.bytes + bytes(0)).decode('utf8')[0:-1]
 
 	def __repr__(self):
 		return f'Address(\'{str(self)}\')'
+
+	@staticmethod
+	def from_decoded_address_hex_string(hex_string):
+		"""Creates an address from a decoded address hex string (typically from REST)."""
+
+		return Address(unhexlify(hex_string))
+
+	@staticmethod
+	def from_namespace_id(namespace_id, network_identifier):
+		"""Creates an address from a namespace id."""
+
+		return Address(bytes([network_identifier + 1]) + namespace_id.value.to_bytes(8, 'little') + bytes([0] * (Address.SIZE - 9)))
 
 
 class Network(BasicNetwork):

--- a/sdk/python/tests/symbol/test_Network.py
+++ b/sdk/python/tests/symbol/test_Network.py
@@ -2,6 +2,7 @@ import unittest
 from binascii import unhexlify
 
 from symbolchain.CryptoTypes import Hash256, PublicKey
+from symbolchain.sc import NamespaceId
 from symbolchain.symbol.Network import Address, Network, NetworkTimestamp
 
 from ..test.BasicAddressTest import AddressTestDescriptor, BasicAddressTest
@@ -41,6 +42,40 @@ class AddressTest(BasicAddressTest, unittest.TestCase):
 			Address,
 			'TBLYH55IHPS5QCCMNWR3GZWKV6WMCKPTNI7KSDA',
 			unhexlify('985783F7A83BE5D8084C6DA3B366CAAFACC129F36A3EA90C'))
+
+	def test_cannot_extract_namespace_id_from_non_alias_address(self):
+		# Arrange:
+		address = Address('TBLYH55IHPS5QCCMNWR3GZWKV6WMCKPTNI7KSDA')
+
+		# Act:
+		namespace_id = address.to_namespace_id()
+
+		# Assert:
+		self.assertEqual(None, namespace_id)
+
+	def test_can_extract_namespace_id_from_alias_address(self):
+		# Arrange:
+		address = Address('THBIMC3THGH5RUYAAAAAAAAAAAAAAAAAAAAAAAA')
+
+		# Act:
+		namespace_id = address.to_namespace_id()
+
+		# Assert:
+		self.assertEqual(NamespaceId(0xD3D88F39730B86C2), namespace_id)
+
+	def test_can_be_created_from_decoded_address_hex_string(self):
+		# Act:
+		address = Address.from_decoded_address_hex_string('980E356BFE40284E4C9C532CB2D5260F6D5FC029D35D2D62')
+
+		# Assert:
+		self.assertEqual(Address('TAHDK276IAUE4TE4KMWLFVJGB5WV7QBJ2NOS2YQ'), address)
+
+	def test_can_be_created_from_namespace_id(self):
+		# Act:
+		address = Address.from_namespace_id(NamespaceId(0xD3D88F39730B86C2), 152)
+
+		# Assert:
+		self.assertEqual(Address('THBIMC3THGH5RUYAAAAAAAAAAAAAAAAAAAAAAAA'), address)
 
 
 class NetworkTest(BasicNetworkTest, unittest.TestCase):


### PR DESCRIPTION
    [sdk/python]: add additional Symbol address utilities
    
     problem: some useful functions from the SDK V2 are missing
    solution: add missing functions:
              - create address alias from namespace id
              - extract namespace id from address alias
              - create address from decoded address hex string (REST format)

    [sdk/javascript]: add additional Symbol address utilities
    
     problem: some useful functions from the SDK V2 are missing
    solution: add missing functions:
              - create address alias from namespace id
              - extract namespace id from address alias
              - create address from decoded address hex string (REST format)
