### PR TITLE
Rest/rosetta/fixes

### DIFF
--- a/client/rest/src/plugins/rosetta/nem/OperationParser.js
+++ b/client/rest/src/plugins/rosetta/nem/OperationParser.js
@@ -110,6 +110,9 @@ export const convertTransactionSdkJsonToRestJson = transactionJson => {
 		renameProperty('rentalFeeSink', 'creationFeeSink');
 	}
 
+	if (transactionJson.action)
+		renameProperty('action', 'supplyType');
+
 	return transactionJson;
 };
 
@@ -350,7 +353,7 @@ export class OperationParser {
 
 			operations.push(this.createCreditOperation({
 				targetPublicKey: transaction.signer,
-				amount: models.MosaicSupplyChangeAction.INCREASE.value === transaction.action ? amount : -amount,
+				amount: models.MosaicSupplyChangeAction.INCREASE.value === transaction.supplyType ? amount : -amount,
 				currency
 			}));
 		} else if (models.TransactionType.NAMESPACE_REGISTRATION.value === transactionType) {

--- a/client/rest/src/plugins/rosetta/nem/OperationParser.js
+++ b/client/rest/src/plugins/rosetta/nem/OperationParser.js
@@ -323,7 +323,7 @@ export class OperationParser {
 					if (levy) {
 						const levyAmount = levy.isAbsolute
 							? levy.fee
-							: amount * levy.fee / 10000;
+							: Math.trunc(amount * levy.fee / 10000);
 						pushDebitCreditOperations(transaction.signer, levy.recipientAddress, levyAmount, levy.currency);
 					}
 				}));

--- a/client/rest/src/plugins/rosetta/nem/OperationParser.js
+++ b/client/rest/src/plugins/rosetta/nem/OperationParser.js
@@ -345,7 +345,7 @@ export class OperationParser {
 
 			operations.push(operation);
 		} else if (models.TransactionType.MOSAIC_SUPPLY_CHANGE.value === transactionType) {
-			const { currency } = this.options.lookupCurrency(transaction.mosaicId);
+			const { currency } = await this.options.lookupCurrency(transaction.mosaicId);
 			const amount = transaction.delta * (10 ** currency.decimals);
 
 			operations.push(this.createCreditOperation({

--- a/client/rest/test/plugins/rosetta/nem/OperationParser_spec.js
+++ b/client/rest/test/plugins/rosetta/nem/OperationParser_spec.js
@@ -944,6 +944,18 @@ describe('NEM OperationParser', () => {
 				rentalFee: 50000
 			});
 		});
+
+		it('can fixup action property', () => {
+			// Act:
+			const restJson = convertTransactionSdkJsonToRestJson({
+				action: 1234
+			});
+
+			// Assert:
+			expect(restJson).to.deep.equal({
+				supplyType: 1234
+			});
+		});
 	});
 
 	// endregion

--- a/client/rest/test/plugins/rosetta/nem/OperationParser_spec.js
+++ b/client/rest/test/plugins/rosetta/nem/OperationParser_spec.js
@@ -155,7 +155,7 @@ describe('NEM OperationParser', () => {
 						{
 							mosaic: {
 								mosaicId: { namespaceId: { name: textEncoder.encode('levy') }, name: textEncoder.encode(levyName) },
-								amount: 12345_000000
+								amount: 12345
 							}
 						}
 					]
@@ -168,8 +168,8 @@ describe('NEM OperationParser', () => {
 
 				// Assert:
 				expect(operations).to.deep.equal([
-					createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-24690000000', `levy.${levyName}`, 3),
-					createTransferOperation(1, 'TALIC33LQMPC3DH73T5Y52SSVE2LRHSGRBGO4KIV', '24690000000', `levy.${levyName}`, 3),
+					createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-24690', `levy.${levyName}`, 3),
+					createTransferOperation(1, 'TALIC33LQMPC3DH73T5Y52SSVE2LRHSGRBGO4KIV', '24690', `levy.${levyName}`, 3),
 					createTransferOperation(2, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', `-${levyAmount}`, 'levy.tax', 2),
 					createTransferOperation(3, 'TDONALICE7O3L63AS3KNDCPT7ZA7HMQTFZGYUCAH', levyAmount, 'levy.tax', 2)
 				]);
@@ -178,7 +178,7 @@ describe('NEM OperationParser', () => {
 
 			it('can parse with single mosaic in bag with absolute levy', () => assertCanParseWithLevy('absolute', '10'));
 
-			it('can parse with single mosaic in bag with relative levy', () => assertCanParseWithLevy('relative', '24690000'));
+			it('can parse with single mosaic in bag with relative levy', () => assertCanParseWithLevy('relative', '24'));
 
 			const createMultipleMosaicDefinition = xemAmount => {
 				const textEncoder = new TextEncoder();


### PR DESCRIPTION
    [rest/client]: truncate percentile levy amounts
    
     problem: when calculating percentile levy amount, it must be full number
    solution: truncate it

    [rest/client]: map SDK JSON 'action' to REST JSON 'supplyType'
    
     problem: REST JSON and SDK JSON use different property names
    solution: add mapping to 'convertTransactionSdkJsonToRestJson'

    [client/rest]: add missing await to lookupCurrency call
    
     problem: call to lookupCurrency is missing await
    solution: add await
