### PR TITLE
[sdk/javascript] fix: missed updating version in the package-lock.json

### DIFF
--- a/sdk/javascript/package-lock.json
+++ b/sdk/javascript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "symbol-sdk",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "symbol-sdk",
-      "version": "3.2.1",
+      "version": "3.2.2",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "~1.4.0",


### PR DESCRIPTION
problem: missed updating the package version in the lock file
solution: update the package version in the lock file