### PR TITLE
[client/rest]: fix ReceiptSource comparison in CatapultProxy

### DIFF
--- a/client/rest/src/plugins/rosetta/CatapultProxy.js
+++ b/client/rest/src/plugins/rosetta/CatapultProxy.js
@@ -22,6 +22,8 @@
 import { RosettaErrorFactory } from './rosettaUtils.js';
 
 const bigIntToHexString = value => value.toString(16).padStart(16, '0').toUpperCase();
+const isReceiptSourceLessThanEqual = (lhs, rhs) =>
+	lhs.primaryId < rhs.primaryId || (lhs.primaryId === rhs.primaryId && lhs.secondaryId <= rhs.secondaryId);
 
 /**
  * Proxy to a catapult node that performs caching for performance optimization, as appropriate.
@@ -164,7 +166,7 @@ export default class CatapultProxy {
 		for (let i = resolutionStatement.statement.resolutionEntries.length - 1; 0 <= i; --i) {
 			const resolutionEntry = resolutionStatement.statement.resolutionEntries[i];
 			const { source } = resolutionEntry;
-			if (source.primaryId <= transactionLocation.primaryId && source.secondaryId <= transactionLocation.secondaryId)
+			if (isReceiptSourceLessThanEqual(source, transactionLocation))
 				return BigInt(`0x${resolutionEntry.resolved}`);
 		}
 

--- a/client/rest/test/plugins/rosetta/CatapultProxy_spec.js
+++ b/client/rest/test/plugins/rosetta/CatapultProxy_spec.js
@@ -405,25 +405,44 @@ describe('CatapultProxy', () => {
 			);
 		});
 
-		it('can resolve unresolved mosaic id with location when matching resolution entries exist', async () => {
+		const assertCanResolveWhenMatchingResolutionEntriesExist = async data => {
 			// Arrange:
 			const proxy = new CatapultProxy(TEST_ENDPOINT);
-			stubFetchResult('statements/resolutions/mosaic?height=1234', true, {
-				data: [
-					makeResolutionStatement('9234567890ABCDEF', [
-						makeResolutionEntry('0234567890ABCDEF', 1, 3),
-						makeResolutionEntry('0034567890ABCDEF', 2, 2),
-						makeResolutionEntry('2234567890ABCDEF', 3, 0)
-					])
-				]
-			});
+			stubFetchResult('statements/resolutions/mosaic?height=1234', true, { data });
 
 			// Act:
 			const mosaicId = await proxy.resolveMosaicId(0x9234567890ABCDEFn, { height: 1234n, primaryId: 2, secondaryId: 3 });
 
 			// Assert:
 			expect(mosaicId).to.equal(0x0034567890ABCDEFn);
-		});
+		};
+
+		it('can resolve unresolved mosaic id with location when matching resolution entries exist (primary GT secondary LT)', async () =>
+			assertCanResolveWhenMatchingResolutionEntriesExist([
+				makeResolutionStatement('9234567890ABCDEF', [
+					makeResolutionEntry('0234567890ABCDEF', 1, 4),
+					makeResolutionEntry('0034567890ABCDEF', 1, 5),
+					makeResolutionEntry('2234567890ABCDEF', 4, 0)
+				])
+			]));
+
+		it('can resolve unresolved mosaic id with location when matching resolution entries exist (primary EQ secondary GT)', async () =>
+			assertCanResolveWhenMatchingResolutionEntriesExist([
+				makeResolutionStatement('9234567890ABCDEF', [
+					makeResolutionEntry('0234567890ABCDEF', 2, 1),
+					makeResolutionEntry('0034567890ABCDEF', 2, 2),
+					makeResolutionEntry('2234567890ABCDEF', 2, 6)
+				])
+			]));
+
+		it('can resolve unresolved mosaic id with location when matching resolution entries exist (primary EQ secondary EQ)', async () =>
+			assertCanResolveWhenMatchingResolutionEntriesExist([
+				makeResolutionStatement('9234567890ABCDEF', [
+					makeResolutionEntry('0234567890ABCDEF', 2, 2),
+					makeResolutionEntry('0034567890ABCDEF', 2, 3),
+					makeResolutionEntry('2234567890ABCDEF', 2, 4)
+				])
+			]));
 
 		it('fails when fetch fails (statements)', async () => {
 			// Arrange:


### PR DESCRIPTION
 problem: secondaryId should only be checked when primaryId is equal
solution: only check secondaryId when primaryId is equal
