### PR TITLE
[jenkins] fix: allow a Jenkins job to run on every commit

### DIFF
--- a/.github/buildConfiguration.yaml
+++ b/.github/buildConfiguration.yaml
@@ -33,6 +33,7 @@ builds:
 
   - name: Linters
     path: linters
+    required: true
 
 customBuilds:
   - name: Nightly Job

--- a/jenkins/shared-library/vars/monorepoControllerPipeline.groovy
+++ b/jenkins/shared-library/vars/monorepoControllerPipeline.groovy
@@ -111,8 +111,9 @@ void triggerJobs(String branchName) {
 	final Map<String, String> allJenkinsfiles = jobHelper.loadJenkinsfileMap(buildConfiguration)
 	final Map<String, String> triggeredJenkinsfile = changedSetHelper.findMultibranchPipelinesToRun(allJenkinsfiles)
 	final Map<String, String> dependencyJenkinsfile = findDependencyMultibranchPipelinesToRun(triggeredJenkinsfile, buildConfiguration)
+	final Map<String, String> requiredJenkinsfile = findRequiredMultibranchPipelinesToRun(buildConfiguration)
 	final String currentJobName = Paths.get(currentBuild.fullProjectName).parent
-	final Map<String, String> jenkinsfilesJobToRun = triggeredJenkinsfile + dependencyJenkinsfile
+	final Map<String, String> jenkinsfilesJobToRun = triggeredJenkinsfile + dependencyJenkinsfile + requiredJenkinsfile
 	Map<String, String> siblingNameMap = jobHelper.siblingJobNames(jenkinsfilesJobToRun, currentJobName)
 
 	if (siblingNameMap.size() == 0) {
@@ -168,4 +169,12 @@ Map<String, String> findDependencyMultibranchPipelinesToRun(Map<String, String> 
 	Map<String, String> dependencyJobMap = [:]
 	dependencyBuilds.each { build -> dependencyJobMap.put(build.name, build.path) }
 	return dependencyJobMap
+}
+
+Map <String, String> findRequiredMultibranchPipelinesToRun(Object buildConfiguration) {
+	Map<String, String> requiredJobMap = [:]
+
+	buildConfiguration.builds.each { build -> build.required?.toBoolean() && requiredJobMap.put(build.name, build.path) }
+	println "required builds: ${requiredJobMap}"
+	return requiredJobMap
 }

--- a/jenkins/shared-library/vars/monorepoControllerPipeline.groovy
+++ b/jenkins/shared-library/vars/monorepoControllerPipeline.groovy
@@ -171,7 +171,7 @@ Map<String, String> findDependencyMultibranchPipelinesToRun(Map<String, String> 
 	return dependencyJobMap
 }
 
-Map <String, String> findRequiredMultibranchPipelinesToRun(Object buildConfiguration) {
+Map<String, String> findRequiredMultibranchPipelinesToRun(Object buildConfiguration) {
 	Map<String, String> requiredJobMap = [:]
 
 	buildConfiguration.builds.each { build -> build.required?.toBoolean() && requiredJobMap.put(build.name, build.path) }


### PR DESCRIPTION
problem: the linter job does not run on every commit which leads
                to lint errors getting committed to dev.
solution: allow a Jenkins job to run on every commit.