### PR TITLE
[client/rest]: add route-only plugins

### DIFF
--- a/client/rest/resources/rest.json
+++ b/client/rest/resources/rest.json
@@ -31,7 +31,9 @@
     "restrictions",
     "transfer"
   ],
-
+  "routeExtensions": [
+    "rosetta"
+  ],
   "db": {
     "url": "mongodb://localhost:27017/",
     "name": "catapult",

--- a/client/rest/src/index.js
+++ b/client/rest/src/index.js
@@ -141,7 +141,12 @@ const registerRoutes = (server, db, services) => {
 	};
 
 	// 2. configure extension routes
-	const { transactionStates, messageChannelDescriptors } = routeSystem.configure(services.config.extensions, server, db, servicesView);
+	const { transactionStates, messageChannelDescriptors } = routeSystem.configure(
+		[].concat(services.config.extensions, services.config.routeExtensions),
+		server,
+		db,
+		servicesView
+	);
 
 	// 3. augment services with extension-dependent config and services
 	servicesView.config.transactionStates = transactionStates;

--- a/client/rest/src/plugins/routeSystem.js
+++ b/client/rest/src/plugins/routeSystem.js
@@ -34,6 +34,7 @@ import { NetworkLocator } from 'symbol-sdk';
 import { Network } from 'symbol-sdk/symbol';
 
 const plugins = {
+	// transactions
 	accountLink: empty,
 	aggregate,
 	lockHash,
@@ -44,7 +45,10 @@ const plugins = {
 	namespace,
 	receipts,
 	restrictions,
-	transfer: empty
+	transfer: empty,
+
+	// other
+	rosetta: empty
 };
 
 export default {

--- a/client/rest/test/plugins/routeSystem_spec.js
+++ b/client/rest/test/plugins/routeSystem_spec.js
@@ -39,6 +39,7 @@ describe('route system', () => {
 
 		// Assert:
 		expect(supportedPluginNames).to.deep.equal([
+			// - transactions
 			'accountLink',
 			'aggregate',
 			'lockHash',
@@ -49,7 +50,10 @@ describe('route system', () => {
 			'namespace',
 			'receipts',
 			'restrictions',
-			'transfer'
+			'transfer',
+
+			// - other
+			'rosetta'
 		]);
 	});
 


### PR DESCRIPTION
 problem: architecture assumes a single set of sdk (transaction) plugins and route plugins
solution: add separate 'routeExtensions' configuration
          in order to allow route plugins to be a superset of sdk plugins
          add placeholder for route-only plugin (rosetta)
