### PR TITLE
[client/rest]: small cleanup after merging all NEM rosetta routes

### DIFF
--- a/client/rest/src/plugins/rosetta/nem/OperationParser.js
+++ b/client/rest/src/plugins/rosetta/nem/OperationParser.js
@@ -191,7 +191,7 @@ export class OperationParser {
 	 * @returns {Transaction} Rosetta transaction.
 	 */
 	async parseTransactionAsRosettaTransaction(transaction, metadata) {
-		const { operations } = await this.parseTransaction(transaction, metadata);
+		const { operations } = await this.parseTransaction(transaction);
 		return new Transaction(new TransactionIdentifier(metadata.hash.data.toUpperCase()), operations);
 	}
 

--- a/client/rest/src/plugins/rosetta/nem/accountRoutes.js
+++ b/client/rest/src/plugins/rosetta/nem/accountRoutes.js
@@ -38,7 +38,7 @@ export default {
 		const blockchainDescriptor = getBlockchainDescriptor(services.config);
 		const network = NetworkLocator.findByName(Network.NETWORKS, blockchainDescriptor.network);
 		const lookupCurrency = createLookupCurrencyFunction(services.proxy);
-		const getChainHeight = () => services.proxy.fetch('chain/height', json => json.height);
+		const getChainHeight = () => services.proxy.fetch('chain/height', jsonObject => jsonObject.height);
 		const getBlockIdentifier = height => services.proxy.localBlockAtHeight(height)
 			.then(blockInfo => new BlockIdentifier(Number(blockInfo.block.height), blockInfo.hash));
 		const parser = new OperationParser(network, {

--- a/client/rest/src/plugins/rosetta/nem/blockRoutes.js
+++ b/client/rest/src/plugins/rosetta/nem/blockRoutes.js
@@ -46,11 +46,7 @@ export default {
 
 		server.post('/block', rosettaPostRouteWithNetwork(blockchainDescriptor, BlockRequest, async typedRequest => {
 			const height = typedRequest.block_identifier.index;
-			const blockInfo = await services.proxy.fetch('local/block/at', undefined, {
-				method: 'POST',
-				body: JSON.stringify({ height }),
-				headers: { 'Content-Type': 'application/json' }
-			});
+			const blockInfo = await services.proxy.localBlockAtHeight(height);
 			const rosettaTransactions = await Promise.all(blockInfo.txes.map(transaction =>
 				parser.parseTransactionAsRosettaTransaction(transaction.tx, { hash: { data: transaction.hash } })));
 

--- a/client/rest/src/plugins/rosetta/nem/networkRoutes.js
+++ b/client/rest/src/plugins/rosetta/nem/networkRoutes.js
@@ -73,18 +73,13 @@ export default {
 		}));
 
 		server.post('/network/status', rosettaPostRouteWithNetwork(blockchainDescriptor, NetworkRequest, async () => {
-			const getBlockInfoAt = height => services.proxy.fetch('local/block/at', undefined, {
-				method: 'POST',
-				body: JSON.stringify({ height }),
-				headers: { 'Content-Type': 'application/json' }
-			});
 			const [currentBlock, peers, genesisBlock] = await Promise.all([
-				services.proxy.fetch('chain/height').then(info => getBlockInfoAt(info.height)),
+				services.proxy.fetch('chain/height').then(info => services.proxy.localBlockAtHeight(info.height)),
 				services.proxy.fetch(
 					'node/peer-list/reachable',
-					json => json.data
+					jsonObject => jsonObject.data
 				).then(nodes => nodes.map(node => new Peer(node.identity['public-key']))),
-				getBlockInfoAt(1)
+				services.proxy.localBlockAtHeight(1)
 			]);
 
 			const network = NetworkLocator.findByName(Network.NETWORKS, blockchainDescriptor.network);

--- a/client/rest/src/plugins/rosetta/symbol/accountRoutes.js
+++ b/client/rest/src/plugins/rosetta/symbol/accountRoutes.js
@@ -40,7 +40,7 @@ export default {
 		const blockchainDescriptor = getBlockchainDescriptor(services.config);
 		const network = NetworkLocator.findByName(Network.NETWORKS, blockchainDescriptor.network);
 		const lookupCurrency = createLookupCurrencyFunction(services.proxy);
-		const getChainHeight = () => services.proxy.fetch('chain/info', json => json.height);
+		const getChainHeight = () => services.proxy.fetch('chain/info', jsonObject => jsonObject.height);
 		const getBlockIdentifier = height => services.proxy.fetch(`blocks/${height}`)
 			.then(blockInfo => new BlockIdentifier(Number(blockInfo.block.height), blockInfo.meta.hash));
 		const parser = new OperationParser(network, {

--- a/client/rest/test/plugins/rosetta/nem/blockRoutes_spec.js
+++ b/client/rest/test/plugins/rosetta/nem/blockRoutes_spec.js
@@ -163,14 +163,6 @@ describe('NEM block routes', () => {
 			}
 		});
 
-		const stubPostLocalBlockAt = (blockHeight, blockHash, blockTimestamp, ok) => {
-			FetchStubHelper.stubPost('local/block/at', ok, createBlocksResponse(blockHeight, blockHash, blockTimestamp), {
-				method: 'POST',
-				body: JSON.stringify({ height: blockHeight }),
-				headers: { 'Content-Type': 'application/json' }
-			});
-		};
-
 		const createMatchingRosettaBlock = (blockIdentifier, parentBlockIdentifier, timestamp) => {
 			const expectedResponse = new BlockResponse();
 			expectedResponse.block = new Block();
@@ -183,7 +175,7 @@ describe('NEM block routes', () => {
 
 		it('fails when fetch fails (local/block/at)', async () => {
 			// Arrange:
-			stubPostLocalBlockAt(1, NEMESIS_BLOCK_HASH, 0, false);
+			FetchStubHelper.stubLocalBlockAt(createBlocksResponse(1, NEMESIS_BLOCK_HASH, 0), false);
 			stubMosaicResolution('xem', 'nem', 6);
 			stubMosaicResolution('hat', 'magic', 3);
 
@@ -193,7 +185,7 @@ describe('NEM block routes', () => {
 
 		it('succeeds when all fetches succeed (nemesis)', async () => {
 			// Arrange:
-			stubPostLocalBlockAt(1, NEMESIS_BLOCK_HASH, 0, true);
+			FetchStubHelper.stubLocalBlockAt(createBlocksResponse(1, NEMESIS_BLOCK_HASH, 0), true);
 			stubMosaicResolution('xem', 'nem', 6);
 			stubMosaicResolution('hat', 'magic', 3);
 
@@ -210,8 +202,8 @@ describe('NEM block routes', () => {
 
 		it('succeeds when all fetches succeed (other block)', async () => {
 			// Arrange:
-			stubPostLocalBlockAt(1, NEMESIS_BLOCK_HASH, 0, true);
-			stubPostLocalBlockAt(2, OTHER_BLOCK_HASH, 20, true);
+			FetchStubHelper.stubLocalBlockAt(createBlocksResponse(1, NEMESIS_BLOCK_HASH, 0), true);
+			FetchStubHelper.stubLocalBlockAt(createBlocksResponse(2, OTHER_BLOCK_HASH, 20), true);
 			stubMosaicResolution('xem', 'nem', 6);
 			stubMosaicResolution('hat', 'magic', 3);
 

--- a/client/rest/test/plugins/rosetta/nem/networkRoutes_spec.js
+++ b/client/rest/test/plugins/rosetta/nem/networkRoutes_spec.js
@@ -160,19 +160,13 @@ describe('NEM network routes', () => {
 			return { data: peers };
 		};
 
-		const stubPostLocalBlockAt = (blockHeight, blockHash, blockTimestamp, ok) => {
-			FetchStubHelper.stubPost('local/block/at', ok, createBlocksResponse(blockHeight, blockHash, blockTimestamp), {
-				method: 'POST',
-				body: JSON.stringify({ height: blockHeight }),
-				headers: { 'Content-Type': 'application/json' }
-			});
-		};
-
 		const setupEndPoints = success => {
 			FetchStubHelper.stubPost('node/info', success, createRosettaNodeVersion());
 			FetchStubHelper.stubPost('chain/height', success, { height: CURRENT_BLOCK_NUMBER });
-			stubPostLocalBlockAt(GENESIS_BLOCK_NUMBER, GENESIS_BLOCK_HASH, 0, success);
-			stubPostLocalBlockAt(CURRENT_BLOCK_NUMBER, CURRENT_BLOCK_HASH, CURRENT_BLOCK_TIMESTAMP, success);
+			FetchStubHelper.stubLocalBlockAt({ height: GENESIS_BLOCK_NUMBER, hash: GENESIS_BLOCK_HASH, timestamp: 0 }, success);
+			FetchStubHelper.stubLocalBlockAt({
+				height: CURRENT_BLOCK_NUMBER, hash: CURRENT_BLOCK_HASH, timestamp: CURRENT_BLOCK_TIMESTAMP
+			}, success);
 			stubFetchResult('node/peer-list/reachable', success, createNodePeersResponse());
 		};
 

--- a/client/rest/test/plugins/rosetta/nem/utils/rosettaTestUtils.js
+++ b/client/rest/test/plugins/rosetta/nem/utils/rosettaTestUtils.js
@@ -47,14 +47,20 @@ export const FetchStubHelper = {
 		});
 	},
 
-	stubLocalBlockAt(options, ok) {
-		FetchStubHelper.stubPost('local/block/at', ok, {
-			block: { height: options.height },
-			hash: options.hash
-		}, {
+	stubLocalBlockAt(optionsOrResponse, ok) {
+		let response = optionsOrResponse;
+		if (undefined === optionsOrResponse.block) {
+			const block = { height: optionsOrResponse.height };
+			if (optionsOrResponse.timestamp)
+				block.timeStamp = optionsOrResponse.timestamp;
+
+			response = { block, hash: optionsOrResponse.hash };
+		}
+
+		FetchStubHelper.stubPost('local/block/at', ok, response, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
-			body: `{"height":${options.height}}`
+			body: `{"height":${response.block.height}}`
 		});
 	}
 };


### PR DESCRIPTION
 problem: small cleanup and refactoring identified during NEM rosetta route development
solution: use helper functions for /local/block/at requests (and test setup)
          drop extra parameter passed to OperationParser.parseTransaction
          minor renaming for consistency
