### PR TITLE
[client/rest]: incremental fixes to NEM rosetta implementation 

### DIFF
--- a/client/rest/src/plugins/rosetta/nem/NemProxy.js
+++ b/client/rest/src/plugins/rosetta/nem/NemProxy.js
@@ -86,12 +86,14 @@ export default class NemProxy {
 	 * @param {number} height Block height.
 	 * @returns {Promise<object>} Block data.
 	 */
-	localBlockAtHeight(height) {
-		return this.fetch('local/block/at', undefined, {
+	async localBlockAtHeight(height) {
+		const block = await this.fetch('local/block/at', undefined, {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({ height })
 		});
+		block.hash = block.hash.toUpperCase();
+		return block;
 	}
 
 	/**

--- a/client/rest/src/plugins/rosetta/nem/OperationParser.js
+++ b/client/rest/src/plugins/rosetta/nem/OperationParser.js
@@ -30,8 +30,6 @@ import TransactionIdentifier from '../openApi/model/TransactionIdentifier.js';
 import { PublicKey, utils } from 'symbol-sdk';
 import { Network, models } from 'symbol-sdk/nem';
 
-const hexStringToUtfString = hex => new TextDecoder().decode(utils.hexToUint8(hex));
-
 // region convertTransactionSdkJsonToRestJson
 
 /**
@@ -40,6 +38,8 @@ const hexStringToUtfString = hex => new TextDecoder().decode(utils.hexToUint8(he
  * @returns {object} Transaction REST JSON model.
  */
 export const convertTransactionSdkJsonToRestJson = transactionJson => {
+	const hexStringToUtfString = hex => new TextDecoder().decode(utils.hexToUint8(hex));
+
 	const convertMosaicIdSdkJsonToRestJson = mosaicId => ({
 		namespaceId: hexStringToUtfString(mosaicId.namespaceId.name),
 		name: hexStringToUtfString(mosaicId.name)
@@ -92,6 +92,9 @@ export const convertTransactionSdkJsonToRestJson = transactionJson => {
 
 	if (transactionJson.minApprovalDelta)
 		renameProperty('minApprovalDelta', 'minCosignatories', minApprovalDelta => ({ relativeChange: minApprovalDelta }));
+
+	if (transactionJson.rentalFeeSink)
+		transactionJson.rentalFeeSink = hexStringToUtfString(transactionJson.rentalFeeSink);
 
 	if (transactionJson.mosaicDefinition) {
 		transactionJson.mosaicDefinition.id = convertMosaicIdSdkJsonToRestJson(transactionJson.mosaicDefinition.id);
@@ -293,7 +296,7 @@ export class OperationParser {
 			const amount = transaction[`${feeName}Fee`];
 			const currency = await this.lookupFeeCurrency();
 
-			pushDebitCreditOperations(transaction.signer, hexStringToUtfString(transaction[`${feeName}FeeSink`]), amount, currency);
+			pushDebitCreditOperations(transaction.signer, transaction[`${feeName}FeeSink`], amount, currency);
 		};
 
 		const transactionType = transaction.type;

--- a/client/rest/src/plugins/rosetta/nem/OperationParser.js
+++ b/client/rest/src/plugins/rosetta/nem/OperationParser.js
@@ -345,8 +345,8 @@ export class OperationParser {
 
 			operations.push(operation);
 		} else if (models.TransactionType.MOSAIC_SUPPLY_CHANGE.value === transactionType) {
-			const amount = transaction.delta;
 			const { currency } = this.options.lookupCurrency(transaction.mosaicId);
+			const amount = transaction.delta * (10 ** currency.decimals);
 
 			operations.push(this.createCreditOperation({
 				targetPublicKey: transaction.signer,
@@ -363,18 +363,18 @@ export class OperationParser {
 			const { mosaicDefinition } = transaction;
 			const initialSupplyProperty = findProperty(mosaicDefinition.properties, 'initialSupply');
 			const divisibilityProperty = findProperty(mosaicDefinition.properties, 'divisibility');
-			if (initialSupplyProperty) {
-				const currency = new Currency(
-					mosaicIdToString(mosaicDefinition.id),
-					undefined === divisibilityProperty ? 0 : parseInt(divisibilityProperty.value, 10)
-				);
 
-				operations.push(this.createCreditOperation({
-					targetPublicKey: transaction.signer,
-					amount: parseInt(initialSupplyProperty.value, 10),
-					currency
-				}));
-			}
+			const initialSupply = undefined === initialSupplyProperty ? 1000 : parseInt(initialSupplyProperty.value, 10);
+			const currency = new Currency(
+				mosaicIdToString(mosaicDefinition.id),
+				undefined === divisibilityProperty ? 0 : parseInt(divisibilityProperty.value, 10)
+			);
+
+			operations.push(this.createCreditOperation({
+				targetPublicKey: transaction.signer,
+				amount: initialSupply * (10 ** currency.decimals),
+				currency
+			}));
 		}
 
 		return operations;

--- a/client/rest/src/plugins/rosetta/nem/blockRoutes.js
+++ b/client/rest/src/plugins/rosetta/nem/blockRoutes.js
@@ -48,7 +48,7 @@ export default {
 
 		const createBlockTransaction = async blockInfo => {
 			const { operations } = await parser.parseBlock(blockInfo);
-			return new Transaction(new TransactionIdentifier(blockInfo.hash.toUpperCase()), operations);
+			return new Transaction(new TransactionIdentifier(blockInfo.hash), operations);
 		};
 
 		server.post('/block', rosettaPostRouteWithNetwork(blockchainDescriptor, BlockRequest, async typedRequest => {
@@ -64,7 +64,7 @@ export default {
 			response.block = new Block();
 			response.block.transactions = rosettaTransactions;
 			response.block.transactions.push(blockTransaction);
-			response.block.block_identifier = new BlockIdentifier(Number(blockInfo.block.height), blockInfo.hash.toUpperCase());
+			response.block.block_identifier = new BlockIdentifier(Number(blockInfo.block.height), blockInfo.hash);
 			response.block.parent_block_identifier = GENESIS_BLOCK_NUMBER === height
 				? response.block.block_identifier
 				: new BlockIdentifier(Number(blockInfo.block.height) - 1, blockInfo.block.prevBlockHash.data.toUpperCase());

--- a/client/rest/src/plugins/rosetta/nem/networkRoutes.js
+++ b/client/rest/src/plugins/rosetta/nem/networkRoutes.js
@@ -86,7 +86,7 @@ export default {
 			const calculateUnixTime = timestamp => Number(network.toDatetime(new NetworkTimestamp(timestamp)).getTime());
 
 			const currentBlockTimestamp = calculateUnixTime(currentBlock.block.timeStamp);
-			const blockToBlockIdentifier = block => new BlockIdentifier(Number(block.block.height), block.hash.toUpperCase());
+			const blockToBlockIdentifier = block => new BlockIdentifier(Number(block.block.height), block.hash);
 			const currentBlockIdentifier = blockToBlockIdentifier(currentBlock);
 			const genesisBlockIdentifier = blockToBlockIdentifier(genesisBlock);
 

--- a/client/rest/test/plugins/rosetta/nem/NemProxy_spec.js
+++ b/client/rest/test/plugins/rosetta/nem/NemProxy_spec.js
@@ -235,7 +235,7 @@ describe('NemProxy', () => {
 		it('fails when fetch fails', async () => {
 			// Arrange:
 			const proxy = new NemProxy(TEST_ENDPOINT);
-			FetchStubHelper.stubLocalBlockAt({ hash: 'AABBCCDD', height: 4321 }, false);
+			FetchStubHelper.stubLocalBlockAt({ hash: 'aabbccdd', height: 4321 }, false);
 
 			// Act + Assert:
 			await assertAsyncErrorThrown(() => proxy.localBlockAtHeight(4321), RosettaErrorFactory.CONNECTION_ERROR);
@@ -244,7 +244,7 @@ describe('NemProxy', () => {
 		it('succeeds when fetch succeeds', async () => {
 			// Arrange:
 			const proxy = new NemProxy(TEST_ENDPOINT);
-			FetchStubHelper.stubLocalBlockAt({ hash: 'AABBCCDD', height: 4321 }, true);
+			FetchStubHelper.stubLocalBlockAt({ hash: 'aabbccdd', height: 4321 }, true);
 
 			// Act:
 			const blockInfo = await proxy.localBlockAtHeight(4321);

--- a/client/rest/test/plugins/rosetta/nem/OperationParser_spec.js
+++ b/client/rest/test/plugins/rosetta/nem/OperationParser_spec.js
@@ -900,7 +900,7 @@ describe('NEM OperationParser', () => {
 
 			// Act:
 			const restJson = convertTransactionSdkJsonToRestJson({
-				rentalFeeSink: 'TBMOSAICOD4F54EE5CDMR23CCBGOAM2XSJBR5OLC',
+				rentalFeeSink: '54424D4F534149434F443446353445453543444D523233434342474F414D3258534A4252354F4C43',
 				rentalFee: 50000,
 
 				mosaicDefinition: {
@@ -929,10 +929,10 @@ describe('NEM OperationParser', () => {
 			});
 		});
 
-		it('does not fixup fee sink properties when mosaicDefinition is not present', () => {
+		it('can fixup fee sink properties when mosaicDefinition is not present', () => {
 			// Act:
 			const restJson = convertTransactionSdkJsonToRestJson({
-				rentalFeeSink: 'TBMOSAICOD4F54EE5CDMR23CCBGOAM2XSJBR5OLC',
+				rentalFeeSink: '54424D4F534149434F443446353445453543444D523233434342474F414D3258534A4252354F4C43',
 				rentalFee: 50000
 			});
 

--- a/client/rest/test/plugins/rosetta/nem/OperationParser_spec.js
+++ b/client/rest/test/plugins/rosetta/nem/OperationParser_spec.js
@@ -395,9 +395,9 @@ describe('NEM OperationParser', () => {
 				expect(signerAddresses.map(address => address.toString())).to.deep.equal(['TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW']);
 			};
 
-			it('can parse increase', () => assertCanParse(models.MosaicSupplyChangeAction.INCREASE, '24680'));
+			it('can parse increase', () => assertCanParse(models.MosaicSupplyChangeAction.INCREASE, '24680000'));
 
-			it('can parse decrease', () => assertCanParse(models.MosaicSupplyChangeAction.DECREASE, '-24680'));
+			it('can parse decrease', () => assertCanParse(models.MosaicSupplyChangeAction.DECREASE, '-24680000'));
 		});
 
 		// endregion
@@ -468,7 +468,9 @@ describe('NEM OperationParser', () => {
 
 			it('can parse without initial supply', () => assertParse({
 				properties: [],
-				additionalOperations: []
+				additionalOperations: [
+					createTransferOperation(2, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '1000', 'foo.bar', 0)
+				]
 			}));
 
 			it('can parse with initial supply and default divisibility', async () => {
@@ -493,7 +495,7 @@ describe('NEM OperationParser', () => {
 						{ property: { name: textEncoder.encode('supplyMutable'), value: textEncoder.encode('false') } }
 					],
 					additionalOperations: [
-						createTransferOperation(2, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '123000', 'foo.bar', 4)
+						createTransferOperation(2, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '1230000000', 'foo.bar', 4)
 					]
 				});
 			});

--- a/client/rest/test/plugins/rosetta/nem/accountRoutes_spec.js
+++ b/client/rest/test/plugins/rosetta/nem/accountRoutes_spec.js
@@ -42,7 +42,7 @@ describe('NEM rosetta account routes', () => {
 	const ACCOUNT_PUBLIC_KEY = '9822CF9571A5551EC19720B87A567A20797B75EC4B6711387643FC352FEF704E';
 	const OTHER_ACCOUNT_ADDRESS = 'TBMKRYST2J3GEZRWHS3MICWFIBSKVHH7F5FA6FH3';
 	const OTHER_ACCOUNT_PUBLIC_KEY = '88D0C34AEA2CB96E226379E71BA6264F4460C27D29F79E24248318397AA48380';
-	const TRANSACTION_HASH = 'C65DF0B9CB47E1D3538DC40481FC613F37DA4DEE816F72FDF63061B2707F6483';
+	const TRANSACTION_HASH = 'c65df0b9cb47e1d3538dc40481fc613f37da4dee816f72fdf63061b2707f6483';
 
 	const assertRosettaErrorRaisedBasic = (...args) => assertRosettaErrorRaisedBasicWithRoutes(accountRoutes, ...args);
 	const assertRosettaSuccessBasic = (...args) => assertRosettaSuccessBasicWithRoutes(accountRoutes, ...args);
@@ -67,7 +67,7 @@ describe('NEM rosetta account routes', () => {
 	const stubAccountResolutions = () => {
 		// setup chain
 		stubFetchResult('chain/height', true, { height: 12345 });
-		FetchStubHelper.stubLocalBlockAt({ height: 12345, hash: 'A4950F27A23B235D5CCD1DC7FF4B0BDC48977E353EA1CF1E3E5F70B9A6B79076' }, true);
+		FetchStubHelper.stubLocalBlockAt({ height: 12345, hash: 'a4950f27a23b235d5ccd1dc7ff4b0bdc48977e353ea1cf1e3e5f70b9a6b79076' }, true);
 
 		// setup account
 		stubFetchResult(`account/mosaic/owned?address=${ACCOUNT_ADDRESS}`, true, {

--- a/client/rest/test/plugins/rosetta/nem/networkRoutes_spec.js
+++ b/client/rest/test/plugins/rosetta/nem/networkRoutes_spec.js
@@ -132,7 +132,7 @@ describe('NEM network routes', () => {
 		const stubFetchResult = FetchStubHelper.stubPost;
 		FetchStubHelper.registerStubCleanup();
 
-		const GENESIS_BLOCK_HASH = '135B9276FE14D6724F87764DD3F8E332813AE9A36D1A7953B12213EA9ACB6B97';
+		const GENESIS_BLOCK_HASH = '135b9276fe14d6724f87764dd3f8e332813ae9a36d1a7953b12213ea9acb6b97';
 		const GENESIS_BLOCK_NUMBER = 1;
 		const CURRENT_BLOCK_HASH = '92435746efd1789e5e906e99b8e3bdc72ab1adecdbeecb321116e59ded0a739c';
 		const CURRENT_BLOCK_NUMBER = 10;
@@ -223,7 +223,7 @@ describe('NEM network routes', () => {
 
 			// - create expected response
 			const expectedResponse = new NetworkStatusResponse();
-			expectedResponse.genesis_block_identifier = new BlockIdentifier(GENESIS_BLOCK_NUMBER, GENESIS_BLOCK_HASH);
+			expectedResponse.genesis_block_identifier = new BlockIdentifier(GENESIS_BLOCK_NUMBER, GENESIS_BLOCK_HASH.toUpperCase());
 			expectedResponse.current_block_identifier = new BlockIdentifier(CURRENT_BLOCK_NUMBER, CURRENT_BLOCK_HASH.toUpperCase());
 			expectedResponse.current_block_timestamp = Number(1427587585000 + (CURRENT_BLOCK_TIMESTAMP * 1000));
 			expectedResponse.peers = NODE_PEERS_PUBLIC_KEYS.map(publicKey => new Peer(publicKey));

--- a/client/rest/test/plugins/rosetta/nem/utils/rosettaTestUtils.js
+++ b/client/rest/test/plugins/rosetta/nem/utils/rosettaTestUtils.js
@@ -48,7 +48,8 @@ export const FetchStubHelper = {
 			if (optionsOrResponse.timestamp)
 				block.timeStamp = optionsOrResponse.timestamp;
 
-			response = { block, hash: optionsOrResponse.hash };
+			// simulate NEM REST, which always returns lowercase hashes
+			response = { block, hash: optionsOrResponse.hash.toLowerCase() };
 		}
 
 		FetchStubHelper.stubPost('local/block/at', ok, response, {


### PR DESCRIPTION
    [client/rest]: NEM rosetta routes should use uppercase hashes everywhere
    
     problem: there is a mix of lowercase and uppercase hashes used as identifiers
    solution: use uppercase everywhere

    [client/rest]: mosaic supplies are represented in NEM whole units
    
     problem: mosaic supplies are being treated as atomic units
    solution: mosaic supplies are actually whole units and need to be multiplied by divisibility
    
     problem: mosaic creation default initial supply is 1000, not 0
    solution: change processing of mosaic definition creation transactions to always create credit

    [client/rest]: hexStringToUtfString should only be called on SDK JSON
    
     problem: hexStringToUtfString is being called on REST JSON
              but REST JSON has non-hex strings already
    solution: move all hexStringToUtfString calls into convertTransactionSdkJsonToRestJson
