### PR TITLE
[client/rest]: workaround race condition in CatapultProxy

### DIFF
--- a/client/rest/src/plugins/rosetta/CatapultProxy.js
+++ b/client/rest/src/plugins/rosetta/CatapultProxy.js
@@ -114,6 +114,9 @@ export default class CatapultProxy {
 				this.fetch('blocks/1')
 			]);
 
+			if (this.cache)
+				return this.readCacheProperty(propertyName);
+
 			this.cache = {
 				nodeInfo: results[0],
 				networkProperties: results[1],


### PR DESCRIPTION
 problem: when multiple cache fill requests are made in parallel, properties will be parsed multiple times
solution: only parse first cache object returned
