### PR TITLE
[client/rest]: skip parsing of receipts without amounts

### DIFF
--- a/client/rest/src/plugins/rosetta/OperationParser.js
+++ b/client/rest/src/plugins/rosetta/OperationParser.js
@@ -313,6 +313,9 @@ export class OperationParser {
 	 * @returns {Array<Operation>} Receipt operations.
 	 */
 	async parseReceipt(receipt) {
+		if (undefined === receipt.amount)
+			return { operations: [] };
+
 		const amount = BigInt(receipt.amount);
 		if (0n === amount)
 			return { operations: [] };

--- a/client/rest/test/plugins/rosetta/OperationParser_spec.js
+++ b/client/rest/test/plugins/rosetta/OperationParser_spec.js
@@ -771,13 +771,16 @@ describe('OperationParser', () => {
 		});
 
 		describe('other', () => {
-			it('can parse', () => runReceiptTest({
+			const createReceiptJson = amount => ({
 				type: 1111,
 				targetAddress: '982390440A195B82D4A06810038B1400CE7CDA7AB3F48F99',
 				mosaicId: generateMosaicAliasId('foo.bar'),
-				amount: '4741734'
-			}, [
-			]));
+				amount
+			});
+
+			it('can parse', () => runReceiptTest(createReceiptJson('4741734'), []));
+
+			it('can parse without amount', () => runReceiptTest(createReceiptJson(undefined), []));
 		});
 	});
 


### PR DESCRIPTION
 problem: OperationParser assumes all receipts have amount property
solution: check if amount property exists
