### PR TITLE
[client/rest]: add postprocessing of epochAdjustment to CatapultProxy

### DIFF
--- a/client/rest/test/plugins/rosetta/CatapultProxy_spec.js
+++ b/client/rest/test/plugins/rosetta/CatapultProxy_spec.js
@@ -265,7 +265,7 @@ describe('CatapultProxy', () => {
 			setCacheFetchResults(failureUrlPath);
 
 			// Sanity:
-			assertAsyncErrorThrown(() => action(proxy), RosettaErrorFactory.CONNECTION_ERROR);
+			await assertAsyncErrorThrown(() => action(proxy), RosettaErrorFactory.CONNECTION_ERROR);
 
 			// Arrange:
 			setCacheFetchResults();


### PR DESCRIPTION
    [client/rest]: add postprocessing of epochAdjustment to CatapultProxy
    
     problem: rosetta block route requires this value parsed
    solution: parse and store parsed value in cache

    [client/rest]: add missing await

     problem: call to assertAsyncErrorThrown is missing await
    solution: add await
