### PR TITLE
[client/rest]: rosetta integration fixes after addition of data routes 

### DIFF
--- a/client/rest/src/plugins/rosetta/accountRoutes.js
+++ b/client/rest/src/plugins/rosetta/accountRoutes.js
@@ -74,6 +74,10 @@ export default {
 			const { blockIdentifier, mosaics } = await getAccountInfo(typedRequest);
 
 			let amounts = await mapMosaicsToRosettaAmounts(mosaics);
+			amounts.forEach(amount => {
+				delete amount.currency.metadata;
+			});
+
 			if (typedRequest.currencies)
 				amounts = amounts.filter(amount => typedRequest.currencies.some(currency => isCurrencyEqual(amount.currency, currency)));
 

--- a/client/rest/src/plugins/rosetta/blockRoutes.js
+++ b/client/rest/src/plugins/rosetta/blockRoutes.js
@@ -44,6 +44,7 @@ export default {
 		const lookupCurrency = createLookupCurrencyFunction(services.proxy);
 		const parser = new OperationParser(network, {
 			includeFeeOperation: true,
+			operationStatus: 'success',
 			lookupCurrency,
 			resolveAddress: (address, transactionLocation) => services.proxy.resolveAddress(address, transactionLocation)
 		});

--- a/client/rest/src/plugins/rosetta/mempoolRoutes.js
+++ b/client/rest/src/plugins/rosetta/mempoolRoutes.js
@@ -40,6 +40,7 @@ export default {
 		const lookupCurrency = createLookupCurrencyFunction(services.proxy);
 		const parser = new OperationParser(network, {
 			includeFeeOperation: true,
+			operationStatus: 'success',
 			lookupCurrency,
 			resolveAddress: (address, transactionLocation) => services.proxy.resolveAddress(address, transactionLocation)
 		});

--- a/client/rest/test/plugins/rosetta/OperationParser_spec.js
+++ b/client/rest/test/plugins/rosetta/OperationParser_spec.js
@@ -34,7 +34,9 @@ import {
 describe('OperationParser', () => {
 	// region utils
 
-	const { createCosignOperation, createMultisigOperation, createTransferOperation } = RosettaOperationFactory;
+	const {
+		createCosignOperation, createMultisigOperation, createTransferOperation, setOperationStatus
+	} = RosettaOperationFactory;
 
 	const encodeParitalDecodedAddress = address => new Address(utils.hexToUint8(address.padEnd(48, '0'))).toString();
 
@@ -398,6 +400,14 @@ describe('OperationParser', () => {
 			it('can parse with fee (confirmed)', () => assertCanParse({ includeFeeOperation: true }, { feeMultiplier: 200 }, [
 				createTransferOperation(0, 'TARZARAKDFNYFVFANAIAHCYUADHHZWT2WP2I7GI', '-20000', 'currency.fee', 2)
 			]));
+
+			it('can parse with fee (confirmed) and operation status', () => assertCanParse(
+				{ includeFeeOperation: true, operationStatus: 'success' },
+				{ feeMultiplier: 200 },
+				[
+					setOperationStatus(createTransferOperation(0, 'TARZARAKDFNYFVFANAIAHCYUADHHZWT2WP2I7GI', '-20000', 'currency.fee', 2))
+				]
+			));
 		});
 
 		// endregion

--- a/client/rest/test/plugins/rosetta/accountRoutes_spec.js
+++ b/client/rest/test/plugins/rosetta/accountRoutes_spec.js
@@ -178,7 +178,11 @@ describe('account routes', () => {
 
 		addAccountSuccessTests('/account/balance', {
 			createValidRequest,
-			createRosettaAmount,
+			createRosettaAmount: (...args) => {
+				const amount = createRosettaAmount(...args);
+				delete amount.currency.metadata;
+				return amount;
+			},
 			Response: AccountBalanceResponse
 		});
 	});

--- a/client/rest/test/plugins/rosetta/blockRoutes_spec.js
+++ b/client/rest/test/plugins/rosetta/blockRoutes_spec.js
@@ -47,7 +47,8 @@ describe('block routes', () => {
 	const TRANSACTION_HASH = 'C65DF0B9CB47E1D3538DC40481FC613F37DA4DEE816F72FDF63061B2707F6483';
 
 	const { createRosettaNetworkIdentifier } = RosettaObjectFactory;
-	const { createTransferOperation } = RosettaOperationFactory;
+	const createTransferOperation = (...args) =>
+		RosettaOperationFactory.setOperationStatus(RosettaOperationFactory.createTransferOperation(...args));
 
 	const createTransactionJson = (height = TEST_BLOCK_HEIGHT) => {
 		const facade = new SymbolFacade('testnet');

--- a/client/rest/test/plugins/rosetta/constructionRoutes_spec.js
+++ b/client/rest/test/plugins/rosetta/constructionRoutes_spec.js
@@ -58,8 +58,7 @@ describe('construction routes', () => {
 		amount: {
 			value: amount,
 			currency: createRosettaCurrency()
-		},
-		status: 'success'
+		}
 	});
 
 	const createRosettaMultisig = (index, address, metadata) => ({
@@ -70,15 +69,13 @@ describe('construction routes', () => {
 			addressAdditions: [],
 			addressDeletions: [],
 			...metadata
-		},
-		status: 'success'
+		}
 	});
 
 	const createRosettaCosignatory = (index, address) => ({
 		operation_identifier: { index },
 		type: 'cosign',
-		account: { address },
-		status: 'success'
+		account: { address }
 	});
 
 	// endregion

--- a/client/rest/test/plugins/rosetta/mempoolRoutes_spec.js
+++ b/client/rest/test/plugins/rosetta/mempoolRoutes_spec.js
@@ -42,7 +42,8 @@ describe('mempool routes', () => {
 	// region type factories
 
 	const { createRosettaNetworkIdentifier, createRosettaPublicKey } = RosettaObjectFactory;
-	const { createTransferOperation } = RosettaOperationFactory;
+	const createTransferOperation = (...args) =>
+		RosettaOperationFactory.setOperationStatus(RosettaOperationFactory.createTransferOperation(...args));
 
 	// endregion
 

--- a/client/rest/test/plugins/rosetta/utils/rosettaTestUtils.js
+++ b/client/rest/test/plugins/rosetta/utils/rosettaTestUtils.js
@@ -107,7 +107,6 @@ export const RosettaOperationFactory = {
 		const operation = new Operation(new OperationIdentifier(index), 'transfer');
 		operation.account = new AccountIdentifier(address);
 		operation.amount = new Amount(amount, currency);
-		operation.status = 'success';
 		return operation;
 	},
 
@@ -119,13 +118,16 @@ export const RosettaOperationFactory = {
 			addressDeletions: [],
 			...metadata
 		};
-		operation.status = 'success';
 		return operation;
 	},
 
 	createCosignOperation: (index, address) => {
 		const operation = new Operation(new OperationIdentifier(index), 'cosign');
 		operation.account = new AccountIdentifier(address);
+		return operation;
+	},
+
+	setOperationStatus: operation => {
 		operation.status = 'success';
 		return operation;
 	}


### PR DESCRIPTION
    [rest/client]: don't return currency metadata from /account/balance
    
     problem: mesh cli does deep compare of metadata and expects it to be unset
    solution: clear metadata from route response


    [rest/client]: operations returned by construction routes should not have operation status
    
     problem: all operations have success operation status
    solution: only return operations with operation status from data routes
