### PR TITLE
[client/rest]: properly handle fee calculation when block fee multiplier is zero

### DIFF
--- a/client/rest/src/plugins/rosetta/symbol/OperationParser.js
+++ b/client/rest/src/plugins/rosetta/symbol/OperationParser.js
@@ -217,11 +217,12 @@ export class OperationParser {
 		}
 
 		if (this.options.includeFeeOperation) {
-			const amount = metadata.feeMultiplier ? BigInt(metadata.feeMultiplier) * BigInt(transaction.size) : BigInt(transaction.maxFee);
+			const amount = undefined !== metadata.feeMultiplier
+				? BigInt(metadata.feeMultiplier) * BigInt(transaction.size)
+				: BigInt(transaction.maxFee);
 			const feeCurrency = await this.options.lookupCurrency('currencyMosaicId');
 
-			operations.push(this.createDebitOperation({
-				id: operations.length,
+			appendOperation(this.createDebitOperation({
 				sourcePublicKey: transaction.signerPublicKey,
 				amount,
 				currency: feeCurrency

--- a/client/rest/test/plugins/rosetta/symbol/OperationParser_spec.js
+++ b/client/rest/test/plugins/rosetta/symbol/OperationParser_spec.js
@@ -401,6 +401,9 @@ describe('OperationParser', () => {
 				createTransferOperation(0, 'TARZARAKDFNYFVFANAIAHCYUADHHZWT2WP2I7GI', '-20000', 'currency.fee', 2)
 			]));
 
+			it('can parse with fee (confirmed, zero)', () => assertCanParse({ includeFeeOperation: true }, { feeMultiplier: 0 }, [
+			]));
+
 			it('can parse with fee (confirmed) and operation status', () => assertCanParse(
 				{ includeFeeOperation: true, operationStatus: 'success' },
 				{ feeMultiplier: 200 },


### PR DESCRIPTION
 problem: weak comparison is treating zero as falsy
solution: check feeMultiplier against undefined