### PR TITLE
[client/rest]: restructure project to use ES6 instead of CJS modules

### DIFF
--- a/client/rest/.c8rc.json
+++ b/client/rest/.c8rc.json
@@ -1,0 +1,4 @@
+{
+  "all": "true",
+  "include": ["src/**"]
+}

--- a/client/rest/.eslintrc
+++ b/client/rest/.eslintrc
@@ -5,6 +5,10 @@ extends:
   - ../../linters/javascript/default.eslintrc
 
 rules:
+  import/extensions:
+  - error
+  - ignorePackages
+
   no-underscore-dangle:
   - error
   - allow:

--- a/client/rest/.nycrc.yaml
+++ b/client/rest/.nycrc.yaml
@@ -1,3 +1,0 @@
-all: true
-include:
-  - src/**

--- a/client/rest/Jenkinsfile
+++ b/client/rest/Jenkinsfile
@@ -9,6 +9,6 @@ defaultCiPipeline {
 	publisher = 'docker'
 	dockerImageName = 'symbolplatform/symbol-rest'
 
-	codeCoverageTool = 'nyc'
+	codeCoverageTool = 'c8'
 	minimumCodeCoverage = 90
 }

--- a/client/rest/package-lock.json
+++ b/client/rest/package-lock.json
@@ -25,6 +25,7 @@
       },
       "devDependencies": {
         "axios": "^1.5.1",
+        "c8": "^10.0.0",
         "chai": "^4.3.10",
         "eslint": "^8.50.0",
         "eslint-config-airbnb": "^19.0.4",
@@ -32,7 +33,6 @@
         "minimist": "^1.2.8",
         "mocha": "^10.2.0",
         "mocha-jenkins-reporter": "^0.4.8",
-        "nyc": "^15.1.0",
         "sinon": "^18.0.0",
         "tmp": "^0.2.1"
       }
@@ -44,401 +44,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@ampproject/remapping": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-      "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/highlight": "^7.22.13",
-        "chalk": "^2.4.2"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/code-frame/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/compat-data": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.7.tgz",
-      "integrity": "sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/core": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
-      "integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
-      "dev": true,
-      "dependencies": {
-        "@ampproject/remapping": "^2.1.0",
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.7",
-        "@babel/helper-compilation-targets": "^7.17.7",
-        "@babel/helper-module-transforms": "^7.17.7",
-        "@babel/helpers": "^7.17.8",
-        "@babel/parser": "^7.17.8",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.3",
-        "@babel/types": "^7.17.0",
-        "convert-source-map": "^1.7.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.1.2",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
-    "node_modules/@babel/generator": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.23.0",
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "@jridgewell/trace-mapping": "^0.3.17",
-        "jsesc": "^2.5.1"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.7.tgz",
-      "integrity": "sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/compat-data": "^7.17.7",
-        "@babel/helper-validator-option": "^7.16.7",
-        "browserslist": "^4.17.5",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-function-name": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.23.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
-      "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.16.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-transforms": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz",
-      "integrity": "sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-simple-access": "^7.17.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/helper-validator-identifier": "^7.16.7",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.3",
-        "@babel/types": "^7.17.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-simple-access": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
-      "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.17.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-      "dev": true,
-      "dependencies": {
-        "@babel/types": "^7.22.5"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-validator-option": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
-      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.8.tgz",
-      "integrity": "sha512-QcL86FGxpfSJwGtAvv4iG93UL6bmqBdmoVY0CMCU2g+oD2ezQse3PT5Pa+jiD6LJndBQi0EDlpzOWNlLuhz5gw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.3",
-        "@babel/types": "^7.17.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "dependencies": {
-        "color-convert": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
-    },
-    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/highlight/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
-      "dev": true,
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -468,63 +73,11 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.0",
-        "@babel/types": "^7.23.0",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/traverse/node_modules/globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "to-fast-properties": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
     },
     "node_modules/@colors/colors": {
       "version": "1.6.0",
@@ -650,121 +203,94 @@
       "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
       "dev": true
     },
-    "node_modules/@istanbuljs/load-nyc-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
-      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dev": true,
       "dependencies": {
-        "camelcase": "^5.3.1",
-        "find-up": "^4.1.0",
-        "get-package-type": "^0.1.0",
-        "js-yaml": "^3.13.1",
-        "resolve-from": "^5.0.0"
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
       "dev": true,
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
       "dev": true,
       "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
       "dev": true,
       "dependencies": {
-        "p-limit": "^2.2.0"
+        "ansi-regex": "^6.0.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
       "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/@istanbuljs/schema": {
@@ -776,33 +302,10 @@
         "node": ">=8"
       }
     },
-    "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/set-array": "^1.0.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
       "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
       "dev": true,
       "engines": {
         "node": ">=6.0.0"
@@ -896,6 +399,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
@@ -954,6 +467,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
       "dev": true
     },
     "node_modules/@types/json-schema": {
@@ -1038,19 +557,6 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
-    "node_modules/aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
-      "dependencies": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1112,24 +618,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/append-transform": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
-      "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
-      "dev": true,
-      "dependencies": {
-        "default-require-extensions": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/archy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-      "dev": true
     },
     "node_modules/are-docs-informative": {
       "version": "0.0.2",
@@ -1370,35 +858,6 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
-    "node_modules/browserslist": {
-      "version": "4.20.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
-      "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/browserslist"
-        }
-      ],
-      "dependencies": {
-        "caniuse-lite": "^1.0.30001317",
-        "electron-to-chromium": "^1.4.84",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.2",
-        "picocolors": "^1.0.0"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
-    },
     "node_modules/bs58": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
@@ -1415,19 +874,228 @@
         "node": ">=16.20.1"
       }
     },
-    "node_modules/caching-transform": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
-      "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
+    "node_modules/c8": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-10.0.0.tgz",
+      "integrity": "sha512-rdQecjxw16P8kwgMBjruaQyfF+R2o/mucCCK4VPktwq2HFMWLOHGyUasb46+WlUOVJX94d6dZolcJxzjCzWmXg==",
       "dev": true,
       "dependencies": {
-        "hasha": "^5.0.0",
-        "make-dir": "^3.0.0",
-        "package-hash": "^4.0.0",
-        "write-file-atomic": "^3.0.0"
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@istanbuljs/schema": "^0.1.3",
+        "find-up": "^5.0.0",
+        "foreground-child": "^3.1.1",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.6",
+        "test-exclude": "^7.0.1",
+        "v8-to-istanbul": "^9.0.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "c8": "bin/c8.js"
       },
       "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/c8/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/c8/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/c8/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/c8/node_modules/foreground-child": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/c8/node_modules/glob": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
+      "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/c8/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/c8/node_modules/minimatch": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+      "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/c8/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/c8/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/c8/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/c8/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/c8/node_modules/test-exclude": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+      "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^9.0.4"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/c8/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/c8/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/call-bind": {
@@ -1450,31 +1118,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/caniuse-lite": {
-      "version": "1.0.30001325",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz",
-      "integrity": "sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/browserslist"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
-        }
-      ]
     },
     "node_modules/chai": {
       "version": "4.4.1",
@@ -1559,15 +1202,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/cliui": {
@@ -1667,12 +1301,6 @@
         "node": ">= 12.0.0"
       }
     },
-    "node_modules/commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-      "dev": true
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1684,15 +1312,6 @@
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
       "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
       "dev": true
-    },
-    "node_modules/convert-source-map": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
-      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "~5.1.1"
-      }
     },
     "node_modules/core-js-pure": {
       "version": "3.21.1",
@@ -1788,15 +1407,6 @@
         }
       }
     },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/deep-eql": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
@@ -1814,18 +1424,6 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
-    },
-    "node_modules/default-require-extensions": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
-      "integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
-      "dev": true,
-      "dependencies": {
-        "strip-bom": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/define-properties": {
       "version": "1.1.3",
@@ -1904,6 +1502,12 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
     "node_modules/ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -1918,18 +1522,11 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
-    "node_modules/electron-to-chromium": {
-      "version": "1.4.103",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.103.tgz",
-      "integrity": "sha512-c/uKWR1Z/W30Wy/sx3dkZoj4BijbXX85QKWu9jJfjho3LBAXNEGAEW3oWiGb+dotA6C6BzCTxL2/aLes7jlUeg==",
-      "dev": true
-    },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/enabled": {
       "version": "2.0.0",
@@ -1994,12 +1591,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/es6-error": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true
     },
     "node_modules/escalade": {
       "version": "3.1.1",
@@ -2475,19 +2066,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true,
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/esquery": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
@@ -2646,23 +2224,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/find-cache-dir": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
-      "dev": true,
-      "dependencies": {
-        "commondir": "^1.0.1",
-        "make-dir": "^3.0.2",
-        "pkg-dir": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
-      }
-    },
     "node_modules/find-my-way": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-7.3.1.tgz",
@@ -2742,19 +2303,6 @@
         }
       }
     },
-    "node_modules/foreground-child": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
-      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "signal-exit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -2786,26 +2334,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/fromentries": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
-      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2816,15 +2344,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
-    "node_modules/gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
@@ -2855,15 +2374,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/get-package-type": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/get-symbol-description": {
@@ -2936,12 +2446,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -3040,31 +2544,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/hasha": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
-      "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
-      "dev": true,
-      "dependencies": {
-        "is-stream": "^2.0.0",
-        "type-fest": "^0.8.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/hasha/node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/he": {
       "version": "1.2.0",
@@ -3203,15 +2682,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
-      }
-    },
-    "node_modules/indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -3489,12 +2959,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
-    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -3519,15 +2983,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-windows": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -3543,92 +2998,51 @@
         "node": ">=8"
       }
     },
-    "node_modules/istanbul-lib-hook": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
-      "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
-      "dev": true,
-      "dependencies": {
-        "append-transform": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-instrument": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
-      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
-      "dev": true,
-      "dependencies": {
-        "@babel/core": "^7.7.5",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.0.0",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-processinfo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
-      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
-      "dev": true,
-      "dependencies": {
-        "archy": "^1.0.0",
-        "cross-spawn": "^7.0.0",
-        "istanbul-lib-coverage": "^3.0.0-alpha.1",
-        "make-dir": "^3.0.0",
-        "p-map": "^3.0.0",
-        "rimraf": "^3.0.0",
-        "uuid": "^3.3.3"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/istanbul-lib-report": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dev": true,
       "dependencies": {
         "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^3.0.0",
+        "make-dir": "^4.0.0",
         "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/istanbul-lib-source-maps": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
-      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^3.0.0",
-        "source-map": "^0.6.1"
       },
       "engines": {
         "node": ">=10"
       }
     },
-    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+    "node_modules/istanbul-lib-report/node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
       "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/istanbul-reports": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.4.tgz",
-      "integrity": "sha512-r1/DshN4KSE7xWEknZLLLLDn5CJybV3nw01VTkp6D5jzLuELlcbudfj/eSQFvrKsJuTVCGnePO7ho82Nw9zzfw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
       "dev": true,
       "dependencies": {
         "html-escaper": "^2.0.0",
@@ -3638,11 +3052,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/jackspeak": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
+      "integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -3670,18 +3103,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true,
-      "bin": {
-        "jsesc": "bin/jsesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
@@ -3698,18 +3119,6 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
-      "dev": true,
-      "bin": {
-        "json5": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/jsprim": {
       "version": "2.0.2",
@@ -3799,12 +3208,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lodash.flattendeep": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
-      "dev": true
-    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -3884,21 +3287,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dev": true,
-      "dependencies": {
-        "semver": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
@@ -3960,6 +3348,15 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/mocha": {
@@ -4284,24 +3681,6 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
-    "node_modules/node-preload": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
-      "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
-      "dev": true,
-      "dependencies": {
-        "process-on-spawn": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/node-releases": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
-      "dev": true
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -4309,192 +3688,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/nyc": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
-      "integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
-      "dev": true,
-      "dependencies": {
-        "@istanbuljs/load-nyc-config": "^1.0.0",
-        "@istanbuljs/schema": "^0.1.2",
-        "caching-transform": "^4.0.0",
-        "convert-source-map": "^1.7.0",
-        "decamelize": "^1.2.0",
-        "find-cache-dir": "^3.2.0",
-        "find-up": "^4.1.0",
-        "foreground-child": "^2.0.0",
-        "get-package-type": "^0.1.0",
-        "glob": "^7.1.6",
-        "istanbul-lib-coverage": "^3.0.0",
-        "istanbul-lib-hook": "^3.0.0",
-        "istanbul-lib-instrument": "^4.0.0",
-        "istanbul-lib-processinfo": "^2.0.2",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^4.0.0",
-        "istanbul-reports": "^3.0.2",
-        "make-dir": "^3.0.0",
-        "node-preload": "^0.2.1",
-        "p-map": "^3.0.0",
-        "process-on-spawn": "^1.0.0",
-        "resolve-from": "^5.0.0",
-        "rimraf": "^3.0.0",
-        "signal-exit": "^3.0.2",
-        "spawn-wrap": "^2.0.0",
-        "test-exclude": "^6.0.0",
-        "yargs": "^15.0.2"
-      },
-      "bin": {
-        "nyc": "bin/nyc.js"
-      },
-      "engines": {
-        "node": ">=8.9"
-      }
-    },
-    "node_modules/nyc/node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
-      }
-    },
-    "node_modules/nyc/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/nyc/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/nyc/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/nyc/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/nyc/node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/nyc/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/nyc/node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/nyc/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/nyc/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "dev": true
-    },
-    "node_modules/nyc/node_modules/yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/nyc/node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dev": true,
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/object-assign": {
@@ -4686,18 +3879,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/p-map": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
-      "dev": true,
-      "dependencies": {
-        "aggregate-error": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
@@ -4706,21 +3887,6 @@
       "peer": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/package-hash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
-      "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
-      "dev": true,
-      "dependencies": {
-        "graceful-fs": "^4.1.15",
-        "hasha": "^5.0.0",
-        "lodash.flattendeep": "^4.4.0",
-        "release-zalgo": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/parent-module": {
@@ -4770,6 +3936,31 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
+      "dev": true,
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
     "node_modules/path-to-regexp": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
@@ -4784,12 +3975,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -4905,88 +4090,6 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.0.0.tgz",
       "integrity": "sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ=="
     },
-    "node_modules/pkg-dir": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
-      "dependencies": {
-        "find-up": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "dev": true,
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-dir/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5008,18 +4111,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
-    "node_modules/process-on-spawn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
-      "integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
-      "dev": true,
-      "dependencies": {
-        "fromentries": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/process-warning": {
       "version": "2.0.0",
@@ -5158,18 +4249,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/release-zalgo": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
-      "dev": true,
-      "dependencies": {
-        "es6-error": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5178,12 +4257,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.22.0",
@@ -5481,12 +4554,6 @@
         "randombytes": "^2.1.0"
       }
     },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
-    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -5525,12 +4592,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
     },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
@@ -5592,23 +4653,6 @@
         "memory-pager": "^1.0.2"
       }
     },
-    "node_modules/spawn-wrap": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
-      "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
-      "dev": true,
-      "dependencies": {
-        "foreground-child": "^2.0.0",
-        "is-windows": "^1.0.2",
-        "make-dir": "^3.0.0",
-        "rimraf": "^3.0.0",
-        "signal-exit": "^3.0.2",
-        "which": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/spdx-exceptions": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
@@ -5666,12 +4710,6 @@
       "engines": {
         "node": ">= 10.x"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
     },
     "node_modules/sshpk": {
       "version": "1.18.0",
@@ -5759,6 +4797,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
     "node_modules/string-width/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -5823,11 +4882,15 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-bom": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
       "engines": {
         "node": ">=8"
       }
@@ -5869,20 +4932,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/test-exclude": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
-      "dev": true,
-      "dependencies": {
-        "@istanbuljs/schema": "^0.1.2",
-        "glob": "^7.1.4",
-        "minimatch": "^3.0.4"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
@@ -5909,15 +4958,6 @@
       "dev": true,
       "engines": {
         "node": ">=14.14"
-      }
-    },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/to-regex-range": {
@@ -6033,15 +5073,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "dev": true,
-      "dependencies": {
-        "is-typedarray": "^1.0.0"
-      }
-    },
     "node_modules/unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -6071,15 +5102,25 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+    "node_modules/v8-to-istanbul": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+      "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
       "dev": true,
-      "bin": {
-        "uuid": "bin/uuid"
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
       }
+    },
+    "node_modules/v8-to-istanbul/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true
     },
     "node_modules/vasync": {
       "version": "2.2.1",
@@ -6164,12 +5205,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
-    },
     "node_modules/winston": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.13.0.tgz",
@@ -6227,22 +5262,28 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "node_modules/write-file-atomic": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-      "dev": true,
-      "dependencies": {
-        "imurmurhash": "^0.1.4",
-        "is-typedarray": "^1.0.0",
-        "signal-exit": "^3.0.2",
-        "typedarray-to-buffer": "^3.1.5"
-      }
     },
     "node_modules/ws": {
       "version": "8.17.0",
@@ -6383,308 +5424,6 @@
       "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
       "dev": true
     },
-    "@ampproject/remapping": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.1.2.tgz",
-      "integrity": "sha512-hoyByceqwKirw7w3Z7gnIIZC3Wx3J484Y3L/cMpXFbr7d9ZQj2mODrirNzcJa+SM3UlpWXYvKV4RlRpFXlWgXg==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/trace-mapping": "^0.3.0"
-      }
-    },
-    "@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
-      "dev": true,
-      "requires": {
-        "@babel/highlight": "^7.22.13",
-        "chalk": "^2.4.2"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
-    "@babel/compat-data": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.17.7.tgz",
-      "integrity": "sha512-p8pdE6j0a29TNGebNm7NzYZWB3xVZJBZ7XGs42uAKzQo8VQ3F0By/cQCtUEABwIqw5zo6WA4NbmxsfzADzMKnQ==",
-      "dev": true
-    },
-    "@babel/core": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
-      "integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
-      "dev": true,
-      "requires": {
-        "@ampproject/remapping": "^2.1.0",
-        "@babel/code-frame": "^7.16.7",
-        "@babel/generator": "^7.17.7",
-        "@babel/helper-compilation-targets": "^7.17.7",
-        "@babel/helper-module-transforms": "^7.17.7",
-        "@babel/helpers": "^7.17.8",
-        "@babel/parser": "^7.17.8",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.3",
-        "@babel/types": "^7.17.0",
-        "convert-source-map": "^1.7.0",
-        "debug": "^4.1.0",
-        "gensync": "^1.0.0-beta.2",
-        "json5": "^2.1.2",
-        "semver": "^6.3.0"
-      }
-    },
-    "@babel/generator": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
-      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.23.0",
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "@jridgewell/trace-mapping": "^0.3.17",
-        "jsesc": "^2.5.1"
-      }
-    },
-    "@babel/helper-compilation-targets": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.7.tgz",
-      "integrity": "sha512-UFzlz2jjd8kroj0hmCFV5zr+tQPi1dpC2cRsDV/3IEW8bJfCPrPpmcSN6ZS8RqIq4LXcmpipCQFPddyFA5Yc7w==",
-      "dev": true,
-      "requires": {
-        "@babel/compat-data": "^7.17.7",
-        "@babel/helper-validator-option": "^7.16.7",
-        "browserslist": "^4.17.5",
-        "semver": "^6.3.0"
-      }
-    },
-    "@babel/helper-environment-visitor": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
-      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
-      "dev": true
-    },
-    "@babel/helper-function-name": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
-      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
-      "dev": true,
-      "requires": {
-        "@babel/template": "^7.22.15",
-        "@babel/types": "^7.23.0"
-      }
-    },
-    "@babel/helper-hoist-variables": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.22.5.tgz",
-      "integrity": "sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.22.5"
-      }
-    },
-    "@babel/helper-module-imports": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
-      "integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.16.7"
-      }
-    },
-    "@babel/helper-module-transforms": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.17.7.tgz",
-      "integrity": "sha512-VmZD99F3gNTYB7fJRDTi+u6l/zxY0BE6OIxPSU7a50s6ZUQkHwSDmV92FfM+oCG0pZRVojGYhkR8I0OGeCVREw==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-environment-visitor": "^7.16.7",
-        "@babel/helper-module-imports": "^7.16.7",
-        "@babel/helper-simple-access": "^7.17.7",
-        "@babel/helper-split-export-declaration": "^7.16.7",
-        "@babel/helper-validator-identifier": "^7.16.7",
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.3",
-        "@babel/types": "^7.17.0"
-      }
-    },
-    "@babel/helper-simple-access": {
-      "version": "7.17.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.17.7.tgz",
-      "integrity": "sha512-txyMCGroZ96i+Pxr3Je3lzEJjqwaRC9buMUgtomcrLe5Nd0+fk1h0LLA+ixUF5OW7AhHuQ7Es1WcQJZmZsz2XA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.17.0"
-      }
-    },
-    "@babel/helper-split-export-declaration": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
-      "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "^7.22.5"
-      }
-    },
-    "@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
-      "dev": true
-    },
-    "@babel/helper-validator-identifier": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
-      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
-      "dev": true
-    },
-    "@babel/helper-validator-option": {
-      "version": "7.16.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
-      "integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==",
-      "dev": true
-    },
-    "@babel/helpers": {
-      "version": "7.17.8",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.17.8.tgz",
-      "integrity": "sha512-QcL86FGxpfSJwGtAvv4iG93UL6bmqBdmoVY0CMCU2g+oD2ezQse3PT5Pa+jiD6LJndBQi0EDlpzOWNlLuhz5gw==",
-      "dev": true,
-      "requires": {
-        "@babel/template": "^7.16.7",
-        "@babel/traverse": "^7.17.3",
-        "@babel/types": "^7.17.0"
-      }
-    },
-    "@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "chalk": "^2.4.2",
-        "js-tokens": "^4.0.0"
-      },
-      "dependencies": {
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
-          "requires": {
-            "color-convert": "^1.9.0"
-          }
-        },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          }
-        },
-        "color-convert": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
-          "requires": {
-            "color-name": "1.1.3"
-          }
-        },
-        "color-name": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
-      }
-    },
-    "@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
-      "dev": true
-    },
     "@babel/runtime": {
       "version": "7.17.8",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
@@ -6706,53 +5445,11 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
-    "@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
-      }
-    },
-    "@babel/traverse": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
-      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.23.0",
-        "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.23.0",
-        "@babel/helper-hoist-variables": "^7.22.5",
-        "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.0",
-        "@babel/types": "^7.23.0",
-        "debug": "^4.1.0",
-        "globals": "^11.1.0"
-      },
-      "dependencies": {
-        "globals": {
-          "version": "11.12.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-          "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-          "dev": true
-        }
-      }
-    },
-    "@babel/types": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
-      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.20",
-        "to-fast-properties": "^2.0.0"
-      }
+    "@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
     },
     "@colors/colors": {
       "version": "1.6.0",
@@ -6844,92 +5541,62 @@
       "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
       "dev": true
     },
-    "@istanbuljs/load-nyc-config": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
-      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+    "@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
       "dev": true,
       "requires": {
-        "camelcase": "^5.3.1",
-        "find-up": "^4.1.0",
-        "get-package-type": "^0.1.0",
-        "js-yaml": "^3.13.1",
-        "resolve-from": "^5.0.0"
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
       },
       "dependencies": {
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "dev": true,
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "js-yaml": {
-          "version": "3.14.1",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-          "dev": true,
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+        "ansi-regex": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+          "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
           "dev": true
         },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+        "ansi-styles": {
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+          "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
           "dev": true
         },
-        "resolve-from": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-          "dev": true
+        "string-width": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+          "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+          "dev": true,
+          "requires": {
+            "eastasianwidth": "^0.2.0",
+            "emoji-regex": "^9.2.2",
+            "strip-ansi": "^7.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+          "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^6.0.1"
+          }
+        },
+        "wrap-ansi": {
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+          "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^6.1.0",
+            "string-width": "^5.0.1",
+            "strip-ansi": "^7.0.1"
+          }
         }
       }
     },
@@ -6939,27 +5606,10 @@
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
     },
-    "@jridgewell/gen-mapping": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-      "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
-      "dev": true,
-      "requires": {
-        "@jridgewell/set-array": "^1.0.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
-        "@jridgewell/trace-mapping": "^0.3.9"
-      }
-    },
     "@jridgewell/resolve-uri": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
       "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
-      "dev": true
-    },
-    "@jridgewell/set-array": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
       "dev": true
     },
     "@jridgewell/sourcemap-codec": {
@@ -7034,6 +5684,13 @@
         "fastq": "^1.6.0"
       }
     },
+    "@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true
+    },
     "@sinonjs/commons": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
@@ -7094,6 +5751,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
+      "dev": true
+    },
+    "@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
       "dev": true
     },
     "@types/json-schema": {
@@ -7160,16 +5823,6 @@
       "dev": true,
       "requires": {}
     },
-    "aggregate-error": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
-      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
-      "dev": true,
-      "requires": {
-        "clean-stack": "^2.0.0",
-        "indent-string": "^4.0.0"
-      }
-    },
     "ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -7212,21 +5865,6 @@
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
       }
-    },
-    "append-transform": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-2.0.0.tgz",
-      "integrity": "sha512-7yeyCEurROLQJFv5Xj4lEGTy0borxepjFv1g22oAdqFu//SrAlDl1O1Nxx15SH1RoliUml6p8dwJW9jvZughhg==",
-      "dev": true,
-      "requires": {
-        "default-require-extensions": "^3.0.0"
-      }
-    },
-    "archy": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
-      "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
-      "dev": true
     },
     "are-docs-informative": {
       "version": "0.0.2",
@@ -7411,19 +6049,6 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
-    "browserslist": {
-      "version": "4.20.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz",
-      "integrity": "sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==",
-      "dev": true,
-      "requires": {
-        "caniuse-lite": "^1.0.30001317",
-        "electron-to-chromium": "^1.4.84",
-        "escalade": "^3.1.1",
-        "node-releases": "^2.0.2",
-        "picocolors": "^1.0.0"
-      }
-    },
     "bs58": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
@@ -7437,16 +6062,158 @@
       "resolved": "https://registry.npmjs.org/bson/-/bson-6.7.0.tgz",
       "integrity": "sha512-w2IquM5mYzYZv6rs3uN2DZTOBe2a0zXLj53TGDqwF4l6Sz/XsISrisXOJihArF9+BZ6Cq/GjVht7Sjfmri7ytQ=="
     },
-    "caching-transform": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-4.0.0.tgz",
-      "integrity": "sha512-kpqOvwXnjjN44D89K5ccQC+RUrsy7jB/XLlRrx0D7/2HNcTPqzsb6XgYoErwko6QsV184CA2YgS1fxDiiDZMWA==",
+    "c8": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-10.0.0.tgz",
+      "integrity": "sha512-rdQecjxw16P8kwgMBjruaQyfF+R2o/mucCCK4VPktwq2HFMWLOHGyUasb46+WlUOVJX94d6dZolcJxzjCzWmXg==",
       "dev": true,
       "requires": {
-        "hasha": "^5.0.0",
-        "make-dir": "^3.0.0",
-        "package-hash": "^4.0.0",
-        "write-file-atomic": "^3.0.0"
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@istanbuljs/schema": "^0.1.3",
+        "find-up": "^5.0.0",
+        "foreground-child": "^3.1.1",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.6",
+        "test-exclude": "^7.0.1",
+        "v8-to-istanbul": "^9.0.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "dependencies": {
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "cliui": {
+          "version": "8.0.1",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.1",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "find-up": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+          "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^6.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "foreground-child": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+          "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "signal-exit": "^4.0.1"
+          }
+        },
+        "glob": {
+          "version": "10.4.1",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
+          "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
+          "dev": true,
+          "requires": {
+            "foreground-child": "^3.1.0",
+            "jackspeak": "^3.1.2",
+            "minimatch": "^9.0.4",
+            "minipass": "^7.1.2",
+            "path-scurry": "^1.11.1"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "minimatch": {
+          "version": "9.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.4.tgz",
+          "integrity": "sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "signal-exit": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+          "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+          "dev": true
+        },
+        "test-exclude": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.1.tgz",
+          "integrity": "sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==",
+          "dev": true,
+          "requires": {
+            "@istanbuljs/schema": "^0.1.2",
+            "glob": "^10.4.1",
+            "minimatch": "^9.0.4"
+          }
+        },
+        "yargs": {
+          "version": "17.7.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+          "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+          "dev": true,
+          "requires": {
+            "cliui": "^8.0.1",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.3",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^21.1.1"
+          }
+        },
+        "yargs-parser": {
+          "version": "21.1.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+          "dev": true
+        }
       }
     },
     "call-bind": {
@@ -7462,18 +6229,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true
-    },
-    "camelcase": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-      "dev": true
-    },
-    "caniuse-lite": {
-      "version": "1.0.30001325",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz",
-      "integrity": "sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==",
       "dev": true
     },
     "chai": {
@@ -7536,12 +6291,6 @@
           }
         }
       }
-    },
-    "clean-stack": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
-      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
-      "dev": true
     },
     "cliui": {
       "version": "7.0.4",
@@ -7630,12 +6379,6 @@
       "integrity": "sha512-buhp5kePrmda3vhc5B9t7pUQXAb2Tnd0qgpkIhPhkHXxJpiPJ11H0ZEU0oBpJ2QztSbzG/ZxMj/CHsYJqRHmyg==",
       "dev": true
     },
-    "commondir": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
-      "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
-      "dev": true
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -7647,15 +6390,6 @@
       "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
       "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
       "dev": true
-    },
-    "convert-source-map": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
-      "integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.1"
-      }
     },
     "core-js-pure": {
       "version": "3.21.1",
@@ -7729,12 +6463,6 @@
         "ms": "2.1.2"
       }
     },
-    "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
-      "dev": true
-    },
     "deep-eql": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
@@ -7749,15 +6477,6 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
-    },
-    "default-require-extensions": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-3.0.0.tgz",
-      "integrity": "sha512-ek6DpXq/SCpvjhpFsLFRVtIxJCRw6fUR42lYMVZuUMK7n8eMz4Uh5clckdBjEpLhn/gEBZo7hDJnJcwdKLKQjg==",
-      "dev": true,
-      "requires": {
-        "strip-bom": "^4.0.0"
-      }
     },
     "define-properties": {
       "version": "1.1.3",
@@ -7813,6 +6532,12 @@
         "nan": "^2.14.0"
       }
     },
+    "eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -7827,18 +6552,11 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
-    "electron-to-chromium": {
-      "version": "1.4.103",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.103.tgz",
-      "integrity": "sha512-c/uKWR1Z/W30Wy/sx3dkZoj4BijbXX85QKWu9jJfjho3LBAXNEGAEW3oWiGb+dotA6C6BzCTxL2/aLes7jlUeg==",
-      "dev": true
-    },
     "emoji-regex": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "enabled": {
       "version": "2.0.0",
@@ -7888,12 +6606,6 @@
         "is-date-object": "^1.0.1",
         "is-symbol": "^1.0.2"
       }
-    },
-    "es6-error": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
-      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-      "dev": true
     },
     "escalade": {
       "version": "3.1.1",
@@ -8254,12 +6966,6 @@
         "eslint-visitor-keys": "^3.4.1"
       }
     },
-    "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "dev": true
-    },
     "esquery": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
@@ -8385,17 +7091,6 @@
         "to-regex-range": "^5.0.1"
       }
     },
-    "find-cache-dir": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
-      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
-      "dev": true,
-      "requires": {
-        "commondir": "^1.0.1",
-        "make-dir": "^3.0.2",
-        "pkg-dir": "^4.1.0"
-      }
-    },
     "find-my-way": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-7.3.1.tgz",
@@ -8449,16 +7144,6 @@
       "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "dev": true
     },
-    "foreground-child": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-2.0.0.tgz",
-      "integrity": "sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^7.0.0",
-        "signal-exit": "^3.0.2"
-      }
-    },
     "form-data": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
@@ -8480,12 +7165,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q=="
     },
-    "fromentries": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
-      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
-      "dev": true
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -8496,12 +7175,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-    },
-    "gensync": {
-      "version": "1.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-      "dev": true
     },
     "get-caller-file": {
       "version": "2.0.5",
@@ -8524,12 +7197,6 @@
         "has": "^1.0.3",
         "has-symbols": "^1.0.1"
       }
-    },
-    "get-package-type": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-      "dev": true
     },
     "get-symbol-description": {
       "version": "1.0.0",
@@ -8580,12 +7247,6 @@
       "requires": {
         "type-fest": "^0.20.2"
       }
-    },
-    "graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
     },
     "graphemer": {
       "version": "1.4.0",
@@ -8646,24 +7307,6 @@
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
           "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-        }
-      }
-    },
-    "hasha": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/hasha/-/hasha-5.2.2.tgz",
-      "integrity": "sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==",
-      "dev": true,
-      "requires": {
-        "is-stream": "^2.0.0",
-        "type-fest": "^0.8.0"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "0.8.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-          "dev": true
         }
       }
     },
@@ -8771,12 +7414,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
-      "dev": true
-    },
-    "indent-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
-      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true
     },
     "inflight": {
@@ -8964,12 +7601,6 @@
         "has-symbols": "^1.0.2"
       }
     },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-      "dev": true
-    },
     "is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -8985,12 +7616,6 @@
         "call-bind": "^1.0.2"
       }
     },
-    "is-windows": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-      "dev": true
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -9003,87 +7628,60 @@
       "integrity": "sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==",
       "dev": true
     },
-    "istanbul-lib-hook": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-3.0.0.tgz",
-      "integrity": "sha512-Pt/uge1Q9s+5VAZ+pCo16TYMWPBIl+oaNIjgLQxcX0itS6ueeaA+pEfThZpH8WxhFgCiEb8sAJY6MdUKgiIWaQ==",
-      "dev": true,
-      "requires": {
-        "append-transform": "^2.0.0"
-      }
-    },
-    "istanbul-lib-instrument": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-4.0.3.tgz",
-      "integrity": "sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==",
-      "dev": true,
-      "requires": {
-        "@babel/core": "^7.7.5",
-        "@istanbuljs/schema": "^0.1.2",
-        "istanbul-lib-coverage": "^3.0.0",
-        "semver": "^6.3.0"
-      }
-    },
-    "istanbul-lib-processinfo": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.2.tgz",
-      "integrity": "sha512-kOwpa7z9hme+IBPZMzQ5vdQj8srYgAtaRqeI48NGmAQ+/5yKiHLV0QbYqQpxsdEF0+w14SoB8YbnHKcXE2KnYw==",
-      "dev": true,
-      "requires": {
-        "archy": "^1.0.0",
-        "cross-spawn": "^7.0.0",
-        "istanbul-lib-coverage": "^3.0.0-alpha.1",
-        "make-dir": "^3.0.0",
-        "p-map": "^3.0.0",
-        "rimraf": "^3.0.0",
-        "uuid": "^3.3.3"
-      }
-    },
     "istanbul-lib-report": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-      "integrity": "sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
       "dev": true,
       "requires": {
         "istanbul-lib-coverage": "^3.0.0",
-        "make-dir": "^3.0.0",
+        "make-dir": "^4.0.0",
         "supports-color": "^7.1.0"
-      }
-    },
-    "istanbul-lib-source-maps": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
-      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.1",
-        "istanbul-lib-coverage": "^3.0.0",
-        "source-map": "^0.6.1"
       },
       "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+        "make-dir": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+          "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+          "dev": true,
+          "requires": {
+            "semver": "^7.5.3"
+          }
+        },
+        "semver": {
+          "version": "7.6.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+          "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
           "dev": true
         }
       }
     },
     "istanbul-reports": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.4.tgz",
-      "integrity": "sha512-r1/DshN4KSE7xWEknZLLLLDn5CJybV3nw01VTkp6D5jzLuELlcbudfj/eSQFvrKsJuTVCGnePO7ho82Nw9zzfw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.7.tgz",
+      "integrity": "sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==",
       "dev": true,
       "requires": {
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
     },
+    "jackspeak": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
+      "integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
+      "dev": true,
+      "requires": {
+        "@isaacs/cliui": "^8.0.2",
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "js-yaml": {
       "version": "4.1.0",
@@ -9105,12 +7703,6 @@
       "integrity": "sha512-YtOli5Cmzy3q4dP26GraSOeAhqecewG04hoO8DY56CH4KJ9Fvv5qKWUCCo3HZob7esJQHCv6/+bnTy72xZZaVQ==",
       "dev": true
     },
-    "jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
-    },
     "json-schema": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
@@ -9126,12 +7718,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
-      "dev": true
-    },
-    "json5": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
-      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
       "dev": true
     },
     "jsprim": {
@@ -9210,12 +7796,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "lodash.flattendeep": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
-      "dev": true
-    },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -9280,15 +7860,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
       "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA=="
     },
-    "make-dir": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
-      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
-      "dev": true,
-      "requires": {
-        "semver": "^6.0.0"
-      }
-    },
     "memory-pager": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
@@ -9332,6 +7903,12 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true
+    },
+    "minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
       "dev": true
     },
     "mocha": {
@@ -9555,175 +8132,11 @@
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
       "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg=="
     },
-    "node-preload": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/node-preload/-/node-preload-0.2.1.tgz",
-      "integrity": "sha512-RM5oyBy45cLEoHqCeh+MNuFAxO0vTFBLskvQbOKnEE7YTTSN4tbN8QWDIPQ6L+WvKsB/qLEGpYe2ZZ9d4W9OIQ==",
-      "dev": true,
-      "requires": {
-        "process-on-spawn": "^1.0.0"
-      }
-    },
-    "node-releases": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
-      "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
-      "dev": true
-    },
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
-    },
-    "nyc": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-15.1.0.tgz",
-      "integrity": "sha512-jMW04n9SxKdKi1ZMGhvUTHBN0EICCRkHemEoE5jm6mTYcqcdas0ATzgUgejlQUHMvpnOZqGB5Xxsv9KxJW1j8A==",
-      "dev": true,
-      "requires": {
-        "@istanbuljs/load-nyc-config": "^1.0.0",
-        "@istanbuljs/schema": "^0.1.2",
-        "caching-transform": "^4.0.0",
-        "convert-source-map": "^1.7.0",
-        "decamelize": "^1.2.0",
-        "find-cache-dir": "^3.2.0",
-        "find-up": "^4.1.0",
-        "foreground-child": "^2.0.0",
-        "get-package-type": "^0.1.0",
-        "glob": "^7.1.6",
-        "istanbul-lib-coverage": "^3.0.0",
-        "istanbul-lib-hook": "^3.0.0",
-        "istanbul-lib-instrument": "^4.0.0",
-        "istanbul-lib-processinfo": "^2.0.2",
-        "istanbul-lib-report": "^3.0.0",
-        "istanbul-lib-source-maps": "^4.0.0",
-        "istanbul-reports": "^3.0.2",
-        "make-dir": "^3.0.0",
-        "node-preload": "^0.2.1",
-        "p-map": "^3.0.0",
-        "process-on-spawn": "^1.0.0",
-        "resolve-from": "^5.0.0",
-        "rimraf": "^3.0.0",
-        "signal-exit": "^3.0.2",
-        "spawn-wrap": "^2.0.0",
-        "test-exclude": "^6.0.0",
-        "yargs": "^15.0.2"
-      },
-      "dependencies": {
-        "cliui": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-          "dev": true,
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^6.2.0"
-          }
-        },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        },
-        "resolve-from": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-          "dev": true
-        },
-        "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.0.0",
-            "string-width": "^4.1.0",
-            "strip-ansi": "^6.0.0"
-          }
-        },
-        "y18n": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-          "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-          "dev": true
-        },
-        "yargs": {
-          "version": "15.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-          "dev": true,
-          "requires": {
-            "cliui": "^6.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^4.1.0",
-            "get-caller-file": "^2.0.1",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
-            "string-width": "^4.2.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.2"
-          }
-        },
-        "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
-        }
-      }
     },
     "object-assign": {
       "version": "4.1.1",
@@ -9869,33 +8282,12 @@
         "p-limit": "^1.1.0"
       }
     },
-    "p-map": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-3.0.0.tgz",
-      "integrity": "sha512-d3qXVTF/s+W+CdJ5A29wywV2n8CQQYahlgz2bFiA+4eVNJbHJodPZ+/gXwPGh0bOqA+j8S+6+ckmvLGPk1QpxQ==",
-      "dev": true,
-      "requires": {
-        "aggregate-error": "^3.0.0"
-      }
-    },
     "p-try": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
       "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
       "dev": true,
       "peer": true
-    },
-    "package-hash": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/package-hash/-/package-hash-4.0.0.tgz",
-      "integrity": "sha512-whdkPIooSu/bASggZ96BWVvZTRMOFxnyUG5PnTSGKoJE2gd5mbVNmR2Nj20QFzxYYgAXpoqC+AiXzl+UMRh7zQ==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.15",
-        "hasha": "^5.0.0",
-        "lodash.flattendeep": "^4.4.0",
-        "release-zalgo": "^1.0.0"
-      }
     },
     "parent-module": {
       "version": "1.0.1",
@@ -9932,6 +8324,24 @@
       "dev": true,
       "peer": true
     },
+    "path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "10.2.2",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+          "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
+          "dev": true
+        }
+      }
+    },
     "path-to-regexp": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
@@ -9942,12 +8352,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
       "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true
-    },
-    "picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
       "dev": true
     },
     "picomatch": {
@@ -10025,66 +8429,6 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-6.0.0.tgz",
       "integrity": "sha512-mMMOwSKrmyl+Y12Ri2xhH1lbzQxwwpuru9VjyJpgFIH4asSj88F2csdMwN6+M5g1Ll4rmsYghHLQJw81tgZ7LQ=="
     },
-    "pkg-dir": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
-      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
-      "dev": true,
-      "requires": {
-        "find-up": "^4.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^4.1.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.2.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
-        },
-        "path-exists": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        }
-      }
-    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -10100,15 +8444,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
-    "process-on-spawn": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
-      "integrity": "sha512-1WsPDsUSMmZH5LeMLegqkPDrsGgsWwk1Exipy2hvB0o/F0ASzbpIctSCcZIK1ykJvtTJULEH+20WOFjMvGnCTg==",
-      "dev": true,
-      "requires": {
-        "fromentries": "^1.2.0"
-      }
     },
     "process-warning": {
       "version": "2.0.0",
@@ -10212,25 +8547,10 @@
         "define-properties": "^1.1.3"
       }
     },
-    "release-zalgo": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
-      "integrity": "sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=",
-      "dev": true,
-      "requires": {
-        "es6-error": "^4.0.1"
-      }
-    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-      "dev": true
-    },
-    "require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
     "resolve": {
@@ -10458,12 +8778,6 @@
         "randombytes": "^2.1.0"
       }
     },
-    "set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
-    },
     "setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -10493,12 +8807,6 @@
         "get-intrinsic": "^1.0.2",
         "object-inspect": "^1.9.0"
       }
-    },
-    "signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "dev": true
     },
     "simple-swizzle": {
       "version": "0.2.2",
@@ -10555,20 +8863,6 @@
         "memory-pager": "^1.0.2"
       }
     },
-    "spawn-wrap": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-2.0.0.tgz",
-      "integrity": "sha512-EeajNjfN9zMnULLwhZZQU3GWBoFNkbngTUPfaawT4RkMiviTxcX0qfhVbGey39mfctfDHkWtuecgQ8NJcyQWHg==",
-      "dev": true,
-      "requires": {
-        "foreground-child": "^2.0.0",
-        "is-windows": "^1.0.2",
-        "make-dir": "^3.0.0",
-        "rimraf": "^3.0.0",
-        "signal-exit": "^3.0.2",
-        "which": "^2.0.1"
-      }
-    },
     "spdx-exceptions": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
@@ -10620,12 +8914,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
       "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ=="
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
     },
     "sshpk": {
       "version": "1.18.0",
@@ -10692,6 +8980,25 @@
         }
       }
     },
+    "string-width-cjs": {
+      "version": "npm:string-width@4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        }
+      }
+    },
     "string.prototype.matchall": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.7.tgz",
@@ -10738,11 +9045,14 @@
         "ansi-regex": "^5.0.1"
       }
     },
-    "strip-bom": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
-      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
-      "dev": true
+    "strip-ansi-cjs": {
+      "version": "npm:strip-ansi@6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1"
+      }
     },
     "strip-json-comments": {
       "version": "3.1.1",
@@ -10765,17 +9075,6 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true,
       "peer": true
-    },
-    "test-exclude": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
-      "dev": true,
-      "requires": {
-        "@istanbuljs/schema": "^0.1.2",
-        "glob": "^7.1.4",
-        "minimatch": "^3.0.4"
-      }
     },
     "text-hex": {
       "version": "1.0.0",
@@ -10800,12 +9099,6 @@
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
       "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
-      "dev": true
-    },
-    "to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
       "dev": true
     },
     "to-regex-range": {
@@ -10893,15 +9186,6 @@
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
       "dev": true
     },
-    "typedarray-to-buffer": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
-      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "dev": true,
-      "requires": {
-        "is-typedarray": "^1.0.0"
-      }
-    },
     "unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -10928,11 +9212,24 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
-    "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+    "v8-to-istanbul": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.2.0.tgz",
+      "integrity": "sha512-/EH/sDgxU2eGxajKdwLCDmQ4FWq+kpi3uCmBGpw1xJtnAxEjlD8j8PEiGWpCIMIs3ciNAgH0d3TTJiUkYzyZjA==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "dependencies": {
+        "convert-source-map": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+          "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+          "dev": true
+        }
+      }
     },
     "vasync": {
       "version": "2.2.1",
@@ -10996,12 +9293,6 @@
         "is-symbol": "^1.0.3"
       }
     },
-    "which-module": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-      "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-      "dev": true
-    },
     "winston": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/winston/-/winston-3.13.0.tgz",
@@ -11047,22 +9338,21 @@
         "strip-ansi": "^6.0.0"
       }
     },
+    "wrap-ansi-cjs": {
+      "version": "npm:wrap-ansi@7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
-    },
-    "write-file-atomic": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
-      "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-      "dev": true,
-      "requires": {
-        "imurmurhash": "^0.1.4",
-        "is-typedarray": "^1.0.0",
-        "signal-exit": "^3.0.2",
-        "typedarray-to-buffer": "^3.1.5"
-      }
     },
     "ws": {
       "version": "8.17.0",

--- a/client/rest/package.json
+++ b/client/rest/package.json
@@ -1,6 +1,7 @@
 {
   "name": "symbol-api-rest",
   "version": "2.4.4",
+  "type": "module",
   "description": "Symbol API REST",
   "main": "src/index.js",
   "scripts": {
@@ -8,7 +9,7 @@
     "lint": "eslint .",
     "test": "mocha --full-trace --recursive ./test",
     "lint:jenkins": "eslint -o lint.client.rest.xml -f junit . || exit 0",
-    "test:jenkins": "nyc --require mocha --reporter=lcov npm run test",
+    "test:jenkins": "c8 --require mocha --no-clean --reporter=lcov npm run test",
     "version": "echo $npm_package_version"
   },
   "keywords": [],
@@ -16,6 +17,7 @@
   "license": "ISC",
   "devDependencies": {
     "axios": "^1.5.1",
+    "c8": "^10.0.0",
     "chai": "^4.3.10",
     "eslint": "^8.50.0",
     "eslint-config-airbnb": "^19.0.4",
@@ -23,7 +25,6 @@
     "minimist": "^1.2.8",
     "mocha": "^10.2.0",
     "mocha-jenkins-reporter": "^0.4.8",
-    "nyc": "^15.1.0",
     "sinon": "^18.0.0",
     "tmp": "^0.2.1"
   },

--- a/client/rest/src/catapult-sdk/crypto/merkleAuditProof.js
+++ b/client/rest/src/catapult-sdk/crypto/merkleAuditProof.js
@@ -19,17 +19,17 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const arrayUtils = require('../utils/arrayUtils');
+import arrayUtils from '../utils/arrayUtils.js';
 
-const NodePosition = Object.freeze({
+export const NodePosition = Object.freeze({
 	left: 'left',
 	right: 'right'
 });
 
-class HashNotFoundError extends Error {}
-class InvalidTree extends Error {}
+export class HashNotFoundError extends Error {}
+export class InvalidTree extends Error {}
 
-const evenify = number => (number % 2 ? number + 1 : number);
+export const evenify = number => (number % 2 ? number + 1 : number);
 
 /**
  * Returns the index of a hash in a Merkle tree.
@@ -37,11 +37,11 @@ const evenify = number => (number % 2 ? number + 1 : number);
  * @param {object} tree Merkle tree object containing the number of hashed elements and the tree of hashes.
  * @returns {number} Index of the first element in the tree matching the given hash, otherwise -1 is returned.
  */
-const indexOfLeafWithHash = (hash, tree) => tree.nodes
+export const indexOfLeafWithHash = (hash, tree) => tree.nodes
 	.slice(0, evenify(tree.count))
 	.findIndex(element => arrayUtils.deepEqual(element, hash));
 
-const siblingOf = nodeIndex => {
+export const siblingOf = nodeIndex => {
 	if (nodeIndex % 2) {
 		return {
 			position: NodePosition.left,
@@ -60,7 +60,7 @@ const siblingOf = nodeIndex => {
  * @param {object} tree Merkle tree object containing the number of elements and the tree of hashes.
  * @returns {Array<object>} Array of objects containing the Merkle tree hash, and its relative position (left or right).
  */
-const buildAuditPath = (hash, tree) => {
+export const buildAuditPath = (hash, tree) => {
 	if (0 === tree.count)
 		throw new InvalidTree();
 
@@ -84,14 +84,4 @@ const buildAuditPath = (hash, tree) => {
 		layerSubindexOfHash = Math.floor(layerSubindexOfHash / 2);
 	}
 	return auditPath;
-};
-
-module.exports = {
-	buildAuditPath,
-	evenify,
-	indexOfLeafWithHash,
-	siblingOf,
-	NodePosition,
-	HashNotFoundError,
-	InvalidTree
 };

--- a/client/rest/src/catapult-sdk/index.js
+++ b/client/rest/src/catapult-sdk/index.js
@@ -19,36 +19,36 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const merkle = require('./crypto/merkleAuditProof');
-const EntityType = require('./model/EntityType');
-const ModelType = require('./model/ModelType');
-const address = require('./model/address');
-const idReducer = require('./model/idReducer');
-const namespace = require('./model/namespace');
-const networkInfo = require('./model/networkInfo');
-const restriction = require('./model/restriction');
-const status = require('./model/status');
-const serialize = require('./modelBinary/serialize');
-const sizes = require('./modelBinary/sizes');
-const { PacketType, StatePathPacketTypes } = require('./packet/PacketType');
-const packetHeader = require('./packet/header');
-const BinaryParser = require('./parser/BinaryParser');
-const PacketParser = require('./parser/PacketParser');
-const catapultModelSystem = require('./plugins/catapultModelSystem');
-const BinarySerializer = require('./serializer/BinarySerializer');
-const SerializedSizeCalculator = require('./serializer/SerializedSizeCalculator');
-const CachedFileLoader = require('./utils/CachedFileLoader');
-const SchemaType = require('./utils/SchemaType');
-const arrayUtils = require('./utils/arrayUtils');
-const base32 = require('./utils/base32');
-const convert = require('./utils/convert');
-const formattingUtils = require('./utils/formattingUtils');
-const future = require('./utils/future');
-const objects = require('./utils/objects');
-const schemaFormatter = require('./utils/schemaFormatter');
-const uint64 = require('./utils/uint64');
+import * as merkle from './crypto/merkleAuditProof.js';
+import EntityType from './model/EntityType.js';
+import ModelType from './model/ModelType.js';
+import address from './model/address.js';
+import idReducer from './model/idReducer.js';
+import namespace from './model/namespace.js';
+import networkInfo from './model/networkInfo.js';
+import restriction from './model/restriction.js';
+import status from './model/status.js';
+import serialize from './modelBinary/serialize.js';
+import sizes from './modelBinary/sizes.js';
+import { PacketType, StatePathPacketTypes } from './packet/PacketType.js';
+import packetHeader from './packet/header.js';
+import BinaryParser from './parser/BinaryParser.js';
+import PacketParser from './parser/PacketParser.js';
+import catapultModelSystem from './plugins/catapultModelSystem.js';
+import BinarySerializer from './serializer/BinarySerializer.js';
+import SerializedSizeCalculator from './serializer/SerializedSizeCalculator.js';
+import CachedFileLoader from './utils/CachedFileLoader.js';
+import SchemaType from './utils/SchemaType.js';
+import arrayUtils from './utils/arrayUtils.js';
+import base32 from './utils/base32.js';
+import convert from './utils/convert.js';
+import formattingUtils from './utils/formattingUtils.js';
+import future from './utils/future.js';
+import objects from './utils/objects.js';
+import schemaFormatter from './utils/schemaFormatter.js';
+import uint64 from './utils/uint64.js';
 
-const catapultSdk = {
+export default {
 	constants: {
 		sizes
 	},
@@ -97,5 +97,3 @@ const catapultSdk = {
 		uint64
 	}
 };
-
-module.exports = catapultSdk;

--- a/client/rest/src/catapult-sdk/model/EntityType.js
+++ b/client/rest/src/catapult-sdk/model/EntityType.js
@@ -23,7 +23,7 @@
  * Catapult model entity types.
  * @enum {number}
  */
-const EntityType = {
+export default {
 	/** Transfer transaction. */
 	transfer: 0x4154,
 
@@ -99,5 +99,3 @@ const EntityType = {
 	/** Namespace metadata transaction */
 	namespaceMetadata: 0x4344
 };
-
-module.exports = EntityType;

--- a/client/rest/src/catapult-sdk/model/ModelFormatterBuilder.js
+++ b/client/rest/src/catapult-sdk/model/ModelFormatterBuilder.js
@@ -20,7 +20,7 @@
  */
 
 /** @module model/ModelFormatterBuilder */
-const schemaFormatter = require('../utils/schemaFormatter');
+import schemaFormatter from '../utils/schemaFormatter.js';
 
 const createFormatter = (type, modelSchema, formattingRules) => ({
 	format: entity => schemaFormatter.format(entity, modelSchema[type], modelSchema, formattingRules)
@@ -29,7 +29,7 @@ const createFormatter = (type, modelSchema, formattingRules) => ({
 /**
  * Builder for creating a model formatter.
  */
-class ModelFormatterBuilder {
+export default class ModelFormatterBuilder {
 	/**
 	 * Creates a model formatter builder.
 	 */
@@ -79,5 +79,3 @@ class ModelFormatterBuilder {
 		return formatter;
 	}
 }
-
-module.exports = ModelFormatterBuilder;

--- a/client/rest/src/catapult-sdk/model/ModelSchemaBuilder.js
+++ b/client/rest/src/catapult-sdk/model/ModelSchemaBuilder.js
@@ -20,13 +20,13 @@
  */
 
 /** @module model/ModelSchemaBuilder */
-const EntityType = require('./EntityType');
-const ModelType = require('./ModelType');
+import EntityType from './EntityType.js';
+import ModelType from './ModelType.js';
 
 /**
  * Builder for creating a model schema.
  */
-class ModelSchemaBuilder {
+export default class ModelSchemaBuilder {
 	/**
 	 * Creates a model schema builder.
 	 */
@@ -354,5 +354,3 @@ class ModelSchemaBuilder {
 		return this.schema;
 	}
 }
-
-module.exports = ModelSchemaBuilder;

--- a/client/rest/src/catapult-sdk/model/ModelType.js
+++ b/client/rest/src/catapult-sdk/model/ModelType.js
@@ -19,7 +19,7 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const SchemaType = require('../utils/SchemaType');
+import SchemaType from '../utils/SchemaType.js';
 
 /**
  * Catapult model extended schema property types.
@@ -67,4 +67,4 @@ const ModelType = {
 Object.assign(ModelType, SchemaType);
 ModelType.max = ModelType.encodedAddress;
 
-module.exports = ModelType;
+export default ModelType;

--- a/client/rest/src/catapult-sdk/model/address.js
+++ b/client/rest/src/catapult-sdk/model/address.js
@@ -19,11 +19,11 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const arrayUtils = require('../utils/arrayUtils');
-const base32 = require('../utils/base32');
-const convert = require('../utils/convert');
-const { sha3_256 } = require('@noble/hashes/sha3');
-const Ripemd160 = require('ripemd160');
+import arrayUtils from '../utils/arrayUtils.js';
+import base32 from '../utils/base32.js';
+import convert from '../utils/convert.js';
+import { sha3_256 } from '@noble/hashes/sha3';
+import Ripemd160 from 'ripemd160';
 
 const constants = {
 	sizes: {
@@ -131,4 +131,4 @@ const address = {
 	}
 };
 
-module.exports = address;
+export default address;

--- a/client/rest/src/catapult-sdk/model/idReducer.js
+++ b/client/rest/src/catapult-sdk/model/idReducer.js
@@ -20,9 +20,9 @@
  */
 
 /** @module model/idReducer */
-const uint64 = require('../utils/uint64');
+import uint64 from '../utils/uint64.js';
 
-const idReducer = {
+export default {
 	/**
 	 * Creates an id to name lookup object around namespace name tuples.
 	 * @param {Array<object>} nameTuples Namespace name tuples.
@@ -87,5 +87,3 @@ const idReducer = {
 		};
 	}
 };
-
-module.exports = idReducer;

--- a/client/rest/src/catapult-sdk/model/namespace.js
+++ b/client/rest/src/catapult-sdk/model/namespace.js
@@ -19,12 +19,13 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const convert = require('../utils/convert');
+import convert from '../utils/convert.js';
+
 /**
  * Catapult model namespace.
  * @enum {number}
  */
-const namespace = {
+export default {
 	/** Namespace alias type. */
 	aliasType: {
 		/** Mosaic alias. */
@@ -48,5 +49,3 @@ const namespace = {
 		return padded;
 	}
 };
-
-module.exports = namespace;

--- a/client/rest/src/catapult-sdk/model/networkInfo.js
+++ b/client/rest/src/catapult-sdk/model/networkInfo.js
@@ -20,8 +20,8 @@
  */
 
 /** @module model/networkInfo */
-const base32 = require('../utils/base32');
-const convert = require('../utils/convert');
+import base32 from '../utils/base32.js';
+import convert from '../utils/convert.js';
 
 /**
  * Information about a catapult network.
@@ -53,7 +53,7 @@ const findNetwork = (key, value) => {
 	return undefined === matchNetworkName ? undefined : networks[matchNetworkName];
 };
 
-const networkInfo = {
+export default {
 	/** @property {module:model/networkInfo~WellKnownNetworks} networks Information about well known networks. */
 	networks,
 
@@ -72,5 +72,3 @@ const networkInfo = {
 	 */
 	findByCharPrefix: charPrefix => findNetwork('charPrefix', charPrefix)
 };
-
-module.exports = networkInfo;

--- a/client/rest/src/catapult-sdk/model/restriction.js
+++ b/client/rest/src/catapult-sdk/model/restriction.js
@@ -23,7 +23,7 @@
  * Catapult model restriction.
  * @enum {number}
  */
-const restriction = {
+export default {
 	mosaicRestriction: {
 		/** Mosaic restriction type. */
 		restrictionType: {
@@ -35,5 +35,3 @@ const restriction = {
 		}
 	}
 };
-
-module.exports = restriction;

--- a/client/rest/src/catapult-sdk/model/status.js
+++ b/client/rest/src/catapult-sdk/model/status.js
@@ -190,7 +190,7 @@ const toStringInternal = code => {
 	}
 };
 
-const status = {
+export default {
 	/**
 	 * Converts a status code to a string.
 	 * @param {number} code Status code.
@@ -208,5 +208,3 @@ const status = {
 		return `unknown status 0x${hexString}`;
 	}
 };
-
-module.exports = status;

--- a/client/rest/src/catapult-sdk/modelBinary/AggregateModelCodec.js
+++ b/client/rest/src/catapult-sdk/modelBinary/AggregateModelCodec.js
@@ -30,7 +30,7 @@
  * @interface
  * @augments {module:modelBinary/ModelCodec}
  */
-const AggregateModelCodec = {
+export default {
 	/**
 	 * Determines whether or not an entity type is supported.
 	 * @instance
@@ -41,4 +41,3 @@ const AggregateModelCodec = {
 };
 
 /* eslint-enable */
-module.exports = AggregateModelCodec;

--- a/client/rest/src/catapult-sdk/modelBinary/ModelCodec.js
+++ b/client/rest/src/catapult-sdk/modelBinary/ModelCodec.js
@@ -29,7 +29,7 @@
  * Codec for serializing and deserializing a model.
  * @interface
  */
-const ModelCodec = {
+export default {
 	/**
 	 * Deserializes a model.
 	 * @instance
@@ -49,4 +49,3 @@ const ModelCodec = {
 };
 
 /* eslint-enable */
-module.exports = ModelCodec;

--- a/client/rest/src/catapult-sdk/modelBinary/ModelCodecBuilder.js
+++ b/client/rest/src/catapult-sdk/modelBinary/ModelCodecBuilder.js
@@ -20,11 +20,11 @@
  */
 
 /** @module modelBinary/ModelCodecBuilder */
-const blockHeaderCodec = require('./blockHeaderCodec');
-const importanceBlockHeaderCodec = require('./importanceBlockHeaderCodec');
-const transactionCodec = require('./transactionCodec');
-const verifiableEntityCodec = require('./verifiableEntityCodec');
-const SerializedSizeCalculator = require('../serializer/SerializedSizeCalculator');
+import blockHeaderCodec from './blockHeaderCodec.js';
+import importanceBlockHeaderCodec from './importanceBlockHeaderCodec.js';
+import transactionCodec from './transactionCodec.js';
+import verifiableEntityCodec from './verifiableEntityCodec.js';
+import SerializedSizeCalculator from '../serializer/SerializedSizeCalculator.js';
 
 const isBlockType = entityType => 0 !== (0x8000 & entityType);
 
@@ -45,7 +45,7 @@ const findCodecs = (entityType, codecs) => {
 /**
  * Builder for creating an aggregate model codec.
  */
-class ModelCodecBuilder {
+export default class ModelCodecBuilder {
 	/**
 	 * Creates a model codec builder.
 	 */
@@ -106,5 +106,3 @@ class ModelCodecBuilder {
 		};
 	}
 }
-
-module.exports = ModelCodecBuilder;

--- a/client/rest/src/catapult-sdk/modelBinary/blockHeaderCodec.js
+++ b/client/rest/src/catapult-sdk/modelBinary/blockHeaderCodec.js
@@ -20,11 +20,11 @@
  */
 
 /** @module modelBinary/blockHeaderCodec */
-const sizes = require('./sizes');
+import sizes from './sizes.js';
 
 const constants = { sizes };
 
-const blockHeaderCodec = {
+export default {
 	/**
 	 * Parses a block header.
 	 * @param {object} parser Parser.
@@ -67,5 +67,3 @@ const blockHeaderCodec = {
 		serializer.writeUint32(blockHeader.feeMultiplier);
 	}
 };
-
-module.exports = blockHeaderCodec;

--- a/client/rest/src/catapult-sdk/modelBinary/embeddedEntityCodec.js
+++ b/client/rest/src/catapult-sdk/modelBinary/embeddedEntityCodec.js
@@ -20,11 +20,11 @@
  */
 
 /** @module modelBinary/embeddedEntityCodec */
-const sizes = require('./sizes');
+import sizes from './sizes.js';
 
 const constants = { sizes };
 
-const embeddedEntityCodec = {
+export default {
 	/**
 	 * Parses an embedded entity.
 	 * @param {object} parser Parser.
@@ -55,5 +55,3 @@ const embeddedEntityCodec = {
 		serializer.writeUint16(entity.type);
 	}
 };
-
-module.exports = embeddedEntityCodec;

--- a/client/rest/src/catapult-sdk/modelBinary/importanceBlockHeaderCodec.js
+++ b/client/rest/src/catapult-sdk/modelBinary/importanceBlockHeaderCodec.js
@@ -20,11 +20,11 @@
  */
 
 /** @module modelBinary/importanceBlockHeaderCodec */
-const sizes = require('./sizes');
+import sizes from './sizes.js';
 
 const constants = { sizes };
 
-const importanceBlockHeaderCodec = {
+export default {
 	/**
 	 * Parses a block header.
 	 * @param {object} parser Parser.
@@ -51,5 +51,3 @@ const importanceBlockHeaderCodec = {
 		serializer.writeBuffer(importanceBlockHeader.previousImportanceBlockHash);
 	}
 };
-
-module.exports = importanceBlockHeaderCodec;

--- a/client/rest/src/catapult-sdk/modelBinary/serialize.js
+++ b/client/rest/src/catapult-sdk/modelBinary/serialize.js
@@ -20,9 +20,9 @@
  */
 
 /** @module modelBinary/serialize */
-const BinarySerializer = require('../serializer/BinarySerializer');
-const SerializedSizeCalculator = require('../serializer/SerializedSizeCalculator');
-const convert = require('../utils/convert');
+import BinarySerializer from '../serializer/BinarySerializer.js';
+import SerializedSizeCalculator from '../serializer/SerializedSizeCalculator.js';
+import convert from '../utils/convert.js';
 
 const serializeToBuffer = (codec, entity) => {
 	const calculator = new SerializedSizeCalculator();
@@ -36,7 +36,7 @@ const serializeToBuffer = (codec, entity) => {
 /**
  * Serializer utility functions.
  */
-const serialize = {
+export default {
 	/**
 	 * Serializes an entity to a hex string using a codec.
 	 * @param {module:modelBinary/ModelCodec} codec Model codec.
@@ -53,5 +53,3 @@ const serialize = {
 	 */
 	toBuffer: serializeToBuffer
 };
-
-module.exports = serialize;

--- a/client/rest/src/catapult-sdk/modelBinary/sizes.js
+++ b/client/rest/src/catapult-sdk/modelBinary/sizes.js
@@ -21,7 +21,7 @@
 
 /** @module modelBinary/sizes */
 
-const sizes = {
+export default {
 	/**
 	 * @property {number} Size of a signature.
 	 */
@@ -61,5 +61,3 @@ const sizes = {
 		scalar: 32
 	}
 };
-
-module.exports = sizes;

--- a/client/rest/src/catapult-sdk/modelBinary/transactionCodec.js
+++ b/client/rest/src/catapult-sdk/modelBinary/transactionCodec.js
@@ -21,7 +21,7 @@
 
 /** @module modelBinary/transactionCodec */
 
-const transactionCodec = {
+export default {
 	/**
 	 * Parses a transaction.
 	 * @param {object} parser Parser.
@@ -44,5 +44,3 @@ const transactionCodec = {
 		serializer.writeUint64(transaction.deadline);
 	}
 };
-
-module.exports = transactionCodec;

--- a/client/rest/src/catapult-sdk/modelBinary/verifiableEntityCodec.js
+++ b/client/rest/src/catapult-sdk/modelBinary/verifiableEntityCodec.js
@@ -20,11 +20,11 @@
  */
 
 /** @module modelBinary/verifiableEntityCodec */
-const sizes = require('./sizes');
+import sizes from './sizes.js';
 
 const constants = { sizes };
 
-const verifiableEntityCodec = {
+export default {
 	/**
 	 * Parses a verifiable entity.
 	 * @param {object} parser Parser.
@@ -57,5 +57,3 @@ const verifiableEntityCodec = {
 		serializer.writeUint16(entity.type);
 	}
 };
-
-module.exports = verifiableEntityCodec;

--- a/client/rest/src/catapult-sdk/packet/PacketType.js
+++ b/client/rest/src/catapult-sdk/packet/PacketType.js
@@ -27,7 +27,7 @@ const statePathBaseType = 0x200;
  * Packet types.
  * @enum {number}
  */
-const PacketType = {
+export const PacketType = {
 	/** A challenge from a server to a client. */
 	serverChallenge: 1,
 
@@ -74,17 +74,14 @@ const PacketType = {
 	mosaicRestrictionsStatePath: statePathBaseType + 0x51
 };
 
-module.exports = {
-	PacketType,
-	StatePathPacketTypes: [
-		PacketType.accountStatePath,
-		PacketType.hashLockStatePath,
-		PacketType.secretLockStatePath,
-		PacketType.metadataStatePath,
-		PacketType.mosaicStatePath,
-		PacketType.multisigStatePath,
-		PacketType.namespaceStatePath,
-		PacketType.accountRestrictionsStatePath,
-		PacketType.mosaicRestrictionsStatePath
-	]
-};
+export const StatePathPacketTypes = [
+	PacketType.accountStatePath,
+	PacketType.hashLockStatePath,
+	PacketType.secretLockStatePath,
+	PacketType.metadataStatePath,
+	PacketType.mosaicStatePath,
+	PacketType.multisigStatePath,
+	PacketType.namespaceStatePath,
+	PacketType.accountRestrictionsStatePath,
+	PacketType.mosaicRestrictionsStatePath
+];

--- a/client/rest/src/catapult-sdk/packet/header.js
+++ b/client/rest/src/catapult-sdk/packet/header.js
@@ -39,4 +39,4 @@ const packetHeader = {
 	}
 };
 
-module.exports = packetHeader;
+export default packetHeader;

--- a/client/rest/src/catapult-sdk/parser/BinaryParser.js
+++ b/client/rest/src/catapult-sdk/parser/BinaryParser.js
@@ -110,7 +110,7 @@ class BufferContainer {
 /**
  * Accepts and buffers binary data and provides an interface for reading from it.
  */
-class BinaryParser {
+export default class BinaryParser {
 	/**
 	 * Creates a binary parser.
 	 */
@@ -176,5 +176,3 @@ class BinaryParser {
 		return this.buffers.size();
 	}
 }
-
-module.exports = BinaryParser;

--- a/client/rest/src/catapult-sdk/parser/PacketParser.js
+++ b/client/rest/src/catapult-sdk/parser/PacketParser.js
@@ -20,8 +20,8 @@
  */
 
 /** @module parser/PacketParser */
-const BinaryParser = require('./BinaryParser');
-const EventEmitter = require('events');
+import BinaryParser from './BinaryParser.js';
+import EventEmitter from 'events';
 
 const Packet_Header_Size = 8;
 
@@ -86,7 +86,7 @@ class PacketParserImpl {
 /**
  * Accepts and buffers binary data and emits events when full packets have been received.
  */
-class PacketParser {
+export default class PacketParser {
 	/**
 	 * Creates a packet parser.
 	 */
@@ -110,5 +110,3 @@ class PacketParser {
 		this.impl.emitter.on('packet', handler);
 	}
 }
-
-module.exports = PacketParser;

--- a/client/rest/src/catapult-sdk/plugins/CatapultPlugin.js
+++ b/client/rest/src/catapult-sdk/plugins/CatapultPlugin.js
@@ -29,7 +29,7 @@
  * Adds support for a particular subsystem.
  * @interface
  */
-const CatapultPlugin = {
+export default {
 	/**
 	 * Registers schema extensions.
 	 * @instance
@@ -46,4 +46,3 @@ const CatapultPlugin = {
 };
 
 /* eslint-enable */
-module.exports = CatapultPlugin;

--- a/client/rest/src/catapult-sdk/plugins/accountLink.js
+++ b/client/rest/src/catapult-sdk/plugins/accountLink.js
@@ -20,9 +20,9 @@
  */
 
 /** @module plugins/accountLink */
-const EntityType = require('../model/EntityType');
-const ModelType = require('../model/ModelType');
-const sizes = require('../modelBinary/sizes');
+import EntityType from '../model/EntityType.js';
+import ModelType from '../model/ModelType.js';
+import sizes from '../modelBinary/sizes.js';
 
 const constants = { sizes };
 
@@ -30,7 +30,7 @@ const constants = { sizes };
  * Creates an accountLink plugin.
  * @type {module:plugins/CatapultPlugin}
  */
-const accountLinkPlugin = {
+export default {
 	registerSchema: builder => {
 		builder.addTransactionSupport(EntityType.accountLink, {
 			linkedPublicKey: ModelType.binary,
@@ -117,5 +117,3 @@ const accountLinkPlugin = {
 		});
 	}
 };
-
-module.exports = accountLinkPlugin;

--- a/client/rest/src/catapult-sdk/plugins/aggregate.js
+++ b/client/rest/src/catapult-sdk/plugins/aggregate.js
@@ -20,11 +20,11 @@
  */
 
 /** @module plugins/aggregate */
-const EntityType = require('../model/EntityType');
-const ModelType = require('../model/ModelType');
-const embeddedEntityCodec = require('../modelBinary/embeddedEntityCodec');
-const sizes = require('../modelBinary/sizes');
-const SerializedSizeCalculator = require('../serializer/SerializedSizeCalculator');
+import EntityType from '../model/EntityType.js';
+import ModelType from '../model/ModelType.js';
+import embeddedEntityCodec from '../modelBinary/embeddedEntityCodec.js';
+import sizes from '../modelBinary/sizes.js';
+import SerializedSizeCalculator from '../serializer/SerializedSizeCalculator.js';
 
 const constants = { sizes: {} };
 Object.assign(constants.sizes, sizes, {
@@ -93,7 +93,7 @@ const innerAggregateTxPaddingSize = innerTransactionSize => {
  * Creates an aggregate plugin.
  * @type {module:plugins/CatapultPlugin}
  */
-const aggregatePlugin = {
+export default {
 	registerSchema: builder => {
 		const aggregateSchema = {
 			transactionsHash: ModelType.binary,
@@ -219,5 +219,3 @@ const aggregatePlugin = {
 		codecBuilder.addTransactionSupport(EntityType.aggregateBonded, aggregateBuilder);
 	}
 };
-
-module.exports = aggregatePlugin;

--- a/client/rest/src/catapult-sdk/plugins/catapultModelSystem.js
+++ b/client/rest/src/catapult-sdk/plugins/catapultModelSystem.js
@@ -20,20 +20,20 @@
  */
 
 /** @module plugins/catapultModelSystem */
-const accountLink = require('./accountLink');
-const aggregate = require('./aggregate');
-const lockHash = require('./lockHash');
-const lockSecret = require('./lockSecret');
-const metadata = require('./metadata');
-const mosaic = require('./mosaic');
-const multisig = require('./multisig');
-const namespace = require('./namespace');
-const receipts = require('./receipts');
-const restrictions = require('./restrictions');
-const transfer = require('./transfer');
-const ModelFormatterBuilder = require('../model/ModelFormatterBuilder');
-const ModelSchemaBuilder = require('../model/ModelSchemaBuilder');
-const ModelCodecBuilder = require('../modelBinary/ModelCodecBuilder');
+import accountLink from './accountLink.js';
+import aggregate from './aggregate.js';
+import lockHash from './lockHash.js';
+import lockSecret from './lockSecret.js';
+import metadata from './metadata.js';
+import mosaic from './mosaic.js';
+import multisig from './multisig.js';
+import namespace from './namespace.js';
+import receipts from './receipts.js';
+import restrictions from './restrictions.js';
+import transfer from './transfer.js';
+import ModelFormatterBuilder from '../model/ModelFormatterBuilder.js';
+import ModelSchemaBuilder from '../model/ModelSchemaBuilder.js';
+import ModelCodecBuilder from '../modelBinary/ModelCodecBuilder.js';
 
 const plugins = {
 	accountLink,
@@ -54,7 +54,7 @@ const plugins = {
  * @class CatapultModelSystem
  * @property {object} schema Complete schema information.
  */
-const catapultModelSystem = {
+export default {
 	/**
 	 * Gets the names of all supported plugins.
 	 * @returns {Array<string>} Names of all supported plugins.
@@ -102,5 +102,3 @@ const catapultModelSystem = {
 		};
 	}
 };
-
-module.exports = catapultModelSystem;

--- a/client/rest/src/catapult-sdk/plugins/lockHash.js
+++ b/client/rest/src/catapult-sdk/plugins/lockHash.js
@@ -20,9 +20,9 @@
  */
 
 /** @module plugins/lockHash */
-const EntityType = require('../model/EntityType');
-const ModelType = require('../model/ModelType');
-const sizes = require('../modelBinary/sizes');
+import EntityType from '../model/EntityType.js';
+import ModelType from '../model/ModelType.js';
+import sizes from '../modelBinary/sizes.js';
 
 const constants = { sizes };
 
@@ -30,7 +30,7 @@ const constants = { sizes };
  * Creates a lock hash plugin.
  * @type {module:plugins/CatapultPlugin}
  */
-const lockHashPlugin = {
+export default {
 	registerSchema: builder => {
 		builder.addSchema('hashLockInfo', {
 			id: ModelType.objectId,
@@ -74,5 +74,3 @@ const lockHashPlugin = {
 		});
 	}
 };
-
-module.exports = lockHashPlugin;

--- a/client/rest/src/catapult-sdk/plugins/lockSecret.js
+++ b/client/rest/src/catapult-sdk/plugins/lockSecret.js
@@ -20,9 +20,9 @@
  */
 
 /** @module plugins/lockSecret */
-const EntityType = require('../model/EntityType');
-const ModelType = require('../model/ModelType');
-const sizes = require('../modelBinary/sizes');
+import EntityType from '../model/EntityType.js';
+import ModelType from '../model/ModelType.js';
+import sizes from '../modelBinary/sizes.js';
 
 const constants = { sizes };
 
@@ -30,7 +30,7 @@ const constants = { sizes };
  * Creates a lock secret plugin.
  * @type {module:plugins/CatapultPlugin}
  */
-const lockSecretPlugin = {
+export default {
 	registerSchema: builder => {
 		builder.addSchema('secretLockInfo', {
 			id: ModelType.objectId,
@@ -109,5 +109,3 @@ const lockSecretPlugin = {
 		});
 	}
 };
-
-module.exports = lockSecretPlugin;

--- a/client/rest/src/catapult-sdk/plugins/metadata.js
+++ b/client/rest/src/catapult-sdk/plugins/metadata.js
@@ -20,10 +20,10 @@
  */
 
 /** @module plugins/metadata */
-const EntityType = require('../model/EntityType');
-const ModelType = require('../model/ModelType');
-const sizes = require('../modelBinary/sizes');
-const convert = require('../utils/convert');
+import EntityType from '../model/EntityType.js';
+import ModelType from '../model/ModelType.js';
+import sizes from '../modelBinary/sizes.js';
+import convert from '../utils/convert.js';
 
 const constants = { sizes };
 
@@ -31,7 +31,7 @@ const constants = { sizes };
  * Creates a metadata plugin.
  * @type {module:plugins/CatapultPlugin}
  */
-const metadataPlugin = {
+export default {
 	registerSchema: builder => {
 		builder.addTransactionSupport(EntityType.accountMetadata, {
 			targetAddress: ModelType.encodedAddress,
@@ -149,5 +149,3 @@ const metadataPlugin = {
 		});
 	}
 };
-
-module.exports = metadataPlugin;

--- a/client/rest/src/catapult-sdk/plugins/mosaic.js
+++ b/client/rest/src/catapult-sdk/plugins/mosaic.js
@@ -20,16 +20,16 @@
  */
 
 /** @module plugins/mosaic */
-const EntityType = require('../model/EntityType');
-const ModelType = require('../model/ModelType');
-const sizes = require('../modelBinary/sizes');
+import EntityType from '../model/EntityType.js';
+import ModelType from '../model/ModelType.js';
+import sizes from '../modelBinary/sizes.js';
 
 const constants = { sizes };
 /**
  * Creates a mosaic plugin.
  * @type {module:plugins/CatapultPlugin}
  */
-const mosaicPlugin = {
+export default {
 	registerSchema: builder => {
 		builder.addTransactionSupport(EntityType.mosaicDefinition, {
 			id: ModelType.uint64HexIdentifier,
@@ -123,5 +123,3 @@ const mosaicPlugin = {
 		});
 	}
 };
-
-module.exports = mosaicPlugin;

--- a/client/rest/src/catapult-sdk/plugins/multisig.js
+++ b/client/rest/src/catapult-sdk/plugins/multisig.js
@@ -20,10 +20,10 @@
  */
 
 /** @module plugins/multisig */
-const EntityType = require('../model/EntityType');
-const ModelType = require('../model/ModelType');
-const sizes = require('../modelBinary/sizes');
-const convert = require('../utils/convert');
+import EntityType from '../model/EntityType.js';
+import ModelType from '../model/ModelType.js';
+import sizes from '../modelBinary/sizes.js';
+import convert from '../utils/convert.js';
 
 const constants = { sizes };
 
@@ -31,7 +31,7 @@ const constants = { sizes };
  * Creates a multisig plugin.
  * @type {module:plugins/CatapultPlugin}
  */
-const multisigPlugin = {
+export default {
 	registerSchema: builder => {
 		builder.addTransactionSupport(EntityType.modifyMultisigAccount, {
 			minRemovalDelta: ModelType.int,
@@ -96,5 +96,3 @@ const multisigPlugin = {
 		});
 	}
 };
-
-module.exports = multisigPlugin;

--- a/client/rest/src/catapult-sdk/plugins/namespace.js
+++ b/client/rest/src/catapult-sdk/plugins/namespace.js
@@ -20,9 +20,9 @@
  */
 
 /** @module plugins/namespace */
-const EntityType = require('../model/EntityType');
-const ModelType = require('../model/ModelType');
-const sizes = require('../modelBinary/sizes');
+import EntityType from '../model/EntityType.js';
+import ModelType from '../model/ModelType.js';
+import sizes from '../modelBinary/sizes.js';
 
 const constants = { sizes };
 
@@ -43,7 +43,7 @@ const getAliasBasicType = type => AliasType[type] || 'namespaceDescriptor.alias.
  * Creates a namespace plugin.
  * @type {module:plugins/CatapultPlugin}
  */
-const namespacePlugin = {
+export default {
 	registerSchema: builder => {
 		builder.addTransactionSupport(EntityType.aliasAddress, {
 			namespaceId: ModelType.uint64HexIdentifier,
@@ -187,5 +187,3 @@ const namespacePlugin = {
 		});
 	}
 };
-
-module.exports = namespacePlugin;

--- a/client/rest/src/catapult-sdk/plugins/receipts.js
+++ b/client/rest/src/catapult-sdk/plugins/receipts.js
@@ -20,7 +20,7 @@
  */
 
 /** @module plugins/receipts */
-const ModelType = require('../model/ModelType');
+import ModelType from '../model/ModelType.js';
 
 // types 2 (balanceCredit), and 3 (balanceDebit) share the schema `receipts.balanceChange`
 const ReceiptType = {
@@ -37,7 +37,7 @@ const getBasicReceiptType = type => ReceiptType[(type & 0xF000) >> 12] || 'recei
  * Creates a receipts plugin.
  * @type {module:plugins/CatapultPlugin}
  */
-const receiptsPlugin = {
+export default {
 	registerSchema: builder => {
 		const addStatementSchema = (statementType, schema) => {
 			const schemaName = `${statementType}Statement`;
@@ -126,5 +126,3 @@ const receiptsPlugin = {
 
 	registerCodecs: () => {}
 };
-
-module.exports = receiptsPlugin;

--- a/client/rest/src/catapult-sdk/plugins/restrictions.js
+++ b/client/rest/src/catapult-sdk/plugins/restrictions.js
@@ -20,9 +20,9 @@
  */
 
 /** @module plugins/restrictions */
-const EntityType = require('../model/EntityType');
-const ModelType = require('../model/ModelType');
-const sizes = require('../modelBinary/sizes');
+import EntityType from '../model/EntityType.js';
+import ModelType from '../model/ModelType.js';
+import sizes from '../modelBinary/sizes.js';
 
 const constants = { sizes };
 
@@ -91,7 +91,7 @@ const accountRestrictionTypeDescriptors = [
  * Creates a restrictions plugin.
  * @type {module:plugins/CatapultPlugin}
  */
-const restrictionsPlugin = {
+export default {
 	AccountRestrictionType: Object.freeze({
 		addressAllow: AccountRestrictionTypeFlags.address,
 		addressBlock: AccountRestrictionTypeFlags.address + accountRestrictionTypeBlockOffset,
@@ -264,5 +264,3 @@ const restrictionsPlugin = {
 		});
 	}
 };
-
-module.exports = restrictionsPlugin;

--- a/client/rest/src/catapult-sdk/plugins/transfer.js
+++ b/client/rest/src/catapult-sdk/plugins/transfer.js
@@ -20,9 +20,9 @@
  */
 
 /** @module plugins/transfer */
-const EntityType = require('../model/EntityType');
-const ModelType = require('../model/ModelType');
-const sizes = require('../modelBinary/sizes');
+import EntityType from '../model/EntityType.js';
+import ModelType from '../model/ModelType.js';
+import sizes from '../modelBinary/sizes.js';
 
 const constants = { sizes };
 
@@ -30,7 +30,7 @@ const constants = { sizes };
  * Creates a transfer plugin.
  * @type {module:plugins/CatapultPlugin}
  */
-const transferPlugin = {
+export default {
 	registerSchema: builder => {
 		builder.addTransactionSupport(EntityType.transfer, {
 			recipientAddress: ModelType.encodedAddress,
@@ -90,5 +90,3 @@ const transferPlugin = {
 		});
 	}
 };
-
-module.exports = transferPlugin;

--- a/client/rest/src/catapult-sdk/serializer/BinarySerializer.js
+++ b/client/rest/src/catapult-sdk/serializer/BinarySerializer.js
@@ -68,7 +68,7 @@ class BufferContainer {
 /**
  * Provides an interface for writing to a fixed size buffer.
  */
-class BinarySerializer {
+export default class BinarySerializer {
 	/**
 	 * Creates a binary serializer.
 	 * @param {number} size Size of the underlying fixed size buffer.
@@ -136,5 +136,3 @@ class BinarySerializer {
 		this.container.writeBuffer(buffer);
 	}
 }
-
-module.exports = BinarySerializer;

--- a/client/rest/src/catapult-sdk/serializer/SerializedSizeCalculator.js
+++ b/client/rest/src/catapult-sdk/serializer/SerializedSizeCalculator.js
@@ -24,7 +24,7 @@
 /**
  * Calculates serialized size using builder pattern.
  */
-class SerializedSizeCalculator {
+export default class SerializedSizeCalculator {
 	/**
 	 * Creates a serialized size calculator.
 	 */
@@ -76,5 +76,3 @@ class SerializedSizeCalculator {
 		this.totalSize += buffer.length;
 	}
 }
-
-module.exports = SerializedSizeCalculator;

--- a/client/rest/src/catapult-sdk/utils/CachedFileLoader.js
+++ b/client/rest/src/catapult-sdk/utils/CachedFileLoader.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const fs = require('fs');
-const util = require('util');
+import fs from 'fs';
+import util from 'util';
 
 const readFile = util.promisify(fs.readFile);
 const stat = util.promisify(fs.stat);
@@ -28,7 +28,7 @@ const stat = util.promisify(fs.stat);
 /**
  * Loads and caches files.
  */
-class CachedFileLoader {
+export default class CachedFileLoader {
 	/**
 	 * Creates a cached file loader.
 	 */
@@ -90,5 +90,3 @@ class CachedFileLoader {
 			});
 	}
 }
-
-module.exports = CachedFileLoader;

--- a/client/rest/src/catapult-sdk/utils/SchemaType.js
+++ b/client/rest/src/catapult-sdk/utils/SchemaType.js
@@ -25,7 +25,7 @@
  * Basic schema property types.
  * @enum {number}
  */
-const SchemaType = {
+export default {
 	/** Default schema property type. */
 	none: 0,
 
@@ -41,5 +41,3 @@ const SchemaType = {
 	/** Maximum value in this enumeration. */
 	max: 3
 };
-
-module.exports = SchemaType;

--- a/client/rest/src/catapult-sdk/utils/arrayUtils.js
+++ b/client/rest/src/catapult-sdk/utils/arrayUtils.js
@@ -21,7 +21,7 @@
 
 /** @module utils/array */
 
-const arrayUtils = {
+export default {
 	/**
 	 * Creates a Uint8Array view on top of input.
 	 * @param {ArrayBuffer|Uint8Array} input Input array.
@@ -84,5 +84,3 @@ const arrayUtils = {
 		return true;
 	}
 };
-
-module.exports = arrayUtils;

--- a/client/rest/src/catapult-sdk/utils/base32.js
+++ b/client/rest/src/catapult-sdk/utils/base32.js
@@ -20,7 +20,7 @@
  */
 
 /** @module utils/base32 */
-const charMapping = require('./charMapping');
+import charMapping from './charMapping.js';
 
 const Alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
 const Decoded_Block_Size = 5;
@@ -72,7 +72,7 @@ const decodeBlock = (input, inputOffset, output, outputOffset) => {
 
 // endregion
 
-const base32 = {
+export default {
 	/**
 	 * Base32 encodes a binary buffer.
 	 * @param {Uint8Array} data Binary data to encode.
@@ -105,5 +105,3 @@ const base32 = {
 		return output;
 	}
 };
-
-module.exports = base32;

--- a/client/rest/src/catapult-sdk/utils/charMapping.js
+++ b/client/rest/src/catapult-sdk/utils/charMapping.js
@@ -27,7 +27,7 @@
  * @property {object} map Character map.
  */
 
-const charMapping = {
+export default {
 	/**
 	 * Creates a builder for building a character map.
 	 * @returns {module:utils/charMapping~CharacterMapBuilder} A character map builder.
@@ -55,5 +55,3 @@ const charMapping = {
 		};
 	}
 };
-
-module.exports = charMapping;

--- a/client/rest/src/catapult-sdk/utils/convert.js
+++ b/client/rest/src/catapult-sdk/utils/convert.js
@@ -19,7 +19,7 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const charMapping = require('./charMapping');
+import charMapping from './charMapping.js';
 
 const Char_To_Nibble_Map = (() => {
 	const builder = charMapping.createBuilder();
@@ -221,4 +221,4 @@ const convert = {
 	}
 };
 
-module.exports = convert;
+export default convert;

--- a/client/rest/src/catapult-sdk/utils/formattingUtils.js
+++ b/client/rest/src/catapult-sdk/utils/formattingUtils.js
@@ -21,7 +21,7 @@
 
 /** @module utils/formattingUtils */
 
-const formattingUtils = {
+export default {
 	/**
 	 * Formats all the entities in an array.
 	 * @param {module:utils/schemaFormatter~EntityFormatter} formatter Formatter.
@@ -49,5 +49,3 @@ const formattingUtils = {
 		};
 	}
 };
-
-module.exports = formattingUtils;

--- a/client/rest/src/catapult-sdk/utils/future.js
+++ b/client/rest/src/catapult-sdk/utils/future.js
@@ -21,7 +21,7 @@
 
 /** @module utils/future */
 
-const future = {
+export default {
 	/**
 	 * Makes a future retryable.
 	 * @param {Function} futureSupplier Function that returns a new instance of the wrapped future.
@@ -53,5 +53,3 @@ const future = {
 		});
 	}
 };
-
-module.exports = future;

--- a/client/rest/src/catapult-sdk/utils/objects.js
+++ b/client/rest/src/catapult-sdk/utils/objects.js
@@ -71,4 +71,4 @@ const objects = {
 	}
 };
 
-module.exports = objects;
+export default objects;

--- a/client/rest/src/catapult-sdk/utils/schemaFormatter.js
+++ b/client/rest/src/catapult-sdk/utils/schemaFormatter.js
@@ -20,7 +20,7 @@
  */
 
 /** @module utils/schemaFormatter */
-const SchemaType = require('./SchemaType');
+import SchemaType from './SchemaType.js';
 
 // if 'definition' is a number, it is the type
 // otherwise, it is an object with an optional type property (default type is undefined)
@@ -102,4 +102,4 @@ const schemaFormatter = {
 	}
 };
 
-module.exports = schemaFormatter;
+export default schemaFormatter;

--- a/client/rest/src/catapult-sdk/utils/uint64.js
+++ b/client/rest/src/catapult-sdk/utils/uint64.js
@@ -21,8 +21,8 @@
 
 /** @module utils/uint64 */
 
-const convert = require('./convert');
-const Long = require('long');
+import convert from './convert.js';
+import Long from 'long';
 
 const readUint32At = (bytes, i) => (bytes[i] + (bytes[i + 1] << 8) + (bytes[i + 2] << 16) + (bytes[i + 3] << 24)) >>> 0;
 
@@ -32,7 +32,7 @@ const readUint32At = (bytes, i) => (bytes[i] + (bytes[i + 1] << 8) + (bytes[i + 
  * @property {number} 0 Low 32bit value.
  * @property {number} 1 High 32bit value.
  */
-const uint64Module = {
+export default {
 	/**
 	 * Tries to compact a uint64 into a simple numeric.
 	 * @param {module:utils/uint64~uint64} uint64 A uint64 value.
@@ -171,5 +171,3 @@ const uint64Module = {
 		return ([result.getLowBitsUnsigned(), result.getHighBitsUnsigned()]);
 	}
 };
-
-module.exports = uint64Module;

--- a/client/rest/src/connection/MessageChannelBuilder.js
+++ b/client/rest/src/connection/MessageChannelBuilder.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { ServerMessageHandler } = require('./serverMessageHandlers');
-const catapult = require('../catapult-sdk/index');
+import ServerMessageHandler from './serverMessageHandlers.js';
+import catapult from '../catapult-sdk/index.js';
 
 const createBlockDescriptor = (marker, handler) => ({
 	filter: topicParam => {
@@ -53,7 +53,7 @@ const createPolicyBasedAddressFilter = (markerByte, emptyAddressHandler, network
 /**
  * Builder for creating message channel information.
  */
-class MessageChannelBuilder {
+export default class MessageChannelBuilder {
 	/**
 	 * Creates a builder.
 	 * @param {object} config Message queue configuration.
@@ -116,5 +116,3 @@ class MessageChannelBuilder {
 		return this.descriptors;
 	}
 }
-
-module.exports = MessageChannelBuilder;

--- a/client/rest/src/connection/catapultConnection.js
+++ b/client/rest/src/connection/catapultConnection.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../catapult-sdk/index');
-const errors = require('../server/errors');
+import catapult from '../catapult-sdk/index.js';
+import errors from '../server/errors.js';
 
 const { PacketParser } = catapult.parser;
 
@@ -30,7 +30,7 @@ const rejectOnClose = reject => () => reject(errors.createServiceUnavailableErro
  * A catapult connection for interacting with api nodes.
  * @class CatapultConnection
  */
-module.exports = {
+export default {
 	/**
 	 * Wraps a catapult connection around a socket connection.
 	 * @param {object} connection Socket connection to wrap.

--- a/client/rest/src/connection/connectionService.js
+++ b/client/rest/src/connection/connectionService.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapultConnection = require('./catapultConnection');
-const errors = require('../server/errors');
-const tls = require('tls');
+import catapultConnection from './catapultConnection.js';
+import errors from '../server/errors.js';
+import tls from 'tls';
 
 /**
  * Creates a catapult connection service for connecting to catapult servers.
@@ -31,7 +31,7 @@ const tls = require('tls');
  * @param {Function} logger A logging function.
  * @returns {object} Catapult connection service.
  */
-module.exports.createConnectionService = (config, logger = () => {}) => {
+export default (config, logger = () => {}) => {
 	const node = config.apiNode;
 	const aliveConnections = {};
 	// the connection is not persisted until authentication is done, and this may take a while,

--- a/client/rest/src/connection/serverMessageHandlers.js
+++ b/client/rest/src/connection/serverMessageHandlers.js
@@ -19,7 +19,7 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../catapult-sdk/index');
+import catapult from '../catapult-sdk/index.js';
 
 const { uint64 } = catapult.utils;
 
@@ -29,7 +29,7 @@ const parserFromData = binaryData => {
 	return parser;
 };
 
-const ServerMessageHandler = Object.freeze({
+export default Object.freeze({
 	block: (codec, emit) => (topic, binaryBlock, hash, generationHash) => {
 		const block = codec.deserialize(parserFromData(binaryBlock));
 		emit({ type: 'blockHeaderWithMetadata', payload: { block, meta: { hash, generationHash } } });
@@ -69,7 +69,3 @@ const ServerMessageHandler = Object.freeze({
 		emit({ type: 'transactionStatus', payload: { hash, code, deadline } });
 	}
 });
-
-module.exports = {
-	ServerMessageHandler
-};

--- a/client/rest/src/connection/zmqService.js
+++ b/client/rest/src/connection/zmqService.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const zmqUtils = require('./zmqUtils');
-const zmq = require('zeromq');
+import zmqUtils from './zmqUtils.js';
+import zmq from 'zeromq';
 
 const createZmqSocket = (key, zmqConfig, logger, currentSocketCount) => {
 	const zsocket = zmq.socket('sub');
@@ -51,7 +51,7 @@ const findSubscriptionInfo = (key, emitter, codec, channelDescriptors) => {
  * @param {object} logger Level-based logger object.
  * @returns {object} Newly created zmq connection service that is a stripped down EventEmitter.
  */
-module.exports.createZmqConnectionService = (zmqConfig, codec, channelDescriptors, logger) =>
+export default (zmqConfig, codec, channelDescriptors, logger) =>
 	zmqUtils.createMultisocketEmitter((key, emitter, currentSocketCount) => {
 		if (currentSocketCount === (!zmqConfig.maxSubscriptions ? 500 : zmqConfig.maxSubscriptions))
 			throw new Error('Max subscriptions reached.');

--- a/client/rest/src/connection/zmqUtils.js
+++ b/client/rest/src/connection/zmqUtils.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const zmq = require('zeromq');
-const EventEmitter = require('events');
+import zmq from 'zeromq';
+import EventEmitter from 'events';
 
 const logAllMonitorEvents = (zsocket, throttle, logger) => {
 	const eventNameLevelPairs = {
@@ -59,7 +59,7 @@ const logAllMonitorEvents = (zsocket, throttle, logger) => {
 	});
 };
 
-module.exports = {
+export default {
 	/**
 	 * Prepares a zmq socket for a connection.
 	 * @param {zmq.Socket} zsocket Zmq socket.

--- a/client/rest/src/db/CatapultDb.js
+++ b/client/rest/src/db/CatapultDb.js
@@ -21,11 +21,11 @@
 
 /** @module db/CatapultDb */
 
-const connector = require('./connector');
-const { convertToLong, buildOffsetCondition, uniqueLongList } = require('./dbUtils');
-const catapult = require('../catapult-sdk/index');
-const MultisigDb = require('../plugins/multisig/MultisigDb');
-const MongoDb = require('mongodb');
+import connector from './connector.js';
+import { buildOffsetCondition, convertToLong, uniqueLongList } from './dbUtils.js';
+import catapult from '../catapult-sdk/index.js';
+import MultisigDb from '../plugins/multisig/MultisigDb.js';
+import MongoDb from 'mongodb';
 
 const { EntityType } = catapult.model;
 const { ObjectId } = MongoDb;
@@ -97,7 +97,7 @@ const TransactionGroup = Object.freeze({
 	partial: 'partialTransactions'
 });
 
-class CatapultDb {
+export default class CatapultDb {
 	// region construction / connect / disconnect
 
 	constructor(options) {
@@ -655,5 +655,3 @@ class CatapultDb {
 
 	// endregion
 }
-
-module.exports = CatapultDb;

--- a/client/rest/src/db/connector.js
+++ b/client/rest/src/db/connector.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const MongoDb = require('mongodb');
-const winston = require('winston');
+import MongoDb from 'mongodb';
+import winston from 'winston';
 
-const connector = {
+export default {
 	connectToDatabase(url, dbName, connectionPoolSize, timeout) {
 		const connectionString = `${url}${dbName}`;
 		return MongoDb.MongoClient.connect(connectionString, {
@@ -37,5 +37,3 @@ const connector = {
 			});
 	}
 };
-
-module.exports = connector;

--- a/client/rest/src/db/dbFormattingRules.js
+++ b/client/rest/src/db/dbFormattingRules.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { longToUint64, bufferToUnresolvedAddress } = require('./dbUtils');
-const catapult = require('../catapult-sdk/index');
-const { Binary } = require('mongodb');
+import { bufferToUnresolvedAddress, longToUint64 } from './dbUtils.js';
+import catapult from '../catapult-sdk/index.js';
+import { Binary } from 'mongodb';
 
 const { ModelType, status } = catapult.model;
 const { convert, uint64 } = catapult.utils;
@@ -35,7 +35,7 @@ const { convert, uint64 } = catapult.utils;
  * this has not been decoupled yet.
  */
 
-module.exports = {
+export default {
 	[ModelType.none]: value => value,
 	[ModelType.binary]: value => (convert.uint8ToHex(value.buffer instanceof ArrayBuffer ? value : value.buffer)),
 	[ModelType.objectId]: value => (undefined === value ? '' : value.toHexString().toUpperCase()),

--- a/client/rest/src/db/dbUtils.js
+++ b/client/rest/src/db/dbUtils.js
@@ -19,14 +19,19 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../catapult-sdk/index');
-const errors = require('../server/errors');
-const MongoDb = require('mongodb');
+import catapult from '../catapult-sdk/index.js';
+import errors from '../server/errors.js';
+import MongoDb from 'mongodb';
 
 const { Long, ObjectId } = MongoDb;
 const { address } = catapult.model;
 
-const convertToLong = value => {
+/**
+ * Converts number to long.
+ * @param {object} value Value to convert.
+ * @returns {MongoDb.Long} Converted value.
+ */
+export const convertToLong = value => {
 	if (Number.isInteger(value))
 		return Long.fromNumber(value);
 
@@ -40,75 +45,65 @@ const convertToLong = value => {
 	throw errors.createInvalidArgumentError(`${value} has an invalid format: not integer or uint64`);
 };
 
-const dbUtils = {
-	/**
-	 * Converts number to long.
-	 * @param {object} value Value to convert.
-	 * @returns {MongoDb.Long} Converted value.
-	 */
-	convertToLong,
+/**
+ * Converts long to uint64.
+ * @param {Long} value Value to convert.
+ * @returns {module:utils/uint64~uint64} Converted value.
+ */
+export const longToUint64 = value => {
+	if (value instanceof Long)
+		return [value.getLowBitsUnsigned(), value.getHighBits() >>> 0];
 
-	/**
-	 * Converts long to uint64.
-	 * @param {Long} value Value to convert.
-	 * @returns {module:utils/uint64~uint64} Converted value.
-	 */
-	longToUint64: value => {
-		if (value instanceof Long)
-			return [value.getLowBitsUnsigned(), value.getHighBits() >>> 0];
-
-		throw errors.createInvalidArgumentError(`${value} has an invalid format: not long`);
-	},
-
-	/**
-	 * Generates an offset condition depending on the offset type, and sorting options provided.
-	 * @param {object} options Sorting options, must contain `offset`, `offsetType`, `sortField`, and `sortDirection`.
-	 * @param {object} sortFieldDbRelation Determines the database path of the provided sort field.
-	 * @returns {object} Offset condition if offset was provided, otherwise returns undefined.
-	 */
-	buildOffsetCondition: (options, sortFieldDbRelation) => {
-		const offsetTypeToDbObject = {
-			objectId: objectIdString => new ObjectId(objectIdString),
-			uint64: convertToLong,
-			uint64Hex: convertToLong
-		};
-
-		if (undefined !== options.offset) {
-			const offsetRequiresParsing = Object.keys(offsetTypeToDbObject).includes(options.offsetType);
-			const offset = offsetRequiresParsing ? offsetTypeToDbObject[options.offsetType](options.offset) : options.offset;
-			return { [sortFieldDbRelation[options.sortField]]: { [1 === options.sortDirection ? '$gt' : '$lt']: offset } };
-		}
-		return undefined;
-	},
-
-	/**
-	 * Formats binary to a base32 address or hex address
-	 * @param {MongoDb.Binary} binary Address|NamespaceId from MongoDb.
-	 * @param {boolean} formatAddressUsingBase32 if base32 format should be used when formatting an address. Hex otherwise.
-	 * @returns {string} the address in base32 format or hex format depending on formatAddressUsingBase32
-	 */
-	bufferToUnresolvedAddress: (binary, formatAddressUsingBase32) => {
-		if (!binary)
-			return undefined;
-
-		const getBuffer = () => {
-			if ((binary instanceof MongoDb.Binary))
-				return binary.buffer;
-
-			if ((binary instanceof Uint8Array))
-				return binary;
-
-			throw new Error(`Cannot convert binary address, unknown ${binary.constructor.name} type`);
-		};
-		return formatAddressUsingBase32 ? address.addressToString(getBuffer()) : catapult.utils.convert.uint8ToHex(getBuffer());
-	},
-
-	/**
-	 * Creates copy of the array without duplicated longs.
-	 * @param {Long[]} duplicatedIds of {Long} objects.
-	 * @returns {Long[]} copy of the original list without duplicated values.
-	 */
-	uniqueLongList: duplicatedIds => duplicatedIds.filter((height, index) =>
-		index === duplicatedIds.findIndex(anotherHeight => anotherHeight.equals(height)))
+	throw errors.createInvalidArgumentError(`${value} has an invalid format: not long`);
 };
-module.exports = dbUtils;
+
+/**
+ * Generates an offset condition depending on the offset type, and sorting options provided.
+ * @param {object} options Sorting options, must contain `offset`, `offsetType`, `sortField`, and `sortDirection`.
+ * @param {object} sortFieldDbRelation Determines the database path of the provided sort field.
+ * @returns {object} Offset condition if offset was provided, otherwise returns undefined.
+ */
+export const buildOffsetCondition = (options, sortFieldDbRelation) => {
+	const offsetTypeToDbObject = {
+		objectId: objectIdString => new ObjectId(objectIdString),
+		uint64: convertToLong,
+		uint64Hex: convertToLong
+	};
+
+	if (undefined !== options.offset) {
+		const offsetRequiresParsing = Object.keys(offsetTypeToDbObject).includes(options.offsetType);
+		const offset = offsetRequiresParsing ? offsetTypeToDbObject[options.offsetType](options.offset) : options.offset;
+		return { [sortFieldDbRelation[options.sortField]]: { [1 === options.sortDirection ? '$gt' : '$lt']: offset } };
+	}
+	return undefined;
+};
+
+/**
+ * Formats binary to a base32 address or hex address
+ * @param {MongoDb.Binary} binary Address|NamespaceId from MongoDb.
+ * @param {boolean} formatAddressUsingBase32 if base32 format should be used when formatting an address. Hex otherwise.
+ * @returns {string} the address in base32 format or hex format depending on formatAddressUsingBase32
+ */
+export const bufferToUnresolvedAddress = (binary, formatAddressUsingBase32) => {
+	if (!binary)
+		return undefined;
+
+	const getBuffer = () => {
+		if ((binary instanceof MongoDb.Binary))
+			return binary.buffer;
+
+		if ((binary instanceof Uint8Array))
+			return binary;
+
+		throw new Error(`Cannot convert binary address, unknown ${binary.constructor.name} type`);
+	};
+	return formatAddressUsingBase32 ? address.addressToString(getBuffer()) : catapult.utils.convert.uint8ToHex(getBuffer());
+};
+
+/**
+ * Creates copy of the array without duplicated longs.
+ * @param {Long[]} duplicatedIds of {Long} objects.
+ * @returns {Long[]} copy of the original list without duplicated values.
+ */
+export const uniqueLongList = duplicatedIds => duplicatedIds.filter((height, index) =>
+	index === duplicatedIds.findIndex(anotherHeight => anotherHeight.equals(height)));

--- a/client/rest/src/db/entityEmitterFactory.js
+++ b/client/rest/src/db/entityEmitterFactory.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const winston = require('winston');
-const EventEmitter = require('events');
+import winston from 'winston';
+import EventEmitter from 'events';
 
-module.exports = {
+export default {
 	createEntityEmitter: createOpEmitter => {
 		const entityEmitter = new EventEmitter();
 		return createOpEmitter({ ns: 'catapult.blocks', op: 'i' })

--- a/client/rest/src/index.js
+++ b/client/rest/src/index.js
@@ -19,19 +19,19 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('./catapult-sdk/index');
-const { createConnectionService } = require('./connection/connectionService');
-const { createZmqConnectionService } = require('./connection/zmqService');
-const CatapultDb = require('./db/CatapultDb');
-const dbFormattingRules = require('./db/dbFormattingRules');
-const routeSystem = require('./plugins/routeSystem');
-const allRoutes = require('./routes/allRoutes');
-const bootstrapper = require('./server/bootstrapper');
-const formatters = require('./server/formatters');
-const messageFormattingRules = require('./server/messageFormattingRules');
-const sshpk = require('sshpk');
-const winston = require('winston');
-const fs = require('fs');
+import catapult from './catapult-sdk/index.js';
+import createConnectionService from './connection/connectionService.js';
+import createZmqConnectionService from './connection/zmqService.js';
+import CatapultDb from './db/CatapultDb.js';
+import dbFormattingRules from './db/dbFormattingRules.js';
+import routeSystem from './plugins/routeSystem.js';
+import allRoutes from './routes/allRoutes.js';
+import bootstrapper from './server/bootstrapper.js';
+import formatters from './server/formatters.js';
+import messageFormattingRules from './server/messageFormattingRules.js';
+import sshpk from 'sshpk';
+import winston from 'winston';
+import fs from 'fs';
 
 const createLoggingTransportConfiguration = loggingConfig => {
 	const transportConfig = Object.assign({}, loggingConfig);

--- a/client/rest/src/plugins/AccountType.js
+++ b/client/rest/src/plugins/AccountType.js
@@ -23,12 +23,10 @@
  * Account id types.
  * @enum {string}
  */
-const AccountType = {
+export default {
 	/** Account id is a public key */
 	publicKey: 'publicKey',
 
 	/** Account id is an address */
 	address: 'address'
 };
-
-module.exports = AccountType;

--- a/client/rest/src/plugins/CatapultRestPlugin.js
+++ b/client/rest/src/plugins/CatapultRestPlugin.js
@@ -37,7 +37,7 @@
  * Adds rest support for a particular subsystem.
  * @interface
  */
-module.exports = {
+export default {
 	/**
 	 * Creates a plugin specific database.
 	 * @instance

--- a/client/rest/src/plugins/aggregate/aggregate.js
+++ b/client/rest/src/plugins/aggregate/aggregate.js
@@ -20,9 +20,9 @@
  */
 
 /** @module plugins/aggregate */
-const aggregateRoutes = require('./aggregateRoutes');
-const catapult = require('../../catapult-sdk/index');
-const { ServerMessageHandler } = require('../../connection/serverMessageHandlers');
+import aggregateRoutes from './aggregateRoutes.js';
+import catapult from '../../catapult-sdk/index.js';
+import ServerMessageHandler from '../../connection/serverMessageHandlers.js';
 
 const { BinaryParser } = catapult.parser;
 
@@ -30,7 +30,7 @@ const { BinaryParser } = catapult.parser;
  * Creates an aggregate plugin.
  * @type {module:plugins/CatapultRestPlugin}
  */
-module.exports = {
+export default {
 	createDb: () => {},
 
 	registerTransactionStates: states => {

--- a/client/rest/src/plugins/aggregate/aggregateRoutes.js
+++ b/client/rest/src/plugins/aggregate/aggregateRoutes.js
@@ -19,13 +19,13 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../catapult-sdk/index');
-const routeUtils = require('../../routes/routeUtils');
+import catapult from '../../catapult-sdk/index.js';
+import routeUtils from '../../routes/routeUtils.js';
 
 const { convert, uint64 } = catapult.utils;
 const { PacketType } = catapult.packet;
 
-module.exports = {
+export default {
 	register: (server, db, services) => {
 		const parseUint64StringToUint8Buffer = numericString => convert.hexToUint8(uint64.toHex(uint64.fromString(numericString)));
 		const parseHexParam = (params, key) => routeUtils.parseArgument(params, key, convert.hexToUint8);

--- a/client/rest/src/plugins/empty.js
+++ b/client/rest/src/plugins/empty.js
@@ -25,7 +25,7 @@
  * Creates an empty plugin.
  * @type {module:plugins/CatapultRestPlugin}
  */
-module.exports = {
+export default {
 	createDb: () => undefined,
 
 	registerTransactionStates: () => {},

--- a/client/rest/src/plugins/lockHash/LockHashDb.js
+++ b/client/rest/src/plugins/lockHash/LockHashDb.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { buildOffsetCondition } = require('../../db/dbUtils');
+import { buildOffsetCondition } from '../../db/dbUtils.js';
 
-class LockHashDb {
+export default class LockHashDb {
 	/**
 	 * Creates LockHashDb around CatapultDb.
 	 * @param {module:db/CatapultDb} db Catapult db instance.
@@ -70,5 +70,3 @@ class LockHashDb {
 
 	// endregion
 }
-
-module.exports = LockHashDb;

--- a/client/rest/src/plugins/lockHash/lockHash.js
+++ b/client/rest/src/plugins/lockHash/lockHash.js
@@ -20,14 +20,14 @@
  */
 
 /** @module plugins/lockHash */
-const LockHashDb = require('./LockHashDb');
-const lockHashRoutes = require('./lockHashRoutes');
+import LockHashDb from './LockHashDb.js';
+import lockHashRoutes from './lockHashRoutes.js';
 
 /**
  * Creates a lock hash plugin.
  * @type {module:plugins/CatapultRestPlugin}
  */
-module.exports = {
+export default {
 	createDb: db => new LockHashDb(db),
 
 	registerTransactionStates: () => {},

--- a/client/rest/src/plugins/lockHash/lockHashRoutes.js
+++ b/client/rest/src/plugins/lockHash/lockHashRoutes.js
@@ -19,13 +19,13 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../catapult-sdk/index');
-const merkleUtils = require('../../routes/merkleUtils');
-const routeUtils = require('../../routes/routeUtils');
+import catapult from '../../catapult-sdk/index.js';
+import merkleUtils from '../../routes/merkleUtils.js';
+import routeUtils from '../../routes/routeUtils.js';
 
 const { PacketType } = catapult.packet;
 
-module.exports = {
+export default {
 	register: (server, db, services) => {
 		const sender = routeUtils.createSender('hashLockInfo');
 

--- a/client/rest/src/plugins/lockSecret/LockSecretDb.js
+++ b/client/rest/src/plugins/lockSecret/LockSecretDb.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { buildOffsetCondition } = require('../../db/dbUtils');
+import { buildOffsetCondition } from '../../db/dbUtils.js';
 
-class LockSecretDb {
+export default class LockSecretDb {
 	/**
 	 * Creates LockSecretDb around CatapultDb.
 	 * @param {module:db/CatapultDb} db Catapult db instance.
@@ -71,5 +71,3 @@ class LockSecretDb {
 
 	// endregion
 }
-
-module.exports = LockSecretDb;

--- a/client/rest/src/plugins/lockSecret/lockSecret.js
+++ b/client/rest/src/plugins/lockSecret/lockSecret.js
@@ -20,14 +20,14 @@
  */
 
 /** @module plugins/lockSecret */
-const LockSecretDb = require('./LockSecretDb');
-const lockSecretRoutes = require('./lockSecretRoutes');
+import LockSecretDb from './LockSecretDb.js';
+import lockSecretRoutes from './lockSecretRoutes.js';
 
 /**
  * Creates a lock secret plugin.
  * @type {module:plugins/CatapultRestPlugin}
  */
-module.exports = {
+export default {
 	createDb: db => new LockSecretDb(db),
 
 	registerTransactionStates: () => {},

--- a/client/rest/src/plugins/lockSecret/lockSecretRoutes.js
+++ b/client/rest/src/plugins/lockSecret/lockSecretRoutes.js
@@ -19,13 +19,13 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../catapult-sdk/index');
-const merkleUtils = require('../../routes/merkleUtils');
-const routeUtils = require('../../routes/routeUtils');
+import catapult from '../../catapult-sdk/index.js';
+import merkleUtils from '../../routes/merkleUtils.js';
+import routeUtils from '../../routes/routeUtils.js';
 
 const { PacketType } = catapult.packet;
 
-module.exports = {
+export default {
 	register: (server, db, services) => {
 		const sender = routeUtils.createSender('secretLockInfo');
 

--- a/client/rest/src/plugins/metadata/MetadataDb.js
+++ b/client/rest/src/plugins/metadata/MetadataDb.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { metal } = require('./metal');
-const { convertToLong, buildOffsetCondition, longToUint64 } = require('../../db/dbUtils');
+import { metal } from './metal.js';
+import { buildOffsetCondition, convertToLong, longToUint64 } from '../../db/dbUtils.js';
 
-class MetadataDb {
+export default class MetadataDb {
 	/**
 	 * Creates MetadataDb around CatapultDb.
 	 * @param {module:db/CatapultDb} db Catapult db instance.
@@ -115,5 +115,3 @@ class MetadataDb {
 		return metal.decode(longToUint64(metadataEntry.scopedMetadataKey), chunks);
 	}
 }
-
-module.exports = MetadataDb;

--- a/client/rest/src/plugins/metadata/metadata.js
+++ b/client/rest/src/plugins/metadata/metadata.js
@@ -20,14 +20,14 @@
  */
 
 /** @module plugins/metadata */
-const MetadataDb = require('./MetadataDb');
-const metadataRoutes = require('./metadataRoutes');
+import MetadataDb from './MetadataDb.js';
+import metadataRoutes from './metadataRoutes.js';
 
 /**
  * Creates a metadata plugin.
  * @type {module:plugins/CatapultRestPlugin}
  */
-module.exports = {
+export default {
 	createDb: db => new MetadataDb(db),
 
 	registerTransactionStates: () => {},

--- a/client/rest/src/plugins/metadata/metadataRoutes.js
+++ b/client/rest/src/plugins/metadata/metadataRoutes.js
@@ -19,18 +19,18 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { MetalSeal } = require('./metal');
-const catapult = require('../../catapult-sdk/index');
-const merkleUtils = require('../../routes/merkleUtils');
-const routeResultTypes = require('../../routes/routeResultTypes');
-const routeUtils = require('../../routes/routeUtils');
-const NodeCache = require('node-cache');
+import { MetalSeal } from './metal.js';
+import catapult from '../../catapult-sdk/index.js';
+import merkleUtils from '../../routes/merkleUtils.js';
+import routeResultTypes from '../../routes/routeResultTypes.js';
+import routeUtils from '../../routes/routeUtils.js';
+import NodeCache from 'node-cache';
 
 const cache = new NodeCache();
 
 const { PacketType } = catapult.packet;
 
-module.exports = {
+export default {
 	register: (server, db, services) => {
 		const metadataSender = routeUtils.createSender(routeResultTypes.metadata);
 

--- a/client/rest/src/plugins/metadata/metal.js
+++ b/client/rest/src/plugins/metadata/metal.js
@@ -1,11 +1,11 @@
-const catapult = require('../../catapult-sdk');
-const { sha3_256 } = require('@noble/hashes/sha3');
-const bs58 = require('bs58');
+import catapult from '../../catapult-sdk/index.js';
+import { sha3_256 } from '@noble/hashes/sha3';
+import bs58 from 'bs58';
 
 const METAL_ID_HEADER_SIGNATURE = [0x0B, 0x2A];
 const METAL_ID_LENGTH = 34;
 
-const metal = {
+export const metal = {
 	/**
 	 * Convert a metal id (e.g. 'FeF65JftVPEGwaua35LnbU9jK46uG3W8karGDDuDwVEh8Z') into its associated composite hash.
 	 * @param {string} metalId Metal id to convert.
@@ -129,7 +129,7 @@ const metal = {
  * MetalSeal is a simple JSON schema for writing file informations
  * filellength, mimetype, filename and comment in text sections.
  */
-class MetalSeal {
+export class MetalSeal {
 	static SCHEMA = 'seal1';
 
 	static COMPAT = [MetalSeal.SCHEMA];
@@ -223,8 +223,3 @@ class MetalSeal {
 		};
 	}
 }
-
-module.exports = {
-	metal,
-	MetalSeal
-};

--- a/client/rest/src/plugins/mosaic/MosaicDb.js
+++ b/client/rest/src/plugins/mosaic/MosaicDb.js
@@ -19,12 +19,12 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { buildOffsetCondition } = require('../../db/dbUtils');
-const MongoDb = require('mongodb');
+import { buildOffsetCondition } from '../../db/dbUtils.js';
+import MongoDb from 'mongodb';
 
 const { Long } = MongoDb;
 
-class MosaicDb {
+export default class MosaicDb {
 	/**
 	 * Creates MosaicDb around CatapultDb.
 	 * @param {module:db/CatapultDb} db Catapult db instance.
@@ -71,5 +71,3 @@ class MosaicDb {
 			.then(entities => Promise.resolve(this.catapultDb.sanitizer.renameIds(entities)));
 	}
 }
-
-module.exports = MosaicDb;

--- a/client/rest/src/plugins/mosaic/mosaic.js
+++ b/client/rest/src/plugins/mosaic/mosaic.js
@@ -20,15 +20,15 @@
  */
 
 /** @module plugins/mosaic */
-const MosaicDb = require('./MosaicDb');
-const mosaicRoutes = require('./mosaicRoutes');
-const supplyRoutes = require('./supplyRoutes');
+import MosaicDb from './MosaicDb.js';
+import mosaicRoutes from './mosaicRoutes.js';
+import supplyRoutes from './supplyRoutes.js';
 
 /**
  * Creates a mosaic plugin.
  * @type {module:plugins/CatapultRestPlugin}
  */
-module.exports = {
+export default {
 	createDb: db => new MosaicDb(db),
 
 	registerTransactionStates: () => {},

--- a/client/rest/src/plugins/mosaic/mosaicRoutes.js
+++ b/client/rest/src/plugins/mosaic/mosaicRoutes.js
@@ -19,15 +19,15 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../catapult-sdk/index');
-const merkleUtils = require('../../routes/merkleUtils');
-const routeUtils = require('../../routes/routeUtils');
+import catapult from '../../catapult-sdk/index.js';
+import merkleUtils from '../../routes/merkleUtils.js';
+import routeUtils from '../../routes/routeUtils.js';
 
 const { PacketType } = catapult.packet;
 
 const { uint64 } = catapult.utils;
 
-module.exports = {
+export default {
 	register: (server, db, services) => {
 		const mosaicSender = routeUtils.createSender('mosaicDescriptor');
 

--- a/client/rest/src/plugins/mosaic/supplyRoutes.js
+++ b/client/rest/src/plugins/mosaic/supplyRoutes.js
@@ -19,17 +19,17 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../catapult-sdk/index');
-const { longToUint64 } = require('../../db/dbUtils');
-const routeUtils = require('../../routes/routeUtils');
-const AccountType = require('../AccountType');
-const ini = require('ini');
+import catapult from '../../catapult-sdk/index.js';
+import { longToUint64 } from '../../db/dbUtils.js';
+import routeUtils from '../../routes/routeUtils.js';
+import AccountType from '../AccountType.js';
+import ini from 'ini';
 
 const { convert, uint64 } = catapult.utils;
 
 const fileLoader = new catapult.utils.CachedFileLoader();
 
-module.exports = {
+export default {
 	register: (server, db, services) => {
 		const sender = routeUtils.createSender('supply');
 

--- a/client/rest/src/plugins/multisig/MultisigDb.js
+++ b/client/rest/src/plugins/multisig/MultisigDb.js
@@ -19,7 +19,7 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-class MultisigDb {
+export default class MultisigDb {
 	/**
 	 * Creates MultisigDb around CatapultDb.
 	 * @param {module:db/CatapultDb} db Catapult db instance.
@@ -42,5 +42,3 @@ class MultisigDb {
 
 	// endregion
 }
-
-module.exports = MultisigDb;

--- a/client/rest/src/plugins/multisig/multisig.js
+++ b/client/rest/src/plugins/multisig/multisig.js
@@ -20,14 +20,14 @@
  */
 
 /** @module plugins/multisig */
-const MultisigDb = require('./MultisigDb');
-const multisigRoutes = require('./multisigRoutes');
+import MultisigDb from './MultisigDb.js';
+import multisigRoutes from './multisigRoutes.js';
 
 /**
  * Creates a multisig plugin.
  * @type {module:plugins/CatapultRestPlugin}
  */
-module.exports = {
+export default {
 	createDb: db => new MultisigDb(db),
 
 	registerTransactionStates: () => {},

--- a/client/rest/src/plugins/multisig/multisigRoutes.js
+++ b/client/rest/src/plugins/multisig/multisigRoutes.js
@@ -19,14 +19,14 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const multisigUtils = require('./multisigUtils');
-const catapult = require('../../catapult-sdk/index');
-const merkleUtils = require('../../routes/merkleUtils');
-const routeUtils = require('../../routes/routeUtils');
+import multisigUtils from './multisigUtils.js';
+import catapult from '../../catapult-sdk/index.js';
+import merkleUtils from '../../routes/merkleUtils.js';
+import routeUtils from '../../routes/routeUtils.js';
 
 const { PacketType } = catapult.packet;
 
-module.exports = {
+export default {
 	register: (server, db, services) => {
 		server.get('/account/:address/multisig', (req, res, next) => {
 			const accountAddress = routeUtils.parseArgument(req.params, 'address', 'address');

--- a/client/rest/src/plugins/multisig/multisigUtils.js
+++ b/client/rest/src/plugins/multisig/multisigUtils.js
@@ -19,7 +19,7 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const multisigUtils = {
+export default {
 	getMultisigGraph: (db, address) => {
 		const getMultisigEntries = (multisigEntries, fieldName) => {
 			const addresses = new Set();
@@ -71,7 +71,4 @@ const multisigUtils = {
 					.then(() => multisigLevels);
 			});
 	}
-
 };
-
-module.exports = multisigUtils;

--- a/client/rest/src/plugins/namespace/NamespaceDb.js
+++ b/client/rest/src/plugins/namespace/NamespaceDb.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../catapult-sdk/index');
-const { convertToLong, buildOffsetCondition, longToUint64 } = require('../../db/dbUtils');
+import catapult from '../../catapult-sdk/index.js';
+import { buildOffsetCondition, convertToLong, longToUint64 } from '../../db/dbUtils.js';
 
 const { uint64 } = catapult.utils;
 
@@ -48,7 +48,7 @@ const addActiveFlag = (namespace, height) => {
 	return namespace;
 };
 
-class NamespaceDb {
+export default class NamespaceDb {
 	/**
 	 * Creates NamespaceDb around CatapultDb.
 	 * @param {module:db/CatapultDb} db Catapult db instance.
@@ -160,5 +160,3 @@ class NamespaceDb {
 		return this.catapultDb.queryDocuments('transactions', conditions);
 	}
 }
-
-module.exports = NamespaceDb;

--- a/client/rest/src/plugins/namespace/namespace.js
+++ b/client/rest/src/plugins/namespace/namespace.js
@@ -20,14 +20,14 @@
  */
 
 /** @module plugins/namespace */
-const NamespaceDb = require('./NamespaceDb');
-const namespaceRoutes = require('./namespaceRoutes');
+import NamespaceDb from './NamespaceDb.js';
+import namespaceRoutes from './namespaceRoutes.js';
 
 /**
  * Creates a namespace plugin.
  * @type {module:plugins/CatapultRestPlugin}
  */
-module.exports = {
+export default {
 	createDb: db => new NamespaceDb(db),
 
 	registerTransactionStates: () => {},

--- a/client/rest/src/plugins/namespace/namespaceRoutes.js
+++ b/client/rest/src/plugins/namespace/namespaceRoutes.js
@@ -19,19 +19,18 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const namespaceUtils = require('./namespaceUtils');
-const catapult = require('../../catapult-sdk/index');
-const dbUtils = require('../../db/dbUtils');
-const merkleUtils = require('../../routes/merkleUtils');
-const routeUtils = require('../../routes/routeUtils');
-const MongoDb = require('mongodb');
+import namespaceUtils from './namespaceUtils.js';
+import catapult from '../../catapult-sdk/index.js';
+import { convertToLong } from '../../db/dbUtils.js';
+import merkleUtils from '../../routes/merkleUtils.js';
+import routeUtils from '../../routes/routeUtils.js';
+import MongoDb from 'mongodb';
 
 const { PacketType } = catapult.packet;
 const { Binary } = MongoDb;
-const { convertToLong } = dbUtils;
 const { uint64 } = catapult.utils;
 
-module.exports = {
+export default {
 	register: (server, db, services) => {
 		const namespaceSender = routeUtils.createSender('namespaceDescriptor');
 

--- a/client/rest/src/plugins/namespace/namespaceUtils.js
+++ b/client/rest/src/plugins/namespace/namespaceUtils.js
@@ -19,7 +19,7 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const namespaceUtils = {
+export default {
 	/**
 	 * Returns function for processing alias names requests.
 	 * @param {module:db/CatapultDb} catapultDb Catapult database.
@@ -98,5 +98,3 @@ const namespaceUtils = {
 		});
 	}
 };
-
-module.exports = namespaceUtils;

--- a/client/rest/src/plugins/receipts/ReceiptsDb.js
+++ b/client/rest/src/plugins/receipts/ReceiptsDb.js
@@ -19,14 +19,14 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../catapult-sdk/index');
-const { convertToLong, buildOffsetCondition } = require('../../db/dbUtils');
+import catapult from '../../catapult-sdk/index.js';
+import { buildOffsetCondition, convertToLong } from '../../db/dbUtils.js';
 
 const { convert, uint64 } = catapult.utils;
 
 const isNamespaceId = id => 0 !== (0x80 & convert.hexToUint8(uint64.toHex(id))[0]);
 
-class ReceiptsDb {
+export default class ReceiptsDb {
 	/**
 	 * Creates ReceiptsDb around CatapultDb.
 	 * @param {module:db/CatapultDb} db Catapult db instance.
@@ -126,5 +126,3 @@ class ReceiptsDb {
 		return { data, pagination: page.pagination };
 	}
 }
-
-module.exports = ReceiptsDb;

--- a/client/rest/src/plugins/receipts/receipts.js
+++ b/client/rest/src/plugins/receipts/receipts.js
@@ -20,14 +20,14 @@
  */
 
 /** @module plugins/receipts */
-const ReceiptsDb = require('./ReceiptsDb');
-const receiptsRoutes = require('./receiptsRoutes');
+import ReceiptsDb from './ReceiptsDb.js';
+import receiptsRoutes from './receiptsRoutes.js';
 
 /**
  * Creates a receipts plugin.
  * @type {module:plugins/CatapultRestPlugin}
  */
-module.exports = {
+export default {
 	createDb: db => new ReceiptsDb(db),
 
 	registerTransactionStates: () => {},

--- a/client/rest/src/plugins/receipts/receiptsRoutes.js
+++ b/client/rest/src/plugins/receipts/receiptsRoutes.js
@@ -19,11 +19,13 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const routeResultTypes = require('../../routes/routeResultTypes');
-const routeUtils = require('../../routes/routeUtils');
-const { NotFoundError } = require('restify-errors');
+import routeResultTypes from '../../routes/routeResultTypes.js';
+import routeUtils from '../../routes/routeUtils.js';
+import restifyErrors from 'restify-errors';
 
-module.exports = {
+const { NotFoundError } = restifyErrors;
+
+export default {
 	register: (server, db, services) => {
 		server.get('/statements/transaction', (req, res, next) => {
 			const { params } = req;

--- a/client/rest/src/plugins/restrictions/RestrictionsDb.js
+++ b/client/rest/src/plugins/restrictions/RestrictionsDb.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { convertToLong, buildOffsetCondition } = require('../../db/dbUtils');
+import { buildOffsetCondition, convertToLong } from '../../db/dbUtils.js';
 
-class RestrictionsDb {
+export default class RestrictionsDb {
 	/**
 	 * Creates RestrictionsDb around CatapultDb.
 	 * @param {module:db/CatapultDb} db Catapult db instance.
@@ -105,5 +105,3 @@ class RestrictionsDb {
 			.then(entities => Promise.resolve(this.catapultDb.sanitizer.renameIds(entities)));
 	}
 }
-
-module.exports = RestrictionsDb;

--- a/client/rest/src/plugins/restrictions/restrictions.js
+++ b/client/rest/src/plugins/restrictions/restrictions.js
@@ -20,14 +20,14 @@
  */
 
 /** @module plugins/restrictions */
-const RestrictionsDb = require('./RestrictionsDb');
-const restrictionsRoutes = require('./restrictionsRoutes');
+import RestrictionsDb from './RestrictionsDb.js';
+import restrictionsRoutes from './restrictionsRoutes.js';
 
 /**
  * Creates a restrictions plugin.
  * @type {module:plugins/CatapultRestPlugin}
  */
-module.exports = {
+export default {
 	createDb: db => new RestrictionsDb(db),
 
 	registerTransactionStates: () => {},

--- a/client/rest/src/plugins/restrictions/restrictionsRoutes.js
+++ b/client/rest/src/plugins/restrictions/restrictionsRoutes.js
@@ -18,16 +18,16 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
-const catapult = require('../../catapult-sdk/index');
-const merkleUtils = require('../../routes/merkleUtils');
-const routeResultTypes = require('../../routes/routeResultTypes');
-const routeUtils = require('../../routes/routeUtils');
+import catapult from '../../catapult-sdk/index.js';
+import merkleUtils from '../../routes/merkleUtils.js';
+import routeResultTypes from '../../routes/routeResultTypes.js';
+import routeUtils from '../../routes/routeUtils.js';
 
 const { PacketType } = catapult.packet;
 
 const { uint64 } = catapult.utils;
 
-module.exports = {
+export default {
 	register: (server, db, services) => {
 		const accountRestrictionsSender = routeUtils.createSender('accountRestrictions');
 

--- a/client/rest/src/plugins/routeSystem.js
+++ b/client/rest/src/plugins/routeSystem.js
@@ -19,18 +19,18 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const aggregate = require('./aggregate/aggregate');
-const empty = require('./empty');
-const lockHash = require('./lockHash/lockHash');
-const lockSecret = require('./lockSecret/lockSecret');
-const metadata = require('./metadata/metadata');
-const mosaic = require('./mosaic/mosaic');
-const multisig = require('./multisig/multisig');
-const namespace = require('./namespace/namespace');
-const receipts = require('./receipts/receipts');
-const restrictions = require('./restrictions/restrictions');
-const catapult = require('../catapult-sdk/index');
-const MessageChannelBuilder = require('../connection/MessageChannelBuilder');
+import aggregate from './aggregate/aggregate.js';
+import empty from './empty.js';
+import lockHash from './lockHash/lockHash.js';
+import lockSecret from './lockSecret/lockSecret.js';
+import metadata from './metadata/metadata.js';
+import mosaic from './mosaic/mosaic.js';
+import multisig from './multisig/multisig.js';
+import namespace from './namespace/namespace.js';
+import receipts from './receipts/receipts.js';
+import restrictions from './restrictions/restrictions.js';
+import catapult from '../catapult-sdk/index.js';
+import MessageChannelBuilder from '../connection/MessageChannelBuilder.js';
 
 const plugins = {
 	accountLink: empty,
@@ -46,7 +46,7 @@ const plugins = {
 	transfer: empty
 };
 
-module.exports = {
+export default {
 	/**
 	 * Gets the names of all supported plugins.
 	 * @returns {Array<string>} Names of all supported plugins.

--- a/client/rest/src/routes/MerkelTree.js
+++ b/client/rest/src/routes/MerkelTree.js
@@ -19,12 +19,12 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../catapult-sdk/index');
-const { sha3_256 } = require('@noble/hashes/sha3');
+import catapult from '../catapult-sdk/index.js';
+import { sha3_256 } from '@noble/hashes/sha3';
 
 const { convert } = catapult.utils;
 
-class MerkleTree {
+export default class MerkleTree {
 	/**
 	 * Creates merkle tree.
 	 */
@@ -214,5 +214,3 @@ class MerkleTree {
 		return catapult.utils.convert.uint8ToHex(sha3_256(catapult.utils.convert.hexToUint8(encodedPath + leafValue)));
 	}
 }
-
-module.exports = MerkleTree;

--- a/client/rest/src/routes/accountRoutes.js
+++ b/client/rest/src/routes/accountRoutes.js
@@ -19,16 +19,16 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const merkleUtils = require('./merkleUtils');
-const routeResultTypes = require('./routeResultTypes');
-const routeUtils = require('./routeUtils');
-const catapult = require('../catapult-sdk/index');
-const AccountType = require('../plugins/AccountType');
-const errors = require('../server/errors');
+import merkleUtils from './merkleUtils.js';
+import routeResultTypes from './routeResultTypes.js';
+import routeUtils from './routeUtils.js';
+import catapult from '../catapult-sdk/index.js';
+import AccountType from '../plugins/AccountType.js';
+import errors from '../server/errors.js';
 
 const { PacketType } = catapult.packet;
 
-module.exports = {
+export default {
 	register: (server, db, services) => {
 		const sender = routeUtils.createSender(routeResultTypes.account);
 

--- a/client/rest/src/routes/allRoutes.js
+++ b/client/rest/src/routes/allRoutes.js
@@ -19,17 +19,17 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const accountRoutes = require('./accountRoutes');
-const blockRoutes = require('./blockRoutes');
-const chainRoutes = require('./chainRoutes');
-const finalizationRoutes = require('./finalizationRoutes');
-const networkRoutes = require('./networkRoutes');
-const nodeRoutes = require('./nodeRoutes');
-const transactionRoutes = require('./transactionRoutes');
-const transactionStatusRoutes = require('./transactionStatusRoutes');
-const wsRoutes = require('./wsRoutes');
+import accountRoutes from './accountRoutes.js';
+import blockRoutes from './blockRoutes.js';
+import chainRoutes from './chainRoutes.js';
+import finalizationRoutes from './finalizationRoutes.js';
+import networkRoutes from './networkRoutes.js';
+import nodeRoutes from './nodeRoutes.js';
+import transactionRoutes from './transactionRoutes.js';
+import transactionStatusRoutes from './transactionStatusRoutes.js';
+import wsRoutes from './wsRoutes.js';
 
-module.exports = {
+export default {
 	register: (...args) => {
 		const allRoutes = [
 			accountRoutes,

--- a/client/rest/src/routes/blockRoutes.js
+++ b/client/rest/src/routes/blockRoutes.js
@@ -19,14 +19,14 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const dbFacade = require('./dbFacade');
-const routeResultTypes = require('./routeResultTypes');
-const routeUtils = require('./routeUtils');
-const catapult = require('../catapult-sdk/index');
+import dbFacade from './dbFacade.js';
+import routeResultTypes from './routeResultTypes.js';
+import routeUtils from './routeUtils.js';
+import catapult from '../catapult-sdk/index.js';
 
 const { uint64 } = catapult.utils;
 
-module.exports = {
+export default {
 	register: (server, db, services) => {
 		server.get('/blocks', (req, res, next) => {
 			const { params } = req;

--- a/client/rest/src/routes/chainRoutes.js
+++ b/client/rest/src/routes/chainRoutes.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const routeResultTypes = require('./routeResultTypes');
+import routeResultTypes from './routeResultTypes.js';
 
-module.exports = {
+export default {
 	register: (server, db) => {
 		server.get('/chain/info', (req, res, next) =>
 			Promise.all([

--- a/client/rest/src/routes/dbFacade.js
+++ b/client/rest/src/routes/dbFacade.js
@@ -19,7 +19,7 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { convertToLong } = require('../db/dbUtils');
+import { convertToLong } from '../db/dbUtils.js';
 
 const extractFromMetadata = (group, transaction) => ({
 	group,
@@ -29,8 +29,7 @@ const extractFromMetadata = (group, transaction) => ({
 	height: transaction.meta.height
 });
 
-const dbFacade = {
-
+export default {
 	/**
 	 * Runs a database operation that is dependent on current chain height.
 	 * @param {module:db/CatapultDb} db Catapult database.
@@ -92,5 +91,3 @@ const dbFacade = {
 		});
 	}
 };
-
-module.exports = dbFacade;

--- a/client/rest/src/routes/finalizationRoutes.js
+++ b/client/rest/src/routes/finalizationRoutes.js
@@ -19,18 +19,19 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const routeResultTypes = require('./routeResultTypes');
-const routeUtils = require('./routeUtils');
-const catapult = require('../catapult-sdk/index');
-const finalizationProofCodec = require('../sockets/finalizationProofCodec');
-const { NotFoundError } = require('restify-errors');
+import routeResultTypes from './routeResultTypes.js';
+import routeUtils from './routeUtils.js';
+import catapult from '../catapult-sdk/index.js';
+import finalizationProofCodec from '../sockets/finalizationProofCodec.js';
+import restifyErrors from 'restify-errors';
 
 const packetHeader = catapult.packet.header;
 const { PacketType } = catapult.packet;
 const { BinaryParser } = catapult.parser;
 const { uint64 } = catapult.utils;
+const { NotFoundError } = restifyErrors;
 
-module.exports = {
+export default {
 	register: (server, db, services) => {
 		const { connections } = services;
 		const { timeout } = services.config.apiNode;

--- a/client/rest/src/routes/merkleUtils.js
+++ b/client/rest/src/routes/merkleUtils.js
@@ -19,15 +19,15 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 /* eslint-disable */
-const errors = require('../server/errors');
-const catapult = require('../catapult-sdk/index');
-const MerkleTree = require('./MerkelTree');
+import errors from '../server/errors.js';
+import catapult from '../catapult-sdk/index.js';
+import MerkleTree from './MerkelTree.js';
 
 const packetHeader = catapult.packet.header;
 const { StatePathPacketTypes } = catapult.packet;
 const { convert } = catapult.utils;
 
-const merkleUtils = {
+export default {
 	/**
 	 * It sends a merkle tree request to api server for the give state path and key.
 	 *
@@ -59,5 +59,3 @@ const merkleUtils = {
 			.then(packet => buildResponse(packet));
 	},
 };
-
-module.exports = merkleUtils;

--- a/client/rest/src/routes/networkRoutes.js
+++ b/client/rest/src/routes/networkRoutes.js
@@ -19,15 +19,15 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../catapult-sdk/index');
-const errors = require('../server/errors');
-const ini = require('ini');
+import catapult from '../catapult-sdk/index.js';
+import errors from '../server/errors.js';
+import ini from 'ini';
 
 const { uint64 } = catapult.utils;
 
 const fileLoader = new catapult.utils.CachedFileLoader();
 
-module.exports = {
+export default {
 	register: (server, db, services) => {
 		const average = array => array.reduce((p, c) => p + c, 0) / array.length;
 		const median = array => {

--- a/client/rest/src/routes/nodeRoutes.js
+++ b/client/rest/src/routes/nodeRoutes.js
@@ -19,19 +19,19 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const routeResultTypes = require('./routeResultTypes');
-const catapult = require('../catapult-sdk/index');
-const nodeInfoCodec = require('../sockets/nodeInfoCodec');
-const nodePeersCodec = require('../sockets/nodePeersCodec');
-const nodeTimeCodec = require('../sockets/nodeTimeCodec');
-const fs = require('fs');
-const path = require('path');
+import routeResultTypes from './routeResultTypes.js';
+import catapult from '../catapult-sdk/index.js';
+import nodeInfoCodec from '../sockets/nodeInfoCodec.js';
+import nodePeersCodec from '../sockets/nodePeersCodec.js';
+import nodeTimeCodec from '../sockets/nodeTimeCodec.js';
+import fs from 'fs';
+import path from 'path';
 
 const packetHeader = catapult.packet.header;
 const { PacketType } = catapult.packet;
 const { BinaryParser } = catapult.parser;
 
-const restVersion = JSON.parse(fs.readFileSync(path.resolve(__dirname, '../../package.json'), 'UTF-8')).version;
+const restVersion = JSON.parse(fs.readFileSync(path.resolve(import.meta.dirname, '../../package.json'), 'UTF-8')).version;
 
 const buildResponse = (packet, codec, resultType) => {
 	const binaryParser = new BinaryParser();
@@ -43,7 +43,7 @@ const buildResponse = (packet, codec, resultType) => {
 	};
 };
 
-module.exports = {
+export default {
 	register: (server, db, services) => {
 		const { connections } = services;
 		const { timeout } = services.config.apiNode;

--- a/client/rest/src/routes/routeResultTypes.js
+++ b/client/rest/src/routes/routeResultTypes.js
@@ -19,7 +19,7 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-module.exports = {
+export default {
 	// with meta data
 	account: 'accountWithMetadata',
 	block: 'blockHeaderWithMetadata',

--- a/client/rest/src/routes/routeUtils.js
+++ b/client/rest/src/routes/routeUtils.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const dbFacade = require('./dbFacade');
-const routeResultTypes = require('./routeResultTypes');
-const catapult = require('../catapult-sdk/index');
-const errors = require('../server/errors');
+import dbFacade from './dbFacade.js';
+import routeResultTypes from './routeResultTypes.js';
+import catapult from '../catapult-sdk/index.js';
+import errors from '../server/errors.js';
 
 const { address } = catapult.model;
 const { buildAuditPath, indexOfLeafWithHash } = catapult.crypto.merkle;
@@ -415,4 +415,4 @@ const routeUtils = {
 		})
 };
 
-module.exports = routeUtils;
+export default routeUtils;

--- a/client/rest/src/routes/transactionRoutes.js
+++ b/client/rest/src/routes/transactionRoutes.js
@@ -19,14 +19,15 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const routeResultTypes = require('./routeResultTypes');
-const routeUtils = require('./routeUtils');
-const catapult = require('../catapult-sdk/index');
-const errors = require('../server/errors');
-const { NotFoundError, InvalidArgumentError } = require('restify-errors');
+import routeResultTypes from './routeResultTypes.js';
+import routeUtils from './routeUtils.js';
+import catapult from '../catapult-sdk/index.js';
+import errors from '../server/errors.js';
+import restifyErrors from 'restify-errors';
 
 const { convert } = catapult.utils;
 const { PacketType } = catapult.packet;
+const { InvalidArgumentError, NotFoundError } = restifyErrors;
 
 const constants = {
 	sizes: {
@@ -37,7 +38,7 @@ const constants = {
 
 const isValidTransactionGroup = group => ['confirmed', 'unconfirmed', 'partial'].includes(group);
 
-module.exports = {
+export default {
 	register: (server, db, services) => {
 		const sender = routeUtils.createSender(routeResultTypes.transaction);
 

--- a/client/rest/src/routes/transactionStatusRoutes.js
+++ b/client/rest/src/routes/transactionStatusRoutes.js
@@ -19,15 +19,15 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const dbFacade = require('./dbFacade');
-const routeResultTypes = require('./routeResultTypes');
-const routeUtils = require('./routeUtils');
-const catapult = require('../catapult-sdk/index');
+import dbFacade from './dbFacade.js';
+import routeResultTypes from './routeResultTypes.js';
+import routeUtils from './routeUtils.js';
+import catapult from '../catapult-sdk/index.js';
 
 const { convert } = catapult.utils;
 const { constants } = catapult;
 
-module.exports = {
+export default {
 	register: (server, db, services) => {
 		routeUtils.addGetPostDocumentRoutes(
 			server,

--- a/client/rest/src/routes/wsRoutes.js
+++ b/client/rest/src/routes/wsRoutes.js
@@ -19,7 +19,7 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-module.exports = {
+export default {
 	register: (server, db, services) => {
 		server.ws('/ws', {
 			newChannel: (channel, sender) => {

--- a/client/rest/src/server/SubscriptionManager.js
+++ b/client/rest/src/server/SubscriptionManager.js
@@ -19,12 +19,12 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const winston = require('winston');
+import winston from 'winston';
 
 /**
  * Manages client subscriptions.
  */
-class SubscriptionManager {
+export default class SubscriptionManager {
 	/**
 	 * Creates a subscription manager.
 	 * @param {object} subscriptionCallbacks Callbacks to invoke in response to subscription changes.
@@ -94,5 +94,3 @@ class SubscriptionManager {
 		});
 	}
 }
-
-module.exports = SubscriptionManager;

--- a/client/rest/src/server/bootstrapper.js
+++ b/client/rest/src/server/bootstrapper.js
@@ -19,15 +19,15 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const SubscriptionManager = require('./SubscriptionManager');
-const errors = require('./errors');
-const websocketMessageHandler = require('./websocketMessageHandler');
-const websocketUtils = require('./websocketUtils');
-const restify = require('restify');
-const restifyErrors = require('restify-errors');
-const winston = require('winston');
-const WebSocket = require('ws');
-const fs = require('fs');
+import SubscriptionManager from './SubscriptionManager.js';
+import errors from './errors.js';
+import websocketMessageHandler from './websocketMessageHandler.js';
+import websocketUtils from './websocketUtils.js';
+import restify from 'restify';
+import restifyErrors from 'restify-errors';
+import winston from 'winston';
+import { WebSocketServer } from 'ws';
+import fs from 'fs';
 
 const isPromise = object => object && object.catch;
 
@@ -103,7 +103,7 @@ const readSSLFileSync = (path, fileType, pathProperty) => {
 	}
 };
 
-module.exports = {
+export default {
 	createCrossDomainHeaderAdder,
 
 	/**
@@ -221,7 +221,7 @@ module.exports = {
 		});
 
 		// handle upgrade events (for websocket support)
-		const wss = new WebSocket.Server({ noServer: true, clientTracking: false });
+		const wss = new WebSocketServer({ noServer: true, clientTracking: false });
 
 		server.on('upgrade', (req, socket, head) => {
 			wss.handleUpgrade(req, socket, head, client => {

--- a/client/rest/src/server/errors.js
+++ b/client/rest/src/server/errors.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const restifyErrors = require('restify-errors');
+import restifyErrors from 'restify-errors';
 
-module.exports = {
+export default {
 	/**
 	 * Converts an arbitrary error to a REST error.
 	 * @param {Error} err Source error.

--- a/client/rest/src/server/formatters.js
+++ b/client/rest/src/server/formatters.js
@@ -19,7 +19,7 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../catapult-sdk/index');
+import catapult from '../catapult-sdk/index.js';
 
 const { formatArray, formatPage } = catapult.utils.formattingUtils;
 
@@ -59,7 +59,7 @@ const formatBody = (modelFormatter, body) => {
 	};
 };
 
-module.exports = {
+export default {
 	/**
 	 * Creates server formatters around a model formatter.
 	 * @param {Array<object>} modelFormatters Model formatters.

--- a/client/rest/src/server/messageFormattingRules.js
+++ b/client/rest/src/server/messageFormattingRules.js
@@ -19,13 +19,13 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../catapult-sdk/index');
-const { bufferToUnresolvedAddress } = require('../db/dbUtils');
+import catapult from '../catapult-sdk/index.js';
+import { bufferToUnresolvedAddress } from '../db/dbUtils.js';
 
 const { ModelType, status } = catapult.model;
 const { convert, uint64 } = catapult.utils;
 
-module.exports = {
+export default {
 	[ModelType.none]: value => value,
 	[ModelType.binary]: value => convert.uint8ToHex(value),
 	[ModelType.statusCode]: status.toString,

--- a/client/rest/src/server/websocketMessageHandler.js
+++ b/client/rest/src/server/websocketMessageHandler.js
@@ -37,7 +37,7 @@ const parseSubscriptionRequest = request => {
 	return { channel: requireString(request, 'subscribe'), action: 'add' };
 };
 
-module.exports = {
+export default {
 	/**
 	 * Handles a websocket message.
 	 * @param {object} client Client that sent the message.

--- a/client/rest/src/server/websocketUtils.js
+++ b/client/rest/src/server/websocketUtils.js
@@ -19,14 +19,14 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../catapult-sdk/index');
-const winston = require('winston');
-const WebSocket = require('ws');
-const crypto = require('crypto');
+import catapult from '../catapult-sdk/index.js';
+import winston from 'winston';
+import WebSocket from 'ws';
+import crypto from 'crypto';
 
 const { base32 } = catapult.utils;
 
-module.exports = {
+export default {
 	/**
 	 * Creates an aggregate subscriber composed of all websocket subscribers to a single topic.
 	 * @param {string} topic Subscribed topic from which the data was received.

--- a/client/rest/src/sockets/finalizationProofCodec.js
+++ b/client/rest/src/sockets/finalizationProofCodec.js
@@ -20,13 +20,13 @@
  */
 
 /** @module sockets/finalizationProofCodec */
-const catapult = require('../catapult-sdk/index');
+import catapult from '../catapult-sdk/index.js';
 
 const { sizes } = catapult.constants;
 
 const headerSize = 56;
 
-const finalizationProofCodec = {
+export default {
 	/**
 	 * Parses finalization proof.
 	 * @param {object} parser Parser.
@@ -83,5 +83,3 @@ const finalizationProofCodec = {
 		return proof;
 	}
 };
-
-module.exports = finalizationProofCodec;

--- a/client/rest/src/sockets/nodeInfoCodec.js
+++ b/client/rest/src/sockets/nodeInfoCodec.js
@@ -20,11 +20,11 @@
  */
 
 /** @module sockets/nodeInfoCodec */
-const catapult = require('../catapult-sdk/index');
+import catapult from '../catapult-sdk/index.js';
 
 const { sizes } = catapult.constants;
 
-const nodeInfoCodec = {
+export default {
 	/**
 	 * Parses a node info.
 	 * @param {object} parser Parser.
@@ -46,5 +46,3 @@ const nodeInfoCodec = {
 		return nodeInfo;
 	}
 };
-
-module.exports = nodeInfoCodec;

--- a/client/rest/src/sockets/nodePeersCodec.js
+++ b/client/rest/src/sockets/nodePeersCodec.js
@@ -20,9 +20,9 @@
  */
 
 /** @module sockets/nodePeersCodec */
-const nodeInfoCodec = require('./nodeInfoCodec');
+import nodeInfoCodec from './nodeInfoCodec.js';
 
-const nodePeersCodec = {
+export default {
 	/**
 	 * Parses node peers, composed of multiple nodes info
 	 * @param {object} parser Parser.
@@ -36,5 +36,3 @@ const nodePeersCodec = {
 		return nodePeers;
 	}
 };
-
-module.exports = nodePeersCodec;

--- a/client/rest/src/sockets/nodeTimeCodec.js
+++ b/client/rest/src/sockets/nodeTimeCodec.js
@@ -21,7 +21,7 @@
 
 /** @module sockets/nodeTimeCodec */
 
-const nodeTimeCodec = {
+export default {
 	/**
 	 * Parses node communication timestamps.
 	 * @param {object} parser Parser.
@@ -34,5 +34,3 @@ const nodeTimeCodec = {
 		}
 	})
 };
-
-module.exports = nodeTimeCodec;

--- a/client/rest/src/sockets/stateTreesCodec.js
+++ b/client/rest/src/sockets/stateTreesCodec.js
@@ -21,11 +21,11 @@
 
 /** @module sockets/stateTreesCodec */
 
-const catapult = require('../catapult-sdk/index');
+import catapult from '../catapult-sdk/index.js';
 
 const { sizes } = catapult.constants;
 
-const stateTreesCodec = {
+export default {
 	/**
 	 * Parses state trees.
 	 * @param {object} parser Parser.
@@ -38,5 +38,3 @@ const stateTreesCodec = {
 		return { tree };
 	}
 };
-
-module.exports = stateTreesCodec;

--- a/client/rest/test/catapult-sdk/binaryTestUtils.js
+++ b/client/rest/test/catapult-sdk/binaryTestUtils.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const test = require('./testUtils');
-const BinaryParser = require('../../src/catapult-sdk/parser/BinaryParser');
-const BinarySerializer = require('../../src/catapult-sdk/serializer/BinarySerializer');
-const { expect } = require('chai');
+import test from './testUtils.js';
+import BinaryParser from '../../src/catapult-sdk/parser/BinaryParser.js';
+import BinarySerializer from '../../src/catapult-sdk/serializer/BinarySerializer.js';
+import { expect } from 'chai';
 
 const binaryTestUtils = {
 	binary: {
@@ -97,4 +97,4 @@ const binaryTestUtils = {
 
 Object.assign(binaryTestUtils, test);
 
-module.exports = binaryTestUtils;
+export default binaryTestUtils;

--- a/client/rest/test/catapult-sdk/crypto/merkleAuditProof_spec.js
+++ b/client/rest/test/catapult-sdk/crypto/merkleAuditProof_spec.js
@@ -19,12 +19,11 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const {
-	indexOfLeafWithHash, buildAuditPath, NodePosition, siblingOf, HashNotFoundError,
-	InvalidTree, evenify
-} = require('../../../src/catapult-sdk/crypto/merkleAuditProof');
-const convert = require('../../../src/catapult-sdk/utils/convert');
-const { expect } = require('chai');
+import {
+	HashNotFoundError, InvalidTree, NodePosition, buildAuditPath, evenify, indexOfLeafWithHash, siblingOf
+} from '../../../src/catapult-sdk/crypto/merkleAuditProof.js';
+import convert from '../../../src/catapult-sdk/utils/convert.js';
+import { expect } from 'chai';
 
 const hexStringToBuffer = input => Buffer.from(convert.hexToUint8(input), 'hex');
 

--- a/client/rest/test/catapult-sdk/model/EntityType_spec.js
+++ b/client/rest/test/catapult-sdk/model/EntityType_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const EntityType = require('../../../src/catapult-sdk/model/EntityType');
-const { expect } = require('chai');
+import EntityType from '../../../src/catapult-sdk/model/EntityType.js';
+import { expect } from 'chai';
 
 describe('entity type enumeration', () => {
 	it('exposes expected types', () => {

--- a/client/rest/test/catapult-sdk/model/ModelFormatterBuilder_spec.js
+++ b/client/rest/test/catapult-sdk/model/ModelFormatterBuilder_spec.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const ModelFormatterBuilder = require('../../../src/catapult-sdk/model/ModelFormatterBuilder');
-const ModelSchemaBuilder = require('../../../src/catapult-sdk/model/ModelSchemaBuilder');
-const ModelType = require('../../../src/catapult-sdk/model/ModelType');
-const { expect } = require('chai');
+import ModelFormatterBuilder from '../../../src/catapult-sdk/model/ModelFormatterBuilder.js';
+import ModelSchemaBuilder from '../../../src/catapult-sdk/model/ModelSchemaBuilder.js';
+import ModelType from '../../../src/catapult-sdk/model/ModelType.js';
+import { expect } from 'chai';
 
 const modelSchema = new ModelSchemaBuilder().build();
 const formattingRules = {

--- a/client/rest/test/catapult-sdk/model/ModelSchemaBuilder_spec.js
+++ b/client/rest/test/catapult-sdk/model/ModelSchemaBuilder_spec.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const EntityType = require('../../../src/catapult-sdk/model/EntityType');
-const ModelSchemaBuilder = require('../../../src/catapult-sdk/model/ModelSchemaBuilder');
-const ModelType = require('../../../src/catapult-sdk/model/ModelType');
-const { expect } = require('chai');
+import EntityType from '../../../src/catapult-sdk/model/EntityType.js';
+import ModelSchemaBuilder from '../../../src/catapult-sdk/model/ModelSchemaBuilder.js';
+import ModelType from '../../../src/catapult-sdk/model/ModelType.js';
+import { expect } from 'chai';
 
 describe('model schema builder', () => {
 	describe('allowed transaction types', () => {

--- a/client/rest/test/catapult-sdk/model/ModelType_spec.js
+++ b/client/rest/test/catapult-sdk/model/ModelType_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const ModelType = require('../../../src/catapult-sdk/model/ModelType');
-const { expect } = require('chai');
+import ModelType from '../../../src/catapult-sdk/model/ModelType.js';
+import { expect } from 'chai';
 
 describe('model type enumeration', () => {
 	it('exposes expected types', () => {

--- a/client/rest/test/catapult-sdk/model/address_spec.js
+++ b/client/rest/test/catapult-sdk/model/address_spec.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const address = require('../../../src/catapult-sdk/model/address');
-const convert = require('../../../src/catapult-sdk/utils/convert');
-const test = require('../testUtils');
-const { expect } = require('chai');
+import address from '../../../src/catapult-sdk/model/address.js';
+import convert from '../../../src/catapult-sdk/utils/convert.js';
+import test from '../testUtils.js';
+import { expect } from 'chai';
 
 const Address_Decoded_Size = 24;
 const Network_Mainnet_Identifier = 0x68;

--- a/client/rest/test/catapult-sdk/model/idReducer_spec.js
+++ b/client/rest/test/catapult-sdk/model/idReducer_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const idReducer = require('../../../src/catapult-sdk/model/idReducer');
-const { expect } = require('chai');
+import idReducer from '../../../src/catapult-sdk/model/idReducer.js';
+import { expect } from 'chai';
 
 describe('id reducer', () => {
 	describe('id to name lookup', () => {

--- a/client/rest/test/catapult-sdk/model/namespace_spec.js
+++ b/client/rest/test/catapult-sdk/model/namespace_spec.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const namespace = require('../../../src/catapult-sdk/model/namespace');
-const convert = require('../../../src/catapult-sdk/utils/convert');
-const { expect } = require('chai');
+import namespace from '../../../src/catapult-sdk/model/namespace.js';
+import convert from '../../../src/catapult-sdk/utils/convert.js';
+import { expect } from 'chai';
 
 describe('namespace', () => {
 	describe('alias type', () => {

--- a/client/rest/test/catapult-sdk/model/networkInfo_spec.js
+++ b/client/rest/test/catapult-sdk/model/networkInfo_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const networkInfo = require('../../../src/catapult-sdk/model/networkInfo');
-const { expect } = require('chai');
+import networkInfo from '../../../src/catapult-sdk/model/networkInfo.js';
+import { expect } from 'chai';
 
 describe('network info', () => {
 	describe('networks', () => {

--- a/client/rest/test/catapult-sdk/model/restriction_spec.js
+++ b/client/rest/test/catapult-sdk/model/restriction_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const restriction = require('../../../src/catapult-sdk/model/restriction');
-const { expect } = require('chai');
+import restriction from '../../../src/catapult-sdk/model/restriction.js';
+import { expect } from 'chai';
 
 describe('restriction', () => {
 	describe('mosaic restriction', () => {

--- a/client/rest/test/catapult-sdk/model/status_spec.js
+++ b/client/rest/test/catapult-sdk/model/status_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const status = require('../../../src/catapult-sdk/model/status');
-const { expect } = require('chai');
+import status from '../../../src/catapult-sdk/model/status.js';
+import { expect } from 'chai';
 
 describe('status', () => {
 	describe('toString', () => {

--- a/client/rest/test/catapult-sdk/modelBinary/ModelCodecBuilder_spec.js
+++ b/client/rest/test/catapult-sdk/modelBinary/ModelCodecBuilder_spec.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const ModelCodecBuilder = require('../../../src/catapult-sdk/modelBinary/ModelCodecBuilder');
-const BinaryParser = require('../../../src/catapult-sdk/parser/BinaryParser');
-const test = require('../binaryTestUtils');
-const { expect } = require('chai');
+import ModelCodecBuilder from '../../../src/catapult-sdk/modelBinary/ModelCodecBuilder.js';
+import BinaryParser from '../../../src/catapult-sdk/parser/BinaryParser.js';
+import test from '../binaryTestUtils.js';
+import { expect } from 'chai';
 
 const constants = {
 	knownTxType: 0x4123,

--- a/client/rest/test/catapult-sdk/modelBinary/blockHeaderCodec_spec.js
+++ b/client/rest/test/catapult-sdk/modelBinary/blockHeaderCodec_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const blockHeaderCodec = require('../../../src/catapult-sdk/modelBinary/blockHeaderCodec');
-const test = require('../binaryTestUtils');
+import blockHeaderCodec from '../../../src/catapult-sdk/modelBinary/blockHeaderCodec.js';
+import test from '../binaryTestUtils.js';
 
 describe('block header codec', () => {
 	const generateBlockHeader = () => {

--- a/client/rest/test/catapult-sdk/modelBinary/embeddedEntityCodec_spec.js
+++ b/client/rest/test/catapult-sdk/modelBinary/embeddedEntityCodec_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const embeddedEntityCodec = require('../../../src/catapult-sdk/modelBinary/embeddedEntityCodec');
-const test = require('../binaryTestUtils');
+import embeddedEntityCodec from '../../../src/catapult-sdk/modelBinary/embeddedEntityCodec.js';
+import test from '../binaryTestUtils.js';
 
 describe('embedded entity codec', () => {
 	const generateEmbeddedEntity = () => {

--- a/client/rest/test/catapult-sdk/modelBinary/importanceBlockHeaderCodec_spec.js
+++ b/client/rest/test/catapult-sdk/modelBinary/importanceBlockHeaderCodec_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const importanceBlockHeaderCodec = require('../../../src/catapult-sdk/modelBinary/importanceBlockHeaderCodec');
-const test = require('../binaryTestUtils');
+import importanceBlockHeaderCodec from '../../../src/catapult-sdk/modelBinary/importanceBlockHeaderCodec.js';
+import test from '../binaryTestUtils.js';
 
 describe('importance block header codec', () => {
 	const generateBlockHeader = () => {

--- a/client/rest/test/catapult-sdk/modelBinary/serialize_spec.js
+++ b/client/rest/test/catapult-sdk/modelBinary/serialize_spec.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const serialize = require('../../../src/catapult-sdk/modelBinary/serialize');
-const convert = require('../../../src/catapult-sdk/utils/convert');
-const { expect } = require('chai');
+import serialize from '../../../src/catapult-sdk/modelBinary/serialize.js';
+import convert from '../../../src/catapult-sdk/utils/convert.js';
+import { expect } from 'chai';
 
 describe('serialize', () => {
 	const getCodec = () => ({

--- a/client/rest/test/catapult-sdk/modelBinary/transactionCodec_spec.js
+++ b/client/rest/test/catapult-sdk/modelBinary/transactionCodec_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const transactionCodec = require('../../../src/catapult-sdk/modelBinary/transactionCodec');
-const test = require('../binaryTestUtils');
+import transactionCodec from '../../../src/catapult-sdk/modelBinary/transactionCodec.js';
+import test from '../binaryTestUtils.js';
 
 describe('transaction codec', () => {
 	const generateTransaction = () => ({

--- a/client/rest/test/catapult-sdk/modelBinary/verifiableEntityCodec_spec.js
+++ b/client/rest/test/catapult-sdk/modelBinary/verifiableEntityCodec_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const verifiableEntityCodec = require('../../../src/catapult-sdk/modelBinary/verifiableEntityCodec');
-const test = require('../binaryTestUtils');
+import verifiableEntityCodec from '../../../src/catapult-sdk/modelBinary/verifiableEntityCodec.js';
+import test from '../binaryTestUtils.js';
 
 describe('verifiable entity codec', () => {
 	const generateVerifiableEntity = () => {

--- a/client/rest/test/catapult-sdk/packet/header_spec.js
+++ b/client/rest/test/catapult-sdk/packet/header_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const packetHeader = require('../../../src/catapult-sdk/packet/header');
-const { expect } = require('chai');
+import packetHeader from '../../../src/catapult-sdk/packet/header.js';
+import { expect } from 'chai';
 
 describe('packet header', () => {
 	describe('constants', () => {

--- a/client/rest/test/catapult-sdk/parser/BinaryParser_spec.js
+++ b/client/rest/test/catapult-sdk/parser/BinaryParser_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const BinaryParser = require('../../../src/catapult-sdk/parser/BinaryParser');
-const { expect } = require('chai');
+import BinaryParser from '../../../src/catapult-sdk/parser/BinaryParser.js';
+import { expect } from 'chai';
 
 describe('BinaryParser', () => {
 	// region push

--- a/client/rest/test/catapult-sdk/parser/PacketParser_spec.js
+++ b/client/rest/test/catapult-sdk/parser/PacketParser_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const PacketParser = require('../../../src/catapult-sdk/parser/PacketParser');
-const { expect } = require('chai');
+import PacketParser from '../../../src/catapult-sdk/parser/PacketParser.js';
+import { expect } from 'chai';
 
 describe('PacketParser', () => {
 	const Test_Buffer_64 = Buffer.of(

--- a/client/rest/test/catapult-sdk/plugins/accountLink_spec.js
+++ b/client/rest/test/catapult-sdk/plugins/accountLink_spec.js
@@ -19,11 +19,11 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const EntityType = require('../../../src/catapult-sdk/model/EntityType');
-const ModelSchemaBuilder = require('../../../src/catapult-sdk/model/ModelSchemaBuilder');
-const accountLinkPlugin = require('../../../src/catapult-sdk/plugins/accountLink');
-const test = require('../binaryTestUtils');
-const { expect } = require('chai');
+import EntityType from '../../../src/catapult-sdk/model/EntityType.js';
+import ModelSchemaBuilder from '../../../src/catapult-sdk/model/ModelSchemaBuilder.js';
+import accountLinkPlugin from '../../../src/catapult-sdk/plugins/accountLink.js';
+import test from '../binaryTestUtils.js';
+import { expect } from 'chai';
 
 describe('account link plugin', () => {
 	describe('register schema', () => {

--- a/client/rest/test/catapult-sdk/plugins/aggregate_spec.js
+++ b/client/rest/test/catapult-sdk/plugins/aggregate_spec.js
@@ -19,15 +19,15 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const EntityType = require('../../../src/catapult-sdk/model/EntityType');
-const ModelSchemaBuilder = require('../../../src/catapult-sdk/model/ModelSchemaBuilder');
-const ModelType = require('../../../src/catapult-sdk/model/ModelType');
-const BinaryParser = require('../../../src/catapult-sdk/parser/BinaryParser');
-const aggregate = require('../../../src/catapult-sdk/plugins/aggregate');
-const BinarySerializer = require('../../../src/catapult-sdk/serializer/BinarySerializer');
-const uint64 = require('../../../src/catapult-sdk/utils/uint64');
-const test = require('../binaryTestUtils');
-const { expect } = require('chai');
+import EntityType from '../../../src/catapult-sdk/model/EntityType.js';
+import ModelSchemaBuilder from '../../../src/catapult-sdk/model/ModelSchemaBuilder.js';
+import ModelType from '../../../src/catapult-sdk/model/ModelType.js';
+import BinaryParser from '../../../src/catapult-sdk/parser/BinaryParser.js';
+import aggregate from '../../../src/catapult-sdk/plugins/aggregate.js';
+import BinarySerializer from '../../../src/catapult-sdk/serializer/BinarySerializer.js';
+import uint64 from '../../../src/catapult-sdk/utils/uint64.js';
+import test from '../binaryTestUtils.js';
+import { expect } from 'chai';
 
 const constants = {
 	knownTxType: 0x0022,

--- a/client/rest/test/catapult-sdk/plugins/catapultModelSystem_spec.js
+++ b/client/rest/test/catapult-sdk/plugins/catapultModelSystem_spec.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const EntityType = require('../../../src/catapult-sdk/model/EntityType');
-const ModelType = require('../../../src/catapult-sdk/model/ModelType');
-const catapultModelSystem = require('../../../src/catapult-sdk/plugins/catapultModelSystem');
-const { expect } = require('chai');
+import EntityType from '../../../src/catapult-sdk/model/EntityType.js';
+import ModelType from '../../../src/catapult-sdk/model/ModelType.js';
+import catapultModelSystem from '../../../src/catapult-sdk/plugins/catapultModelSystem.js';
+import { expect } from 'chai';
 
 const formattingRules = {
 	[ModelType.none]: () => 'none',

--- a/client/rest/test/catapult-sdk/plugins/lockHash_spec.js
+++ b/client/rest/test/catapult-sdk/plugins/lockHash_spec.js
@@ -19,11 +19,11 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const EntityType = require('../../../src/catapult-sdk/model/EntityType');
-const ModelSchemaBuilder = require('../../../src/catapult-sdk/model/ModelSchemaBuilder');
-const lockHash = require('../../../src/catapult-sdk/plugins/lockHash');
-const test = require('../binaryTestUtils');
-const { expect } = require('chai');
+import EntityType from '../../../src/catapult-sdk/model/EntityType.js';
+import ModelSchemaBuilder from '../../../src/catapult-sdk/model/ModelSchemaBuilder.js';
+import lockHash from '../../../src/catapult-sdk/plugins/lockHash.js';
+import test from '../binaryTestUtils.js';
+import { expect } from 'chai';
 
 describe('lock hash plugin', () => {
 	describe('register schema', () => {

--- a/client/rest/test/catapult-sdk/plugins/lockSecret_spec.js
+++ b/client/rest/test/catapult-sdk/plugins/lockSecret_spec.js
@@ -19,11 +19,11 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const EntityType = require('../../../src/catapult-sdk/model/EntityType');
-const ModelSchemaBuilder = require('../../../src/catapult-sdk/model/ModelSchemaBuilder');
-const lockSecret = require('../../../src/catapult-sdk/plugins/lockSecret');
-const test = require('../binaryTestUtils');
-const { expect } = require('chai');
+import EntityType from '../../../src/catapult-sdk/model/EntityType.js';
+import ModelSchemaBuilder from '../../../src/catapult-sdk/model/ModelSchemaBuilder.js';
+import lockSecret from '../../../src/catapult-sdk/plugins/lockSecret.js';
+import test from '../binaryTestUtils.js';
+import { expect } from 'chai';
 
 describe('lock secret plugin', () => {
 	describe('register schema', () => {

--- a/client/rest/test/catapult-sdk/plugins/metadata_spec.js
+++ b/client/rest/test/catapult-sdk/plugins/metadata_spec.js
@@ -19,11 +19,11 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const EntityType = require('../../../src/catapult-sdk/model/EntityType');
-const ModelSchemaBuilder = require('../../../src/catapult-sdk/model/ModelSchemaBuilder');
-const metadataPlugin = require('../../../src/catapult-sdk/plugins/metadata');
-const test = require('../binaryTestUtils');
-const { expect } = require('chai');
+import EntityType from '../../../src/catapult-sdk/model/EntityType.js';
+import ModelSchemaBuilder from '../../../src/catapult-sdk/model/ModelSchemaBuilder.js';
+import metadataPlugin from '../../../src/catapult-sdk/plugins/metadata.js';
+import test from '../binaryTestUtils.js';
+import { expect } from 'chai';
 
 describe('metadata plugin', () => {
 	describe('register schema', () => {

--- a/client/rest/test/catapult-sdk/plugins/mosaic_spec.js
+++ b/client/rest/test/catapult-sdk/plugins/mosaic_spec.js
@@ -19,11 +19,11 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const EntityType = require('../../../src/catapult-sdk/model/EntityType');
-const ModelSchemaBuilder = require('../../../src/catapult-sdk/model/ModelSchemaBuilder');
-const mosaic = require('../../../src/catapult-sdk/plugins/mosaic');
-const test = require('../binaryTestUtils');
-const { expect } = require('chai');
+import EntityType from '../../../src/catapult-sdk/model/EntityType.js';
+import ModelSchemaBuilder from '../../../src/catapult-sdk/model/ModelSchemaBuilder.js';
+import mosaic from '../../../src/catapult-sdk/plugins/mosaic.js';
+import test from '../binaryTestUtils.js';
+import { expect } from 'chai';
 
 const constants = {
 	sizes: {

--- a/client/rest/test/catapult-sdk/plugins/multisig_spec.js
+++ b/client/rest/test/catapult-sdk/plugins/multisig_spec.js
@@ -19,11 +19,11 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const EntityType = require('../../../src/catapult-sdk/model/EntityType');
-const ModelSchemaBuilder = require('../../../src/catapult-sdk/model/ModelSchemaBuilder');
-const multisig = require('../../../src/catapult-sdk/plugins/multisig');
-const test = require('../binaryTestUtils');
-const { expect } = require('chai');
+import EntityType from '../../../src/catapult-sdk/model/EntityType.js';
+import ModelSchemaBuilder from '../../../src/catapult-sdk/model/ModelSchemaBuilder.js';
+import multisig from '../../../src/catapult-sdk/plugins/multisig.js';
+import test from '../binaryTestUtils.js';
+import { expect } from 'chai';
 
 const constants = {
 	sizes: {

--- a/client/rest/test/catapult-sdk/plugins/namespace_spec.js
+++ b/client/rest/test/catapult-sdk/plugins/namespace_spec.js
@@ -19,13 +19,13 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const EntityType = require('../../../src/catapult-sdk/model/EntityType');
-const ModelSchemaBuilder = require('../../../src/catapult-sdk/model/ModelSchemaBuilder');
-const ModelType = require('../../../src/catapult-sdk/model/ModelType');
-const namespace = require('../../../src/catapult-sdk/plugins/namespace');
-const schemaFormatter = require('../../../src/catapult-sdk/utils/schemaFormatter');
-const test = require('../binaryTestUtils');
-const { expect } = require('chai');
+import EntityType from '../../../src/catapult-sdk/model/EntityType.js';
+import ModelSchemaBuilder from '../../../src/catapult-sdk/model/ModelSchemaBuilder.js';
+import ModelType from '../../../src/catapult-sdk/model/ModelType.js';
+import namespace from '../../../src/catapult-sdk/plugins/namespace.js';
+import schemaFormatter from '../../../src/catapult-sdk/utils/schemaFormatter.js';
+import test from '../binaryTestUtils.js';
+import { expect } from 'chai';
 
 const constants = {
 	sizes: {

--- a/client/rest/test/catapult-sdk/plugins/receipts_spec.js
+++ b/client/rest/test/catapult-sdk/plugins/receipts_spec.js
@@ -19,11 +19,11 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const ModelSchemaBuilder = require('../../../src/catapult-sdk/model/ModelSchemaBuilder');
-const ModelType = require('../../../src/catapult-sdk/model/ModelType');
-const receiptsPlugin = require('../../../src/catapult-sdk/plugins/receipts');
-const schemaFormatter = require('../../../src/catapult-sdk/utils/schemaFormatter');
-const { expect } = require('chai');
+import ModelSchemaBuilder from '../../../src/catapult-sdk/model/ModelSchemaBuilder.js';
+import ModelType from '../../../src/catapult-sdk/model/ModelType.js';
+import receiptsPlugin from '../../../src/catapult-sdk/plugins/receipts.js';
+import schemaFormatter from '../../../src/catapult-sdk/utils/schemaFormatter.js';
+import { expect } from 'chai';
 
 describe('receipts plugin', () => {
 	describe('register schema', () => {

--- a/client/rest/test/catapult-sdk/plugins/restrictions_spec.js
+++ b/client/rest/test/catapult-sdk/plugins/restrictions_spec.js
@@ -19,12 +19,13 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const EntityType = require('../../../src/catapult-sdk/model/EntityType');
-const ModelSchemaBuilder = require('../../../src/catapult-sdk/model/ModelSchemaBuilder');
-const restrictionsPlugin = require('../../../src/catapult-sdk/plugins/restrictions');
-const { AccountRestrictionType } = require('../../../src/catapult-sdk/plugins/restrictions');
-const test = require('../binaryTestUtils');
-const { expect } = require('chai');
+import EntityType from '../../../src/catapult-sdk/model/EntityType.js';
+import ModelSchemaBuilder from '../../../src/catapult-sdk/model/ModelSchemaBuilder.js';
+import restrictionsPlugin from '../../../src/catapult-sdk/plugins/restrictions.js';
+import test from '../binaryTestUtils.js';
+import { expect } from 'chai';
+
+const { AccountRestrictionType } = restrictionsPlugin;
 
 describe('restrictions plugin', () => {
 	describe('account restriction types enumeration', () => {

--- a/client/rest/test/catapult-sdk/plugins/transfer_spec.js
+++ b/client/rest/test/catapult-sdk/plugins/transfer_spec.js
@@ -19,11 +19,11 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const EntityType = require('../../../src/catapult-sdk/model/EntityType');
-const ModelSchemaBuilder = require('../../../src/catapult-sdk/model/ModelSchemaBuilder');
-const transfer = require('../../../src/catapult-sdk/plugins/transfer');
-const test = require('../binaryTestUtils');
-const { expect } = require('chai');
+import EntityType from '../../../src/catapult-sdk/model/EntityType.js';
+import ModelSchemaBuilder from '../../../src/catapult-sdk/model/ModelSchemaBuilder.js';
+import transfer from '../../../src/catapult-sdk/plugins/transfer.js';
+import test from '../binaryTestUtils.js';
+import { expect } from 'chai';
 
 const constants = {
 	sizes: {

--- a/client/rest/test/catapult-sdk/serializer/BinarySerializer_spec.js
+++ b/client/rest/test/catapult-sdk/serializer/BinarySerializer_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const BinarySerializer = require('../../../src/catapult-sdk/serializer/BinarySerializer');
-const { expect } = require('chai');
+import BinarySerializer from '../../../src/catapult-sdk/serializer/BinarySerializer.js';
+import { expect } from 'chai';
 
 describe('BinarySerializer', () => {
 	// region constructor

--- a/client/rest/test/catapult-sdk/serializer/SerializedSizeCalculator_spec.js
+++ b/client/rest/test/catapult-sdk/serializer/SerializedSizeCalculator_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const SerializedSizeCalculator = require('../../../src/catapult-sdk/serializer/SerializedSizeCalculator');
-const { expect } = require('chai');
+import SerializedSizeCalculator from '../../../src/catapult-sdk/serializer/SerializedSizeCalculator.js';
+import { expect } from 'chai';
 
 describe('EntitySizeCalculator', () => {
 	const addTypeSerializerTests = (name, validData, expectedSize) => {

--- a/client/rest/test/catapult-sdk/testUtils.js
+++ b/client/rest/test/catapult-sdk/testUtils.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const sizes = require('../../src/catapult-sdk/modelBinary/sizes');
-const crypto = require('crypto');
+import sizes from '../../src/catapult-sdk/modelBinary/sizes.js';
+import crypto from 'crypto';
 
-module.exports = {
+export default {
 	constants: { sizes },
 
 	random: {

--- a/client/rest/test/catapult-sdk/utils/CachedFileLoader_spec.js
+++ b/client/rest/test/catapult-sdk/utils/CachedFileLoader_spec.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const CachedFileLoader = require('../../../src/catapult-sdk/utils/CachedFileLoader');
-const { expect } = require('chai');
-const tmp = require('tmp');
-const fs = require('fs');
+import CachedFileLoader from '../../../src/catapult-sdk/utils/CachedFileLoader.js';
+import { expect } from 'chai';
+import tmp from 'tmp';
+import fs from 'fs';
 
 describe('CachedFileLoader', () => {
 	const createSplitProcessor = () => {

--- a/client/rest/test/catapult-sdk/utils/SchemaType_spec.js
+++ b/client/rest/test/catapult-sdk/utils/SchemaType_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const SchemaType = require('../../../src/catapult-sdk/utils/SchemaType');
-const { expect } = require('chai');
+import SchemaType from '../../../src/catapult-sdk/utils/SchemaType.js';
+import { expect } from 'chai';
 
 describe('schema type enumeration', () => {
 	it('exposes expected types', () => {

--- a/client/rest/test/catapult-sdk/utils/arrayUtils_spec.js
+++ b/client/rest/test/catapult-sdk/utils/arrayUtils_spec.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const arrayUtils = require('../../../src/catapult-sdk/utils/arrayUtils');
-const convert = require('../../../src/catapult-sdk/utils/convert');
-const { expect } = require('chai');
+import arrayUtils from '../../../src/catapult-sdk/utils/arrayUtils.js';
+import convert from '../../../src/catapult-sdk/utils/convert.js';
+import { expect } from 'chai';
 
 describe('array', () => {
 	describe('uint8View', () => {

--- a/client/rest/test/catapult-sdk/utils/base32_spec.js
+++ b/client/rest/test/catapult-sdk/utils/base32_spec.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const base32 = require('../../../src/catapult-sdk/utils/base32');
-const convert = require('../../../src/catapult-sdk/utils/convert');
-const { expect } = require('chai');
+import base32 from '../../../src/catapult-sdk/utils/base32.js';
+import convert from '../../../src/catapult-sdk/utils/convert.js';
+import { expect } from 'chai';
 
 describe('base32', () => {
 	const Test_Vectors = [

--- a/client/rest/test/catapult-sdk/utils/charMapping_spec.js
+++ b/client/rest/test/catapult-sdk/utils/charMapping_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const charMapping = require('../../../src/catapult-sdk/utils/charMapping');
-const { expect } = require('chai');
+import charMapping from '../../../src/catapult-sdk/utils/charMapping.js';
+import { expect } from 'chai';
 
 describe('char mapping', () => {
 	describe('builder', () => {

--- a/client/rest/test/catapult-sdk/utils/convert_spec.js
+++ b/client/rest/test/catapult-sdk/utils/convert_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const convert = require('../../../src/catapult-sdk/utils/convert');
-const { expect } = require('chai');
+import convert from '../../../src/catapult-sdk/utils/convert.js';
+import { expect } from 'chai';
 
 describe('convert', () => {
 	describe('toByte', () => {

--- a/client/rest/test/catapult-sdk/utils/formattingUtils_spec.js
+++ b/client/rest/test/catapult-sdk/utils/formattingUtils_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const formattingUtils = require('../../../src/catapult-sdk/utils/formattingUtils');
-const { expect } = require('chai');
+import formattingUtils from '../../../src/catapult-sdk/utils/formattingUtils.js';
+import { expect } from 'chai';
 
 const createEntity = seed => ({ foo: seed, bar: seed + 1, bazz: seed + 2 });
 

--- a/client/rest/test/catapult-sdk/utils/future_spec.js
+++ b/client/rest/test/catapult-sdk/utils/future_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const future = require('../../../src/catapult-sdk/utils/future');
-const { expect } = require('chai');
+import future from '../../../src/catapult-sdk/utils/future.js';
+import { expect } from 'chai';
 
 describe('future', () => {
 	describe('makeRetryable', () => {

--- a/client/rest/test/catapult-sdk/utils/objects_spec.js
+++ b/client/rest/test/catapult-sdk/utils/objects_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const objects = require('../../../src/catapult-sdk/utils/objects');
-const { expect } = require('chai');
+import objects from '../../../src/catapult-sdk/utils/objects.js';
+import { expect } from 'chai';
 
 describe('objects', () => {
 	const propertyTypeDescriptors = [

--- a/client/rest/test/catapult-sdk/utils/schemaFormatter_spec.js
+++ b/client/rest/test/catapult-sdk/utils/schemaFormatter_spec.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const SchemaType = require('../../../src/catapult-sdk/utils/SchemaType');
-const schemaFormatter = require('../../../src/catapult-sdk/utils/schemaFormatter');
-const { expect } = require('chai');
+import SchemaType from '../../../src/catapult-sdk/utils/SchemaType.js';
+import schemaFormatter from '../../../src/catapult-sdk/utils/schemaFormatter.js';
+import { expect } from 'chai';
 
 describe('schema formatter', () => {
 	describe('basic triggering', () => {

--- a/client/rest/test/catapult-sdk/utils/uint64_spec.js
+++ b/client/rest/test/catapult-sdk/utils/uint64_spec.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const convert = require('../../../src/catapult-sdk/utils/convert');
-const uint64 = require('../../../src/catapult-sdk/utils/uint64');
-const { expect } = require('chai');
+import convert from '../../../src/catapult-sdk/utils/convert.js';
+import uint64 from '../../../src/catapult-sdk/utils/uint64.js';
+import { expect } from 'chai';
 
 describe('uint64', () => {
 	describe('compact', () => {

--- a/client/rest/test/connection/MessageChannelBuilder_spec.js
+++ b/client/rest/test/connection/MessageChannelBuilder_spec.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const MessageChannelBuilder = require('../../src/connection/MessageChannelBuilder');
-const { ServerMessageHandler } = require('../../src/connection/serverMessageHandlers');
-const test = require('../testUtils');
-const { expect } = require('chai');
+import MessageChannelBuilder from '../../src/connection/MessageChannelBuilder.js';
+import ServerMessageHandler from '../../src/connection/serverMessageHandlers.js';
+import test from '../testUtils.js';
+import { expect } from 'chai';
 
 describe('message channel builder', () => {
 	const networkIdentifier = 152;

--- a/client/rest/test/connection/MockSocket.js
+++ b/client/rest/test/connection/MockSocket.js
@@ -19,7 +19,7 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-class MockSocket {
+export default class MockSocket {
 	constructor() {
 		this.authorized = false;
 		this.numWrites = 0;
@@ -51,7 +51,3 @@ class MockSocket {
 		}
 	}
 }
-
-module.exports = {
-	MockSocket
-};

--- a/client/rest/test/connection/catapultConnection_spec.js
+++ b/client/rest/test/connection/catapultConnection_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapultConnection = require('../../src/connection/catapultConnection');
-const { expect } = require('chai');
+import catapultConnection from '../../src/connection/catapultConnection.js';
+import { expect } from 'chai';
 
 describe('catapult connection', () => {
 	const createTestContext = () => {

--- a/client/rest/test/connection/connectionService_spec.js
+++ b/client/rest/test/connection/connectionService_spec.js
@@ -19,11 +19,11 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { MockSocket } = require('./MockSocket');
-const { createConnectionService } = require('../../src/connection/connectionService');
-const { expect } = require('chai');
-const sinon = require('sinon');
-const tls = require('tls');
+import MockSocket from './MockSocket.js';
+import createConnectionService from '../../src/connection/connectionService.js';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import tls from 'tls';
 
 describe('connection service', () => {
 	const sockets = [];

--- a/client/rest/test/connection/serverMessageHandlers_spec.js
+++ b/client/rest/test/connection/serverMessageHandlers_spec.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { ServerMessageHandler } = require('../../src/connection/serverMessageHandlers');
-const test = require('../testUtils');
-const { expect } = require('chai');
+import ServerMessageHandler from '../../src/connection/serverMessageHandlers.js';
+import test from '../testUtils.js';
+import { expect } from 'chai';
 
 describe('server message handlers', () => {
 	const createMockCodec = value => {

--- a/client/rest/test/connection/zmqService_spec.js
+++ b/client/rest/test/connection/zmqService_spec.js
@@ -19,12 +19,12 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../src/catapult-sdk/index');
-const MessageChannelBuilder = require('../../src/connection/MessageChannelBuilder');
-const { createZmqConnectionService } = require('../../src/connection/zmqService');
-const test = require('../testUtils');
-const { expect } = require('chai');
-const zmq = require('zeromq');
+import catapult from '../../src/catapult-sdk/index.js';
+import MessageChannelBuilder from '../../src/connection/MessageChannelBuilder.js';
+import createZmqConnectionService from '../../src/connection/zmqService.js';
+import test from '../testUtils.js';
+import { expect } from 'chai';
+import zmq from 'zeromq';
 
 describe('zmq service', () => {
 	const cleanupActions = [];

--- a/client/rest/test/connection/zmqUtils_spec.js
+++ b/client/rest/test/connection/zmqUtils_spec.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const zmqUtils = require('../../src/connection/zmqUtils');
-const test = require('../testUtils');
-const { expect } = require('chai');
+import zmqUtils from '../../src/connection/zmqUtils.js';
+import test from '../testUtils.js';
+import { expect } from 'chai';
 
 describe('zmqUtils', () => {
 	const createMockZsocket = () => {

--- a/client/rest/test/db/CatapultDb_spec.js
+++ b/client/rest/test/db/CatapultDb_spec.js
@@ -19,14 +19,14 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const test = require('./utils/dbTestUtils');
-const testDbOptions = require('./utils/testDbOptions');
-const catapult = require('../../src/catapult-sdk/index');
-const CatapultDb = require('../../src/db/CatapultDb');
-const { uniqueLongList } = require('../../src/db/dbUtils');
-const { expect } = require('chai');
-const MongoDb = require('mongodb');
-const sinon = require('sinon');
+import test from './utils/dbTestUtils.js';
+import testDbOptions from './utils/testDbOptions.js';
+import catapult from '../../src/catapult-sdk/index.js';
+import CatapultDb from '../../src/db/CatapultDb.js';
+import { uniqueLongList } from '../../src/db/dbUtils.js';
+import { expect } from 'chai';
+import MongoDb from 'mongodb';
+import sinon from 'sinon';
 
 const { address, EntityType } = catapult.model;
 

--- a/client/rest/test/db/connector_spec.js
+++ b/client/rest/test/db/connector_spec.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const testDbOptions = require('./utils/testDbOptions');
-const connector = require('../../src/db/connector');
-const { expect } = require('chai');
+import testDbOptions from './utils/testDbOptions.js';
+import connector from '../../src/db/connector.js';
+import { expect } from 'chai';
 
 describe('connector', () => {
 	const connections = [];

--- a/client/rest/test/db/dbFormattingRules_spec.js
+++ b/client/rest/test/db/dbFormattingRules_spec.js
@@ -19,12 +19,12 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../src/catapult-sdk/index');
-const formattingRules = require('../../src/db/dbFormattingRules');
-const { convertToLong } = require('../../src/db/dbUtils');
-const test = require('../testUtils');
-const { expect } = require('chai');
-const { Binary } = require('mongodb');
+import catapult from '../../src/catapult-sdk/index.js';
+import formattingRules from '../../src/db/dbFormattingRules.js';
+import { convertToLong } from '../../src/db/dbUtils.js';
+import test from '../testUtils.js';
+import { expect } from 'chai';
+import { Binary } from 'mongodb';
 
 const { ModelType } = catapult.model;
 

--- a/client/rest/test/db/dbUtils_spec.js
+++ b/client/rest/test/db/dbUtils_spec.js
@@ -19,10 +19,11 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const dbUtils = require('../../src/db/dbUtils');
-const { convertToLong } = require('../../src/db/dbUtils');
-const { expect } = require('chai');
-const MongoDb = require('mongodb');
+import {
+	bufferToUnresolvedAddress, buildOffsetCondition, convertToLong, longToUint64, uniqueLongList
+} from '../../src/db/dbUtils.js';
+import { expect } from 'chai';
+import MongoDb from 'mongodb';
 
 const { ObjectId } = MongoDb;
 
@@ -30,29 +31,29 @@ describe('db utils', () => {
 	describe('convertToLong', () => {
 		it('can convert from integer to long', () => {
 			// Act + Assert:
-			expect(dbUtils.convertToLong(123)).to.deep.equal(new MongoDb.Long(123, 0));
+			expect(convertToLong(123)).to.deep.equal(new MongoDb.Long(123, 0));
 		});
 
 		it('can convert from uint64 array to long', () => {
 			// Act + Assert:
-			expect(dbUtils.convertToLong([123, 456])).to.deep.equal(new MongoDb.Long(123, 456));
+			expect(convertToLong([123, 456])).to.deep.equal(new MongoDb.Long(123, 456));
 		});
 
 		it('can convert from negative one to long', () => {
 			// Act + Assert:
-			expect(dbUtils.convertToLong(-1)).to.deep.equal(MongoDb.Long.NEG_ONE);
+			expect(convertToLong(-1)).to.deep.equal(MongoDb.Long.NEG_ONE);
 		});
 
 		it('can convert from one to long', () => {
 			// Act + Assert:
-			expect(dbUtils.convertToLong(1)).to.deep.equal(MongoDb.Long.ONE);
-			expect(dbUtils.convertToLong([1, 0])).to.deep.equal(MongoDb.Long.ONE);
+			expect(convertToLong(1)).to.deep.equal(MongoDb.Long.ONE);
+			expect(convertToLong([1, 0])).to.deep.equal(MongoDb.Long.ONE);
 		});
 
 		it('can convert from zero to long', () => {
 			// Act + Assert:
-			expect(dbUtils.convertToLong(0)).to.deep.equal(MongoDb.Long.ZERO);
-			expect(dbUtils.convertToLong([0, 0])).to.deep.equal(MongoDb.Long.ZERO);
+			expect(convertToLong(0)).to.deep.equal(MongoDb.Long.ZERO);
+			expect(convertToLong([0, 0])).to.deep.equal(MongoDb.Long.ZERO);
 		});
 
 		it('returns same value if value is already long', () => {
@@ -60,51 +61,51 @@ describe('db utils', () => {
 			const longValue = MongoDb.Long.fromNumber(12345);
 
 			// Act + Assert:
-			expect(dbUtils.convertToLong(longValue)).to.deep.equal(longValue);
+			expect(convertToLong(longValue)).to.deep.equal(longValue);
 		});
 
 		it('throws error if value not integer and not array', () => {
 			// Act + Assert:
-			expect(() => dbUtils.convertToLong('abc')).to.throw('abc has an invalid format: not integer or uint64');
+			expect(() => convertToLong('abc')).to.throw('abc has an invalid format: not integer or uint64');
 		});
 	});
 
 	describe('longToUint64', () => {
 		it('can convert from long to uint64', () => {
 			// Act + Assert:
-			expect(dbUtils.longToUint64(new MongoDb.Long(123, 456))).to.deep.equal([123, 456]);
+			expect(longToUint64(new MongoDb.Long(123, 456))).to.deep.equal([123, 456]);
 		});
 
 		it('can convert from one, long value, to uint64', () => {
 			// Act + Assert:
-			expect(dbUtils.longToUint64(MongoDb.Long.ONE)).to.deep.equal([1, 0]);
+			expect(longToUint64(MongoDb.Long.ONE)).to.deep.equal([1, 0]);
 		});
 
 		it('can convert from zero, long value, to uint64', () => {
 			// Act + Assert:
-			expect(dbUtils.longToUint64(MongoDb.Long.ZERO)).to.deep.equal([0, 0]);
+			expect(longToUint64(MongoDb.Long.ZERO)).to.deep.equal([0, 0]);
 		});
 
 		it('throws error if value not long', () => {
 			// Act + Assert:
-			expect(() => dbUtils.longToUint64('abc')).to.throw('abc has an invalid format: not long');
+			expect(() => longToUint64('abc')).to.throw('abc has an invalid format: not long');
 		});
 	});
 	describe('uniqueLongList', () => {
 		it('unique list empty', () => {
 			// Act + Assert
-			expect(dbUtils.uniqueLongList([])).to.deep.equal([]);
+			expect(uniqueLongList([])).to.deep.equal([]);
 		});
 
 		it('unique list not duplicated', () => {
 			// Act + Assert
-			expect(dbUtils.uniqueLongList([convertToLong(1), convertToLong(2), convertToLong(3)]))
+			expect(uniqueLongList([convertToLong(1), convertToLong(2), convertToLong(3)]))
 				.to.deep.equal([convertToLong(1), convertToLong(2), convertToLong(3)]);
 		});
 
 		it('unique list duplicated', () => {
 			// Act + Assert
-			expect(dbUtils.uniqueLongList([convertToLong(3), convertToLong(1), convertToLong(3)]))
+			expect(uniqueLongList([convertToLong(3), convertToLong(1), convertToLong(3)]))
 				.to.deep.equal([convertToLong(3), convertToLong(1)]);
 		});
 	});
@@ -116,7 +117,7 @@ describe('db utils', () => {
 			const sortFieldDbRelation = { id: '_id' };
 
 			// Act + Assert
-			expect(dbUtils.buildOffsetCondition(options, sortFieldDbRelation)).to.equal(undefined);
+			expect(buildOffsetCondition(options, sortFieldDbRelation)).to.equal(undefined);
 		});
 
 		it('can create object id offset condition', () => {
@@ -130,7 +131,7 @@ describe('db utils', () => {
 			const sortFieldDbRelation = { id: '_id' };
 
 			// Act + Assert
-			expect(dbUtils.buildOffsetCondition(options, sortFieldDbRelation)).to.deep.equal({
+			expect(buildOffsetCondition(options, sortFieldDbRelation)).to.deep.equal({
 				_id: { $lt: new ObjectId('112233445566778899AABBCC') }
 			});
 		});
@@ -146,7 +147,7 @@ describe('db utils', () => {
 			const sortFieldDbRelation = { height: 'height' };
 
 			// Act + Assert
-			expect(dbUtils.buildOffsetCondition(options, sortFieldDbRelation)).to.deep.equal({
+			expect(buildOffsetCondition(options, sortFieldDbRelation)).to.deep.equal({
 				height: { $lt: convertToLong([1234, 5678]) }
 			});
 		});
@@ -162,7 +163,7 @@ describe('db utils', () => {
 			const sortFieldDbRelation = { id: '_id' };
 
 			// Act + Assert
-			expect(dbUtils.buildOffsetCondition(options, sortFieldDbRelation)).to.deep.equal({
+			expect(buildOffsetCondition(options, sortFieldDbRelation)).to.deep.equal({
 				_id: { $lt: convertToLong([1234, 5678]) }
 			});
 		});
@@ -174,7 +175,7 @@ describe('db utils', () => {
 			const object = Buffer.from('98E0D138EAF2AC342C015FF0B631EC3622E8AFFA04BFCC56', 'hex');
 
 			// Act:
-			const result = dbUtils.bufferToUnresolvedAddress(object, true);
+			const result = bufferToUnresolvedAddress(object, true);
 
 			// Assert:
 			expect(result).to.equal('TDQNCOHK6KWDILABL7YLMMPMGYRORL72AS74YVQ');
@@ -185,7 +186,7 @@ describe('db utils', () => {
 			const object = Buffer.from('98E0D138EAF2AC342C015FF0B631EC3622E8AFFA04BFCC56', 'hex');
 
 			// Act:
-			const result = dbUtils.bufferToUnresolvedAddress(object);
+			const result = bufferToUnresolvedAddress(object);
 
 			// Assert:
 			expect(result).to.equal('98E0D138EAF2AC342C015FF0B631EC3622E8AFFA04BFCC56');
@@ -196,7 +197,7 @@ describe('db utils', () => {
 			const object = undefined;
 
 			// Act:
-			const result = dbUtils.bufferToUnresolvedAddress(object);
+			const result = bufferToUnresolvedAddress(object);
 
 			// Assert:
 			expect(result).to.equal(undefined);
@@ -207,7 +208,7 @@ describe('db utils', () => {
 			const object = '99CAAB0FD01CCF25BA000000000000000000000000000000';
 
 			// act + Assert:
-			expect(() => dbUtils.bufferToUnresolvedAddress(object)).to.throw('Cannot convert binary address, unknown String type');
+			expect(() => bufferToUnresolvedAddress(object)).to.throw('Cannot convert binary address, unknown String type');
 		});
 	});
 });

--- a/client/rest/test/db/entityEmitterFactory_spec.js
+++ b/client/rest/test/db/entityEmitterFactory_spec.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const entityEmitterFactory = require('../../src/db/entityEmitterFactory');
-const { expect } = require('chai');
-const EventEmitter = require('events');
+import entityEmitterFactory from '../../src/db/entityEmitterFactory.js';
+import { expect } from 'chai';
+import EventEmitter from 'events';
 
 describe('entity emitter factory', () => {
 	it('registers block listener', () => {

--- a/client/rest/test/db/utils/dbTestUtils.js
+++ b/client/rest/test/db/utils/dbTestUtils.js
@@ -19,12 +19,12 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const testDbOptions = require('./testDbOptions');
-const catapult = require('../../../src/catapult-sdk/index');
-const CatapultDb = require('../../../src/db/CatapultDb');
-const { convertToLong } = require('../../../src/db/dbUtils');
-const test = require('../../testUtils');
-const MongoDb = require('mongodb');
+import testDbOptions from './testDbOptions.js';
+import catapult from '../../../src/catapult-sdk/index.js';
+import CatapultDb from '../../../src/db/CatapultDb.js';
+import { convertToLong } from '../../../src/db/dbUtils.js';
+import test from '../../testUtils.js';
+import MongoDb from 'mongodb';
 
 const { address } = catapult.model;
 
@@ -302,4 +302,4 @@ const dbTestUtils = {
 };
 Object.assign(dbTestUtils, test);
 
-module.exports = dbTestUtils;
+export default dbTestUtils;

--- a/client/rest/test/db/utils/testDbOptions.js
+++ b/client/rest/test/db/utils/testDbOptions.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../../src/catapult-sdk/index');
-const parseArgs = require('minimist');
+import catapult from '../../../src/catapult-sdk/index.js';
+import parseArgs from 'minimist';
 
-module.exports = {
+export default {
 	url: (() => {
 		const args = parseArgs(process.argv.slice(2));
 		const mongoHost = args.mongoHost || '127.0.0.1';

--- a/client/rest/test/plugins/aggregate/aggregateRoutes_spec.js
+++ b/client/rest/test/plugins/aggregate/aggregateRoutes_spec.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../../src/catapult-sdk/index');
-const aggregateRoutes = require('../../../src/plugins/aggregate/aggregateRoutes');
-const { test } = require('../../routes/utils/routeTestUtils');
+import catapult from '../../../src/catapult-sdk/index.js';
+import aggregateRoutes from '../../../src/plugins/aggregate/aggregateRoutes.js';
+import test from '../../routes/utils/routeTestUtils.js';
 
 const { PacketType } = catapult.packet;
 

--- a/client/rest/test/plugins/aggregate/aggregate_spec.js
+++ b/client/rest/test/plugins/aggregate/aggregate_spec.js
@@ -19,11 +19,11 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { ServerMessageHandler } = require('../../../src/connection/serverMessageHandlers');
-const aggregate = require('../../../src/plugins/aggregate/aggregate');
-const { test } = require('../../routes/utils/routeTestUtils');
-const pluginTest = require('../utils/pluginTestUtils');
-const { expect } = require('chai');
+import ServerMessageHandler from '../../../src/connection/serverMessageHandlers.js';
+import aggregate from '../../../src/plugins/aggregate/aggregate.js';
+import test from '../../routes/utils/routeTestUtils.js';
+import pluginTest from '../utils/pluginTestUtils.js';
+import { expect } from 'chai';
 
 describe('aggregate plugin', () => {
 	pluginTest.assertThat.pluginDoesNotCreateDb(aggregate);

--- a/client/rest/test/plugins/empty_spec.js
+++ b/client/rest/test/plugins/empty_spec.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const pluginTest = require('./utils/pluginTestUtils');
-const empty = require('../../src/plugins/empty');
-const { test } = require('../routes/utils/routeTestUtils');
+import pluginTest from './utils/pluginTestUtils.js';
+import empty from '../../src/plugins/empty.js';
+import test from '../routes/utils/routeTestUtils.js';
 
 describe('transfer plugin', () => {
 	pluginTest.assertThat.pluginDoesNotCreateDb(empty);

--- a/client/rest/test/plugins/lockHash/LockHashDb_spec.js
+++ b/client/rest/test/plugins/lockHash/LockHashDb_spec.js
@@ -19,11 +19,11 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const CatapultDb = require('../../../src/db/CatapultDb');
-const HashLocksDb = require('../../../src/plugins/lockHash/LockHashDb');
-const test = require('../../db/utils/dbTestUtils');
-const { expect } = require('chai');
-const sinon = require('sinon');
+import CatapultDb from '../../../src/db/CatapultDb.js';
+import HashLocksDb from '../../../src/plugins/lockHash/LockHashDb.js';
+import test from '../../db/utils/dbTestUtils.js';
+import { expect } from 'chai';
+import sinon from 'sinon';
 
 describe('hash locks db', () => {
 	const ownerAddressTest1 = test.random.address();

--- a/client/rest/test/plugins/lockHash/lockHashRoutes_spec.js
+++ b/client/rest/test/plugins/lockHash/lockHashRoutes_spec.js
@@ -19,15 +19,15 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../../src/catapult-sdk/index');
-const lockHashRoutes = require('../../../src/plugins/lockHash/lockHashRoutes');
-const routeUtils = require('../../../src/routes/routeUtils');
-const { MockServer } = require('../../routes/utils/routeTestUtils');
-const { test } = require('../../routes/utils/routeTestUtils');
-const { expect } = require('chai');
-const sinon = require('sinon');
+import catapult from '../../../src/catapult-sdk/index.js';
+import lockHashRoutes from '../../../src/plugins/lockHash/lockHashRoutes.js';
+import routeUtils from '../../../src/routes/routeUtils.js';
+import test from '../../routes/utils/routeTestUtils.js';
+import { expect } from 'chai';
+import sinon from 'sinon';
 
 const { address } = catapult.model;
+const { MockServer } = test;
 
 describe('lock hash routes', () => {
 	describe('hash locks', () => {

--- a/client/rest/test/plugins/lockHash/lockHash_spec.js
+++ b/client/rest/test/plugins/lockHash/lockHash_spec.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const LockHashDb = require('../../../src/plugins/lockHash/LockHashDb');
-const lockHash = require('../../../src/plugins/lockHash/lockHash');
-const { test } = require('../../routes/utils/routeTestUtils');
-const pluginTest = require('../utils/pluginTestUtils');
+import LockHashDb from '../../../src/plugins/lockHash/LockHashDb.js';
+import lockHash from '../../../src/plugins/lockHash/lockHash.js';
+import test from '../../routes/utils/routeTestUtils.js';
+import pluginTest from '../utils/pluginTestUtils.js';
 
 describe('lock hash plugin', () => {
 	pluginTest.assertThat.pluginCreatesDb(lockHash, LockHashDb);

--- a/client/rest/test/plugins/lockSecret/LockSecretDb_spec.js
+++ b/client/rest/test/plugins/lockSecret/LockSecretDb_spec.js
@@ -19,11 +19,11 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const CatapultDb = require('../../../src/db/CatapultDb');
-const SecretLocksDb = require('../../../src/plugins/lockSecret/LockSecretDb');
-const test = require('../../db/utils/dbTestUtils');
-const { expect } = require('chai');
-const sinon = require('sinon');
+import CatapultDb from '../../../src/db/CatapultDb.js';
+import SecretLocksDb from '../../../src/plugins/lockSecret/LockSecretDb.js';
+import test from '../../db/utils/dbTestUtils.js';
+import { expect } from 'chai';
+import sinon from 'sinon';
 
 describe('secret locks db', () => {
 	const ownerAddressTest1 = test.random.address();

--- a/client/rest/test/plugins/lockSecret/lockSecretRoutes_spec.js
+++ b/client/rest/test/plugins/lockSecret/lockSecretRoutes_spec.js
@@ -19,16 +19,16 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../../src/catapult-sdk/index');
-const lockSecretRoutes = require('../../../src/plugins/lockSecret/lockSecretRoutes');
-const routeUtils = require('../../../src/routes/routeUtils');
-const { MockServer } = require('../../routes/utils/routeTestUtils');
-const { test } = require('../../routes/utils/routeTestUtils');
-const { expect } = require('chai');
-const sinon = require('sinon');
+import catapult from '../../../src/catapult-sdk/index.js';
+import lockSecretRoutes from '../../../src/plugins/lockSecret/lockSecretRoutes.js';
+import routeUtils from '../../../src/routes/routeUtils.js';
+import test from '../../routes/utils/routeTestUtils.js';
+import { expect } from 'chai';
+import sinon from 'sinon';
 
 const { address } = catapult.model;
 const { convert } = catapult.utils;
+const { MockServer } = test;
 
 describe('lock secret routes', () => {
 	describe('secret locks', () => {

--- a/client/rest/test/plugins/lockSecret/lockSecret_spec.js
+++ b/client/rest/test/plugins/lockSecret/lockSecret_spec.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const LockSecretDb = require('../../../src/plugins/lockSecret/LockSecretDb');
-const lockSecret = require('../../../src/plugins/lockSecret/lockSecret');
-const { test } = require('../../routes/utils/routeTestUtils');
-const pluginTest = require('../utils/pluginTestUtils');
+import LockSecretDb from '../../../src/plugins/lockSecret/LockSecretDb.js';
+import lockSecret from '../../../src/plugins/lockSecret/lockSecret.js';
+import test from '../../routes/utils/routeTestUtils.js';
+import pluginTest from '../utils/pluginTestUtils.js';
 
 describe('lock secret plugin', () => {
 	pluginTest.assertThat.pluginCreatesDb(lockSecret, LockSecretDb);

--- a/client/rest/test/plugins/metadata/MetadataDb_spec.js
+++ b/client/rest/test/plugins/metadata/MetadataDb_spec.js
@@ -19,15 +19,15 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { testData } = require('./metalUtils');
-const catapult = require('../../../src/catapult-sdk/index');
-const CatapultDb = require('../../../src/db/CatapultDb');
-const { convertToLong } = require('../../../src/db/dbUtils');
-const MetadataDb = require('../../../src/plugins/metadata/MetadataDb');
-const { MetalSeal } = require('../../../src/plugins/metadata/metal');
-const test = require('../../db/utils/dbTestUtils');
-const { expect } = require('chai');
-const sinon = require('sinon');
+import { testData } from './metalUtils.js';
+import catapult from '../../../src/catapult-sdk/index.js';
+import CatapultDb from '../../../src/db/CatapultDb.js';
+import { convertToLong } from '../../../src/db/dbUtils.js';
+import MetadataDb from '../../../src/plugins/metadata/MetadataDb.js';
+import { MetalSeal } from '../../../src/plugins/metadata/metal.js';
+import test from '../../db/utils/dbTestUtils.js';
+import { expect } from 'chai';
+import sinon from 'sinon';
 
 const { address } = catapult.model;
 

--- a/client/rest/test/plugins/metadata/metadataRoutes_spec.js
+++ b/client/rest/test/plugins/metadata/metadataRoutes_spec.js
@@ -19,14 +19,15 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../../src/catapult-sdk/index');
-const metadataRoutes = require('../../../src/plugins/metadata/metadataRoutes');
-const routeUtils = require('../../../src/routes/routeUtils');
-const { MockServer } = require('../../routes/utils/routeTestUtils');
-const { expect } = require('chai');
-const sinon = require('sinon');
+import catapult from '../../../src/catapult-sdk/index.js';
+import metadataRoutes from '../../../src/plugins/metadata/metadataRoutes.js';
+import routeUtils from '../../../src/routes/routeUtils.js';
+import test from '../../routes/utils/routeTestUtils.js';
+import { expect } from 'chai';
+import sinon from 'sinon';
 
 const { address } = catapult.model;
+const { MockServer } = test;
 
 describe('metadata routes', () => {
 	describe('metadata', () => {

--- a/client/rest/test/plugins/metadata/metadata_spec.js
+++ b/client/rest/test/plugins/metadata/metadata_spec.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const MetadataDb = require('../../../src/plugins/metadata/MetadataDb');
-const metadata = require('../../../src/plugins/metadata/metadata');
-const { test } = require('../../routes/utils/routeTestUtils');
-const pluginTest = require('../utils/pluginTestUtils');
+import MetadataDb from '../../../src/plugins/metadata/MetadataDb.js';
+import metadata from '../../../src/plugins/metadata/metadata.js';
+import test from '../../routes/utils/routeTestUtils.js';
+import pluginTest from '../utils/pluginTestUtils.js';
 
 describe('metadata plugin', () => {
 	pluginTest.assertThat.pluginCreatesDb(metadata, MetadataDb);

--- a/client/rest/test/plugins/metadata/metalUtils.js
+++ b/client/rest/test/plugins/metadata/metalUtils.js
@@ -1,12 +1,12 @@
-const { sha3_256 } = require('@noble/hashes/sha3');
-const fs = require('fs');
+import { sha3_256 } from '@noble/hashes/sha3';
+import fs from 'fs';
 
-const FILE_PATH = `${__dirname}/resources/metadata.json`;
-const MOSAIC_FILE_PATH = `${__dirname}/resources/metadata_mosaic.json`;
-const IMAGE_PATH = `${__dirname}/resources/image.png`;
+const FILE_PATH = `${import.meta.dirname}/resources/metadata.json`;
+const MOSAIC_FILE_PATH = `${import.meta.dirname}/resources/metadata_mosaic.json`;
+const IMAGE_PATH = `${import.meta.dirname}/resources/image.png`;
 const CHUNK_PAYLOAD_MAX_SIZE = 1012;
 
-const combinePayloadWithText = (payload, text) => {
+export const combinePayloadWithText = (payload, text) => {
 	const textBytes = text ? Buffer.from(text, 'utf8') : Buffer.alloc(0);
 	const isEndAtMidChunk = textBytes.length % CHUNK_PAYLOAD_MAX_SIZE;
 	const textSize = isEndAtMidChunk ? textBytes.length + 1 : textBytes.length;
@@ -32,7 +32,7 @@ const combinePayloadWithText = (payload, text) => {
 	};
 };
 
-const generateChecksum = input => {
+export const generateChecksum = input => {
 	if (0 === input.length)
 		throw new Error('Input must not be empty');
 
@@ -56,24 +56,17 @@ const loadAndFormatMetadata = filePath => {
 const { metadatas, chunks } = loadAndFormatMetadata(FILE_PATH);
 const { metadatas: mosaicMetadatas, chunks: mosaicChunks } = loadAndFormatMetadata(MOSAIC_FILE_PATH);
 
-const getMetadata = (id, isMosaic = false) => {
+export const getMetadata = (id, isMosaic = false) => {
 	const targetArray = isMosaic ? mosaicMetadatas : metadatas;
 	return targetArray.find(obj => obj.id === id);
 };
 
 const imageBytes = fs.readFileSync(IMAGE_PATH);
 
-const testData = {
+export const testData = {
 	metadatas,
 	mosaicMetadatas,
 	chunks,
 	mosaicChunks,
 	imageBytes
-};
-
-module.exports = {
-	combinePayloadWithText,
-	generateChecksum,
-	getMetadata,
-	testData
 };

--- a/client/rest/test/plugins/metadata/metal_spec.js
+++ b/client/rest/test/plugins/metadata/metal_spec.js
@@ -19,15 +19,17 @@
  * along with Catapult.	If not, see <http://www.gnu.org/licenses/>.
  */
 
-const {
+import {
 	combinePayloadWithText,
 	generateChecksum,
 	getMetadata,
 	testData
-} = require('./metalUtils');
-const { hexToUint8 } = require('../../../src/catapult-sdk/utils/convert');
-const { metal, MetalSeal } = require('../../../src/plugins/metadata/metal');
-const { expect } = require('chai');
+} from './metalUtils.js';
+import convert from '../../../src/catapult-sdk/utils/convert.js';
+import { MetalSeal, metal } from '../../../src/plugins/metadata/metal.js';
+import { expect } from 'chai';
+
+const { hexToUint8 } = convert;
 
 describe('metal', () => {
 	describe('extractCompositeHashFromMetalId', () => {

--- a/client/rest/test/plugins/mosaic/MosaicDb_spec.js
+++ b/client/rest/test/plugins/mosaic/MosaicDb_spec.js
@@ -19,13 +19,13 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../../src/catapult-sdk/index');
-const CatapultDb = require('../../../src/db/CatapultDb');
-const MosaicDb = require('../../../src/plugins/mosaic/MosaicDb');
-const test = require('../../db/utils/dbTestUtils');
-const { expect } = require('chai');
-const MongoDb = require('mongodb');
-const sinon = require('sinon');
+import catapult from '../../../src/catapult-sdk/index.js';
+import CatapultDb from '../../../src/db/CatapultDb.js';
+import MosaicDb from '../../../src/plugins/mosaic/MosaicDb.js';
+import test from '../../db/utils/dbTestUtils.js';
+import { expect } from 'chai';
+import MongoDb from 'mongodb';
+import sinon from 'sinon';
 
 const { Binary, Long } = MongoDb;
 const { address } = catapult.model;

--- a/client/rest/test/plugins/mosaic/mosaicRoutes_spec.js
+++ b/client/rest/test/plugins/mosaic/mosaicRoutes_spec.js
@@ -19,15 +19,15 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../../src/catapult-sdk/index');
-const mosaicRoutes = require('../../../src/plugins/mosaic/mosaicRoutes');
-const routeUtils = require('../../../src/routes/routeUtils');
-const { MockServer } = require('../../routes/utils/routeTestUtils');
-const { test } = require('../../routes/utils/routeTestUtils');
-const { expect } = require('chai');
-const sinon = require('sinon');
+import catapult from '../../../src/catapult-sdk/index.js';
+import mosaicRoutes from '../../../src/plugins/mosaic/mosaicRoutes.js';
+import routeUtils from '../../../src/routes/routeUtils.js';
+import test from '../../routes/utils/routeTestUtils.js';
+import { expect } from 'chai';
+import sinon from 'sinon';
 
 const { address } = catapult.model;
+const { MockServer } = test;
 
 describe('mosaic routes', () => {
 	describe('mosaics', () => {

--- a/client/rest/test/plugins/mosaic/mosaic_spec.js
+++ b/client/rest/test/plugins/mosaic/mosaic_spec.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const MosaicDb = require('../../../src/plugins/mosaic/MosaicDb');
-const mosaic = require('../../../src/plugins/mosaic/mosaic');
-const { test } = require('../../routes/utils/routeTestUtils');
-const pluginTest = require('../utils/pluginTestUtils');
+import MosaicDb from '../../../src/plugins/mosaic/MosaicDb.js';
+import mosaic from '../../../src/plugins/mosaic/mosaic.js';
+import test from '../../routes/utils/routeTestUtils.js';
+import pluginTest from '../utils/pluginTestUtils.js';
 
 describe('mosaic plugin', () => {
 	pluginTest.assertThat.pluginCreatesDb(mosaic, MosaicDb);

--- a/client/rest/test/plugins/mosaic/supplyRoutes_spec.js
+++ b/client/rest/test/plugins/mosaic/supplyRoutes_spec.js
@@ -19,14 +19,16 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../../src/catapult-sdk/index');
-const { convertToLong } = require('../../../src/db/dbUtils');
-const supplyRoutes = require('../../../src/plugins/mosaic/supplyRoutes');
-const { MockServer } = require('../../routes/utils/routeTestUtils');
-const { expect } = require('chai');
-const sinon = require('sinon');
-const tmp = require('tmp');
-const fs = require('fs');
+import catapult from '../../../src/catapult-sdk/index.js';
+import { convertToLong } from '../../../src/db/dbUtils.js';
+import supplyRoutes from '../../../src/plugins/mosaic/supplyRoutes.js';
+import test from '../../routes/utils/routeTestUtils.js';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import tmp from 'tmp';
+import fs from 'fs';
+
+const { MockServer } = test;
 
 describe('supply routes', () => {
 	describe('network currency supply', () => {

--- a/client/rest/test/plugins/multisig/MultisigDb_spec.js
+++ b/client/rest/test/plugins/multisig/MultisigDb_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const entitiesByAccounts = require('./entriesByAccountsTestUtils');
-const test = require('./multisigDbTestUtils');
+import entitiesByAccounts from './entriesByAccountsTestUtils.js';
+import test from './multisigDbTestUtils.js';
 
 describe('multisig db', () => {
 	describe('multisigs by addresses', () =>

--- a/client/rest/test/plugins/multisig/entriesByAccountsTestUtils.js
+++ b/client/rest/test/plugins/multisig/entriesByAccountsTestUtils.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const test = require('../../testUtils');
-const { expect } = require('chai');
+import test from '../../testUtils.js';
+import { expect } from 'chai';
 
 const createOwner = test.random.account;
 
@@ -99,4 +99,4 @@ const addTests = traits => {
 	});
 };
 
-module.exports = { addTests };
+export default { addTests };

--- a/client/rest/test/plugins/multisig/multisigDbTestUtils.js
+++ b/client/rest/test/plugins/multisig/multisigDbTestUtils.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const MultisigDb = require('../../../src/plugins/multisig/MultisigDb');
-const dbTestUtils = require('../../db/utils/dbTestUtils');
-const test = require('../../testUtils');
-const MongoDb = require('mongodb');
+import MultisigDb from '../../../src/plugins/multisig/MultisigDb.js';
+import dbTestUtils from '../../db/utils/dbTestUtils.js';
+import test from '../../testUtils.js';
+import MongoDb from 'mongodb';
 
 const { Binary } = MongoDb;
 
@@ -45,4 +45,4 @@ const multisigDbTestUtils = {
 };
 Object.assign(multisigDbTestUtils, test);
 
-module.exports = multisigDbTestUtils;
+export default multisigDbTestUtils;

--- a/client/rest/test/plugins/multisig/multisigRoutes_spec.js
+++ b/client/rest/test/plugins/multisig/multisigRoutes_spec.js
@@ -19,11 +19,11 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const routeAddressGetTestUtils = require('./routeAddressGetTestUtils');
-const catapult = require('../../../src/catapult-sdk/index');
-const multisigRoutes = require('../../../src/plugins/multisig/multisigRoutes');
-const { test } = require('../../routes/utils/routeTestUtils');
-const { expect } = require('chai');
+import routeAddressGetTestUtils from './routeAddressGetTestUtils.js';
+import catapult from '../../../src/catapult-sdk/index.js';
+import multisigRoutes from '../../../src/plugins/multisig/multisigRoutes.js';
+import test from '../../routes/utils/routeTestUtils.js';
+import { expect } from 'chai';
 
 describe('multisig routes', () => {
 	describe('get by account', () => {

--- a/client/rest/test/plugins/multisig/multisig_spec.js
+++ b/client/rest/test/plugins/multisig/multisig_spec.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const MultisigDb = require('../../../src/plugins/multisig/MultisigDb');
-const multisig = require('../../../src/plugins/multisig/multisig');
-const { test } = require('../../routes/utils/routeTestUtils');
-const pluginTest = require('../utils/pluginTestUtils');
+import MultisigDb from '../../../src/plugins/multisig/MultisigDb.js';
+import multisig from '../../../src/plugins/multisig/multisig.js';
+import test from '../../routes/utils/routeTestUtils.js';
+import pluginTest from '../utils/pluginTestUtils.js';
 
 describe('multisig plugin', () => {
 	pluginTest.assertThat.pluginCreatesDb(multisig, MultisigDb);

--- a/client/rest/test/plugins/multisig/routeAddressGetTestUtils.js
+++ b/client/rest/test/plugins/multisig/routeAddressGetTestUtils.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../../src/catapult-sdk/index');
-const { test } = require('../../routes/utils/routeTestUtils');
+import catapult from '../../../src/catapult-sdk/index.js';
+import test from '../../routes/utils/routeTestUtils.js';
 
 const Valid_Address = test.sets.addresses.valid[0];
 
@@ -62,4 +62,4 @@ const routeAddressGetTestUtils = {
 	}
 };
 
-module.exports = routeAddressGetTestUtils;
+export default routeAddressGetTestUtils;

--- a/client/rest/test/plugins/namespace/NamespaceDb_spec.js
+++ b/client/rest/test/plugins/namespace/NamespaceDb_spec.js
@@ -19,20 +19,19 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const test = require('./namespaceDbTestUtils');
-const catapult = require('../../../src/catapult-sdk/index');
-const CatapultDb = require('../../../src/db/CatapultDb');
-const dbUtils = require('../../../src/db/dbUtils');
-const NamespaceDb = require('../../../src/plugins/namespace/NamespaceDb');
-const dbTestUtils = require('../../db/utils/dbTestUtils');
-const testDbOptions = require('../../db/utils/testDbOptions');
-const { expect } = require('chai');
-const MongoDb = require('mongodb');
-const sinon = require('sinon');
+import test from './namespaceDbTestUtils.js';
+import catapult from '../../../src/catapult-sdk/index.js';
+import CatapultDb from '../../../src/db/CatapultDb.js';
+import { convertToLong } from '../../../src/db/dbUtils.js';
+import NamespaceDb from '../../../src/plugins/namespace/NamespaceDb.js';
+import dbTestUtils from '../../db/utils/dbTestUtils.js';
+import testDbOptions from '../../db/utils/testDbOptions.js';
+import { expect } from 'chai';
+import MongoDb from 'mongodb';
+import sinon from 'sinon';
 
 const { address } = catapult.model;
 const { uint64 } = catapult.utils;
-const { convertToLong } = dbUtils;
 const { Binary } = MongoDb;
 
 describe('namespace db', () => {

--- a/client/rest/test/plugins/namespace/namespaceDbTestUtils.js
+++ b/client/rest/test/plugins/namespace/namespaceDbTestUtils.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const NamespaceDb = require('../../../src/plugins/namespace/NamespaceDb');
-const dbTestUtils = require('../../db/utils/dbTestUtils');
-const test = require('../../testUtils');
-const MongoDb = require('mongodb');
+import NamespaceDb from '../../../src/plugins/namespace/NamespaceDb.js';
+import dbTestUtils from '../../db/utils/dbTestUtils.js';
+import test from '../../testUtils.js';
+import MongoDb from 'mongodb';
 
 const { Binary, Long } = MongoDb;
 
@@ -103,4 +103,4 @@ const namespaceDbTestUtils = {
 };
 Object.assign(namespaceDbTestUtils, test);
 
-module.exports = namespaceDbTestUtils;
+export default namespaceDbTestUtils;

--- a/client/rest/test/plugins/namespace/namespaceRoutes_spec.js
+++ b/client/rest/test/plugins/namespace/namespaceRoutes_spec.js
@@ -19,20 +19,20 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../../src/catapult-sdk/index');
-const { convertToLong } = require('../../../src/db/dbUtils');
-const namespaceRoutes = require('../../../src/plugins/namespace/namespaceRoutes');
-const namespaceUtils = require('../../../src/plugins/namespace/namespaceUtils');
-const routeUtils = require('../../../src/routes/routeUtils');
-const { MockServer } = require('../../routes/utils/routeTestUtils');
-const { test } = require('../../routes/utils/routeTestUtils');
-const { expect } = require('chai');
-const MongoDb = require('mongodb');
-const sinon = require('sinon');
+import catapult from '../../../src/catapult-sdk/index.js';
+import { convertToLong } from '../../../src/db/dbUtils.js';
+import namespaceRoutes from '../../../src/plugins/namespace/namespaceRoutes.js';
+import namespaceUtils from '../../../src/plugins/namespace/namespaceUtils.js';
+import routeUtils from '../../../src/routes/routeUtils.js';
+import test from '../../routes/utils/routeTestUtils.js';
+import { expect } from 'chai';
+import MongoDb from 'mongodb';
+import sinon from 'sinon';
 
 const { Binary } = MongoDb;
 const { uint64 } = catapult.utils;
 const { address } = catapult.model;
+const { MockServer } = test;
 
 describe('namespace routes', () => {
 	describe('namespaces', () => {

--- a/client/rest/test/plugins/namespace/namespaceUtils_spec.js
+++ b/client/rest/test/plugins/namespace/namespaceUtils_spec.js
@@ -19,11 +19,11 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../../src/catapult-sdk/index');
-const { convertToLong } = require('../../../src/db/dbUtils');
-const namespaceUtils = require('../../../src/plugins/namespace/namespaceUtils');
-const { expect } = require('chai');
-const sinon = require('sinon');
+import catapult from '../../../src/catapult-sdk/index.js';
+import { convertToLong } from '../../../src/db/dbUtils.js';
+import namespaceUtils from '../../../src/plugins/namespace/namespaceUtils.js';
+import { expect } from 'chai';
+import sinon from 'sinon';
 
 const { aliasNamesRoutesProcessor } = namespaceUtils;
 

--- a/client/rest/test/plugins/namespace/namespace_spec.js
+++ b/client/rest/test/plugins/namespace/namespace_spec.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const NamespaceDb = require('../../../src/plugins/namespace/NamespaceDb');
-const namespace = require('../../../src/plugins/namespace/namespace');
-const { test } = require('../../routes/utils/routeTestUtils');
-const pluginTest = require('../utils/pluginTestUtils');
+import NamespaceDb from '../../../src/plugins/namespace/NamespaceDb.js';
+import namespace from '../../../src/plugins/namespace/namespace.js';
+import test from '../../routes/utils/routeTestUtils.js';
+import pluginTest from '../utils/pluginTestUtils.js';
 
 describe('namespace plugin', () => {
 	pluginTest.assertThat.pluginCreatesDb(namespace, NamespaceDb);

--- a/client/rest/test/plugins/receipts/ReceiptsDb_spec.js
+++ b/client/rest/test/plugins/receipts/ReceiptsDb_spec.js
@@ -19,14 +19,14 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../../src/catapult-sdk/index');
-const CatapultDb = require('../../../src/db/CatapultDb');
-const { convertToLong, uniqueLongList } = require('../../../src/db/dbUtils');
-const ReceiptsDb = require('../../../src/plugins/receipts/ReceiptsDb');
-const test = require('../../db/utils/dbTestUtils');
-const { expect } = require('chai');
-const MongoDb = require('mongodb');
-const sinon = require('sinon');
+import catapult from '../../../src/catapult-sdk/index.js';
+import CatapultDb from '../../../src/db/CatapultDb.js';
+import { convertToLong, uniqueLongList } from '../../../src/db/dbUtils.js';
+import ReceiptsDb from '../../../src/plugins/receipts/ReceiptsDb.js';
+import test from '../../db/utils/dbTestUtils.js';
+import { expect } from 'chai';
+import MongoDb from 'mongodb';
+import sinon from 'sinon';
 
 const { Binary, Long } = MongoDb;
 const { address } = catapult.model;

--- a/client/rest/test/plugins/receipts/receiptsRoutes_spec.js
+++ b/client/rest/test/plugins/receipts/receiptsRoutes_spec.js
@@ -19,14 +19,15 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../../src/catapult-sdk/index');
-const receiptsRoutes = require('../../../src/plugins/receipts/receiptsRoutes');
-const routeUtils = require('../../../src/routes/routeUtils');
-const { MockServer } = require('../../routes/utils/routeTestUtils');
-const { expect } = require('chai');
-const sinon = require('sinon');
+import catapult from '../../../src/catapult-sdk/index.js';
+import receiptsRoutes from '../../../src/plugins/receipts/receiptsRoutes.js';
+import routeUtils from '../../../src/routes/routeUtils.js';
+import test from '../../routes/utils/routeTestUtils.js';
+import { expect } from 'chai';
+import sinon from 'sinon';
 
 const { address } = catapult.model;
+const { MockServer } = test;
 
 describe('receipts routes', () => {
 	describe('transaction statements', () => {

--- a/client/rest/test/plugins/receipts/receipts_spec.js
+++ b/client/rest/test/plugins/receipts/receipts_spec.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const ReceiptsDb = require('../../../src/plugins/receipts/ReceiptsDb');
-const receipts = require('../../../src/plugins/receipts/receipts');
-const { test } = require('../../routes/utils/routeTestUtils');
-const pluginTest = require('../utils/pluginTestUtils');
+import ReceiptsDb from '../../../src/plugins/receipts/ReceiptsDb.js';
+import receipts from '../../../src/plugins/receipts/receipts.js';
+import test from '../../routes/utils/routeTestUtils.js';
+import pluginTest from '../utils/pluginTestUtils.js';
 
 describe('receipts plugin', () => {
 	pluginTest.assertThat.pluginCreatesDb(receipts, ReceiptsDb);

--- a/client/rest/test/plugins/restrictions/RestrictionsDb_spec.js
+++ b/client/rest/test/plugins/restrictions/RestrictionsDb_spec.js
@@ -19,14 +19,14 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const test = require('./restrictionsDbTestUtils');
-const catapult = require('../../../src/catapult-sdk/index');
-const CatapultDb = require('../../../src/db/CatapultDb');
-const { convertToLong } = require('../../../src/db/dbUtils');
-const RestrictionsDb = require('../../../src/plugins/restrictions/RestrictionsDb');
-const dbTestUtils = require('../../db/utils/dbTestUtils');
-const { expect } = require('chai');
-const sinon = require('sinon');
+import test from './restrictionsDbTestUtils.js';
+import catapult from '../../../src/catapult-sdk/index.js';
+import CatapultDb from '../../../src/db/CatapultDb.js';
+import { convertToLong } from '../../../src/db/dbUtils.js';
+import RestrictionsDb from '../../../src/plugins/restrictions/RestrictionsDb.js';
+import dbTestUtils from '../../db/utils/dbTestUtils.js';
+import { expect } from 'chai';
+import sinon from 'sinon';
 
 describe('restrictions db', () => {
 	describe('account restrictions', () => {

--- a/client/rest/test/plugins/restrictions/restrictionsDbTestUtils.js
+++ b/client/rest/test/plugins/restrictions/restrictionsDbTestUtils.js
@@ -19,11 +19,11 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../../src/catapult-sdk/index');
-const RestrictionsDb = require('../../../src/plugins/restrictions/RestrictionsDb');
-const dbTestUtils = require('../../db/utils/dbTestUtils');
-const test = require('../../testUtils');
-const MongoDb = require('mongodb');
+import catapult from '../../../src/catapult-sdk/index.js';
+import RestrictionsDb from '../../../src/plugins/restrictions/RestrictionsDb.js';
+import dbTestUtils from '../../db/utils/dbTestUtils.js';
+import test from '../../testUtils.js';
+import MongoDb from 'mongodb';
 
 const { EntityType, restriction } = catapult.model;
 const { Binary, ObjectId, Long } = MongoDb;
@@ -120,4 +120,4 @@ const restrictionsDbTestUtils = {
 
 Object.assign(restrictionsDbTestUtils, test);
 
-module.exports = restrictionsDbTestUtils;
+export default restrictionsDbTestUtils;

--- a/client/rest/test/plugins/restrictions/restrictionsRoutes_spec.js
+++ b/client/rest/test/plugins/restrictions/restrictionsRoutes_spec.js
@@ -19,17 +19,17 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../../src/catapult-sdk/index');
-const restrictionsRoutes = require('../../../src/plugins/restrictions/restrictionsRoutes');
-const routeResultTypes = require('../../../src/routes/routeResultTypes');
-const routeUtils = require('../../../src/routes/routeUtils');
-const { MockServer } = require('../../routes/utils/routeTestUtils');
-const { test } = require('../../routes/utils/routeTestUtils');
-const { expect } = require('chai');
-const sinon = require('sinon');
+import catapult from '../../../src/catapult-sdk/index.js';
+import restrictionsRoutes from '../../../src/plugins/restrictions/restrictionsRoutes.js';
+import routeResultTypes from '../../../src/routes/routeResultTypes.js';
+import routeUtils from '../../../src/routes/routeUtils.js';
+import test from '../../routes/utils/routeTestUtils.js';
+import { expect } from 'chai';
+import sinon from 'sinon';
 
 const { address } = catapult.model;
 const { addresses } = test.sets;
+const { MockServer } = test;
 
 describe('restrictions routes', () => {
 	describe('account restrictions', () => {

--- a/client/rest/test/plugins/restrictions/restrictions_spec.js
+++ b/client/rest/test/plugins/restrictions/restrictions_spec.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const RestrictionsDb = require('../../../src/plugins/restrictions/RestrictionsDb');
-const restrictions = require('../../../src/plugins/restrictions/restrictions');
-const { test } = require('../../routes/utils/routeTestUtils');
-const pluginTest = require('../utils/pluginTestUtils');
+import RestrictionsDb from '../../../src/plugins/restrictions/RestrictionsDb.js';
+import restrictions from '../../../src/plugins/restrictions/restrictions.js';
+import test from '../../routes/utils/routeTestUtils.js';
+import pluginTest from '../utils/pluginTestUtils.js';
 
 describe('restrictions plugin', () => {
 	pluginTest.assertThat.pluginCreatesDb(restrictions, RestrictionsDb);

--- a/client/rest/test/plugins/routeSystem_spec.js
+++ b/client/rest/test/plugins/routeSystem_spec.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const routeSystem = require('../../src/plugins/routeSystem');
-const { test } = require('../routes/utils/routeTestUtils');
-const { expect } = require('chai');
+import routeSystem from '../../src/plugins/routeSystem.js';
+import test from '../routes/utils/routeTestUtils.js';
+import { expect } from 'chai';
 
 describe('route system', () => {
 	const servicesTemplate = { config: { websocket: {}, network: { name: 'testnet' } }, connections: {} };

--- a/client/rest/test/plugins/utils/pluginTestUtils.js
+++ b/client/rest/test/plugins/utils/pluginTestUtils.js
@@ -19,7 +19,7 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { expect } = require('chai');
+import { expect } from 'chai';
 
 const wrapCreateDbTest = (resultName, action) => {
 	describe('create db', () => {
@@ -27,7 +27,7 @@ const wrapCreateDbTest = (resultName, action) => {
 	});
 };
 
-module.exports = {
+export default {
 	assertThat: {
 		pluginDoesNotCreateDb: plugin => {
 			wrapCreateDbTest('undefined', () => {

--- a/client/rest/test/routes/MerkleTree_spec.js
+++ b/client/rest/test/routes/MerkleTree_spec.js
@@ -18,11 +18,11 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
-const catapult = require('../../src/catapult-sdk/index');
-const MerkleTree = require('../../src/routes/MerkelTree');
-const { expect } = require('chai');
-const fs = require('fs');
-const fsPath = require('path');
+import catapult from '../../src/catapult-sdk/index.js';
+import MerkleTree from '../../src/routes/MerkelTree.js';
+import { expect } from 'chai';
+import fs from 'fs';
+import fsPath from 'path';
 
 describe('MerkleTree', () => {
 	describe('merkle tree parse', () => {
@@ -298,7 +298,7 @@ describe('MerkleTree', () => {
 		});
 
 		describe('merkle tree parse from testnet examples', () => {
-			const treePath = fsPath.resolve(__dirname, '../merkle/trees.json');
+			const treePath = fsPath.resolve(import.meta.dirname, '../merkle/trees.json');
 			const trees = JSON.parse(fs.readFileSync(treePath, 'UTF-8').trim());
 			trees.forEach(tree => {
 				const fieldName = Object.keys(tree).filter(n => 'raw' !== n)[0];

--- a/client/rest/test/routes/accountRoutes_spec.js
+++ b/client/rest/test/routes/accountRoutes_spec.js
@@ -19,20 +19,19 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { MockServer } = require('./utils/routeTestUtils');
-const { test } = require('./utils/routeTestUtils');
-const catapult = require('../../src/catapult-sdk/index');
-const MerkleTree = require('../../src/routes/MerkelTree');
-const accountRoutes = require('../../src/routes/accountRoutes');
-const routeResultTypes = require('../../src/routes/routeResultTypes');
-const routeUtils = require('../../src/routes/routeUtils');
-const { expect } = require('chai');
-const sinon = require('sinon');
+import test from './utils/routeTestUtils.js';
+import catapult from '../../src/catapult-sdk/index.js';
+import MerkleTree from '../../src/routes/MerkelTree.js';
+import accountRoutes from '../../src/routes/accountRoutes.js';
+import routeResultTypes from '../../src/routes/routeResultTypes.js';
+import routeUtils from '../../src/routes/routeUtils.js';
+import { expect } from 'chai';
+import sinon from 'sinon';
 
 const { PacketType } = catapult.packet;
-
 const { address } = catapult.model;
 const { convert } = catapult.utils;
+const { MockServer } = test;
 
 describe('account routes', () => {
 	const testAddress = 'NAR3W7B4BCOZSZMFIZRYB3N5YGOUSWIYJCJ6HDA';

--- a/client/rest/test/routes/allRoutes_spec.js
+++ b/client/rest/test/routes/allRoutes_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { test } = require('./utils/routeTestUtils');
-const allRoutes = require('../../src/routes/allRoutes');
+import test from './utils/routeTestUtils.js';
+import allRoutes from '../../src/routes/allRoutes.js';
 
 describe('all routes', () => {
 	const registerAll = server => {

--- a/client/rest/test/routes/blockRoutes_spec.js
+++ b/client/rest/test/routes/blockRoutes_spec.js
@@ -19,17 +19,18 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { MockServer, test } = require('./utils/routeTestUtils');
-const catapult = require('../../src/catapult-sdk/index');
-const { convertToLong } = require('../../src/db/dbUtils');
-const blockRoutes = require('../../src/routes/blockRoutes');
-const routeResultTypes = require('../../src/routes/routeResultTypes');
-const routeUtils = require('../../src/routes/routeUtils');
-const { expect } = require('chai');
-const sinon = require('sinon');
+import test from './utils/routeTestUtils.js';
+import catapult from '../../src/catapult-sdk/index.js';
+import { convertToLong } from '../../src/db/dbUtils.js';
+import blockRoutes from '../../src/routes/blockRoutes.js';
+import routeResultTypes from '../../src/routes/routeResultTypes.js';
+import routeUtils from '../../src/routes/routeUtils.js';
+import { expect } from 'chai';
+import sinon from 'sinon';
 
 const { address } = catapult.model;
 const { convert } = catapult.utils;
+const { MockServer } = test;
 
 describe('block routes', () => {
 	const addChainStatisticToDb = db => { db.chainStatisticCurrent = () => Promise.resolve({ height: convertToLong(10) }); };

--- a/client/rest/test/routes/chainRoutes_spec.js
+++ b/client/rest/test/routes/chainRoutes_spec.js
@@ -19,13 +19,14 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { MockServer, test } = require('./utils/routeTestUtils');
-const chainRoutes = require('../../src/routes/chainRoutes');
-const { expect } = require('chai');
-const MongoDb = require('mongodb');
-const sinon = require('sinon');
+import test from './utils/routeTestUtils.js';
+import chainRoutes from '../../src/routes/chainRoutes.js';
+import { expect } from 'chai';
+import MongoDb from 'mongodb';
+import sinon from 'sinon';
 
 const { Binary, Long } = MongoDb;
+const { MockServer } = test;
 
 describe('chain routes', () => {
 	describe('get', () => {

--- a/client/rest/test/routes/dbFacade_spec.js
+++ b/client/rest/test/routes/dbFacade_spec.js
@@ -19,13 +19,13 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const CatapultDb = require('../../src/db/CatapultDb');
-const { convertToLong } = require('../../src/db/dbUtils');
-const dbFacade = require('../../src/routes/dbFacade');
-const testDbOptions = require('../db/utils/testDbOptions');
-const { expect } = require('chai');
-const { Binary } = require('mongodb');
-const sinon = require('sinon');
+import CatapultDb from '../../src/db/CatapultDb.js';
+import { convertToLong } from '../../src/db/dbUtils.js';
+import dbFacade from '../../src/routes/dbFacade.js';
+import testDbOptions from '../db/utils/testDbOptions.js';
+import { expect } from 'chai';
+import { Binary } from 'mongodb';
+import sinon from 'sinon';
 
 const Testnet_Network = testDbOptions.networkId;
 

--- a/client/rest/test/routes/finalizationRoutes_spec.js
+++ b/client/rest/test/routes/finalizationRoutes_spec.js
@@ -19,10 +19,12 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { MockServer } = require('./utils/routeTestUtils');
-const finalizationRoutes = require('../../src/routes/finalizationRoutes');
-const routeResultTypes = require('../../src/routes/routeResultTypes');
-const { expect } = require('chai');
+import test from './utils/routeTestUtils.js';
+import finalizationRoutes from '../../src/routes/finalizationRoutes.js';
+import routeResultTypes from '../../src/routes/routeResultTypes.js';
+import { expect } from 'chai';
+
+const { MockServer } = test;
 
 describe('finalization routes', () => {
 	describe('get', () => {

--- a/client/rest/test/routes/networkRoutes_spec.js
+++ b/client/rest/test/routes/networkRoutes_spec.js
@@ -19,12 +19,14 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { MockServer, test } = require('./utils/routeTestUtils');
-const networkRoutes = require('../../src/routes/networkRoutes');
-const { expect } = require('chai');
-const sinon = require('sinon');
-const tmp = require('tmp');
-const fs = require('fs');
+import test from './utils/routeTestUtils.js';
+import networkRoutes from '../../src/routes/networkRoutes.js';
+import { expect } from 'chai';
+import sinon from 'sinon';
+import tmp from 'tmp';
+import fs from 'fs';
+
+const { MockServer } = test;
 
 describe('network routes', () => {
 	describe('get', () => {

--- a/client/rest/test/routes/nodeRoutes_spec.js
+++ b/client/rest/test/routes/nodeRoutes_spec.js
@@ -19,10 +19,12 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { MockServer, test } = require('./utils/routeTestUtils');
-const nodeRoutes = require('../../src/routes/nodeRoutes');
-const errors = require('../../src/server/errors');
-const { expect } = require('chai');
+import test from './utils/routeTestUtils.js';
+import nodeRoutes from '../../src/routes/nodeRoutes.js';
+import errors from '../../src/server/errors.js';
+import { expect } from 'chai';
+
+const { MockServer } = test;
 
 const restVersion = '2.4.4';
 

--- a/client/rest/test/routes/routeResultTypes_spec.js
+++ b/client/rest/test/routes/routeResultTypes_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const routeResultTypes = require('../../src/routes/routeResultTypes');
-const { expect } = require('chai');
+import routeResultTypes from '../../src/routes/routeResultTypes.js';
+import { expect } from 'chai';
 
 describe('routeResultTypes', () => {
 	it('has correct links to schema', () => {

--- a/client/rest/test/routes/routeUtils_spec.js
+++ b/client/rest/test/routes/routeUtils_spec.js
@@ -19,13 +19,13 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { test } = require('./utils/routeTestUtils');
-const catapult = require('../../src/catapult-sdk/index');
-const { convertToLong } = require('../../src/db/dbUtils');
-const routeUtils = require('../../src/routes/routeUtils');
-const { expect } = require('chai');
-const MongoDb = require('mongodb');
-const sinon = require('sinon');
+import test from './utils/routeTestUtils.js';
+import catapult from '../../src/catapult-sdk/index.js';
+import { convertToLong } from '../../src/db/dbUtils.js';
+import routeUtils from '../../src/routes/routeUtils.js';
+import { expect } from 'chai';
+import MongoDb from 'mongodb';
+import sinon from 'sinon';
 
 const { Binary, ObjectId } = MongoDb;
 const { convert } = catapult.utils;

--- a/client/rest/test/routes/transactionRoutes_spec.js
+++ b/client/rest/test/routes/transactionRoutes_spec.js
@@ -19,16 +19,17 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { MockServer, test } = require('./utils/routeTestUtils');
-const catapult = require('../../src/catapult-sdk/index');
-const routeResultTypes = require('../../src/routes/routeResultTypes');
-const routeUtils = require('../../src/routes/routeUtils');
-const transactionRoutes = require('../../src/routes/transactionRoutes');
-const { expect } = require('chai');
-const sinon = require('sinon');
+import test from './utils/routeTestUtils.js';
+import catapult from '../../src/catapult-sdk/index.js';
+import routeResultTypes from '../../src/routes/routeResultTypes.js';
+import routeUtils from '../../src/routes/routeUtils.js';
+import transactionRoutes from '../../src/routes/transactionRoutes.js';
+import { expect } from 'chai';
+import sinon from 'sinon';
 
 const { address } = catapult.model;
 const { convert } = catapult.utils;
+const { MockServer } = test;
 
 const TransactionGroups = {
 	confirmed: 'confirmed',

--- a/client/rest/test/routes/transactionStatusRoutes_spec.js
+++ b/client/rest/test/routes/transactionStatusRoutes_spec.js
@@ -19,16 +19,17 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { MockServer } = require('./utils/routeTestUtils');
-const catapult = require('../../src/catapult-sdk/index');
-const dbFacade = require('../../src/routes/dbFacade');
-const routeResultTypes = require('../../src/routes/routeResultTypes');
-const routeUtils = require('../../src/routes/routeUtils');
-const transactionStatusRoutes = require('../../src/routes/transactionStatusRoutes');
-const { expect } = require('chai');
-const sinon = require('sinon');
+import test from './utils/routeTestUtils.js';
+import catapult from '../../src/catapult-sdk/index.js';
+import dbFacade from '../../src/routes/dbFacade.js';
+import routeResultTypes from '../../src/routes/routeResultTypes.js';
+import routeUtils from '../../src/routes/routeUtils.js';
+import transactionStatusRoutes from '../../src/routes/transactionStatusRoutes.js';
+import { expect } from 'chai';
+import sinon from 'sinon';
 
 const { convert } = catapult.utils;
+const { MockServer } = test;
 
 describe('transaction status routes', () => {
 	describe('calls addGetPostDocumentRoutes once with correct params', () => {

--- a/client/rest/test/routes/utils/routeTestUtils.js
+++ b/client/rest/test/routes/utils/routeTestUtils.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const test = require('../../testUtils');
-const { expect } = require('chai');
-const sinon = require('sinon');
+import test from '../../testUtils.js';
+import { expect } from 'chai';
+import sinon from 'sinon';
 
 const makeTestName = (base, desc) => (desc ? `${base} ${desc}` : base);
 
@@ -645,7 +645,6 @@ const routeTestUtils = {
 };
 Object.assign(routeTestUtils, test);
 
-module.exports = {
-	MockServer,
-	test: routeTestUtils
-};
+routeTestUtils.MockServer = MockServer;
+
+export default routeTestUtils;

--- a/client/rest/test/routes/wsRoutes_spec.js
+++ b/client/rest/test/routes/wsRoutes_spec.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const { test } = require('./utils/routeTestUtils');
-const wsRoutes = require('../../src/routes/wsRoutes');
-const { expect } = require('chai');
+import test from './utils/routeTestUtils.js';
+import wsRoutes from '../../src/routes/wsRoutes.js';
+import { expect } from 'chai';
 
 describe('web socket routes', () => {
 	const setupWebsocketTest = (action, assertCaptures) => {

--- a/client/rest/test/server/SubscriptionManager_spec.js
+++ b/client/rest/test/server/SubscriptionManager_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const SubscriptionManager = require('../../src/server/SubscriptionManager');
-const { expect } = require('chai');
+import SubscriptionManager from '../../src/server/SubscriptionManager.js';
+import { expect } from 'chai';
 
 describe('subscription manager', () => {
 	const createSubscription = (channel, client) => ({ channel, client });

--- a/client/rest/test/server/bootstrapper_spec.js
+++ b/client/rest/test/server/bootstrapper_spec.js
@@ -19,21 +19,21 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../src/catapult-sdk/index');
-const MessageChannelBuilder = require('../../src/connection/MessageChannelBuilder');
-const { createZmqConnectionService } = require('../../src/connection/zmqService');
-const bootstrapper = require('../../src/server/bootstrapper');
-const errors = require('../../src/server/errors');
-const formatters = require('../../src/server/formatters');
-const test = require('../testUtils');
-const axios = require('axios');
-const { AssertionError, expect } = require('chai');
-const restify = require('restify');
-const sinon = require('sinon');
-const winston = require('winston');
-const WebSocket = require('ws');
-const zmq = require('zeromq');
-const EventEmitter = require('events');
+import catapult from '../../src/catapult-sdk/index.js';
+import MessageChannelBuilder from '../../src/connection/MessageChannelBuilder.js';
+import createZmqConnectionService from '../../src/connection/zmqService.js';
+import bootstrapper from '../../src/server/bootstrapper.js';
+import errors from '../../src/server/errors.js';
+import formatters from '../../src/server/formatters.js';
+import test from '../testUtils.js';
+import axios from 'axios';
+import { AssertionError, expect } from 'chai';
+import restify from 'restify';
+import sinon from 'sinon';
+import winston from 'winston';
+import WebSocket from 'ws';
+import zmq from 'zeromq';
+import EventEmitter from 'events';
 
 const supportedHttpMethods = ['get', 'post', 'put'];
 
@@ -723,17 +723,17 @@ describe('server (bootstrapper)', () => {
 		it('creates https server with certificate and key given', () => createServer({
 			port: 3001,
 			protocol: 'HTTPS',
-			sslKeyPath: `${__dirname}/certs/restSSL.key`,
-			sslCertificatePath: `${__dirname}/certs/restSSL.crt`
+			sslKeyPath: `${import.meta.dirname}/certs/restSSL.key`,
+			sslCertificatePath: `${import.meta.dirname}/certs/restSSL.crt`
 		}));
 
 		it('throws error when the key path is missing', () => {
-			expect(() => createServer({ port: 3001, protocol: 'HTTPS', sslCertificatePath: `${__dirname}/certs/restSSL.crt` }))
+			expect(() => createServer({ port: 3001, protocol: 'HTTPS', sslCertificatePath: `${import.meta.dirname}/certs/restSSL.crt` }))
 				.to.throw('No SSL Key found, \'sslKeyPath\' property in the configuration must be provided.');
 		});
 
 		it('throws error when the certificate path is missing', () => {
-			expect(() => createServer({ port: 3001, protocol: 'HTTPS', sslKeyPath: `${__dirname}/certs/restSSL.key` }))
+			expect(() => createServer({ port: 3001, protocol: 'HTTPS', sslKeyPath: `${import.meta.dirname}/certs/restSSL.key` }))
 				.to.throw('No SSL Certificate found, '
 				+ '\'sslCertificatePath\' property in the configuration must be provided.');
 		});
@@ -754,8 +754,8 @@ describe('server (bootstrapper)', () => {
 			const server = createServer({
 				port: httpsPort,
 				protocol: 'HTTPS',
-				sslKeyPath: `${__dirname}/certs/restSSL.key`,
-				sslCertificatePath: `${__dirname}/certs/restSSL.crt`
+				sslKeyPath: `${import.meta.dirname}/certs/restSSL.key`,
+				sslCertificatePath: `${import.meta.dirname}/certs/restSSL.crt`
 			});
 
 			addRestRoutes(server);

--- a/client/rest/test/server/errors_spec.js
+++ b/client/rest/test/server/errors_spec.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const errors = require('../../src/server/errors');
-const { expect } = require('chai');
-const restifyErrors = require('restify-errors');
+import errors from '../../src/server/errors.js';
+import { expect } from 'chai';
+import restifyErrors from 'restify-errors';
 
 describe('errors', () => {
 	describe('toRestError', () => {

--- a/client/rest/test/server/formatters_spec.js
+++ b/client/rest/test/server/formatters_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const formatters = require('../../src/server/formatters');
-const { expect } = require('chai');
+import formatters from '../../src/server/formatters.js';
+import { expect } from 'chai';
 
 describe('formatters', () => {
 	const createFormatters = name => formatters.create({

--- a/client/rest/test/server/messageFormattingRules_spec.js
+++ b/client/rest/test/server/messageFormattingRules_spec.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../src/catapult-sdk/index');
-const formattingRules = require('../../src/server/messageFormattingRules');
-const test = require('../testUtils');
-const { expect } = require('chai');
+import catapult from '../../src/catapult-sdk/index.js';
+import formattingRules from '../../src/server/messageFormattingRules.js';
+import test from '../testUtils.js';
+import { expect } from 'chai';
 
 const { ModelType } = catapult.model;
 

--- a/client/rest/test/server/websocketMessageHandler_spec.js
+++ b/client/rest/test/server/websocketMessageHandler_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const websocketMessageHandler = require('../../src/server/websocketMessageHandler');
-const { expect } = require('chai');
+import websocketMessageHandler from '../../src/server/websocketMessageHandler.js';
+import { expect } from 'chai';
 
 describe('websocketMessageHandler', () => {
 	// region invalid

--- a/client/rest/test/server/websocketUtils_spec.js
+++ b/client/rest/test/server/websocketUtils_spec.js
@@ -19,8 +19,8 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const websocketUtils = require('../../src/server/websocketUtils');
-const { expect } = require('chai');
+import websocketUtils from '../../src/server/websocketUtils.js';
+import { expect } from 'chai';
 
 describe('websocketUtils', () => {
 	const createMockSender = (options = {}) => {
@@ -42,39 +42,42 @@ describe('websocketUtils', () => {
 
 	describe('createMultisender', () => {
 		describe('send', () => {
+			const createMultisender = senders =>
+				websocketUtils.createMultisender('topicName', senders, value => ({ str: value.id.toString(), value }));
+
 			it('does nothing when there are no subscribers', () => {
 				// Arrange:
-				const multisender = websocketUtils.createMultisender('topicName', [], value => ({ str: value.toString(), value }));
+				const multisender = createMultisender([]);
 
 				// Act + Assert: no exceptions
-				multisender.send(123);
+				multisender.send({ id: 123 });
 			});
 
 			it('forwards formatted data to single subscriber', () => {
 				// Arrange:
 				const sender = createMockSender();
-				const multisender = websocketUtils.createMultisender('topicName', [sender], value => ({ str: value.toString(), value }));
+				const multisender = createMultisender([sender]);
 
 				// Act:
-				multisender.send(123);
+				multisender.send({ id: 123 });
 
 				// Assert:
-				expect(sender.payloads).to.deep.equal([{ str: '123', value: 123 }]);
+				expect(sender.payloads).to.deep.equal([{ str: '123', value: { id: 123, topic: 'topicName' } }]);
 				expect(sender.numCloseCalls).to.equal(0);
 			});
 
 			it('forwards formatted data to multiple subscribers', () => {
 				// Arrange:
 				const senders = [createMockSender(), createMockSender(), createMockSender()];
-				const multisender = websocketUtils.createMultisender('topicName', senders, value => ({ str: value.toString(), value }));
+				const multisender = createMultisender(senders);
 
 				// Act:
-				multisender.send(123);
+				multisender.send({ id: 123 });
 
 				// Assert:
 				senders.forEach((sender, index) => {
 					const message = `sender ${index}`;
-					expect(sender.payloads, message).to.deep.equal([{ str: '123', value: 123 }]);
+					expect(sender.payloads, message).to.deep.equal([{ str: '123', value: { id: 123, topic: 'topicName' } }]);
 					expect(sender.numCloseCalls).to.equal(0);
 				});
 			});
@@ -82,15 +85,15 @@ describe('websocketUtils', () => {
 			it('closes subscriber on send error', () => {
 				// Arrange:
 				const senders = [createMockSender(), createMockSender({ raiseSendError: true }), createMockSender()];
-				const multisender = websocketUtils.createMultisender('topicName', senders, value => ({ str: value.toString(), value }));
+				const multisender = createMultisender(senders);
 
 				// Act:
-				multisender.send(123);
+				multisender.send({ id: 123 });
 
 				// Assert: only the second sender should have been closed
 				senders.forEach((sender, index) => {
 					const message = `sender ${index}`;
-					expect(sender.payloads, message).to.deep.equal([{ str: '123', value: 123 }]);
+					expect(sender.payloads, message).to.deep.equal([{ str: '123', value: { id: 123, topic: 'topicName' } }]);
 					expect(sender.numCloseCalls, message).to.equal(1 === index ? 1 : 0);
 				});
 			});

--- a/client/rest/test/sockets/finalizationProofCodec_spec.js
+++ b/client/rest/test/sockets/finalizationProofCodec_spec.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../src/catapult-sdk/index');
-const finalizationProofCodec = require('../../src/sockets/finalizationProofCodec');
-const { expect } = require('chai');
+import catapult from '../../src/catapult-sdk/index.js';
+import finalizationProofCodec from '../../src/sockets/finalizationProofCodec.js';
+import { expect } from 'chai';
 
 const { BinaryParser } = catapult.parser;
 

--- a/client/rest/test/sockets/nodeInfoCodec_spec.js
+++ b/client/rest/test/sockets/nodeInfoCodec_spec.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../src/catapult-sdk/index');
-const nodeInfoCodec = require('../../src/sockets/nodeInfoCodec');
-const { expect } = require('chai');
+import catapult from '../../src/catapult-sdk/index.js';
+import nodeInfoCodec from '../../src/sockets/nodeInfoCodec.js';
+import { expect } from 'chai';
 
 const { BinaryParser } = catapult.parser;
 

--- a/client/rest/test/sockets/nodePeersCodec_spec.js
+++ b/client/rest/test/sockets/nodePeersCodec_spec.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../src/catapult-sdk/index');
-const nodePeersCodec = require('../../src/sockets/nodePeersCodec');
-const { expect } = require('chai');
+import catapult from '../../src/catapult-sdk/index.js';
+import nodePeersCodec from '../../src/sockets/nodePeersCodec.js';
+import { expect } from 'chai';
 
 const { BinaryParser } = catapult.parser;
 

--- a/client/rest/test/sockets/nodeTimeCodec_spec.js
+++ b/client/rest/test/sockets/nodeTimeCodec_spec.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../src/catapult-sdk/index');
-const nodeTimeCodec = require('../../src/sockets/nodeTimeCodec');
-const { expect } = require('chai');
+import catapult from '../../src/catapult-sdk/index.js';
+import nodeTimeCodec from '../../src/sockets/nodeTimeCodec.js';
+import { expect } from 'chai';
 
 const { BinaryParser } = catapult.parser;
 

--- a/client/rest/test/sockets/stateTreeCodec_spec.js
+++ b/client/rest/test/sockets/stateTreeCodec_spec.js
@@ -19,9 +19,9 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../../src/catapult-sdk/index');
-const stateTreesCodec = require('../../src/sockets/stateTreesCodec');
-const { expect } = require('chai');
+import catapult from '../../src/catapult-sdk/index.js';
+import stateTreesCodec from '../../src/sockets/stateTreesCodec.js';
+import { expect } from 'chai';
 
 const { BinaryParser } = catapult.parser;
 const { convert } = catapult.utils;

--- a/client/rest/test/testUtils.js
+++ b/client/rest/test/testUtils.js
@@ -19,10 +19,10 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-const catapult = require('../src/catapult-sdk/index');
-const MongoDb = require('mongodb');
-const winston = require('winston');
-const crypto = require('crypto');
+import catapult from '../src/catapult-sdk/index.js';
+import MongoDb from 'mongodb';
+import winston from 'winston';
+import crypto from 'crypto';
 
 const { sizes } = catapult.constants;
 const random = {
@@ -38,7 +38,7 @@ const random = {
 	})
 };
 
-module.exports = {
+export default {
 	constants: { sizes },
 	random,
 	factory: {


### PR DESCRIPTION
     problem: REST is using CJS modules
    solution: migrate REST to ES6 modules

first commit is most of rote changes
second commit fixes breakages
third commit cleans up exports