### PR TITLE
[client/rest]: fixes to CatapultProxy and OperationParser and addition of more utilities for data routes

### DIFF
--- a/client/rest/src/plugins/rosetta/CatapultProxy.js
+++ b/client/rest/src/plugins/rosetta/CatapultProxy.js
@@ -21,7 +21,7 @@
 
 import { RosettaErrorFactory } from './rosettaUtils.js';
 
-const bigIntToHexString = value => value.toString(16).toUpperCase();
+const bigIntToHexString = value => value.toString(16).padStart(16, '0').toUpperCase();
 
 /**
  * Proxy to a catapult node that performs caching for performance optimization, as appropriate.
@@ -76,7 +76,7 @@ export default class CatapultProxy {
 			pageNumber++;
 
 			// eslint-disable-next-line no-await-in-loop
-			response = await this.fetch(nextUrlPath, undefined, requestOptions);
+			response = await this.fetch(nextUrlPath, jsonObject => jsonObject.data, requestOptions);
 			jsonObjects.push(...response);
 		} while (response.length === pageSize);
 

--- a/client/rest/src/plugins/rosetta/CatapultProxy.js
+++ b/client/rest/src/plugins/rosetta/CatapultProxy.js
@@ -102,6 +102,10 @@ export default class CatapultProxy {
 				networkProperties: results[1],
 				nemesisBlock: results[2]
 			};
+
+			const chainProperties = this.cache.networkProperties.chain;
+			if (chainProperties && chainProperties.currencyMosaicId)
+				chainProperties.currencyMosaicId = chainProperties.currencyMosaicId.replace(/'/g, '');
 		}
 
 		return this.cache[propertyName];
@@ -187,7 +191,8 @@ export default class CatapultProxy {
 
 		const mosaic = {
 			name: results[1].names.length ? results[1].names[0] : bigIntToHexString(resolvedMosaicId),
-			divisibility: results[0]
+			divisibility: results[0],
+			id: bigIntToHexString(resolvedMosaicId)
 		};
 		this.mosaicPropertiesMap.set(resolvedMosaicId, mosaic);
 		return mosaic;

--- a/client/rest/src/plugins/rosetta/OperationParser.js
+++ b/client/rest/src/plugins/rosetta/OperationParser.js
@@ -23,6 +23,8 @@ import AccountIdentifier from './openApi/model/AccountIdentifier.js';
 import Amount from './openApi/model/Amount.js';
 import Operation from './openApi/model/Operation.js';
 import OperationIdentifier from './openApi/model/OperationIdentifier.js';
+import Transaction from './openApi/model/Transaction.js';
+import TransactionIdentifier from './openApi/model/TransactionIdentifier.js';
 import { PublicKey, utils } from 'symbol-sdk';
 import { Address, Network, models } from 'symbol-sdk/symbol';
 
@@ -127,6 +129,17 @@ export class OperationParser {
 
 		operation.amount = new Amount((-options.amount).toString(), options.currency);
 		return operation;
+	}
+
+	/**
+	 * Parses a transaction into a rosetta transaction.
+	 * @param {object} transaction Transaction to process (REST object model is assumed).
+	 * @param {object} metadata Transaction metadata.
+	 * @returns {Transaction} Rosetta transaction.
+	 */
+	async parseTransactionAsRosettaTransaction(transaction, metadata) {
+		const { operations } = await this.parseTransaction(transaction, metadata);
+		return new Transaction(new TransactionIdentifier(metadata.hash), operations);
 	}
 
 	/**

--- a/client/rest/src/plugins/rosetta/constructionRoutes.js
+++ b/client/rest/src/plugins/rosetta/constructionRoutes.js
@@ -19,7 +19,7 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import OperationParser from './OperationParser.js';
+import { OperationParser, convertTransactionSdkJsonToRestJson } from './OperationParser.js';
 import AccountIdentifier from './openApi/model/AccountIdentifier.js';
 import ConstructionCombineRequest from './openApi/model/ConstructionCombineRequest.js';
 import ConstructionCombineResponse from './openApi/model/ConstructionCombineResponse.js';
@@ -268,7 +268,9 @@ export default {
 					return xymCurrency;
 				}
 			});
-			const { operations, signerAddresses } = await parser.parseTransaction(aggregateTransaction.toJson());
+
+			const aggregateTransactionJson = convertTransactionSdkJsonToRestJson(aggregateTransaction.toJson());
+			const { operations, signerAddresses } = await parser.parseTransaction(aggregateTransactionJson);
 
 			const response = new ConstructionParseResponse();
 			response.operations = operations;


### PR DESCRIPTION
    [client/rest]: add additional utilities needed by data routes
    
     problem: common logic in data routes should be refactored
    solution: refactor and add new utilities

    [client/rest]: fixes to OperationParser
    
     problem: JSON used in tests is slightly different from REST JSON
    solution: use REST JSON in tests and update implementation

    [client/rest]: fixes to CatapultProxy
    
     problem: pagination routes return object with data array, not array directly
    solution: update fetchAll to extract data array
    
     problem: bigint to hex string formatting drops leading zeros
    solution: always return 16 character strings
