### PR TITLE
[client/rest]: replace unused addressToPublicKey with lookupPublicKeys

### DIFF
--- a/client/rest/src/db/CatapultDb.js
+++ b/client/rest/src/db/CatapultDb.js
@@ -643,17 +643,17 @@ export default class CatapultDb {
 
 	// endregion
 
-	// region utils
+	// region lookup public keys
 
 	/**
-	 * Retrieves account publickey projection for the given address.
-	 * @param {Uint8Array} accountAddress Account address.
-	 * @returns {Promise<Buffer>} Promise that resolves to the account public key.
+	 * Retrieves account public keys projection for the given addresses.
+	 * @param {Array<Uint8Array>} accountAddresses Account addresses.
+	 * @returns {Promise<Buffer>} Promise that resolves to the account public keys.
 	 */
-	addressToPublicKey(accountAddress) {
-		const conditions = { 'account.address': Buffer.from(accountAddress) };
-		const projection = { 'account.publicKey': 1 };
-		return this.queryDocument('accounts', conditions, projection);
+	lookupPublicKeys(accountAddresses) {
+		const conditions = { 'account.address': { $in: accountAddresses.map(accountAddress => Buffer.from(accountAddress)) } };
+		const projection = { 'account.address': 1, 'account.publicKey': 1 };
+		return this.queryDocuments('accounts', conditions, projection);
 	}
 
 	// endregion

--- a/client/rest/src/routes/routeUtils.js
+++ b/client/rest/src/routes/routeUtils.js
@@ -368,21 +368,7 @@ const routeUtils = {
 
 				return next();
 			});
-	},
-
-	/**
-	 * Returns account public key from account address .
-	 * @param {module:db/CatapultDb} db Catapult database.
-	 * @param {Uint8Array} accountAddress Account address.
-	 * @returns {Promise<Uint8Array>} Account public key.
-	 */
-	addressToPublicKey: (db, accountAddress) => db.addressToPublicKey(accountAddress)
-		.then(result => {
-			if (!result)
-				return Promise.reject(Error('account not found'));
-
-			return result.account.publicKey.buffer;
-		})
+	}
 };
 
 export default routeUtils;

--- a/client/rest/test/routes/routeUtils_spec.js
+++ b/client/rest/test/routes/routeUtils_spec.js
@@ -29,7 +29,7 @@ import sinon from 'sinon';
 import { utils } from 'symbol-sdk';
 import { Address } from 'symbol-sdk/symbol';
 
-const { Binary, ObjectId } = MongoDb;
+const { ObjectId } = MongoDb;
 
 const invalidObjectIdStrings = [
 	'112233445566778899AABB', // too short
@@ -808,40 +808,6 @@ describe('route utils', () => {
 				});
 				expect(nextFake.calledOnce).to.equal(true);
 			});
-		});
-	});
-
-	describe('addressToPublicKey', () => {
-		const { addresses, publicKeys } = test.sets;
-		const accountAddress = new Address(addresses.valid[0]).bytes;
-		const accountPublicKey = utils.hexToUint8(publicKeys.valid[0]);
-
-		it('return correct public key from account address ', () => {
-			// Arrange:
-			const dbAddressToPublicKeyFake = sinon.fake.resolves({
-				_id: undefined,
-				account: { publicKey: new Binary(Buffer.from(accountPublicKey)) }
-			});
-			const db = { addressToPublicKey: dbAddressToPublicKeyFake };
-			// Act:
-			return routeUtils.addressToPublicKey(db, accountAddress).then(result => {
-				// Assert:
-				expect(dbAddressToPublicKeyFake.calledOnceWith(accountAddress)).to.equal(true);
-				expect(result.equals(accountPublicKey)).to.be.equal(true);
-			});
-		});
-
-		it('rejects with error when account id is not found', () => {
-			// Arrange:
-			const dbAddressToPublicKeyFake = sinon.fake.resolves(undefined);
-			const db = { addressToPublicKey: dbAddressToPublicKeyFake };
-			// Act:
-			return routeUtils.addressToPublicKey(db, accountAddress)
-				// Assert:
-				.then(() => expect.fail())
-				.catch(err => {
-					expect(err.toString()).to.include('account not found');
-				});
 		});
 	});
 });


### PR DESCRIPTION
 problem: addressToPublicKey only supports a single address and is not used
solution: replace it with lookupPublicKeys and support multiple addresses