### PR TITLE
[jenkins] fix: GitHub commands only requires the token

### DIFF
--- a/.github/jenkinsfile/cloneSymbolBranches.groovy
+++ b/.github/jenkinsfile/cloneSymbolBranches.groovy
@@ -1,5 +1,5 @@
 cloneGitHubBranchesPipeline {
-	sourceRepoUrl = 'https://github.com/symbol/symbol'
-	destRepoUrl = 'https://github.com/symbol/symbol-internal'
+	sourceRepoUrl = 'https://github.com/Symbol/symbol'
+	destRepoUrl = 'https://github.com/Symbol/symbol-internal'
 	branches = ['dev', 'main']
 }

--- a/jenkins/shared-library/vars/githubHelper.groovy
+++ b/jenkins/shared-library/vars/githubHelper.groovy
@@ -2,7 +2,7 @@ import groovy.json.JsonOutput
 
 boolean isGitHubRepositoryPublic(String orgName, String repoName) {
 	try {
-		executeGitAuthenticatedCommand {
+		withGitHubToken {
 			final Object repo = getRepositoryInfo("${GITHUB_TOKEN}", orgName, repoName)
 			return repo.name == repoName && repo.visibility == 'public'
 		}
@@ -103,11 +103,19 @@ void configureGitHub() {
 	runScript('git config user.email "jenkins@symbol.dev"')
 }
 
-void executeGitAuthenticatedCommand(Closure command) {
+void withGitHubToken(Closure closure) {
 	withCredentials([usernamePassword(credentialsId: helper.resolveGitHubCredentialsId(),
 			usernameVariable: 'GITHUB_USER',
 			passwordVariable: 'GITHUB_TOKEN')]) {
-		final String replaceUrl = "https://${GITHUB_USER}:${GITHUB_TOKEN}@github.com/.insteadOf https://github.com/"
+		closure()
+	}
+}
+
+void executeGitAuthenticatedCommand(Closure command) {
+	withGitHubToken {
+		final String ownerName = helper.resolveOrganizationName()
+		final String replaceUrl = 'https://$GITHUB_USER:$GITHUB_TOKEN@github.com/' +
+			"${ownerName}.insteadOf https://github.com/${ownerName}"
 
 		configureGitHub()
 		runScript("git config url.${replaceUrl}")

--- a/jenkins/shared-library/vars/githubHelper.groovy
+++ b/jenkins/shared-library/vars/githubHelper.groovy
@@ -115,7 +115,7 @@ void executeGitAuthenticatedCommand(Closure command) {
 	withGitHubToken {
 		final String ownerName = helper.resolveOrganizationName()
 		final String replaceUrl = 'https://$GITHUB_USER:$GITHUB_TOKEN@github.com/' +
-			"${ownerName}.insteadOf https://github.com/${ownerName}"
+			"${ownerName}/.insteadOf https://github.com/${ownerName}/"
 
 		configureGitHub()
 		runScript("git config url.${replaceUrl}")


### PR DESCRIPTION
problem: private repo failing to clone repo due to the GitHub token does not have permissions
                this happens when there are a lot of Jenkins jobs that reuse worker nodes but not
                in the same org(esp during the nightly builds)
solution: limit the GitHub token to the org since the GitHub token is org-specific.
               also, only configure Git for push/PR.