### PR TITLE
[client/rest]: add support for NEM /construction/derive

### DIFF
--- a/client/rest/src/plugins/rosetta/nem/NemProxy.js
+++ b/client/rest/src/plugins/rosetta/nem/NemProxy.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016-2019, Jaguar0625, gimre, BloodyRookie, Tech Bureau, Corp.
+ * Copyright (c) 2020-present, Jaguar0625, gimre, BloodyRookie.
+ * All rights reserved.
+ *
+ * This file is part of Catapult.
+ *
+ * Catapult is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Catapult is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { RosettaErrorFactory } from '../rosettaUtils.js';
+
+/**
+ * Proxy to a NEM node that performs caching for performance optimization, as appropriate.
+ */
+export default class NemProxy {
+	/**
+	 * Creates a proxy around an endpoint.
+	 * @param {string} endpoint NEM endpoint.
+	 */
+	constructor(endpoint) {
+		this.endpoint = endpoint;
+	}
+
+	/**
+	 * Performs an (uncached) fetch request on the endpoint.
+	 * @param {string} urlPath Request path.
+	 * @param {Function} jsonProjection Processes result.
+	 * @param {object} requestOptions Additional fetch request options.
+	 * @returns {object} Result of fetch and projection.
+	 */
+	async fetch(urlPath, jsonProjection = undefined, requestOptions = {}) {
+		try {
+			const response = await global.fetch(`${this.endpoint}/${urlPath}`, requestOptions);
+			if (!response.ok)
+				throw RosettaErrorFactory.CONNECTION_ERROR;
+
+			const jsonObject = await response.json();
+			return jsonProjection ? jsonProjection(jsonObject) : jsonObject;
+		} catch (err) {
+			throw RosettaErrorFactory.CONNECTION_ERROR;
+		}
+	}
+}

--- a/client/rest/src/plugins/rosetta/nem/constructionRoutes.js
+++ b/client/rest/src/plugins/rosetta/nem/constructionRoutes.js
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2016-2019, Jaguar0625, gimre, BloodyRookie, Tech Bureau, Corp.
+ * Copyright (c) 2020-present, Jaguar0625, gimre, BloodyRookie.
+ * All rights reserved.
+ *
+ * This file is part of Catapult.
+ *
+ * Catapult is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Catapult is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { getBlockchainDescriptor } from './rosettaUtils.js';
+import AccountIdentifier from '../openApi/model/AccountIdentifier.js';
+import ConstructionDeriveRequest from '../openApi/model/ConstructionDeriveRequest.js';
+import ConstructionDeriveResponse from '../openApi/model/ConstructionDeriveResponse.js';
+import ConstructionMetadataRequest from '../openApi/model/ConstructionMetadataRequest.js';
+import ConstructionMetadataResponse from '../openApi/model/ConstructionMetadataResponse.js';
+import ConstructionPreprocessRequest from '../openApi/model/ConstructionPreprocessRequest.js';
+import ConstructionPreprocessResponse from '../openApi/model/ConstructionPreprocessResponse.js';
+import CurveType from '../openApi/model/CurveType.js';
+import { RosettaErrorFactory, rosettaPostRouteWithNetwork } from '../rosettaUtils.js';
+import { PublicKey } from 'symbol-sdk';
+import { NemFacade } from 'symbol-sdk/nem';
+
+export default {
+	register: (server, db, services) => {
+		const blockchainDescriptor = getBlockchainDescriptor(services.config);
+		const facade = new NemFacade(blockchainDescriptor.network);
+
+		const parsePublicKey = rosettaPublicKey => {
+			if (new CurveType().edwards25519_keccak !== rosettaPublicKey.curve_type)
+				throw RosettaErrorFactory.UNSUPPORTED_CURVE;
+
+			try {
+				return new PublicKey(rosettaPublicKey.hex_bytes);
+			} catch (err) {
+				throw RosettaErrorFactory.INVALID_PUBLIC_KEY;
+			}
+		};
+
+		const constructionPostRoute = (...args) => rosettaPostRouteWithNetwork(blockchainDescriptor, ...args);
+
+		server.post('/construction/derive', constructionPostRoute(ConstructionDeriveRequest, typedRequest => {
+			const publicKey = parsePublicKey(typedRequest.public_key);
+			const address = facade.network.publicKeyToAddress(publicKey);
+
+			const response = new ConstructionDeriveResponse();
+			response.account_identifier = new AccountIdentifier(address.toString());
+			return response;
+		}));
+
+		server.post('/construction/preprocess', constructionPostRoute(ConstructionPreprocessRequest, typedRequest => {
+			const response = new ConstructionPreprocessResponse();
+			response.options = {};
+			response.required_public_keys = [];
+
+			typedRequest.operations.forEach(operation => {
+				if ('transfer' === operation.type) {
+					if (0n > BigInt(operation.amount.value))
+						response.required_public_keys.push(operation.account);
+				} else if (['multisig', 'cosign'].includes(operation.type)) {
+					response.required_public_keys.push(operation.account);
+				}
+			});
+
+			return response;
+		}));
+
+		const getNetworkTime = () => services.proxy.fetch('time-sync/network-time', jsonObject => jsonObject.receiveTimeStamp);
+
+		server.post('/construction/metadata', constructionPostRoute(ConstructionMetadataRequest, async () => {
+			// ignore request object because only global metadata is needed for transaction construction
+
+			const timestamp = await getNetworkTime();
+
+			const response = new ConstructionMetadataResponse();
+			response.metadata = {
+				networkTime: Math.trunc(timestamp / 1000)
+			};
+			return response;
+		}));
+	}
+};

--- a/client/rest/src/plugins/rosetta/nem/rosettaUtils.js
+++ b/client/rest/src/plugins/rosetta/nem/rosettaUtils.js
@@ -19,26 +19,12 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** @module plugins/rosetta/nem */
-import NemProxy from './NemProxy.js';
-import constructionRoutes from './constructionRoutes.js';
-
 /**
- * Creates a rosetta plugin.
- * @type {module:plugins/CatapultRestPlugin}
+ * Extracts blockchain descriptor from services configuration.
+ * @param {object} config Services configuration.
+ * @returns {object} Blockchain descriptor.
  */
-export default {
-	createDb: db => db,
-
-	registerTransactionStates: () => {},
-
-	registerMessageChannels: () => {},
-
-	registerRoutes: (server, db, services) => {
-		const proxy = new NemProxy(services.config.restEndpoint);
-
-		[
-			constructionRoutes
-		].forEach(routes => routes.register(server, db, { ...services, proxy }));
-	}
-};
+export const getBlockchainDescriptor = config => ({ // eslint-disable-line import/prefer-default-export
+	blockchain: 'NEM',
+	network: config.network.name
+});

--- a/client/rest/src/plugins/rosetta/openApi/model/CurveType.js
+++ b/client/rest/src/plugins/rosetta/openApi/model/CurveType.js
@@ -46,6 +46,11 @@ export default class CurveType {
 		 */
 		"edwards25519" = "edwards25519";
 
+		/**
+		 * value: "edwards25519_keccak"
+		 * @const
+		 */
+		"edwards25519_keccak" = "edwards25519_keccak";
 
 		/**
 		 * value: "tweedle"

--- a/client/rest/src/plugins/rosetta/rosettaUtils.js
+++ b/client/rest/src/plugins/rosetta/rosettaUtils.js
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2016-2019, Jaguar0625, gimre, BloodyRookie, Tech Bureau, Corp.
+ * Copyright (c) 2020-present, Jaguar0625, gimre, BloodyRookie.
+ * All rights reserved.
+ *
+ * This file is part of Catapult.
+ *
+ * Catapult is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Catapult is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import RosettaApiError from './openApi/model/Error.js';
+import { sendJson } from '../../routes/simpleSend.js';
+
+/**
+ * Error thrown when a rosetta endpoint encounters an error.
+ */
+class RosettaError extends Error {
+	constructor(code, message, retriable) {
+		super(message);
+
+		this.apiError = new RosettaApiError(code, message, retriable);
+	}
+}
+
+/**
+ * Factory for creating rosetta errors.
+ */
+export class RosettaErrorFactory {
+	static get UNSUPPORTED_NETWORK() {
+		return new RosettaError(1, 'unsupported network', false);
+	}
+
+	static get UNSUPPORTED_CURVE() {
+		return new RosettaError(2, 'unsupported curve', false);
+	}
+
+	static get INVALID_PUBLIC_KEY() {
+		return new RosettaError(3, 'invalid public key', false);
+	}
+
+	static get INVALID_REQUEST_DATA() {
+		return new RosettaError(4, 'invalid request data', false);
+	}
+
+	static get CONNECTION_ERROR() {
+		return new RosettaError(5, 'unable to connect to network', true);
+	}
+
+	static get SYNC_DURING_OPERATION() {
+		return new RosettaError(6, 'sync was detected during operation', true);
+	}
+
+	static get NOT_SUPPORTED_ERROR() {
+		return new RosettaError(99, 'operation is not supported in rosetta', false);
+	}
+
+	static get INTERNAL_SERVER_ERROR() {
+		return new RosettaError(100, 'internal server error', false);
+	}
+}
+
+/**
+ * Orchestrates a rosetta POST route by validating request data, including network, before calling user handler.
+ * @param {object} blockchainDescriptor Blockchain descriptor.
+ * @param {object} Request Type of request object.
+ * @param {Function} handler User callback that is called with request data after validating request.
+ * @returns {Function} Restify POST handler.
+ */
+export const rosettaPostRouteWithNetwork = (blockchainDescriptor, Request, handler) => async (req, res, next) => {
+	const send = data => {
+		const sender = sendJson(res, next);
+		return data instanceof RosettaError ? sender(data.apiError, 500) : sender(data, undefined);
+	};
+
+	try {
+		Request.validateJSON(req.body);
+	} catch (err) {
+		return send(RosettaErrorFactory.INVALID_REQUEST_DATA);
+	}
+
+	const typedRequest = Request.constructFromObject(req.body);
+	const isTargetNetwork = networkIdentifier =>
+		blockchainDescriptor.blockchain === networkIdentifier.blockchain && blockchainDescriptor.network === networkIdentifier.network;
+	if (!isTargetNetwork(typedRequest.network_identifier))
+		return send(RosettaErrorFactory.UNSUPPORTED_NETWORK);
+
+	try {
+		const response = await handler(typedRequest);
+		return send(response);
+	} catch (err) {
+		return send(err instanceof RosettaError ? err : RosettaErrorFactory.INTERNAL_SERVER_ERROR);
+	}
+};

--- a/client/rest/src/plugins/rosetta/symbol/CatapultProxy.js
+++ b/client/rest/src/plugins/rosetta/symbol/CatapultProxy.js
@@ -19,7 +19,7 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { RosettaErrorFactory } from './rosettaUtils.js';
+import { RosettaErrorFactory } from '../rosettaUtils.js';
 
 const bigIntToHexString = value => value.toString(16).padStart(16, '0').toUpperCase();
 const isReceiptSourceLessThanEqual = (lhs, rhs) =>

--- a/client/rest/src/plugins/rosetta/symbol/mempoolRoutes.js
+++ b/client/rest/src/plugins/rosetta/symbol/mempoolRoutes.js
@@ -20,14 +20,13 @@
  */
 
 import { OperationParser } from './OperationParser.js';
-import {
-	createLookupCurrencyFunction, rosettaPostRouteWithNetwork
-} from './rosettaUtils.js';
+import { createLookupCurrencyFunction, getBlockchainDescriptor } from './rosettaUtils.js';
 import MempoolResponse from '../openApi/model/MempoolResponse.js';
 import MempoolTransactionRequest from '../openApi/model/MempoolTransactionRequest.js';
 import MempoolTransactionResponse from '../openApi/model/MempoolTransactionResponse.js';
 import NetworkRequest from '../openApi/model/NetworkRequest.js';
 import TransactionIdentifier from '../openApi/model/TransactionIdentifier.js';
+import { rosettaPostRouteWithNetwork } from '../rosettaUtils.js';
 import { NetworkLocator } from 'symbol-sdk';
 import { Network } from 'symbol-sdk/symbol';
 
@@ -35,8 +34,8 @@ export default {
 	register: (server, db, services) => {
 		const PAGE_SIZE = 100;
 
-		const networkName = services.config.network.name;
-		const network = NetworkLocator.findByName(Network.NETWORKS, networkName);
+		const blockchainDescriptor = getBlockchainDescriptor(services.config);
+		const network = NetworkLocator.findByName(Network.NETWORKS, blockchainDescriptor.network);
 		const lookupCurrency = createLookupCurrencyFunction(services.proxy);
 		const parser = new OperationParser(network, {
 			includeFeeOperation: true,
@@ -45,7 +44,7 @@ export default {
 			resolveAddress: (address, transactionLocation) => services.proxy.resolveAddress(address, transactionLocation)
 		});
 
-		server.post('/mempool', rosettaPostRouteWithNetwork(networkName, NetworkRequest, async () => {
+		server.post('/mempool', rosettaPostRouteWithNetwork(blockchainDescriptor, NetworkRequest, async () => {
 			const transactions = await services.proxy.fetchAll('transactions/unconfirmed', PAGE_SIZE);
 
 			const response = new MempoolResponse();
@@ -53,12 +52,16 @@ export default {
 			return response;
 		}));
 
-		server.post('/mempool/transaction', rosettaPostRouteWithNetwork(networkName, MempoolTransactionRequest, async typedRequest => {
-			const transactionHash = typedRequest.transaction_identifier.hash;
-			const transaction = await services.proxy.fetch(`transactions/unconfirmed/${transactionHash}`);
-			const response = new MempoolTransactionResponse();
-			response.transaction = await parser.parseTransactionAsRosettaTransaction(transaction.transaction, transaction.meta);
-			return response;
-		}));
+		server.post('/mempool/transaction', rosettaPostRouteWithNetwork(
+			blockchainDescriptor,
+			MempoolTransactionRequest,
+			async typedRequest => {
+				const transactionHash = typedRequest.transaction_identifier.hash;
+				const transaction = await services.proxy.fetch(`transactions/unconfirmed/${transactionHash}`);
+				const response = new MempoolTransactionResponse();
+				response.transaction = await parser.parseTransactionAsRosettaTransaction(transaction.transaction, transaction.meta);
+				return response;
+			}
+		));
 	}
 };

--- a/client/rest/src/plugins/rosetta/symbol/rosettaUtils.js
+++ b/client/rest/src/plugins/rosetta/symbol/rosettaUtils.js
@@ -19,89 +19,17 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { sendJson } from '../../../routes/simpleSend.js';
 import Currency from '../openApi/model/Currency.js';
-import RosettaApiError from '../openApi/model/Error.js';
 
 /**
- * Error thrown when a rosetta endpoint encounters an error.
+ * Extracts blockchain descriptor from services configuration.
+ * @param {object} config Services configuration.
+ * @returns {object} Blockchain descriptor.
  */
-class RosettaError extends Error {
-	constructor(code, message, retriable) {
-		super(message);
-
-		this.apiError = new RosettaApiError(code, message, retriable);
-	}
-}
-
-/**
- * Factory for creating rosetta errors.
- */
-export class RosettaErrorFactory {
-	static get UNSUPPORTED_NETWORK() {
-		return new RosettaError(1, 'unsupported network', false);
-	}
-
-	static get UNSUPPORTED_CURVE() {
-		return new RosettaError(2, 'unsupported curve', false);
-	}
-
-	static get INVALID_PUBLIC_KEY() {
-		return new RosettaError(3, 'invalid public key', false);
-	}
-
-	static get INVALID_REQUEST_DATA() {
-		return new RosettaError(4, 'invalid request data', false);
-	}
-
-	static get CONNECTION_ERROR() {
-		return new RosettaError(5, 'unable to connect to network', true);
-	}
-
-	static get SYNC_DURING_OPERATION() {
-		return new RosettaError(6, 'sync was detected during operation', true);
-	}
-
-	static get NOT_SUPPORTED_ERROR() {
-		return new RosettaError(99, 'operation is not supported in rosetta', false);
-	}
-
-	static get INTERNAL_SERVER_ERROR() {
-		return new RosettaError(100, 'internal server error', false);
-	}
-}
-
-/**
- * Orchestrates a rosetta POST route by validating request data, including network, before calling user handler.
- * @param {string} networkName Network name.
- * @param {object} Request Type of request object.
- * @param {Function} handler User callback that is called with request data after validating request.
- * @returns {Function} Restify POST handler.
- */
-export const rosettaPostRouteWithNetwork = (networkName, Request, handler) => async (req, res, next) => {
-	const send = data => {
-		const sender = sendJson(res, next);
-		return data instanceof RosettaError ? sender(data.apiError, 500) : sender(data, undefined);
-	};
-
-	try {
-		Request.validateJSON(req.body);
-	} catch (err) {
-		return send(RosettaErrorFactory.INVALID_REQUEST_DATA);
-	}
-
-	const typedRequest = Request.constructFromObject(req.body);
-	const checkNetwork = networkIdentifier => ('Symbol' === networkIdentifier.blockchain && networkName === networkIdentifier.network);
-	if (!checkNetwork(typedRequest.network_identifier))
-		return send(RosettaErrorFactory.UNSUPPORTED_NETWORK);
-
-	try {
-		const response = await handler(typedRequest);
-		return send(response);
-	} catch (err) {
-		return send(err instanceof RosettaError ? err : RosettaErrorFactory.INTERNAL_SERVER_ERROR);
-	}
-};
+export const getBlockchainDescriptor = config => ({
+	blockchain: 'Symbol',
+	network: config.network.name
+});
 
 /**
  * Creates the lookup currency function used by the operation parser.

--- a/client/rest/test/plugins/rosetta/nem/NemProxy_spec.js
+++ b/client/rest/test/plugins/rosetta/nem/NemProxy_spec.js
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2016-2019, Jaguar0625, gimre, BloodyRookie, Tech Bureau, Corp.
+ * Copyright (c) 2020-present, Jaguar0625, gimre, BloodyRookie.
+ * All rights reserved.
+ *
+ * This file is part of Catapult.
+ *
+ * Catapult is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Catapult is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { FetchStubHelper } from './utils/rosettaTestUtils.js';
+import NemProxy from '../../../../src/plugins/rosetta/nem/NemProxy.js';
+import { RosettaErrorFactory } from '../../../../src/plugins/rosetta/rosettaUtils.js';
+import { expect } from 'chai';
+
+describe('NemProxy', () => {
+	// region utils
+
+	const TEST_ENDPOINT = 'http://localhost:3456';
+
+	const assertAsyncErrorThrown = async (func, expectedRosettaError) => {
+		try {
+			await func();
+			expect.fail(`no error thrown - expected ${expectedRosettaError.message}`);
+		} catch (err) {
+			expect(err.apiError).deep.equal(expectedRosettaError.apiError);
+		}
+	};
+
+	const stubFetchResult = FetchStubHelper.stubPost;
+	FetchStubHelper.registerStubCleanup();
+
+	// endregion
+
+	// region fetch
+
+	describe('fetch', () => {
+		it('fails when fetch fails (headers)', async () => {
+			// Arrange:
+			const proxy = new NemProxy(TEST_ENDPOINT);
+			stubFetchResult('custom/route', false, { foo: 123, bar: 246 });
+
+			// Act + Assert:
+			await assertAsyncErrorThrown(() => proxy.fetch('custom/route'), RosettaErrorFactory.CONNECTION_ERROR);
+
+			expect(global.fetch.callCount).to.equal(1);
+		});
+
+		it('fails when fetch fails (body)', async () => {
+			// Arrange:
+			const proxy = new NemProxy(TEST_ENDPOINT);
+			stubFetchResult('custom/route', true, Promise.reject(Error('fetch failed')));
+
+			// Act + Assert:
+			await assertAsyncErrorThrown(() => proxy.fetch('custom/route'), RosettaErrorFactory.CONNECTION_ERROR);
+
+			expect(global.fetch.callCount).to.equal(1);
+		});
+
+		const assertFetchCalls = expectedResponseOptions => {
+			expect(global.fetch.callCount).to.equal(1);
+			expect(global.fetch.withArgs(`${TEST_ENDPOINT}/custom/route`, expectedResponseOptions).callCount).to.equal(1);
+		};
+
+		it('returns valid response on success (without projection)', async () => {
+			// Arrange:
+			const proxy = new NemProxy(TEST_ENDPOINT);
+			stubFetchResult('custom/route', true, { foo: 123, bar: 246 });
+
+			// Act:
+			const result = await proxy.fetch('custom/route');
+
+			// Assert:
+			assertFetchCalls({});
+			expect(result).to.deep.equal({ foo: 123, bar: 246 });
+		});
+
+		it('returns valid response on success (with projection)', async () => {
+			// Arrange:
+			const proxy = new NemProxy(TEST_ENDPOINT);
+			stubFetchResult('custom/route', true, { foo: 123, bar: 246 });
+
+			// Act:
+			const result = await proxy.fetch('custom/route', jsonObject => jsonObject.bar);
+
+			// Assert:
+			assertFetchCalls({});
+			expect(result).to.equal(246);
+		});
+
+		it('forwards request options to underlying fetch', async () => {
+			// Arrange:
+			const proxy = new NemProxy(TEST_ENDPOINT);
+			stubFetchResult('custom/route', true, { foo: 123, bar: 246 });
+
+			// Act:
+			const result = await proxy.fetch('custom/route', undefined, { method: 'POST' });
+
+			// Assert:
+			assertFetchCalls({ method: 'POST' });
+			expect(result).to.deep.equal({ foo: 123, bar: 246 });
+		});
+	});
+
+	// endregion
+});

--- a/client/rest/test/plugins/rosetta/nem/constructionRoutes_spec.js
+++ b/client/rest/test/plugins/rosetta/nem/constructionRoutes_spec.js
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2016-2019, Jaguar0625, gimre, BloodyRookie, Tech Bureau, Corp.
+ * Copyright (c) 2020-present, Jaguar0625, gimre, BloodyRookie.
+ * All rights reserved.
+ *
+ * This file is part of Catapult.
+ *
+ * Catapult is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Catapult is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import {
+	FetchStubHelper,
+	RosettaObjectFactory,
+	assertRosettaErrorRaisedBasicWithRoutes,
+	assertRosettaSuccessBasicWithRoutes
+} from './utils/rosettaTestUtils.js';
+import constructionRoutes from '../../../../src/plugins/rosetta/nem/constructionRoutes.js';
+import AccountIdentifier from '../../../../src/plugins/rosetta/openApi/model/AccountIdentifier.js';
+import ConstructionDeriveResponse from '../../../../src/plugins/rosetta/openApi/model/ConstructionDeriveResponse.js';
+import ConstructionMetadataResponse from '../../../../src/plugins/rosetta/openApi/model/ConstructionMetadataResponse.js';
+import ConstructionPreprocessResponse from '../../../../src/plugins/rosetta/openApi/model/ConstructionPreprocessResponse.js';
+import { RosettaErrorFactory } from '../../../../src/plugins/rosetta/rosettaUtils.js';
+
+describe('construction routes', () => {
+	const assertRosettaErrorRaisedBasic = (...args) => assertRosettaErrorRaisedBasicWithRoutes(constructionRoutes, ...args);
+	const assertRosettaSuccessBasic = (...args) => assertRosettaSuccessBasicWithRoutes(constructionRoutes, ...args);
+
+	// region type factories
+
+	const { createRosettaNetworkIdentifier, createRosettaPublicKey } = RosettaObjectFactory;
+
+	const createRosettaCurrency = () => ({
+		symbol: 'nem.xem',
+		decimals: 6
+	});
+
+	const createRosettaTransfer = (index, address, amount) => ({
+		operation_identifier: { index },
+		type: 'transfer',
+		account: { address },
+		amount: {
+			value: amount,
+			currency: createRosettaCurrency()
+		}
+	});
+
+	const createRosettaMultisig = (index, address, metadata) => ({
+		operation_identifier: { index },
+		type: 'multisig',
+		account: { address },
+		metadata: {
+			addressAdditions: [],
+			addressDeletions: [],
+			...metadata
+		}
+	});
+
+	const createRosettaCosignatory = (index, address) => ({
+		operation_identifier: { index },
+		type: 'cosign',
+		account: { address }
+	});
+
+	// endregion
+
+	// region derive
+
+	describe('derive', () => {
+		const createValidRequest = () => ({
+			network_identifier: createRosettaNetworkIdentifier(),
+			public_key: createRosettaPublicKey('DEE852011049D890E97DD4F1D4D7F76824C16854578DADA9918BF943FBF5CC13')
+		});
+
+		const assertRosettaErrorRaised = (expectedError, malformRequest) =>
+			assertRosettaErrorRaisedBasic('/construction/derive', createValidRequest(), expectedError, malformRequest);
+
+		it('fails when request is invalid', () => assertRosettaErrorRaised(RosettaErrorFactory.INVALID_REQUEST_DATA, request => {
+			delete request.network_identifier.network;
+		}));
+
+		it('fails when public key curve type is unsupported', () => assertRosettaErrorRaised(
+			RosettaErrorFactory.UNSUPPORTED_CURVE,
+			request => {
+				request.public_key.curve_type = 'secp256k1';
+			}
+		));
+
+		it('fails when public key is invalid', () => assertRosettaErrorRaised(RosettaErrorFactory.INVALID_PUBLIC_KEY, request => {
+			request.public_key.hex_bytes += '0';
+		}));
+
+		it('returns valid response on success', async () => {
+			// Arrange: create expected response
+			const expectedResponse = new ConstructionDeriveResponse();
+			expectedResponse.account_identifier = new AccountIdentifier('TCHESTYVD2P6P646AMY7WSNG73PCPZDUQPN4KCPY');
+
+			// Act + Assert:
+			await assertRosettaSuccessBasic('/construction/derive', createValidRequest(), expectedResponse);
+		});
+	});
+
+	// endregion
+
+	// region preprocess
+
+	describe('preprocess', () => {
+		const createValidTransferRequest = () => ({
+			network_identifier: createRosettaNetworkIdentifier(),
+			operations: [
+				createRosettaTransfer(0, 'TARZARAKDFNYFVFANAIAHCYUADHHZWT2WP2I7GI', '100'),
+				createRosettaTransfer(1, 'TDI2ZPA7U72GHU2ZDP4C4J6T5YMFSLWEW4OZQKI', '-100')
+			]
+		});
+
+		const createValidMultisigRequest = () => ({
+			network_identifier: createRosettaNetworkIdentifier(),
+			operations: [
+				createRosettaMultisig(0, 'TCJEJJBKDI62U4ZMO4VI7YAUVJE4STVCOBDSHXQ', {
+					minApprovalDelta: 1,
+					minRemovalDelta: 2,
+					addressAdditions: ['TDI2ZPA7U72GHU2ZDP4C4J6T5YMFSLWEW4OZQKI', 'TCULEHFGXY7E6TWBXH7CVKNKFSUH43RNWW52NWQ']
+				}),
+				createRosettaCosignatory(1, 'TDI2ZPA7U72GHU2ZDP4C4J6T5YMFSLWEW4OZQKI'),
+				createRosettaCosignatory(2, 'TCULEHFGXY7E6TWBXH7CVKNKFSUH43RNWW52NWQ')
+			]
+		});
+
+		const assertRosettaErrorRaised = (expectedError, malformRequest) =>
+			assertRosettaErrorRaisedBasic('/construction/preprocess', createValidTransferRequest(), expectedError, malformRequest);
+
+		it('fails when request is invalid', () => assertRosettaErrorRaised(RosettaErrorFactory.INVALID_REQUEST_DATA, request => {
+			delete request.network_identifier.network;
+		}));
+
+		it('returns valid response on success (transfer)', async () => {
+			// Arrange: create expected response
+			const expectedResponse = new ConstructionPreprocessResponse();
+			expectedResponse.options = {};
+			expectedResponse.required_public_keys = [
+				new AccountIdentifier('TDI2ZPA7U72GHU2ZDP4C4J6T5YMFSLWEW4OZQKI')
+			];
+
+			// Act + Assert:
+			await assertRosettaSuccessBasic('/construction/preprocess', createValidTransferRequest(), expectedResponse);
+		});
+
+		it('returns valid response on success (multisig)', async () => {
+			// Arrange: create expected response
+			const expectedResponse = new ConstructionPreprocessResponse();
+			expectedResponse.options = {};
+			expectedResponse.required_public_keys = [
+				new AccountIdentifier('TCJEJJBKDI62U4ZMO4VI7YAUVJE4STVCOBDSHXQ'),
+				new AccountIdentifier('TDI2ZPA7U72GHU2ZDP4C4J6T5YMFSLWEW4OZQKI'),
+				new AccountIdentifier('TCULEHFGXY7E6TWBXH7CVKNKFSUH43RNWW52NWQ')
+			];
+
+			// Act + Assert:
+			await assertRosettaSuccessBasic('/construction/preprocess', createValidMultisigRequest(), expectedResponse);
+		});
+	});
+
+	// endregion
+
+	// region metadata
+
+	describe('metadata', () => {
+		const stubFetchResult = FetchStubHelper.stubPost;
+		FetchStubHelper.registerStubCleanup();
+
+		const createValidRequest = () => ({
+			network_identifier: createRosettaNetworkIdentifier()
+		});
+
+		const assertRosettaErrorRaised = (expectedError, malformRequest) =>
+			assertRosettaErrorRaisedBasic('/construction/metadata', createValidRequest(), expectedError, malformRequest);
+
+		const createTimeSyncNetworkTimeResult = () => ({
+			sendTimeStamp: 1000100,
+			receiveTimeStamp: 1001100
+		});
+
+		it('fails when request is invalid', () => assertRosettaErrorRaised(RosettaErrorFactory.INVALID_REQUEST_DATA, request => {
+			delete request.network_identifier.network;
+		}));
+
+		it('fails when fetch fails (time-sync/network-time)', async () => {
+			// Arrange:
+			stubFetchResult('time-sync/network-time', false, createTimeSyncNetworkTimeResult());
+
+			// Act + Assert:
+			await assertRosettaErrorRaised(RosettaErrorFactory.CONNECTION_ERROR, () => {});
+		});
+
+		it('returns valid response on success', async () => {
+			// Arrange:
+			stubFetchResult('time-sync/network-time', true, createTimeSyncNetworkTimeResult());
+
+			// - create expected response
+			const expectedResponse = new ConstructionMetadataResponse();
+			expectedResponse.metadata = {
+				networkTime: 1001
+			};
+
+			// Act + Assert:
+			await assertRosettaSuccessBasic('/construction/metadata', createValidRequest(), expectedResponse);
+		});
+	});
+
+	// endregion
+});

--- a/client/rest/test/plugins/rosetta/nem/rosettaUtils_spec.js
+++ b/client/rest/test/plugins/rosetta/nem/rosettaUtils_spec.js
@@ -19,26 +19,24 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-/** @module plugins/rosetta/nem */
-import NemProxy from './NemProxy.js';
-import constructionRoutes from './constructionRoutes.js';
+import { getBlockchainDescriptor } from '../../../../src/plugins/rosetta/nem/rosettaUtils.js';
+import { expect } from 'chai';
 
-/**
- * Creates a rosetta plugin.
- * @type {module:plugins/CatapultRestPlugin}
- */
-export default {
-	createDb: db => db,
+describe('rosetta utils (NEM)', () => {
+	// region getBlockchainDescriptor
 
-	registerTransactionStates: () => {},
+	describe('getBlockchainDescriptor', () => {
+		it('extracts blockchain descriptor from config', () => {
+			// Act:
+			const blockchainDescriptor = getBlockchainDescriptor({ network: { name: 'alpha' } });
 
-	registerMessageChannels: () => {},
+			// Assert:
+			expect(blockchainDescriptor).to.deep.equal({
+				blockchain: 'NEM',
+				network: 'alpha'
+			});
+		});
+	});
 
-	registerRoutes: (server, db, services) => {
-		const proxy = new NemProxy(services.config.restEndpoint);
-
-		[
-			constructionRoutes
-		].forEach(routes => routes.register(server, db, { ...services, proxy }));
-	}
-};
+	// endregion
+});

--- a/client/rest/test/plugins/rosetta/nem/rosetta_spec.js
+++ b/client/rest/test/plugins/rosetta/nem/rosetta_spec.js
@@ -44,6 +44,10 @@ describe('NEM rosetta plugin', () => {
 
 			// Assert:
 			test.assert.assertRoutes(routes, [
+				// construction routes
+				'/construction/derive',
+				'/construction/preprocess',
+				'/construction/metadata'
 			]);
 		});
 	});

--- a/client/rest/test/plugins/rosetta/nem/utils/rosettaTestUtils.js
+++ b/client/rest/test/plugins/rosetta/nem/utils/rosettaTestUtils.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2016-2019, Jaguar0625, gimre, BloodyRookie, Tech Bureau, Corp.
+ * Copyright (c) 2020-present, Jaguar0625, gimre, BloodyRookie.
+ * All rights reserved.
+ *
+ * This file is part of Catapult.
+ *
+ * Catapult is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Catapult is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import NemProxy from '../../../../../src/plugins/rosetta/nem/NemProxy.js';
+import {
+	BasicFetchStubHelper,
+	assertRosettaErrorRaisedBasicWithRegister,
+	assertRosettaSuccessBasicWithRegister
+} from '../../utils/rosettaTestUtils.js';
+
+// region FetchStubHelper
+
+export const FetchStubHelper = { ...BasicFetchStubHelper };
+
+// endregion
+
+// region RosettaObjectFactory
+
+export const RosettaObjectFactory = {
+	createRosettaNetworkIdentifier: () => ({
+		blockchain: 'NEM',
+		network: 'testnet'
+	}),
+
+	createRosettaPublicKey: hexBytes => ({
+		hex_bytes: hexBytes,
+		curve_type: 'edwards25519_keccak'
+	})
+};
+
+// endregion
+
+// region asserts
+
+const createRegisterRoutes = routes => server => {
+	routes.register(server, {}, {
+		config: {
+			network: { name: 'testnet' }
+		},
+		proxy: new NemProxy('http://localhost:3456')
+	});
+};
+
+export const assertRosettaErrorRaisedBasicWithRoutes = async (routes, ...args) => assertRosettaErrorRaisedBasicWithRegister(
+	createRegisterRoutes(routes),
+	...args
+);
+
+export const assertRosettaSuccessBasicWithRoutes = async (routes, ...args) => assertRosettaSuccessBasicWithRegister(
+	createRegisterRoutes(routes),
+	...args
+);
+
+// endregion

--- a/client/rest/test/plugins/rosetta/rosettaUtils_spec.js
+++ b/client/rest/test/plugins/rosetta/rosettaUtils_spec.js
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2016-2019, Jaguar0625, gimre, BloodyRookie, Tech Bureau, Corp.
+ * Copyright (c) 2020-present, Jaguar0625, gimre, BloodyRookie.
+ * All rights reserved.
+ *
+ * This file is part of Catapult.
+ *
+ * Catapult is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Catapult is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import ConstructionDeriveRequest from '../../../src/plugins/rosetta/openApi/model/ConstructionDeriveRequest.js';
+import RosettaApiError from '../../../src/plugins/rosetta/openApi/model/Error.js';
+import { RosettaErrorFactory, rosettaPostRouteWithNetwork } from '../../../src/plugins/rosetta/rosettaUtils.js';
+import { expect } from 'chai';
+
+describe('rosetta utils', () => {
+	// region RosettaErrorFactory
+
+	describe('RosettaErrorFactory', () => {
+		it('all have unique codes', () => {
+			// Arrange: filter out properties added to every class
+			const defaultClassPropertyNames = Object.getOwnPropertyNames(class C {});
+			const errorNames = Object.getOwnPropertyNames(RosettaErrorFactory)
+				.filter(name => !defaultClassPropertyNames.includes(name));
+
+			// Act:
+			const errorCodeSet = new Set(errorNames.map(name => RosettaErrorFactory[name].apiError.code));
+
+			// Assert:
+			expect(errorCodeSet.size).to.equal(errorNames.length);
+		});
+	});
+
+	// endregion
+
+	// region rosettaPostRouteWithNetwork
+
+	describe('rosettaPostRouteWithNetwork', () => {
+		// use /construction/derive types in these tests
+
+		const createValidRequest = () => ({
+			network_identifier: {
+				blockchain: 'Foo',
+				network: 'testnet'
+			},
+			public_key: {
+				hex_bytes: 'E85D10BF47FFBCE2230F70CB43ED2DDE04FCF342524B383972F86EA1FF773C79',
+				curve_type: 'edwards25519'
+			}
+		});
+
+		const createRosettaRouteTestSetup = () => {
+			const routeContext = { numNextCalls: 0 };
+			const next = () => { ++routeContext.numNextCalls; };
+
+			routeContext.responses = [];
+			routeContext.headers = [];
+			const res = {
+				statusCode: 200,
+				send: response => { routeContext.responses.push(response); },
+				setHeader: (name, value) => { routeContext.headers.push({ name, value }); }
+			};
+
+			return { routeContext, next, res };
+		};
+
+		const assertRosettaErrorRaised = (routeContext, res, expectedError) => {
+			expect(routeContext.numNextCalls).to.equal(1);
+			expect(routeContext.responses.length).to.equal(1);
+			expect(res.statusCode).to.equal(500);
+
+			const response = routeContext.responses[0];
+			expect(response).to.deep.equal(expectedError.apiError);
+			expect(() => RosettaApiError.validateJSON(response)).to.not.throw();
+		};
+
+		it('fails when request is invalid', async () => {
+			// Arrange: corrupt the request by removing a required subfield
+			const { routeContext, next, res } = createRosettaRouteTestSetup();
+			const request = createValidRequest();
+			delete request.network_identifier.network;
+
+			// Act:
+			const postHandler = rosettaPostRouteWithNetwork({ blockchain: 'Foo', network: 'testnet' }, ConstructionDeriveRequest, () => {});
+			await postHandler({ body: request }, res, next);
+
+			// Assert:
+			assertRosettaErrorRaised(routeContext, res, RosettaErrorFactory.INVALID_REQUEST_DATA);
+		});
+
+		const assertFailsWhenIsNotTargetNetwork = async blockchainDescriptor => {
+			// Arrange:
+			const { routeContext, next, res } = createRosettaRouteTestSetup();
+			const request = createValidRequest();
+
+			// Act:
+			const postHandler = rosettaPostRouteWithNetwork(blockchainDescriptor, ConstructionDeriveRequest, () => {});
+			await postHandler({ body: request }, res, next);
+
+			// Assert:
+			assertRosettaErrorRaised(routeContext, res, RosettaErrorFactory.UNSUPPORTED_NETWORK);
+		};
+
+		it('fails when blockchain is invalid', () => assertFailsWhenIsNotTargetNetwork({ blockchain: 'Symbol', network: 'testnet' }));
+
+		it('fails when network is invalid', () => assertFailsWhenIsNotTargetNetwork({ blockchain: 'Foo', network: 'mainnet' }));
+
+		const assertFailsWhenHandlerRaisesError = async (raisedError, expectedError) => {
+			// Arrange:
+			const { routeContext, next, res } = createRosettaRouteTestSetup();
+			const request = createValidRequest();
+
+			// Act:
+			const postHandler = rosettaPostRouteWithNetwork(
+				{ blockchain: 'Foo', network: 'testnet' },
+				ConstructionDeriveRequest, () => Promise.reject(raisedError)
+			);
+			await postHandler({ body: request }, res, next);
+
+			// Assert:
+			assertRosettaErrorRaised(routeContext, res, expectedError);
+		};
+
+		it('fails when handler raises error (rosetta)', () => assertFailsWhenHandlerRaisesError(
+			RosettaErrorFactory.INVALID_PUBLIC_KEY,
+			RosettaErrorFactory.INVALID_PUBLIC_KEY
+		));
+
+		it('fails when handler raises error (unknown)', () => assertFailsWhenHandlerRaisesError(
+			Error('unknown error'),
+			RosettaErrorFactory.INTERNAL_SERVER_ERROR
+		));
+
+		const assertSuccessWhenValid = async handler => {
+			// Arrange:
+			const { routeContext, next, res } = createRosettaRouteTestSetup();
+			const request = createValidRequest();
+
+			// Act:
+			const postHandler = rosettaPostRouteWithNetwork({ blockchain: 'Foo', network: 'testnet' }, ConstructionDeriveRequest, handler);
+			await postHandler({ body: request }, res, next);
+
+			// Assert:
+			expect(routeContext.numNextCalls).to.equal(1);
+			expect(routeContext.responses.length).to.equal(1);
+			expect(res.statusCode).to.equal(200);
+			expect(routeContext.responses[0]).to.deep.equal({ foo: 'testnet' });
+		};
+
+		it('succeeds when blockchain descriptor is valid', () => assertSuccessWhenValid(typedRequest => ({
+			foo: typedRequest.network_identifier.network
+		})));
+
+		it('succeeds when blockchain descriptor is valid (async)', () => assertSuccessWhenValid(typedRequest => (Promise.resolve({
+			foo: typedRequest.network_identifier.network
+		}))));
+	});
+
+	// endregion
+});

--- a/client/rest/test/plugins/rosetta/symbol/CatapultProxy_spec.js
+++ b/client/rest/test/plugins/rosetta/symbol/CatapultProxy_spec.js
@@ -20,8 +20,8 @@
  */
 
 import { FetchStubHelper } from './utils/rosettaTestUtils.js';
+import { RosettaErrorFactory } from '../../../../src/plugins/rosetta/rosettaUtils.js';
 import CatapultProxy from '../../../../src/plugins/rosetta/symbol/CatapultProxy.js';
-import { RosettaErrorFactory } from '../../../../src/plugins/rosetta/symbol/rosettaUtils.js';
 import { expect } from 'chai';
 
 describe('CatapultProxy', () => {

--- a/client/rest/test/plugins/rosetta/symbol/accountRoutes_spec.js
+++ b/client/rest/test/plugins/rosetta/symbol/accountRoutes_spec.js
@@ -32,9 +32,9 @@ import Amount from '../../../../src/plugins/rosetta/openApi/model/Amount.js';
 import BlockIdentifier from '../../../../src/plugins/rosetta/openApi/model/BlockIdentifier.js';
 import Coin from '../../../../src/plugins/rosetta/openApi/model/Coin.js';
 import CoinIdentifier from '../../../../src/plugins/rosetta/openApi/model/CoinIdentifier.js';
+import { RosettaErrorFactory } from '../../../../src/plugins/rosetta/rosettaUtils.js';
 import { convertTransactionSdkJsonToRestJson } from '../../../../src/plugins/rosetta/symbol/OperationParser.js';
 import accountRoutes from '../../../../src/plugins/rosetta/symbol/accountRoutes.js';
-import { RosettaErrorFactory } from '../../../../src/plugins/rosetta/symbol/rosettaUtils.js';
 import { SymbolFacade, generateMosaicAliasId } from 'symbol-sdk/symbol';
 
 describe('account routes', () => {

--- a/client/rest/test/plugins/rosetta/symbol/blockRoutes_spec.js
+++ b/client/rest/test/plugins/rosetta/symbol/blockRoutes_spec.js
@@ -32,9 +32,9 @@ import BlockResponse from '../../../../src/plugins/rosetta/openApi/model/BlockRe
 import BlockTransactionResponse from '../../../../src/plugins/rosetta/openApi/model/BlockTransactionResponse.js';
 import Transaction from '../../../../src/plugins/rosetta/openApi/model/Transaction.js';
 import TransactionIdentifier from '../../../../src/plugins/rosetta/openApi/model/TransactionIdentifier.js';
+import { RosettaErrorFactory } from '../../../../src/plugins/rosetta/rosettaUtils.js';
 import { convertTransactionSdkJsonToRestJson } from '../../../../src/plugins/rosetta/symbol/OperationParser.js';
 import blockRoutes from '../../../../src/plugins/rosetta/symbol/blockRoutes.js';
-import { RosettaErrorFactory } from '../../../../src/plugins/rosetta/symbol/rosettaUtils.js';
 import { SymbolFacade, generateMosaicAliasId } from 'symbol-sdk/symbol';
 
 describe('block routes', () => {

--- a/client/rest/test/plugins/rosetta/symbol/constructionRoutes_spec.js
+++ b/client/rest/test/plugins/rosetta/symbol/constructionRoutes_spec.js
@@ -36,8 +36,8 @@ import ConstructionPayloadsResponse from '../../../../src/plugins/rosetta/openAp
 import ConstructionPreprocessResponse from '../../../../src/plugins/rosetta/openApi/model/ConstructionPreprocessResponse.js';
 import TransactionIdentifier from '../../../../src/plugins/rosetta/openApi/model/TransactionIdentifier.js';
 import TransactionIdentifierResponse from '../../../../src/plugins/rosetta/openApi/model/TransactionIdentifierResponse.js';
+import { RosettaErrorFactory } from '../../../../src/plugins/rosetta/rosettaUtils.js';
 import constructionRoutes from '../../../../src/plugins/rosetta/symbol/constructionRoutes.js';
-import { RosettaErrorFactory } from '../../../../src/plugins/rosetta/symbol/rosettaUtils.js';
 import sinon from 'sinon';
 import { utils } from 'symbol-sdk';
 import { models } from 'symbol-sdk/symbol';

--- a/client/rest/test/plugins/rosetta/symbol/mempoolRoutes_spec.js
+++ b/client/rest/test/plugins/rosetta/symbol/mempoolRoutes_spec.js
@@ -30,9 +30,9 @@ import MempoolResponse from '../../../../src/plugins/rosetta/openApi/model/Mempo
 import MempoolTransactionResponse from '../../../../src/plugins/rosetta/openApi/model/MempoolTransactionResponse.js';
 import Transaction from '../../../../src/plugins/rosetta/openApi/model/Transaction.js';
 import TransactionIdentifier from '../../../../src/plugins/rosetta/openApi/model/TransactionIdentifier.js';
+import { RosettaErrorFactory } from '../../../../src/plugins/rosetta/rosettaUtils.js';
 import { convertTransactionSdkJsonToRestJson } from '../../../../src/plugins/rosetta/symbol/OperationParser.js';
 import mempoolRoutes from '../../../../src/plugins/rosetta/symbol/mempoolRoutes.js';
-import { RosettaErrorFactory } from '../../../../src/plugins/rosetta/symbol/rosettaUtils.js';
 import { SymbolFacade, generateMosaicAliasId } from 'symbol-sdk/symbol';
 
 describe('mempool routes', () => {

--- a/client/rest/test/plugins/rosetta/symbol/networkRoutes_spec.js
+++ b/client/rest/test/plugins/rosetta/symbol/networkRoutes_spec.js
@@ -31,8 +31,8 @@ import NetworkStatusResponse from '../../../../src/plugins/rosetta/openApi/model
 import OperationStatus from '../../../../src/plugins/rosetta/openApi/model/OperationStatus.js';
 import Peer from '../../../../src/plugins/rosetta/openApi/model/Peer.js';
 import Version from '../../../../src/plugins/rosetta/openApi/model/Version.js';
+import { RosettaErrorFactory } from '../../../../src/plugins/rosetta/rosettaUtils.js';
 import networkRoutes from '../../../../src/plugins/rosetta/symbol/networkRoutes.js';
-import { RosettaErrorFactory } from '../../../../src/plugins/rosetta/symbol/rosettaUtils.js';
 import { expect } from 'chai';
 
 describe('network routes', () => {

--- a/client/rest/test/plugins/rosetta/symbol/rosettaUtils_spec.js
+++ b/client/rest/test/plugins/rosetta/symbol/rosettaUtils_spec.js
@@ -19,148 +19,26 @@
  * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import ConstructionDeriveRequest from '../../../../src/plugins/rosetta/openApi/model/ConstructionDeriveRequest.js';
 import Currency from '../../../../src/plugins/rosetta/openApi/model/Currency.js';
-import RosettaApiError from '../../../../src/plugins/rosetta/openApi/model/Error.js';
 import {
-	RosettaErrorFactory, createLookupCurrencyFunction, rosettaPostRouteWithNetwork, stitchBlockTransactions
+	createLookupCurrencyFunction, getBlockchainDescriptor, stitchBlockTransactions
 } from '../../../../src/plugins/rosetta/symbol/rosettaUtils.js';
 import { expect } from 'chai';
 
-describe('rosetta utils', () => {
-	// region RosettaErrorFactory
+describe('rosetta utils (Symbol)', () => {
+	// region getBlockchainDescriptor
 
-	describe('RosettaErrorFactory', () => {
-		it('all have unique codes', () => {
-			// Arrange: filter out properties added to every class
-			const defaultClassPropertyNames = Object.getOwnPropertyNames(class C {});
-			const errorNames = Object.getOwnPropertyNames(RosettaErrorFactory)
-				.filter(name => !defaultClassPropertyNames.includes(name));
-
+	describe('getBlockchainDescriptor', () => {
+		it('extracts blockchain descriptor from config', () => {
 			// Act:
-			const errorCodeSet = new Set(errorNames.map(name => RosettaErrorFactory[name].apiError.code));
+			const blockchainDescriptor = getBlockchainDescriptor({ network: { name: 'alpha' } });
 
 			// Assert:
-			expect(errorCodeSet.size).to.equal(errorNames.length);
-		});
-	});
-
-	// endregion
-
-	// region rosettaPostRouteWithNetwork
-
-	describe('rosettaPostRouteWithNetwork', () => {
-		// use /construction/derive types in these tests
-
-		const createValidRequest = () => ({
-			network_identifier: {
+			expect(blockchainDescriptor).to.deep.equal({
 				blockchain: 'Symbol',
-				network: 'testnet'
-			},
-			public_key: {
-				hex_bytes: 'E85D10BF47FFBCE2230F70CB43ED2DDE04FCF342524B383972F86EA1FF773C79',
-				curve_type: 'edwards25519'
-			}
+				network: 'alpha'
+			});
 		});
-
-		const createRosettaRouteTestSetup = () => {
-			const routeContext = { numNextCalls: 0 };
-			const next = () => { ++routeContext.numNextCalls; };
-
-			routeContext.responses = [];
-			routeContext.headers = [];
-			const res = {
-				statusCode: 200,
-				send: response => { routeContext.responses.push(response); },
-				setHeader: (name, value) => { routeContext.headers.push({ name, value }); }
-			};
-
-			return { routeContext, next, res };
-		};
-
-		const assertRosettaErrorRaised = (routeContext, res, expectedError) => {
-			expect(routeContext.numNextCalls).to.equal(1);
-			expect(routeContext.responses.length).to.equal(1);
-			expect(res.statusCode).to.equal(500);
-
-			const response = routeContext.responses[0];
-			expect(response).to.deep.equal(expectedError.apiError);
-			expect(() => RosettaApiError.validateJSON(response)).to.not.throw();
-		};
-
-		it('fails when request is invalid', async () => {
-			// Arrange: corrupt the request by removing a required subfield
-			const { routeContext, next, res } = createRosettaRouteTestSetup();
-			const request = createValidRequest();
-			delete request.network_identifier.network;
-
-			// Act:
-			const postHandler = rosettaPostRouteWithNetwork('testnet', ConstructionDeriveRequest, () => {});
-			await postHandler({ body: request }, res, next);
-
-			// Assert:
-			assertRosettaErrorRaised(routeContext, res, RosettaErrorFactory.INVALID_REQUEST_DATA);
-		});
-
-		it('fails when network is invalid', async () => {
-			// Arrange:
-			const { routeContext, next, res } = createRosettaRouteTestSetup();
-			const request = createValidRequest();
-
-			// Act:
-			const postHandler = rosettaPostRouteWithNetwork('mainnet', ConstructionDeriveRequest, () => {});
-			await postHandler({ body: request }, res, next);
-
-			// Assert:
-			assertRosettaErrorRaised(routeContext, res, RosettaErrorFactory.UNSUPPORTED_NETWORK);
-		});
-
-		const assertFailsWhenHandlerRaisesError = async (raisedError, expectedError) => {
-			// Arrange:
-			const { routeContext, next, res } = createRosettaRouteTestSetup();
-			const request = createValidRequest();
-
-			// Act:
-			const postHandler = rosettaPostRouteWithNetwork('testnet', ConstructionDeriveRequest, () => Promise.reject(raisedError));
-			await postHandler({ body: request }, res, next);
-
-			// Assert:
-			assertRosettaErrorRaised(routeContext, res, expectedError);
-		};
-
-		it('fails when handler raises error (rosetta)', () => assertFailsWhenHandlerRaisesError(
-			RosettaErrorFactory.INVALID_PUBLIC_KEY,
-			RosettaErrorFactory.INVALID_PUBLIC_KEY
-		));
-
-		it('fails when handler raises error (unknown)', () => assertFailsWhenHandlerRaisesError(
-			Error('unknown error'),
-			RosettaErrorFactory.INTERNAL_SERVER_ERROR
-		));
-
-		const assertSuccessWhenValid = async handler => {
-			// Arrange:
-			const { routeContext, next, res } = createRosettaRouteTestSetup();
-			const request = createValidRequest();
-
-			// Act:
-			const postHandler = rosettaPostRouteWithNetwork('testnet', ConstructionDeriveRequest, handler);
-			await postHandler({ body: request }, res, next);
-
-			// Assert:
-			expect(routeContext.numNextCalls).to.equal(1);
-			expect(routeContext.responses.length).to.equal(1);
-			expect(res.statusCode).to.equal(200);
-			expect(routeContext.responses[0]).to.deep.equal({ foo: 'testnet' });
-		};
-
-		it('succeeds when network is valid', () => assertSuccessWhenValid(typedRequest => ({
-			foo: typedRequest.network_identifier.network
-		})));
-
-		it('succeeds when network is valid (async)', () => assertSuccessWhenValid(typedRequest => (Promise.resolve({
-			foo: typedRequest.network_identifier.network
-		}))));
 	});
 
 	// endregion

--- a/client/rest/test/plugins/rosetta/utils/rosettaTestUtils.js
+++ b/client/rest/test/plugins/rosetta/utils/rosettaTestUtils.js
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2016-2019, Jaguar0625, gimre, BloodyRookie, Tech Bureau, Corp.
+ * Copyright (c) 2020-present, Jaguar0625, gimre, BloodyRookie.
+ * All rights reserved.
+ *
+ * This file is part of Catapult.
+ *
+ * Catapult is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Catapult is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Catapult.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import RosettaApiError from '../../../../src/plugins/rosetta/openApi/model/Error.js';
+import MockServer from '../../../routes/utils/MockServer.js';
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+// region BasicFetchStubHelper
+
+export const BasicFetchStubHelper = {
+	stubPost: (urlPath, ok, jsonResult, expectedRequestOptions = undefined, callNumber = undefined) => {
+		if (!global.fetch.restore)
+			sinon.stub(global, 'fetch');
+
+		const proxy = global.fetch.withArgs(`http://localhost:3456/${urlPath}`, expectedRequestOptions || sinon.match.any);
+		const result = Promise.resolve({
+			ok,
+			json: () => jsonResult
+		});
+
+		if (callNumber)
+			proxy[`on${callNumber}Call`]().returns(result);
+		else
+			proxy.returns(result);
+	},
+
+	registerStubCleanup: () => {
+		afterEach(() => {
+			if (global.fetch.restore)
+				global.fetch.restore();
+		});
+	}
+};
+
+// endregion
+
+// region asserts
+
+const createMockServer = registerRoutes => {
+	const mockServer = new MockServer();
+	registerRoutes(mockServer.server);
+	return mockServer;
+};
+
+export const assertRosettaErrorRaisedBasicWithRegister = async (registerRoutes, routeName, request, expectedError, malformRequest) => {
+	// Arrange:
+	const mockServer = createMockServer(registerRoutes);
+	const route = mockServer.getRoute(routeName).post();
+
+	malformRequest(request);
+
+	// Act:
+	await mockServer.callRoute(route, { body: request });
+
+	// Assert:
+	expect(mockServer.send.calledOnce).to.equal(true);
+	expect(mockServer.next.calledOnce).to.equal(true);
+	expect(mockServer.res.statusCode).to.equal(500);
+
+	const response = mockServer.send.firstCall.args[0];
+	expect(response).to.deep.equal(expectedError.apiError);
+	expect(() => RosettaApiError.validateJSON(response)).to.not.throw();
+};
+
+export const assertRosettaSuccessBasicWithRegister = async (registerRoutes, routeName, request, expectedResponse, compareOptions = {}) => {
+	// Arrange:
+	const mockServer = createMockServer(registerRoutes);
+	const route = mockServer.getRoute(routeName).post();
+
+	// Act:
+	await mockServer.callRoute(route, { body: request });
+
+	// Assert:
+	expect(mockServer.send.calledOnce).to.equal(true);
+	expect(mockServer.next.calledOnce).to.equal(true);
+	expect(mockServer.res.statusCode).to.equal(undefined);
+
+	const response = mockServer.send.firstCall.args[0];
+	if (compareOptions.roundtripJson)
+		expect(JSON.parse(JSON.stringify(response))).to.deep.equal(JSON.parse(JSON.stringify(expectedResponse)));
+	else
+		expect(response).to.deep.equal(expectedResponse);
+
+	expect(() => expectedResponse.constructor.validateJSON(response)).to.not.throw();
+};
+
+// endregion


### PR DESCRIPTION
    [client/rest]: add support for NEM /construction/derive
    
     problem: start adding NEM construction routes
    solution: add NEM /construction/derive
              refactor shared Symbol and NEM test utilities


    [client/rest]: promote shared NEM and Symbol rosetta utils
    
     problem: all rosetta utils are under /symbol but some can be used by nem
    solution: move shared utils up a level
