### PR TITLE
[sdk]: add extract signing payload to facades

### DIFF
--- a/sdk/javascript/src/facade/NemFacade.js
+++ b/sdk/javascript/src/facade/NemFacade.js
@@ -219,14 +219,23 @@ export class NemFacade {
 	}
 
 	/**
+	 * Gets the payload to sign given a NEM transaction.
+	 * @param {nc.Transaction} transaction Transaction object.
+	 * @returns {Uint8Array} Verifiable data to sign.
+	 */
+	extractSigningPayload(transaction) { // eslint-disable-line class-methods-use-this
+		const nonVerifiableTransaction = TransactionFactory.toNonVerifiableTransaction(transaction);
+		return nonVerifiableTransaction.serialize();
+	}
+
+	/**
 	 * Signs a NEM transaction.
 	 * @param {KeyPair} keyPair Key pair.
 	 * @param {nc.Transaction} transaction Transaction object.
 	 * @returns {Signature} Transaction signature.
 	 */
-	signTransaction(keyPair, transaction) { // eslint-disable-line class-methods-use-this
-		const nonVerifiableTransaction = TransactionFactory.toNonVerifiableTransaction(transaction);
-		return keyPair.sign(nonVerifiableTransaction.serialize());
+	signTransaction(keyPair, transaction) {
+		return keyPair.sign(this.extractSigningPayload(transaction));
 	}
 
 	/**
@@ -235,9 +244,8 @@ export class NemFacade {
 	 * @param {Signature} signature Signature to verify.
 	 * @returns {boolean} \c true if transaction signature is verified.
 	 */
-	verifyTransaction(transaction, signature) { // eslint-disable-line class-methods-use-this
-		const nonVerifiableTransaction = TransactionFactory.toNonVerifiableTransaction(transaction);
-		return new Verifier(transaction.signerPublicKey).verify(nonVerifiableTransaction.serialize(), signature);
+	verifyTransaction(transaction, signature) {
+		return new Verifier(transaction.signerPublicKey).verify(this.extractSigningPayload(transaction), signature);
 	}
 
 	/**

--- a/sdk/javascript/src/facade/SymbolFacade.js
+++ b/sdk/javascript/src/facade/SymbolFacade.js
@@ -287,16 +287,25 @@ export class SymbolFacade {
 	}
 
 	/**
+	 * Gets the payload to sign given a Symbol transaction.
+	 * @param {sc.Transaction} transaction Transaction object.
+	 * @returns {Uint8Array} Verifiable data to sign.
+	 */
+	extractSigningPayload(transaction) {
+		return new Uint8Array([
+			...this.network.generationHashSeed.bytes,
+			...transactionDataBuffer(transaction.serialize())
+		]);
+	}
+
+	/**
 	 * Signs a Symbol transaction.
 	 * @param {KeyPair} keyPair Key pair.
 	 * @param {sc.Transaction} transaction Transaction object.
 	 * @returns {Signature} Transaction signature.
 	 */
 	signTransaction(keyPair, transaction) {
-		return keyPair.sign(new Uint8Array([
-			...this.network.generationHashSeed.bytes,
-			...transactionDataBuffer(transaction.serialize())
-		]));
+		return keyPair.sign(this.extractSigningPayload(transaction));
 	}
 
 	/**
@@ -306,10 +315,7 @@ export class SymbolFacade {
 	 * @returns {boolean} \c true if transaction signature is verified.
 	 */
 	verifyTransaction(transaction, signature) {
-		const verifyBuffer = new Uint8Array([
-			...this.network.generationHashSeed.bytes,
-			...transactionDataBuffer(transaction.serialize())
-		]);
+		const verifyBuffer = new Uint8Array(this.extractSigningPayload(transaction));
 		return new Verifier(transaction.signerPublicKey).verify(verifyBuffer, signature);
 	}
 

--- a/sdk/javascript/test/facade/NemFacade_spec.js
+++ b/sdk/javascript/test/facade/NemFacade_spec.js
@@ -300,7 +300,7 @@ describe('NEM Facade', () => {
 			expect(signature).to.deep.equal(descriptor.transactionSignature);
 		});
 
-		it(`can verify ${descriptor.name} transaction`, () => {
+		const assertCanVerifyTransaction = sign => {
 			// Arrange:
 			const privateKey = new PrivateKey('EDB671EB741BD676969D8A035271D1EE5E75DF33278083D877F23615EB839FEC');
 			const facade = new NemFacade('testnet');
@@ -311,11 +311,22 @@ describe('NEM Facade', () => {
 			expect(transaction.signature).to.deep.equal(Signature.zero());
 
 			// Act:
-			const signature = facade.signTransaction(new NemFacade.KeyPair(privateKey), transaction);
+			const signature = sign(facade, new NemFacade.KeyPair(privateKey), transaction);
 			const isVerified = facade.verifyTransaction(transaction, signature);
 
 			// Assert:
 			expect(isVerified).to.equal(true);
+		};
+
+		it(`can verify signed ${descriptor.name} transaction`, () => {
+			assertCanVerifyTransaction((facade, keyPair, transaction) => facade.signTransaction(keyPair, transaction));
+		});
+
+		it(`can verify signed ${descriptor.name} transaction signing payload`, () => {
+			assertCanVerifyTransaction((facade, keyPair, transaction) => {
+				const signingPayload = facade.extractSigningPayload(transaction);
+				return keyPair.sign(signingPayload);
+			});
 		});
 	};
 

--- a/sdk/javascript/test/facade/SymbolFacade_spec.js
+++ b/sdk/javascript/test/facade/SymbolFacade_spec.js
@@ -504,7 +504,7 @@ describe('Symbol Facade', () => {
 		].join('')));
 	});
 
-	const assertCanVerifyTransaction = transactionFactory => {
+	const assertCanVerifyTransaction = (transactionFactory, sign) => {
 		// Arrange:
 		const privateKey = new PrivateKey('EDB671EB741BD676969D8A035271D1EE5E75DF33278083D877F23615EB839FEC');
 		const facade = new SymbolFacade('testnet');
@@ -515,19 +515,38 @@ describe('Symbol Facade', () => {
 		expect(transaction.signature).to.deep.equal(Signature.zero());
 
 		// Act:
-		const signature = facade.signTransaction(new SymbolFacade.KeyPair(privateKey), transaction);
+		const signature = sign(facade, new SymbolFacade.KeyPair(privateKey), transaction);
 		const isVerified = facade.verifyTransaction(transaction, signature);
 
 		// Assert:
 		expect(isVerified).to.equal(true);
 	};
 
-	it('can verify transaction', () => {
-		assertCanVerifyTransaction(createRealTransfer);
+	const assertCanVerifySignedTransaction = transactionFactory => {
+		assertCanVerifyTransaction(transactionFactory, (facade, keyPair, transaction) => facade.signTransaction(keyPair, transaction));
+	};
+
+	it('can verify signed transaction', () => {
+		assertCanVerifySignedTransaction(createRealTransfer);
 	});
 
-	it('can verify aggregate transaction', () => {
-		assertCanVerifyTransaction(createRealAggregate);
+	it('can verify signed aggregate transaction', () => {
+		assertCanVerifySignedTransaction(createRealAggregate);
+	});
+
+	const assertCanVerifySignedTransactionSigningPayload = transactionFactory => {
+		assertCanVerifyTransaction(transactionFactory, (facade, keyPair, transaction) => {
+			const signingPayload = facade.extractSigningPayload(transaction);
+			return keyPair.sign(signingPayload);
+		});
+	};
+
+	it('can verify signed transaction signing payload', () => {
+		assertCanVerifySignedTransactionSigningPayload(createRealTransfer);
+	});
+
+	it('can verify signed aggregate transaction signing payload', () => {
+		assertCanVerifySignedTransactionSigningPayload(createRealAggregate);
 	});
 
 	// endregion

--- a/sdk/python/symbolchain/facade/NemFacade.py
+++ b/sdk/python/symbolchain/facade/NemFacade.py
@@ -93,16 +93,18 @@ class NemFacade:
 		return Hash256(sha3.keccak_256(non_verifiable_transaction.serialize()).digest())
 
 	@staticmethod
-	def sign_transaction(key_pair, transaction):
-		"""Signs a NEM transaction."""
+	def extract_signing_payload(transaction):
+		"""Gets the payload to sign given a NEM transaction."""
 		non_verifiable_transaction = TransactionFactory.to_non_verifiable_transaction(transaction)
-		return key_pair.sign(non_verifiable_transaction.serialize())
+		return non_verifiable_transaction.serialize()
 
-	@staticmethod
-	def verify_transaction(transaction, signature):
+	def sign_transaction(self, key_pair, transaction):
+		"""Signs a NEM transaction."""
+		return key_pair.sign(self.extract_signing_payload(transaction))
+
+	def verify_transaction(self, transaction, signature):
 		"""Verifies a NEM transaction."""
-		non_verifiable_transaction = TransactionFactory.to_non_verifiable_transaction(transaction)
-		return Verifier(transaction.signer_public_key).verify(non_verifiable_transaction.serialize(), signature)
+		return Verifier(transaction.signer_public_key).verify(self.extract_signing_payload(transaction), signature)
 
 	def bip32_path(self, account_id):
 		"""Creates a network compatible BIP32 path for the specified account."""

--- a/sdk/python/symbolchain/facade/SymbolFacade.py
+++ b/sdk/python/symbolchain/facade/SymbolFacade.py
@@ -116,17 +116,19 @@ class SymbolFacade:
 		hasher.update(self._transaction_data_buffer(transaction.serialize()))
 		return Hash256(hasher.digest())
 
-	def sign_transaction(self, key_pair, transaction):
-		"""Signs a Symbol transaction."""
+	def extract_signing_payload(self, transaction):
+		"""Gets the payload to sign given a Symbol transaction."""
 		sign_buffer = self.network.generation_hash_seed.bytes
 		sign_buffer += self._transaction_data_buffer(transaction.serialize())
-		return key_pair.sign(sign_buffer)
+		return sign_buffer
+
+	def sign_transaction(self, key_pair, transaction):
+		"""Signs a Symbol transaction."""
+		return key_pair.sign(self.extract_signing_payload(transaction))
 
 	def verify_transaction(self, transaction, signature):
 		"""Verifies a Symbol transaction."""
-		verify_buffer = self.network.generation_hash_seed.bytes
-		verify_buffer += self._transaction_data_buffer(transaction.serialize())
-		return Verifier(transaction.signer_public_key).verify(verify_buffer, signature)
+		return Verifier(transaction.signer_public_key).verify(self.extract_signing_payload(transaction), signature)
 
 	def cosign_transaction(self, key_pair, transaction, detached=False):
 		"""Cosigns a Symbol transaction."""


### PR DESCRIPTION
    [sdk/python]: add extract_signing_payload to facades
    
     problem: there is no easy way to get signed data payload, which is needed to allow signing by hardware keys
    solution: add extract_signing_payload to facades


    [sdk/javascript]: add extractSigningPayload to facades
    
     problem: there is no easy way to get signed data payload, which is needed to allow signing by hardware keys
    solution: add extractSigningPayload to facades
