### PR TITLE
[build] vcpkg patch for VS >= 17.10

### DIFF
--- a/client/catapult/vcpkg.json
+++ b/client/catapult/vcpkg.json
@@ -336,7 +336,7 @@
     },
     {
       "name": "boost-modular-build-helper",
-      "version": "1.83.0#0"
+      "version": "1.84.0#3"
     },
     {
       "name": "boost-move",


### PR DESCRIPTION
This PR introduces only bump `boost-modular-build-helper` to version 1.84.0 to solve an issue surfaced [after release VS 2022 >= 17.10](https://github.com/microsoft/vcpkg/issues/38980).

The component is only ancillary to vcpkg builds and does not impact managed code in any way.