### PR TITLE
[client/rest]: update rosetta to support id being set in currency metadata

### DIFF
--- a/client/rest/src/plugins/rosetta/accountRoutes.js
+++ b/client/rest/src/plugins/rosetta/accountRoutes.js
@@ -74,10 +74,6 @@ export default {
 			const { blockIdentifier, mosaics } = await getAccountInfo(typedRequest);
 
 			let amounts = await mapMosaicsToRosettaAmounts(mosaics);
-			amounts.forEach(amount => {
-				delete amount.currency.metadata;
-			});
-
 			if (typedRequest.currencies)
 				amounts = amounts.filter(amount => typedRequest.currencies.some(currency => isCurrencyEqual(amount.currency, currency)));
 

--- a/client/rest/src/plugins/rosetta/constructionRoutes.js
+++ b/client/rest/src/plugins/rosetta/constructionRoutes.js
@@ -41,7 +41,7 @@ import SignatureType from './openApi/model/SignatureType.js';
 import SigningPayload from './openApi/model/SigningPayload.js';
 import TransactionIdentifier from './openApi/model/TransactionIdentifier.js';
 import TransactionIdentifierResponse from './openApi/model/TransactionIdentifierResponse.js';
-import { RosettaErrorFactory, rosettaPostRouteWithNetwork } from './rosettaUtils.js';
+import { RosettaErrorFactory, createLookupCurrencyFunction, rosettaPostRouteWithNetwork } from './rosettaUtils.js';
 import { NetworkLocator, PublicKey, utils } from 'symbol-sdk';
 import {
 	Network, NetworkTimestamp, SymbolFacade, generateMosaicAliasId, models
@@ -52,6 +52,7 @@ export default {
 		const networkName = services.config.network.name;
 		const network = NetworkLocator.findByName(Network.NETWORKS, networkName);
 		const facade = new SymbolFacade(network);
+		const lookupCurrency = createLookupCurrencyFunction(services.proxy);
 
 		const parsePublicKey = rosettaPublicKey => {
 			if (new CurveType().edwards25519 !== rosettaPublicKey.curve_type)
@@ -250,6 +251,8 @@ export default {
 
 		server.post('/construction/parse', rosettaPostRouteWithNetwork(networkName, ConstructionParseRequest, async typedRequest => {
 			const currencyMosaicId = generateMosaicAliasId('symbol.xym');
+			const xymCurrency = await lookupCurrency('currencyMosaicId'); // need to store resolved id in currency metadata
+
 			const aggregateTransaction = facade.transactionFactory.static.deserialize(utils.hexToUint8(typedRequest.transaction));
 
 			const supportedTransactionTypes = [
@@ -259,7 +262,6 @@ export default {
 			if (!aggregateTransaction.transactions.every(transaction => supportedTransactionTypes.includes(transaction.type.value)))
 				throw RosettaErrorFactory.NOT_SUPPORTED_ERROR;
 
-			const xymCurrency = new Currency('symbol.xym', 6);
 			const parser = new OperationParser(facade.network, {
 				lookupCurrency: mosaicId => {
 					if (currencyMosaicId !== mosaicId)

--- a/client/rest/test/plugins/rosetta/accountRoutes_spec.js
+++ b/client/rest/test/plugins/rosetta/accountRoutes_spec.js
@@ -178,11 +178,7 @@ describe('account routes', () => {
 
 		addAccountSuccessTests('/account/balance', {
 			createValidRequest,
-			createRosettaAmount: (...args) => {
-				const amount = createRosettaAmount(...args);
-				delete amount.currency.metadata;
-				return amount;
-			},
+			createRosettaAmount,
 			Response: AccountBalanceResponse
 		});
 	});


### PR DESCRIPTION
 problem: resolved mosaic id should be specified in currency metadata
solution: update construction/parse to resolve 'currencyMosaicId' and set metadata
          restore currency metadata in account/balance