### PR TITLE
[jenkins] fix: curl command failing on Windows

### DIFF
--- a/jenkins/shared-library/vars/githubHelper.groovy
+++ b/jenkins/shared-library/vars/githubHelper.groovy
@@ -12,6 +12,7 @@ boolean isGitHubRepositoryPublic(String orgName, String repoName) {
 	}
 }
 
+// groovylint-disable-next-line FactoryMethodName
 String buildCurlCommand(String token, String url, String data = null, Boolean post = false) {
 	return [
 		'curl -L',

--- a/jenkins/shared-library/vars/githubHelper.groovy
+++ b/jenkins/shared-library/vars/githubHelper.groovy
@@ -13,13 +13,9 @@ boolean isGitHubRepositoryPublic(String orgName, String repoName) {
 }
 
 Object getRepositoryInfo(String token, String ownerName, String repositoryName) {
-	final String getRepoCommand = """
-		curl -L \\
-		  -H "Accept: application/vnd.github+json" \\
-		  -H "Authorization: Bearer ${token}" \\
-		  -H "X-GitHub-Api-Version: 2022-11-28" \\
-		  https://api.github.com/repos/${ownerName}/${repositoryName} \\
-	"""
+	final String getRepoCommand = new StringBuilder().append('curl -L -H "Accept: application/vnd.github+json"')
+		.append(""" -H "Authorization: Bearer ${token}" """)
+		.append("""-H "X-GitHub-Api-Version: 2022-11-28"  https://api.github.com/repos/${ownerName}/${repositoryName}""")
 
 	final String getRepoResponse = executeGithubApiRequest(getRepoCommand)
 	return yamlHelper.readYamlFromText(getRepoResponse)
@@ -29,12 +25,8 @@ String executeGithubApiRequest(String command) {
 	String results = ''
 	helper.withTempDir {
 		String file = "./${System.currentTimeMillis()}"
-		final String response = runScript("${command} -s -w '%{http_code}\\n' -o ${file}", true).trim()
+		runScript("${command} -s -o ${file}")
 		results = readFile(file).trim()
-		if ('200' != response) {
-			String error = "GitHub API request failed: ${response}\n ${results}"
-			throw new IllegalArgumentException(error)
-		}
 	}
 
 	return results
@@ -51,15 +43,10 @@ Object createPullRequest(
 	String body
 ) {
 	final String jsonBody = JsonOutput.toJson(body)
-	final String pullRequestCommand = """
-		curl -L \\
-			-X POST \\
-			-H "Accept: application/vnd.github+json" \\
-			-H "Authorization: Bearer ${token}" \\
-			-H "X-GitHub-Api-Version: 2022-11-28" \\
-			https://api.github.com/repos/${ownerName}/${repositoryName}/pulls \\
-			-d '{"title":"${title}","body":${jsonBody},"head":"${prBranchName}","base":"${baseBranchName}"}'
-	"""
+	final String pullRequestCommand = new StringBuilder().append('curl -L -X POST -H "Accept: application/vnd.github+json" ')
+		.append("""-H "Authorization: Bearer ${token}" """)
+		.append("""-H "X-GitHub-Api-Version: 2022-11-28" https://api.github.com/repos/${ownerName}/${repositoryName}/pulls """)
+		.append("""-d '{"title":"${title}","body":${jsonBody},"head":"${prBranchName}","base":"${baseBranchName}"}'""")
 
 	final String pullRequestResponse = executeGithubApiRequest(pullRequestCommand)
 	final Object pullRequest = yamlHelper.readYamlFromText(pullRequestResponse)
@@ -68,15 +55,11 @@ Object createPullRequest(
 }
 
 Object requestReviewersForPullRequest(String token, String ownerName, String repositoryName, int pullRequestNumber, List reviewers) {
-	final String reviewersCommand = """
-		curl -L \\
-			-X POST \\
-			-H "Accept: application/vnd.github+json" \\
-			-H "Authorization: Bearer ${token}" \\
-			-H "X-GitHub-Api-Version: 2022-11-28" \\
-			https://api.github.com/repos/${ownerName}/${repositoryName}/pulls/${pullRequestNumber}/requested_reviewers \\
-			-d '{"reviewers": ["${reviewers.join('", "')}"]}'
-	"""
+	final String reviewersCommand = new StringBuilder().append('curl -L -X POST -H "Accept: application/vnd.github+json" ')
+		.append("""-H "Authorization: Bearer ${token}" """)
+		.append('-H "X-GitHub-Api-Version: 2022-11-28" ')
+		.append("""https://api.github.com/repos/${ownerName}/${repositoryName}/pulls/${pullRequestNumber}/requested_reviewers """)
+		.append("""-d '{"reviewers": ["${reviewers.join('", "')}"]}'""")
 
 	String response = executeGithubApiRequest(reviewersCommand)
 	println "Reviewers requested: ${response}"
@@ -115,7 +98,7 @@ void executeGitAuthenticatedCommand(Closure command) {
 		final String replaceUrl = "https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/.insteadOf https://github.com/"
 
 		configureGitHub()
-		sh("git config url.${replaceUrl}")
+		runScript("git config url.${replaceUrl}")
 		command()
 	}
 }

--- a/jenkins/shared-library/vars/githubHelper.groovy
+++ b/jenkins/shared-library/vars/githubHelper.groovy
@@ -12,7 +12,7 @@ boolean isGitHubRepositoryPublic(String orgName, String repoName) {
 	}
 }
 
-String getCurlCommand(String token, String url, String data = null, Boolean post = false) {
+String buildCurlCommand(String token, String url, String data = null, Boolean post = false) {
 	return [
 		'curl -L',
 		'--fail',
@@ -26,7 +26,7 @@ String getCurlCommand(String token, String url, String data = null, Boolean post
 }
 
 Object getRepositoryInfo(String token, String ownerName, String repositoryName) {
-	final String getRepoCommand = getCurlCommand(token, "https://api.github.com/repos/${ownerName}/${repositoryName}")
+	final String getRepoCommand = buildCurlCommand(token, "https://api.github.com/repos/${ownerName}/${repositoryName}")
 	final String getRepoResponse = executeGithubApiRequest(getRepoCommand)
 	return yamlHelper.readYamlFromText(getRepoResponse)
 }
@@ -53,7 +53,7 @@ Object createPullRequest(
 	String body
 ) {
 	final String jsonBody = JsonOutput.toJson(body)
-	final String pullRequestCommand = getCurlCommand(
+	final String pullRequestCommand = buildCurlCommand(
 		token,
 		"https://api.github.com/repos/${ownerName}/${repositoryName}/pulls",
 		"{'title':'${title}','body':${jsonBody},'head':'${prBranchName}','base':'${baseBranchName}'}",
@@ -66,7 +66,7 @@ Object createPullRequest(
 }
 
 Object requestReviewersForPullRequest(String token, String ownerName, String repositoryName, int pullRequestNumber, List reviewers) {
-	final String reviewersCommand = getCurlCommand(
+	final String reviewersCommand = buildCurlCommand(
 		token,
 		"https://api.github.com/repos/${ownerName}/${repositoryName}/pulls/${pullRequestNumber}/requested_reviewers",
 		"{'reviewers': ['${reviewers.join('\', \'')}']}",

--- a/jenkins/shared-library/vars/githubHelper.groovy
+++ b/jenkins/shared-library/vars/githubHelper.groovy
@@ -18,11 +18,11 @@ String buildCurlCommand(String token, String url, String data = null, Boolean po
 		'curl -L',
 		'--fail',
 		post ? '-X POST' : '',
-		'-H "Accept: application/vnd.github+json"',
+		'-H \"Accept: application/vnd.github+json\"',
 		"-H \"Authorization: Bearer ${token}\"",
-		'-H "X-GitHub-Api-Version: 2022-11-28"',
+		'-H \"X-GitHub-Api-Version: 2022-11-28\"',
 		url,
-		data ? "-d '${data}'" : ''
+		data ? "-d \'${data}\'" : ''
 	].join(' ')
 }
 
@@ -57,7 +57,7 @@ Object createPullRequest(
 	final String pullRequestCommand = buildCurlCommand(
 		token,
 		"https://api.github.com/repos/${ownerName}/${repositoryName}/pulls",
-		"{\"title\":\"${title}\",\"body\":\"${jsonBody}\",\"head\":\"${prBranchName}\",\"base\":\"${baseBranchName}\"}",
+		"{\"title\":\"${title}\",\"body\":${jsonBody},\"head\":\"${prBranchName}\",\"base\":\"${baseBranchName}\"}",
 		true
 	)
 	final String pullRequestResponse = executeGithubApiRequest(pullRequestCommand)

--- a/jenkins/shared-library/vars/githubHelper.groovy
+++ b/jenkins/shared-library/vars/githubHelper.groovy
@@ -19,7 +19,7 @@ String getCurlCommand(String token, String url, String data = null, Boolean post
 		post ? '-X POST' : '',
 		'-H "Accept: application/vnd.github+json"',
 		"-H \"Authorization: Bearer ${token}\"",
-		'-H "X-GitHub-Api-Version: 2022-11-28"'
+		'-H "X-GitHub-Api-Version: 2022-11-28"',
 		url,
 		data ? "-d '${data}'" : ''
 	].join(' ')

--- a/jenkins/shared-library/vars/githubHelper.groovy
+++ b/jenkins/shared-library/vars/githubHelper.groovy
@@ -57,7 +57,7 @@ Object createPullRequest(
 	final String pullRequestCommand = buildCurlCommand(
 		token,
 		"https://api.github.com/repos/${ownerName}/${repositoryName}/pulls",
-		"{'title':'${title}','body':${jsonBody},'head':'${prBranchName}','base':'${baseBranchName}'}",
+		"{\"title\":\"${title}\",\"body\":\"${jsonBody}\",\"head\":\"${prBranchName}\",\"base\":\"${baseBranchName}\"}",
 		true
 	)
 	final String pullRequestResponse = executeGithubApiRequest(pullRequestCommand)
@@ -70,7 +70,7 @@ Object requestReviewersForPullRequest(String token, String ownerName, String rep
 	final String reviewersCommand = buildCurlCommand(
 		token,
 		"https://api.github.com/repos/${ownerName}/${repositoryName}/pulls/${pullRequestNumber}/requested_reviewers",
-		"{'reviewers': ['${reviewers.join('\', \'')}']}",
+		"{\"reviewers\": [\"${reviewers.join('\", \"')}\"]}",
 		true
 	)
 	String response = executeGithubApiRequest(reviewersCommand)

--- a/jenkins/shared-library/vars/helper.groovy
+++ b/jenkins/shared-library/vars/helper.groovy
@@ -113,7 +113,11 @@ String resolveGitHubCredentialsId() {
 }
 
 void withTempDir(Closure body) {
-	dir(pwd(tmp: true)) {
+	// if Jenkinsfile is in the root of the repository, Jenkins will use a tmp directory
+	// which is not mounted to docker and fail the command.
+	// use the workspace tmp folder which is mounted in docker
+	String tmp = Paths.get("${WORKSPACE_TMP}").resolve("${System.currentTimeMillis()}")
+	dir(tmp) {
 		try {
 			body()
 		} finally {

--- a/jenkins/shared-library/vars/helper.groovy
+++ b/jenkins/shared-library/vars/helper.groovy
@@ -1,3 +1,4 @@
+import java.nio.file.Paths
 import java.time.LocalDateTime
 
 Boolean isManualBuild(String manualBranch) {


### PR DESCRIPTION
problem: the curl command is failing on Windows due to multiple issues
       1. Windows cmd shell does not use backslash for multi-line command
       2. in the curl write-out format the % was getting removed
solution: 1. use StringBuilder to format the curl command
              2. remove the write-out option curl will return failure to shell