### PR TITLE
[linters]: allow space indentation in reStructuredText files

### DIFF
--- a/linters/scripts/lint_indents.sh
+++ b/linters/scripts/lint_indents.sh
@@ -4,9 +4,10 @@ set -ex
 
 ! rg \
 		--files-with-matches \
-		--type-not=markdown \
 		--type-not=json \
-		--type-not=yaml \
 		--type-not=license \
+		--type-not=markdown \
+		--type-not=rst \
+		--type-not=yaml \
 		'^  ' "$(git rev-parse --show-toplevel)" \
 	| grep -vE '\.eslintrc|testnet/summary\.txt|.git/hooks/.*\.sample'


### PR DESCRIPTION
 problem: space indentation is recommended for rst files
          generated rst files are space indented
solution: skip tab indentation check for rst files