### PR TITLE
[client/rest]: add CatapultProxy for caching responses

### DIFF
--- a/client/rest/src/plugins/rosetta/CatapultProxy.js
+++ b/client/rest/src/plugins/rosetta/CatapultProxy.js
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2016-2019, Jaguar0625, gimre, BloodyRookie, Tech Bureau, Corp.
+ * Copyright (c) 2020-present, Jaguar0625, gimre, BloodyRookie.
+ * All rights reserved.
+ *
+ * This file is part of Catapult.
+ *
+ * Catapult is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Catapult is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { RosettaErrorFactory } from './rosettaUtils.js';
+
+const bigIntToHexString = value => value.toString(16).toUpperCase();
+
+/**
+ * Proxy to a catapult node that performs caching for performance optimization, as appropriate.
+ */
+export default class CatapultProxy {
+	/**
+	 * Creates a proxy around an endpoint.
+	 * @param {string} endpoint Catapult endpoint.
+	 */
+	constructor(endpoint) {
+		this.endpoint = endpoint;
+
+		this.node = undefined;
+		this.network = undefined;
+		this.mosaicPropertiesMap = new Map();
+	}
+
+	/**
+	 * Performs an (uncached) fetch request on the endpoint.
+	 * @param {string} urlPath Request path.
+	 * @param {Function} jsonProjection Processes result.
+	 * @param {object} requestOptions Additional fetch request options.
+	 * @returns {object} Result of fetch and projection.
+	 */
+	async fetch(urlPath, jsonProjection = undefined, requestOptions = {}) {
+		try {
+			const response = await global.fetch(`${this.endpoint}/${urlPath}`, requestOptions);
+			if (!response.ok)
+				throw RosettaErrorFactory.CONNECTION_ERROR;
+
+			const jsonObject = await response.json();
+			return jsonProjection ? jsonProjection(jsonObject) : jsonObject;
+		} catch (err) {
+			throw RosettaErrorFactory.CONNECTION_ERROR;
+		}
+	}
+
+	/**
+	 * @private
+	 */
+	async load() {
+		const results = await Promise.all([
+			this.fetch('node/info'),
+			this.fetch('network/properties')
+		]);
+
+		this.node = results[0];
+		this.network = results[1];
+	}
+
+	/**
+	 * Gets (potentially cached) catapult node information.
+	 * @returns {object} Catapult node information.
+	 */
+	async nodeInfo() {
+		if (!this.node)
+			await this.load();
+
+		return this.node;
+	}
+
+	/**
+	 * Gets (potentially cached) catapult network information.
+	 * @returns {object} Catapult network information.
+	 */
+	async networkProperties() {
+		if (!this.network)
+			await this.load();
+
+		return this.network;
+	}
+
+	/**
+	 * Resolves a mosaic id.
+	 * @param {bigint} unresolvedMosaicId Unresolved mosaic id.
+	 * @param {object} transactionLocation Location of transaction for which to perform the resolution.
+	 * @returns {bigint} Resolved mosaic id.
+	 */
+	async resolveMosaicId(unresolvedMosaicId, transactionLocation = undefined) {
+		if (0n === (unresolvedMosaicId & (1n << 63n)))
+			return unresolvedMosaicId;
+
+		if (!transactionLocation) {
+			const mosaicIdHexString = await this.fetch(
+				`namespaces/${bigIntToHexString(unresolvedMosaicId)}`,
+				jsonObject => jsonObject.namespace.alias.mosaicId
+			);
+			return BigInt(`0x${mosaicIdHexString}`);
+		}
+
+		const statements = await this.fetch(
+			`statements/resolutions/mosaic?height=${transactionLocation.height}`,
+			jsonObject => jsonObject.data
+		);
+		const resolutionStatement = statements.find(statement => unresolvedMosaicId === BigInt(`0x${statement.statement.unresolved}`));
+		if (!resolutionStatement)
+			throw RosettaErrorFactory.INTERNAL_SERVER_ERROR;
+
+		for (let i = resolutionStatement.statement.resolutionEntries.length - 1; 0 <= i; --i) {
+			const resolutionEntry = resolutionStatement.statement.resolutionEntries[i];
+			const { source } = resolutionEntry;
+			if (source.primaryId <= transactionLocation.primaryId && source.secondaryId <= transactionLocation.secondaryId)
+				return BigInt(`0x${resolutionEntry.resolved}`);
+		}
+
+		throw RosettaErrorFactory.INTERNAL_SERVER_ERROR;
+	}
+
+	/**
+	 * Retrieves (potentially cached) mosaic properties.
+	 * @param {bigint} resolvedMosaicId Resolved mosaic id.
+	 * @returns {object} Properties about the mosaic.
+	 */
+	async mosaicProperties(resolvedMosaicId) {
+		if (this.mosaicPropertiesMap.has(resolvedMosaicId))
+			return this.mosaicPropertiesMap.get(resolvedMosaicId);
+
+		const results = await Promise.all([
+			this.fetch(`mosaics/${bigIntToHexString(resolvedMosaicId)}`, jsonObject => jsonObject.mosaic.divisibility),
+			this.fetch('namespaces/mosaic/names', jsonObject => jsonObject.mosaicNames[0], {
+				method: 'POST',
+				body: JSON.stringify({ mosaicIds: [bigIntToHexString(resolvedMosaicId)] }),
+				headers: { 'Content-Type': 'application/json' }
+			})
+		]);
+
+		const mosaic = {
+			name: results[1].names.length ? results[1].names[0] : bigIntToHexString(resolvedMosaicId),
+			divisibility: results[0]
+		};
+		this.mosaicPropertiesMap.set(resolvedMosaicId, mosaic);
+		return mosaic;
+	}
+}

--- a/client/rest/src/plugins/rosetta/rosetta.js
+++ b/client/rest/src/plugins/rosetta/rosetta.js
@@ -20,6 +20,7 @@
  */
 
 /** @module plugins/rosetta */
+import CatapultProxy from './CatapultProxy.js';
 import constructionRoutes from './constructionRoutes.js';
 
 /**
@@ -33,9 +34,12 @@ export default {
 
 	registerMessageChannels: () => {},
 
-	registerRoutes: (...args) => {
+	registerRoutes: (server, db, services) => {
+		const restUrl = `${services.config.rest.protocol}://localhost:${services.config.rest.port}`;
+		const proxy = new CatapultProxy(restUrl);
+
 		[
 			constructionRoutes
-		].forEach(routes => routes.register(...args));
+		].forEach(routes => routes.register(server, db, { ...services, proxy }));
 	}
 };

--- a/client/rest/test/plugins/rosetta/CatapultProxy_spec.js
+++ b/client/rest/test/plugins/rosetta/CatapultProxy_spec.js
@@ -1,0 +1,345 @@
+/*
+ * Copyright (c) 2016-2019, Jaguar0625, gimre, BloodyRookie, Tech Bureau, Corp.
+ * Copyright (c) 2020-present, Jaguar0625, gimre, BloodyRookie.
+ * All rights reserved.
+ *
+ * This file is part of Catapult.
+ *
+ * Catapult is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Catapult is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import CatapultProxy from '../../../src/plugins/rosetta/CatapultProxy.js';
+import { RosettaErrorFactory } from '../../../src/plugins/rosetta/rosettaUtils.js';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+describe('CatapultProxy', () => {
+	const assertAsyncErrorThrown = async (func, expectedRosettaError) => {
+		try {
+			await func();
+			expect.fail(`no error thrown - expected ${expectedRosettaError.message}`);
+		} catch (err) {
+			expect(err.apiError).deep.equal(expectedRosettaError.apiError);
+		}
+	};
+
+	const stubFetchResult = (urlPath, ok, jsonResult) => {
+		if (!global.fetch.restore)
+			sinon.stub(global, 'fetch');
+
+		global.fetch.withArgs(`http://localhost:3456/${urlPath}`).returns(Promise.resolve({
+			ok,
+			json: () => jsonResult
+		}));
+	};
+
+	afterEach(() => {
+		if (global.fetch.restore)
+			global.fetch.restore();
+	});
+
+	describe('fetch', () => {
+		it('fails when fetch fails (headers)', async () => {
+			// Arrange:
+			const proxy = new CatapultProxy('http://localhost:3456');
+			stubFetchResult('custom/route', false, { foo: 123, bar: 246 });
+
+			// Act + Assert:
+			await assertAsyncErrorThrown(() => proxy.fetch('custom/route'), RosettaErrorFactory.CONNECTION_ERROR);
+		});
+
+		it('fails when fetch fails (body)', async () => {
+			// Arrange:
+			const proxy = new CatapultProxy('http://localhost:3456');
+			stubFetchResult('custom/route', true, Promise.reject(Error('fetch failed')));
+
+			// Act + Assert:
+			await assertAsyncErrorThrown(() => proxy.fetch('custom/route'), RosettaErrorFactory.CONNECTION_ERROR);
+		});
+
+		it('returns valid response on success (without projection)', async () => {
+			// Arrange:
+			const proxy = new CatapultProxy('http://localhost:3456');
+			stubFetchResult('custom/route', true, { foo: 123, bar: 246 });
+
+			// Act:
+			const result = await proxy.fetch('custom/route');
+
+			// Assert:
+			expect(result).to.deep.equal({ foo: 123, bar: 246 });
+		});
+
+		it('returns valid response on success (with projection)', async () => {
+			// Arrange:
+			const proxy = new CatapultProxy('http://localhost:3456');
+			stubFetchResult('custom/route', true, { foo: 123, bar: 246 });
+
+			// Act:
+			const result = await proxy.fetch('custom/route', jsonObject => jsonObject.bar);
+
+			// Assert:
+			expect(result).to.equal(246);
+		});
+	});
+
+	const runGlobalCacheQueryTest = async (action, expectedResult) => {
+		// Arrange:
+		const proxy = new CatapultProxy('http://localhost:3456');
+		stubFetchResult('node/info', true, { node: 'alpha' });
+		stubFetchResult('network/properties', true, { network: 'beta' });
+
+		// Act:
+		const result = await action(proxy);
+
+		// Assert: only initial calls were made
+		expect(global.fetch.callCount).to.equal(2);
+		expect(result).to.deep.equal(expectedResult);
+	};
+
+	const runGlobalCacheErrorRetryTest = async (failureUrlPath, action, expectedResult) => {
+		// Arrange:
+		const proxy = new CatapultProxy('http://localhost:3456');
+		stubFetchResult('node/info', 'node/info' !== failureUrlPath, { node: 'alpha' });
+		stubFetchResult('network/properties', 'network/properties' !== failureUrlPath, { network: 'beta' });
+
+		// Sanity:
+		assertAsyncErrorThrown(() => action(proxy), RosettaErrorFactory.CONNECTION_ERROR);
+
+		// Arrange:
+		stubFetchResult('node/info', true, { node: 'alpha' });
+		stubFetchResult('network/properties', true, { network: 'beta' });
+
+		// Act:
+		const result = await action(proxy);
+
+		// Assert: first (failure) and second (success) calls were made
+		expect(global.fetch.callCount).to.equal(4);
+		expect(result).to.deep.equal(expectedResult);
+	};
+
+	describe('nodeInfo', () => {
+		it('can retrieve', () => runGlobalCacheQueryTest(proxy => proxy.nodeInfo(), { node: 'alpha' }));
+
+		it('can retrieve (cached)', () => runGlobalCacheQueryTest(async proxy => {
+			await proxy.nodeInfo();
+			await proxy.nodeInfo();
+			return proxy.nodeInfo();
+		}, { node: 'alpha' }));
+
+		it('can retrieve after failure', () => runGlobalCacheErrorRetryTest('node/info', proxy => proxy.nodeInfo(), { node: 'alpha' }));
+	});
+
+	describe('networkProperties', () => {
+		it('can retrieve', () => runGlobalCacheQueryTest(proxy => proxy.networkProperties(), { network: 'beta' }));
+
+		it('can retrieve (cached)', () => runGlobalCacheQueryTest(async proxy => {
+			await proxy.networkProperties();
+			await proxy.networkProperties();
+			return proxy.networkProperties();
+		}, { network: 'beta' }));
+
+		it('can retrieve after failure', () => runGlobalCacheErrorRetryTest(
+			'network/properties',
+			proxy => proxy.networkProperties(),
+			{ network: 'beta' }
+		));
+	});
+
+	describe('resolveMosaicId', () => {
+		it('can resolve resolved mosaic id', async () => {
+			// Arrange:
+			const proxy = new CatapultProxy('http://localhost:3456');
+
+			// Act:
+			const mosaicId = await proxy.resolveMosaicId(0x1234567890ABCDEFn);
+
+			// Assert:
+			expect(mosaicId).to.equal(0x1234567890ABCDEFn);
+		});
+
+		it('can resolve unresolved mosaic id without location', async () => {
+			// Arrange:
+			const proxy = new CatapultProxy('http://localhost:3456');
+			stubFetchResult('namespaces/9234567890ABCDEF', true, { namespace: { alias: { mosaicId: '1234567890ABCDEF' } } });
+
+			// Act:
+			const mosaicId = await proxy.resolveMosaicId(0x9234567890ABCDEFn);
+
+			// Assert:
+			expect(mosaicId).to.equal(0x1234567890ABCDEFn);
+		});
+
+		it('fails when fetch fails (namespaces)', async () => {
+			// Arrange:
+			const proxy = new CatapultProxy('http://localhost:3456');
+			stubFetchResult('namespaces/9234567890ABCDEF', false, { namespace: { alias: { mosaicId: '1234567890ABCDEF' } } });
+
+			// Act + Assert:
+			await assertAsyncErrorThrown(() => proxy.resolveMosaicId(0x9234567890ABCDEFn), RosettaErrorFactory.CONNECTION_ERROR);
+		});
+
+		const makeResolutionStatement = (unresolved, resolutionEntries) => ({ statement: { unresolved, resolutionEntries } });
+		const makeResolutionEntry = (resolved, primaryId, secondaryId) => ({ resolved, source: { primaryId, secondaryId } });
+
+		it('cannot resolve unresolved mosaic id with location when no matching statements exist', async () => {
+			// Arrange:
+			const proxy = new CatapultProxy('http://localhost:3456');
+			stubFetchResult('statements/resolutions/mosaic?height=1234', true, {
+				data: [
+					makeResolutionStatement('AAAAAAAAAAAAAAAA', [
+						makeResolutionEntry('BBBBBBBBBBBBBBBB', 1, 0)
+					])
+				]
+			});
+
+			// Act + Assert:
+			await assertAsyncErrorThrown(
+				() => proxy.resolveMosaicId(0x9234567890ABCDEFn, { height: 1234n, primaryId: 2, secondaryId: 3 }),
+				RosettaErrorFactory.INTERNAL_SERVER_ERROR
+			);
+		});
+
+		it('cannot resolve unresolved mosaic id with location when no matching resolution entries exist', async () => {
+			// Arrange:
+			const proxy = new CatapultProxy('http://localhost:3456');
+			stubFetchResult('statements/resolutions/mosaic?height=1234', true, {
+				data: [
+					makeResolutionStatement('9234567890ABCDEF', [
+						makeResolutionEntry('1234567890ABCDEF', 2, 4),
+						makeResolutionEntry('2234567890ABCDEF', 3, 0)
+					])
+				]
+			});
+
+			// Act + Assert:
+			await assertAsyncErrorThrown(
+				() => proxy.resolveMosaicId(0x9234567890ABCDEFn, { height: 1234n, primaryId: 2, secondaryId: 3 }),
+				RosettaErrorFactory.INTERNAL_SERVER_ERROR
+			);
+		});
+
+		it('can resolve unresolved mosaic id with location when matching resolution entries exist', async () => {
+			// Arrange:
+			const proxy = new CatapultProxy('http://localhost:3456');
+			stubFetchResult('statements/resolutions/mosaic?height=1234', true, {
+				data: [
+					makeResolutionStatement('9234567890ABCDEF', [
+						makeResolutionEntry('0234567890ABCDEF', 1, 3),
+						makeResolutionEntry('1234567890ABCDEF', 2, 2),
+						makeResolutionEntry('2234567890ABCDEF', 3, 0)
+					])
+				]
+			});
+
+			// Act:
+			const mosaicId = await proxy.resolveMosaicId(0x9234567890ABCDEFn, { height: 1234n, primaryId: 2, secondaryId: 3 });
+
+			// Assert:
+			expect(mosaicId).to.equal(0x1234567890ABCDEFn);
+		});
+
+		it('fails when fetch fails (statements)', async () => {
+			// Arrange:
+			const proxy = new CatapultProxy('http://localhost:3456');
+			stubFetchResult('statements/resolutions/mosaic?height=1234', false, {
+				data: [
+					makeResolutionStatement('9234567890ABCDEF', [
+						makeResolutionEntry('0234567890ABCDEF', 1, 3),
+						makeResolutionEntry('1234567890ABCDEF', 2, 2),
+						makeResolutionEntry('2234567890ABCDEF', 3, 0)
+					])
+				]
+			});
+
+			// Act + Assert:
+			await assertAsyncErrorThrown(
+				() => proxy.resolveMosaicId(0x9234567890ABCDEFn, { height: 1234n, primaryId: 2, secondaryId: 3 }),
+				RosettaErrorFactory.CONNECTION_ERROR
+			);
+		});
+	});
+
+	describe('mosaicProperties', () => {
+		it('can retrieve properties for mosaic with name', async () => {
+			// Arrange:
+			const proxy = new CatapultProxy('http://localhost:3456');
+			stubFetchResult('mosaics/1234567890ABCDEF', true, { mosaic: { divisibility: 3 } });
+			stubFetchResult('namespaces/mosaic/names', true, { mosaicNames: [{ names: ['alpha', 'beta'] }] });
+
+			// Act:
+			const mosaicProperties = await proxy.mosaicProperties(0x1234567890ABCDEFn);
+
+			// Assert:
+			expect(mosaicProperties).to.deep.equal({
+				name: 'alpha',
+				divisibility: 3
+			});
+		});
+
+		it('can retrieve properties for mosaic without name', async () => {
+			// Arrange:
+			const proxy = new CatapultProxy('http://localhost:3456');
+			stubFetchResult('mosaics/1234567890ABCDEF', true, { mosaic: { divisibility: 3 } });
+			stubFetchResult('namespaces/mosaic/names', true, { mosaicNames: [{ names: [] }] });
+
+			// Act:
+			const mosaicProperties = await proxy.mosaicProperties(0x1234567890ABCDEFn);
+
+			// Assert:
+			expect(mosaicProperties).to.deep.equal({
+				name: '1234567890ABCDEF',
+				divisibility: 3
+			});
+		});
+
+		it('can retrieve properties for mosaic with name (cached)', async () => {
+			// Arrange:
+			const proxy = new CatapultProxy('http://localhost:3456');
+			stubFetchResult('mosaics/1234567890ABCDEF', true, { mosaic: { divisibility: 3 } });
+			stubFetchResult('namespaces/mosaic/names', true, { mosaicNames: [{ names: ['alpha', 'beta'] }] });
+
+			// Act:
+			await proxy.mosaicProperties(0x1234567890ABCDEFn);
+			await proxy.mosaicProperties(0x1234567890ABCDEFn);
+			const mosaicProperties = await proxy.mosaicProperties(0x1234567890ABCDEFn);
+
+			// Assert: only initial calls were made
+			expect(global.fetch.callCount).to.equal(2);
+			expect(mosaicProperties).to.deep.equal({
+				name: 'alpha',
+				divisibility: 3
+			});
+		});
+
+		it('fails when fetch fails (mosaics)', async () => {
+			// Arrange:
+			const proxy = new CatapultProxy('http://localhost:3456');
+			stubFetchResult('mosaics/1234567890ABCDEF', false, { mosaic: { divisibility: 3 } });
+			stubFetchResult('namespaces/mosaic/names', true, { mosaicNames: [{ names: ['alpha', 'beta'] }] });
+
+			// Act + Assert:
+			await assertAsyncErrorThrown(() => proxy.mosaicProperties(0x1234567890ABCDEFn), RosettaErrorFactory.CONNECTION_ERROR);
+		});
+
+		it('fails when fetch fails (namespaces/mosaic/names)', async () => {
+			// Arrange:
+			const proxy = new CatapultProxy('http://localhost:3456');
+			stubFetchResult('mosaics/1234567890ABCDEF', true, { mosaic: { divisibility: 3 } });
+			stubFetchResult('namespaces/mosaic/names', false, { mosaicNames: [{ names: ['alpha', 'beta'] }] });
+
+			// Act + Assert:
+			await assertAsyncErrorThrown(() => proxy.mosaicProperties(0x1234567890ABCDEFn), RosettaErrorFactory.CONNECTION_ERROR);
+		});
+	});
+});


### PR DESCRIPTION
 problem: data routes can benefit from response caching
solution: promote fetch helper from constructionRoutes to CatapultProxy
          add caching support for repetitive data requests
