### PR TITLE
[client/rest]: update NEM rosetta to handle mosaic (re)definitions

### DIFF
--- a/client/rest/src/plugins/rosetta/nem/NemProxy.js
+++ b/client/rest/src/plugins/rosetta/nem/NemProxy.js
@@ -106,7 +106,7 @@ export default class NemProxy {
 		if (this.mosaicPropertiesMap.has(fullyQualifiedName))
 			return this.mosaicPropertiesMap.get(fullyQualifiedName);
 
-		const mosaicDefinition = await this.fetch(`mosaic/definition/last?mosaicId=${mosaicId.namespaceId}:${mosaicId.name}`);
+		const mosaicDefinition = await this.fetch(`mosaic/definition/last?mosaicId=${fullyQualifiedName}`);
 
 		const findProperty = (properties, name) => properties.find(property => name === property.name);
 		const divisibilityProperty = findProperty(mosaicDefinition.properties, 'divisibility');

--- a/client/rest/src/plugins/rosetta/nem/OperationParser.js
+++ b/client/rest/src/plugins/rosetta/nem/OperationParser.js
@@ -335,7 +335,7 @@ export class OperationParser {
 				pushTransferOperations(amount, currency);
 			} else {
 				await Promise.all(transaction.mosaics.map(async mosaic => {
-					const amount = Math.trunc((transaction.amount / 1000000) * mosaic.quantity);
+					const amount = Math.trunc((transaction.amount * mosaic.quantity) / 1000000);
 					const { currency, levy } = await lookupCurrency(mosaic.mosaicId);
 
 					pushTransferOperations(amount, currency);

--- a/client/rest/src/plugins/rosetta/nem/blockRoutes.js
+++ b/client/rest/src/plugins/rosetta/nem/blockRoutes.js
@@ -49,8 +49,13 @@ export default {
 		server.post('/block', rosettaPostRouteWithNetwork(blockchainDescriptor, BlockRequest, async typedRequest => {
 			const height = typedRequest.block_identifier.index;
 			const blockInfo = await services.proxy.localBlockAtHeight(height);
-			const rosettaTransactions = await Promise.all(blockInfo.txes.map(transaction =>
-				parser.parseTransactionAsRosettaTransaction(transaction.tx, { hash: { data: transaction.hash } })));
+			const rosettaTransactions = await Promise.all(blockInfo.txes.map(transaction => parser.parseTransactionAsRosettaTransaction(
+				transaction.tx,
+				{
+					hash: { data: transaction.hash },
+					height
+				}
+			)));
 			const blockTransaction = await createBlockTransaction(blockInfo);
 
 			const calculateBlockTimestamp = timestamp => Number(network.toDatetime(new NetworkTimestamp(timestamp)).getTime());

--- a/client/rest/src/plugins/rosetta/nem/rosettaUtils.js
+++ b/client/rest/src/plugins/rosetta/nem/rosettaUtils.js
@@ -36,7 +36,7 @@ export const getBlockchainDescriptor = config => ({ // eslint-disable-line impor
  * @param {object} mosaicId NEM mosaic id object.
  * @returns {string} Fully qualified mosaic name.
  */
-export const mosaicIdToString = mosaicId => `${mosaicId.namespaceId}.${mosaicId.name}`;
+export const mosaicIdToString = mosaicId => `${mosaicId.namespaceId}:${mosaicId.name}`;
 
 /**
  * Calculates NEM XEM transfer fee.
@@ -57,7 +57,7 @@ export const calculateXemTransferFee = amount => {
  */
 export const createLookupCurrencyFunction = proxy => async (mosaicId, transactionLocation) => {
 	if ('currencyMosaicId' === mosaicId || ('nem' === mosaicId.namespaceId && 'xem' === mosaicId.name))
-		return { currency: new Currency('nem.xem', 6) };
+		return { currency: new Currency('nem:xem', 6) };
 
 	const mosaicProperties = await proxy.mosaicProperties(mosaicId, transactionLocation);
 	const currency = new Currency(mosaicIdToString(mosaicId), mosaicProperties.divisibility);

--- a/client/rest/test/plugins/rosetta/nem/OperationParser_spec.js
+++ b/client/rest/test/plugins/rosetta/nem/OperationParser_spec.js
@@ -202,6 +202,12 @@ describe('NEM OperationParser', () => {
 				expectedAmount: '1707618'
 			}));
 
+			it('can parse with single mosaic in fractional bag [2]', () => assertCanParseSingleMosaicInBagXem({
+				amount: 32_495622,
+				mosaicAmount: 1_000000,
+				expectedAmount: '32495622'
+			}));
+
 			const assertCanParseWithLevy = async (levyName, levyAmount) => {
 				// Arrange:
 				const textEncoder = new TextEncoder();

--- a/client/rest/test/plugins/rosetta/nem/OperationParser_spec.js
+++ b/client/rest/test/plugins/rosetta/nem/OperationParser_spec.js
@@ -52,13 +52,13 @@ describe('NEM OperationParser', () => {
 
 	const lookupCurrencyDefault = (mosaicId, transactionLocation) => {
 		if ('currencyMosaicId' === mosaicId)
-			return { currency: new Currency('currency.fee', 2) };
+			return { currency: new Currency('currency:fee', 2) };
 
 		if ('levy' === mosaicId.namespaceId) {
 			return {
 				currency: new Currency(mosaicIdToString(mosaicId), 3),
 				levy: {
-					currency: new Currency('levy.tax', 2),
+					currency: new Currency('levy:tax', 2),
 					isAbsolute: 'absolute' === mosaicId.name,
 					fee: 10,
 					recipientAddress: 'TDONALICE7O3L63AS3KNDCPT7ZA7HMQTFZGYUCAH'
@@ -128,8 +128,8 @@ describe('NEM OperationParser', () => {
 
 				// Assert:
 				expect(operations).to.deep.equal([
-					createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-12345000000', 'currency.fee', 2),
-					createTransferOperation(1, 'TALIC33LQMPC3DH73T5Y52SSVE2LRHSGRBGO4KIV', '12345000000', 'currency.fee', 2)
+					createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-12345000000', 'currency:fee', 2),
+					createTransferOperation(1, 'TALIC33LQMPC3DH73T5Y52SSVE2LRHSGRBGO4KIV', '12345000000', 'currency:fee', 2)
 				]);
 				expect(signerAddresses.map(address => address.toString())).to.deep.equal(['TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW']);
 			};
@@ -187,7 +187,7 @@ describe('NEM OperationParser', () => {
 				...options,
 				namespaceId: 'nem',
 				mosaicName: 'xem',
-				expectedMosaicProperties: ['nem.xem', 6]
+				expectedMosaicProperties: ['nem:xem', 6]
 			});
 
 			it('can parse with single mosaic in bag', () => assertCanParseSingleMosaicInBagXem({
@@ -228,10 +228,10 @@ describe('NEM OperationParser', () => {
 
 				// Assert:
 				expect(operations).to.deep.equal([
-					createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-24690', `levy.${levyName}`, 3),
-					createTransferOperation(1, 'TALIC33LQMPC3DH73T5Y52SSVE2LRHSGRBGO4KIV', '24690', `levy.${levyName}`, 3),
-					createTransferOperation(2, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', `-${levyAmount}`, 'levy.tax', 2),
-					createTransferOperation(3, 'TDONALICE7O3L63AS3KNDCPT7ZA7HMQTFZGYUCAH', levyAmount, 'levy.tax', 2)
+					createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-24690', `levy:${levyName}`, 3),
+					createTransferOperation(1, 'TALIC33LQMPC3DH73T5Y52SSVE2LRHSGRBGO4KIV', '24690', `levy:${levyName}`, 3),
+					createTransferOperation(2, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', `-${levyAmount}`, 'levy:tax', 2),
+					createTransferOperation(3, 'TDONALICE7O3L63AS3KNDCPT7ZA7HMQTFZGYUCAH', levyAmount, 'levy:tax', 2)
 				]);
 				expect(signerAddresses.map(address => address.toString())).to.deep.equal(['TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW']);
 			};
@@ -282,12 +282,12 @@ describe('NEM OperationParser', () => {
 
 				// Assert:
 				expect(operations).to.deep.equal([
-					createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-22222000000', 'baz.baz', 3),
-					createTransferOperation(1, 'TALIC33LQMPC3DH73T5Y52SSVE2LRHSGRBGO4KIV', '22222000000', 'baz.baz', 3),
-					createTransferOperation(2, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-24690000000', 'nem.xem', 6),
-					createTransferOperation(3, 'TALIC33LQMPC3DH73T5Y52SSVE2LRHSGRBGO4KIV', '24690000000', 'nem.xem', 6),
-					createTransferOperation(4, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-448866000000', 'foo.bar', 3),
-					createTransferOperation(5, 'TALIC33LQMPC3DH73T5Y52SSVE2LRHSGRBGO4KIV', '448866000000', 'foo.bar', 3)
+					createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-22222000000', 'baz:baz', 3),
+					createTransferOperation(1, 'TALIC33LQMPC3DH73T5Y52SSVE2LRHSGRBGO4KIV', '22222000000', 'baz:baz', 3),
+					createTransferOperation(2, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-24690000000', 'nem:xem', 6),
+					createTransferOperation(3, 'TALIC33LQMPC3DH73T5Y52SSVE2LRHSGRBGO4KIV', '24690000000', 'nem:xem', 6),
+					createTransferOperation(4, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-448866000000', 'foo:bar', 3),
+					createTransferOperation(5, 'TALIC33LQMPC3DH73T5Y52SSVE2LRHSGRBGO4KIV', '448866000000', 'foo:bar', 3)
 				]);
 				expect(signerAddresses.map(address => address.toString())).to.deep.equal(['TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW']);
 			});
@@ -300,7 +300,7 @@ describe('NEM OperationParser', () => {
 				metadata: { height: 22 },
 				namespaceId: 'check',
 				mosaicName: 'location',
-				expectedMosaicProperties: ['check.location', 22]
+				expectedMosaicProperties: ['check:location', 22]
 			}));
 
 			it('filters out zero transfers', async () => {
@@ -321,10 +321,10 @@ describe('NEM OperationParser', () => {
 
 				// Assert:
 				expect(operations).to.deep.equal([
-					createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-22222000000', 'baz.baz', 3),
-					createTransferOperation(1, 'TALIC33LQMPC3DH73T5Y52SSVE2LRHSGRBGO4KIV', '22222000000', 'baz.baz', 3),
-					createTransferOperation(2, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-448866000000', 'foo.bar', 3),
-					createTransferOperation(3, 'TALIC33LQMPC3DH73T5Y52SSVE2LRHSGRBGO4KIV', '448866000000', 'foo.bar', 3)
+					createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-22222000000', 'baz:baz', 3),
+					createTransferOperation(1, 'TALIC33LQMPC3DH73T5Y52SSVE2LRHSGRBGO4KIV', '22222000000', 'baz:baz', 3),
+					createTransferOperation(2, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-448866000000', 'foo:bar', 3),
+					createTransferOperation(3, 'TALIC33LQMPC3DH73T5Y52SSVE2LRHSGRBGO4KIV', '448866000000', 'foo:bar', 3)
 				]);
 				expect(signerAddresses.map(address => address.toString())).to.deep.equal(['TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW']);
 			});
@@ -479,7 +479,7 @@ describe('NEM OperationParser', () => {
 				expectedAmount,
 				namespaceId: 'foo',
 				mosaicName: 'bar',
-				expectedMosaicProperties: ['foo.bar', 3]
+				expectedMosaicProperties: ['foo:bar', 3]
 			});
 
 			it('can parse increase', () => assertCanParseSupplyChangeFooBar(models.MosaicSupplyChangeAction.INCREASE, '24680000'));
@@ -493,7 +493,7 @@ describe('NEM OperationParser', () => {
 				metadata: { height: 2 },
 				namespaceId: 'check',
 				mosaicName: 'location',
-				expectedMosaicProperties: ['check.location', 2]
+				expectedMosaicProperties: ['check:location', 2]
 			}));
 		});
 
@@ -520,8 +520,8 @@ describe('NEM OperationParser', () => {
 
 				// Assert:
 				expect(operations).to.deep.equal([
-					createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-50000', 'currency.fee', 2),
-					createTransferOperation(1, 'TAMESPACEWH4MKFMBCVFERDPOOP4FK7MTDJEYP35', '50000', 'currency.fee', 2)
+					createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-50000', 'currency:fee', 2),
+					createTransferOperation(1, 'TAMESPACEWH4MKFMBCVFERDPOOP4FK7MTDJEYP35', '50000', 'currency:fee', 2)
 				]);
 				expect(signerAddresses.map(address => address.toString())).to.deep.equal(['TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW']);
 			});
@@ -556,8 +556,8 @@ describe('NEM OperationParser', () => {
 
 				// Assert:
 				expect(operations).to.deep.equal([
-					createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-50000', 'currency.fee', 2),
-					createTransferOperation(1, 'TBMOSAICOD4F54EE5CDMR23CCBGOAM2XSJBR5OLC', '50000', 'currency.fee', 2),
+					createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-50000', 'currency:fee', 2),
+					createTransferOperation(1, 'TBMOSAICOD4F54EE5CDMR23CCBGOAM2XSJBR5OLC', '50000', 'currency:fee', 2),
 					...options.additionalOperations
 				]);
 				expect(signerAddresses.map(address => address.toString())).to.deep.equal(['TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW']);
@@ -566,7 +566,7 @@ describe('NEM OperationParser', () => {
 			it('can parse without initial supply', () => assertParse({
 				properties: [],
 				additionalOperations: [
-					createTransferOperation(2, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '1000', 'foo.bar', 0)
+					createTransferOperation(2, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '1000', 'foo:bar', 0)
 				]
 			}));
 
@@ -578,7 +578,7 @@ describe('NEM OperationParser', () => {
 						{ property: { name: textEncoder.encode('supplyMutable'), value: textEncoder.encode('false') } }
 					],
 					additionalOperations: [
-						createTransferOperation(2, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '123000', 'foo.bar', 0)
+						createTransferOperation(2, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '123000', 'foo:bar', 0)
 					]
 				});
 			});
@@ -592,7 +592,7 @@ describe('NEM OperationParser', () => {
 						{ property: { name: textEncoder.encode('supplyMutable'), value: textEncoder.encode('false') } }
 					],
 					additionalOperations: [
-						createTransferOperation(2, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '1230000000', 'foo.bar', 4)
+						createTransferOperation(2, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '1230000000', 'foo:bar', 4)
 					]
 				});
 			});
@@ -627,13 +627,13 @@ describe('NEM OperationParser', () => {
 			it('can parse', () => assertCanParse({}, []));
 
 			it('can parse with fee', () => assertCanParse({ includeFeeOperation: true }, [
-				createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-123456', 'currency.fee', 2)
+				createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-123456', 'currency:fee', 2)
 			]));
 
 			it('can parse with fee and operation status', () => assertCanParse(
 				{ includeFeeOperation: true, operationStatus: 'success' },
 				[
-					setOperationStatus(createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-123456', 'currency.fee', 2))
+					setOperationStatus(createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-123456', 'currency:fee', 2))
 				]
 			));
 		});
@@ -676,8 +676,8 @@ describe('NEM OperationParser', () => {
 
 				// Assert:
 				expect(operations).to.deep.equal([
-					createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-12345000000', 'currency.fee', 2),
-					createTransferOperation(1, 'TALIC33LQMPC3DH73T5Y52SSVE2LRHSGRBGO4KIV', '12345000000', 'currency.fee', 2),
+					createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-12345000000', 'currency:fee', 2),
+					createTransferOperation(1, 'TALIC33LQMPC3DH73T5Y52SSVE2LRHSGRBGO4KIV', '12345000000', 'currency:fee', 2),
 					createCosignOperation(2, 'TBALNEMNEMKIMWLF65HTUWMQVX5G55EBBIWS4WQC'),
 					...options.additionalOperations
 				]);
@@ -715,7 +715,7 @@ describe('NEM OperationParser', () => {
 				additionalOperations: [
 					createCosignOperation(3, 'TBGJAGUAQY47BULYL4GRYBJLOI6XKXPJUXU25JRJ'),
 					createCosignOperation(4, 'TDONALICE7O3L63AS3KNDCPT7ZA7HMQTFZGYUCAH'),
-					createTransferOperation(5, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-8765', 'currency.fee', 2)
+					createTransferOperation(5, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-8765', 'currency:fee', 2)
 				],
 				expectedSignerAddresses: [
 					'TBALNEMNEMKIMWLF65HTUWMQVX5G55EBBIWS4WQC',
@@ -759,7 +759,7 @@ describe('NEM OperationParser', () => {
 				const { operations } = await parseTransaction(parser, transaction, metadata);
 
 				// Assert: precision is derived from location
-				const mosaicProperties = ['check.location', expectedPrecision];
+				const mosaicProperties = ['check:location', expectedPrecision];
 				expect(operations).to.deep.equal([
 					createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-24690000000', ...mosaicProperties),
 					createTransferOperation(1, 'TALIC33LQMPC3DH73T5Y52SSVE2LRHSGRBGO4KIV', '24690000000', ...mosaicProperties)
@@ -798,7 +798,7 @@ describe('NEM OperationParser', () => {
 				const { operations } = await parseTransaction(parser, transaction, metadata);
 
 				// Assert: precision is derived from location
-				const mosaicProperties = ['check.location', expectedPrecision];
+				const mosaicProperties = ['check:location', expectedPrecision];
 				expect(operations).to.deep.equal([
 					createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-24690000000', ...mosaicProperties),
 					createTransferOperation(1, 'TALIC33LQMPC3DH73T5Y52SSVE2LRHSGRBGO4KIV', '24690000000', ...mosaicProperties),
@@ -848,8 +848,8 @@ describe('NEM OperationParser', () => {
 			expect(rosettaTransaction).to.deep.equal(new Transaction(
 				new TransactionIdentifier('7B7A5E55E3F788C036B759B6AD46FF91A67DC956BB4B360587F366397F251C62'),
 				[
-					createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-12345000000', 'currency.fee', 2),
-					createTransferOperation(1, 'TALIC33LQMPC3DH73T5Y52SSVE2LRHSGRBGO4KIV', '12345000000', 'currency.fee', 2)
+					createTransferOperation(0, 'TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW', '-12345000000', 'currency:fee', 2),
+					createTransferOperation(1, 'TALIC33LQMPC3DH73T5Y52SSVE2LRHSGRBGO4KIV', '12345000000', 'currency:fee', 2)
 				]
 			));
 		});
@@ -878,7 +878,7 @@ describe('NEM OperationParser', () => {
 				beneficiary: 'TBGJAGUAQY47BULYL4GRYBJLOI6XKXPJUXU25JRJ',
 				totalFee: 12345
 			}, [
-				createTransferOperation(0, 'TBGJAGUAQY47BULYL4GRYBJLOI6XKXPJUXU25JRJ', '12345', 'currency.fee', 2)
+				createTransferOperation(0, 'TBGJAGUAQY47BULYL4GRYBJLOI6XKXPJUXU25JRJ', '12345', 'currency:fee', 2)
 			]);
 		});
 

--- a/client/rest/test/plugins/rosetta/nem/accountRoutes_spec.js
+++ b/client/rest/test/plugins/rosetta/nem/accountRoutes_spec.js
@@ -132,9 +132,9 @@ describe('NEM rosetta account routes', () => {
 			const expectedResponse = new options.Response(
 				new BlockIdentifier(12345, 'A4950F27A23B235D5CCD1DC7FF4B0BDC48977E353EA1CF1E3E5F70B9A6B79076'),
 				[
-					options.createRosettaAmount('123', 'foo.bar', 3),
-					options.createRosettaAmount('262', 'cat.dog', 4),
-					options.createRosettaAmount('112', 'nem.xem', 6)
+					options.createRosettaAmount('123', 'foo:bar', 3),
+					options.createRosettaAmount('262', 'cat:dog', 4),
+					options.createRosettaAmount('112', 'nem:xem', 6)
 				]
 			);
 
@@ -149,16 +149,16 @@ describe('NEM rosetta account routes', () => {
 			// - add currency filter
 			const request = options.createValidRequest();
 			request.currencies = [
-				{ symbol: 'foo.baz', decimals: 3 }, // name mismatch
-				{ symbol: 'cat.dog', decimals: 4 },
-				{ symbol: 'nem.xem', decimals: 1 } // decimals mismatch
+				{ symbol: 'foo:baz', decimals: 3 }, // name mismatch
+				{ symbol: 'cat:dog', decimals: 4 },
+				{ symbol: 'nem:xem', decimals: 1 } // decimals mismatch
 			];
 
 			// - create expected response
 			const expectedResponse = new options.Response(
 				new BlockIdentifier(12345, 'A4950F27A23B235D5CCD1DC7FF4B0BDC48977E353EA1CF1E3E5F70B9A6B79076'),
 				[
-					options.createRosettaAmount('262', 'cat.dog', 4)
+					options.createRosettaAmount('262', 'cat:dog', 4)
 				]
 			);
 
@@ -286,9 +286,9 @@ describe('NEM rosetta account routes', () => {
 				{ namespaceId: 'cat', name: 'dog', amount: 200 }
 			];
 			const expectedResponse = [
-				createRosettaCoin('123', 'foo.bar', 3),
-				createRosettaCoin('462', 'cat.dog', 4),
-				createRosettaCoin('112', 'nem.xem', 6)
+				createRosettaCoin('123', 'foo:bar', 3),
+				createRosettaCoin('462', 'cat:dog', 4),
+				createRosettaCoin('112', 'nem:xem', 6)
 			];
 			const transactionJson = createTransactionJson(mosaicsToReceive, OTHER_ACCOUNT_PUBLIC_KEY, ACCOUNT_ADDRESS);
 			const unconfirmedTransactionsJson = createUnconfirmedTransactionsResponse([transactionJson]);
@@ -304,9 +304,9 @@ describe('NEM rosetta account routes', () => {
 				{ namespaceId: 'nem', name: 'xem', amount: 150 }
 			];
 			const expectedResponse = [
-				createRosettaCoin('123', 'foo.bar', 3),
-				createRosettaCoin('312', 'cat.dog', 4),
-				createRosettaCoin('262', 'nem.xem', 6)
+				createRosettaCoin('123', 'foo:bar', 3),
+				createRosettaCoin('312', 'cat:dog', 4),
+				createRosettaCoin('262', 'nem:xem', 6)
 			];
 			const transactionJson = createTransactionJson(mosaicsToReceive, OTHER_ACCOUNT_PUBLIC_KEY, ACCOUNT_ADDRESS);
 			const unconfirmedTransactionsJson = createUnconfirmedTransactionsResponse([transactionJson]);
@@ -322,10 +322,10 @@ describe('NEM rosetta account routes', () => {
 				{ namespaceId: 'new', name: 'coin', amount: 50 }
 			];
 			const expectedResponse = [
-				createRosettaCoin('123', 'foo.bar', 3),
-				createRosettaCoin('272', 'cat.dog', 4),
-				createRosettaCoin('112', 'nem.xem', 6),
-				createRosettaCoin('50', 'new.coin', 5)
+				createRosettaCoin('123', 'foo:bar', 3),
+				createRosettaCoin('272', 'cat:dog', 4),
+				createRosettaCoin('112', 'nem:xem', 6),
+				createRosettaCoin('50', 'new:coin', 5)
 			];
 			const transactionJson = createTransactionJson(mosaicsToReceive, OTHER_ACCOUNT_PUBLIC_KEY, ACCOUNT_ADDRESS);
 			const unconfirmedTransactionsJson = createUnconfirmedTransactionsResponse([transactionJson]);
@@ -340,9 +340,9 @@ describe('NEM rosetta account routes', () => {
 				{ namespaceId: 'cat', name: 'dog', amount: 1 }
 			];
 			const expectedResponse = [
-				createRosettaCoin('123', 'foo.bar', 3),
-				createRosettaCoin('261', 'cat.dog', 4),
-				createRosettaCoin('62', 'nem.xem', 6)
+				createRosettaCoin('123', 'foo:bar', 3),
+				createRosettaCoin('261', 'cat:dog', 4),
+				createRosettaCoin('62', 'nem:xem', 6)
 			];
 			const transactionJson = createTransactionJson(mosaicsToSend, ACCOUNT_PUBLIC_KEY, OTHER_ACCOUNT_ADDRESS);
 			const unconfirmedTransactionsJson = createUnconfirmedTransactionsResponse([transactionJson]);
@@ -358,9 +358,9 @@ describe('NEM rosetta account routes', () => {
 				{ namespaceId: 'nem', name: 'xem', amount: 2 }
 			];
 			const expectedResponse = [
-				createRosettaCoin('123', 'foo.bar', 3),
-				createRosettaCoin('62', 'cat.dog', 4),
-				createRosettaCoin('60', 'nem.xem', 6)
+				createRosettaCoin('123', 'foo:bar', 3),
+				createRosettaCoin('62', 'cat:dog', 4),
+				createRosettaCoin('60', 'nem:xem', 6)
 			];
 			const transactionJson = createTransactionJson(mosaicsToSend, ACCOUNT_PUBLIC_KEY, OTHER_ACCOUNT_ADDRESS);
 			const unconfirmedTransactionsJson = createUnconfirmedTransactionsResponse([transactionJson]);
@@ -381,9 +381,9 @@ describe('NEM rosetta account routes', () => {
 				{ namespaceId: 'foo', name: 'bar', amount: 23 }
 			];
 			const expectedResponse = [
-				createRosettaCoin('146', 'foo.bar', 3),
-				createRosettaCoin('262', 'cat.dog', 4),
-				createRosettaCoin('80', 'nem.xem', 6)
+				createRosettaCoin('146', 'foo:bar', 3),
+				createRosettaCoin('262', 'cat:dog', 4),
+				createRosettaCoin('80', 'nem:xem', 6)
 			];
 			const outgoingTransactionJson = createTransactionJson(mosaicsToSend, ACCOUNT_PUBLIC_KEY, OTHER_ACCOUNT_ADDRESS);
 			const incomingTransactionJson = createTransactionJson(mosaicsToReceive, OTHER_ACCOUNT_PUBLIC_KEY, ACCOUNT_ADDRESS);
@@ -400,9 +400,9 @@ describe('NEM rosetta account routes', () => {
 				{ namespaceId: 'nem', name: 'xem', amount: 3 }
 			];
 			const expectedResponse = [
-				createRosettaCoin('123', 'foo.bar', 3),
-				createRosettaCoin('262', 'cat.dog', 4),
-				createRosettaCoin('112', 'nem.xem', 6)
+				createRosettaCoin('123', 'foo:bar', 3),
+				createRosettaCoin('262', 'cat:dog', 4),
+				createRosettaCoin('112', 'nem:xem', 6)
 			];
 			const transactionJson = createTransactionJson(mosaicsToSend, ACCOUNT_PUBLIC_KEY, OTHER_ACCOUNT_ADDRESS);
 			const unconfirmedTransactionsJson = createUnconfirmedTransactionsResponse([transactionJson]);
@@ -418,9 +418,9 @@ describe('NEM rosetta account routes', () => {
 				{ namespaceId: 'nem', name: 'xem', amount: 2 }
 			];
 			const expectedResponse = [
-				createRosettaCoin('123', 'foo.bar', 3),
-				createRosettaCoin('62', 'cat.dog', 4),
-				createRosettaCoin('35', 'nem.xem', 6)
+				createRosettaCoin('123', 'foo:bar', 3),
+				createRosettaCoin('62', 'cat:dog', 4),
+				createRosettaCoin('35', 'nem:xem', 6)
 			];
 			const multisigTransactionJson = createAggregateTransactionJson(mosaicsToSend, ACCOUNT_PUBLIC_KEY, OTHER_ACCOUNT_ADDRESS);
 			const unconfirmedTransactionsJson = createUnconfirmedTransactionsResponse([multisigTransactionJson]);

--- a/client/rest/test/plugins/rosetta/nem/blockRoutes_spec.js
+++ b/client/rest/test/plugins/rosetta/nem/blockRoutes_spec.js
@@ -101,8 +101,8 @@ describe('NEM block routes', () => {
 	};
 
 	const createMatchingRosettaTransaction = () => {
-		const transferCurrencyProperties = ['magic.hat', 3];
-		const feeCurrencyProperties = ['nem.xem', 6];
+		const transferCurrencyProperties = ['magic:hat', 3];
+		const feeCurrencyProperties = ['nem:xem', 6];
 		return new Transaction(new TransactionIdentifier(TRANSACTION_HASH.toUpperCase()), [
 			createTransferOperation(0, SIGNER_ADDRESS, '-40000000', ...feeCurrencyProperties),
 			createTransferOperation(1, RECIPIENT_ADDRESS, '40000000', ...feeCurrencyProperties),
@@ -113,7 +113,7 @@ describe('NEM block routes', () => {
 	};
 
 	const createMatchingRosettaBlockTransaction = blockHash => {
-		const feeCurrencyProperties = ['nem.xem', 6];
+		const feeCurrencyProperties = ['nem:xem', 6];
 		return new Transaction(new TransactionIdentifier(blockHash), [
 			createTransferOperation(0, BENEFICIARY_ADDRESS, '112233', ...feeCurrencyProperties)
 		]);

--- a/client/rest/test/plugins/rosetta/nem/blockRoutes_spec.js
+++ b/client/rest/test/plugins/rosetta/nem/blockRoutes_spec.js
@@ -179,7 +179,7 @@ describe('NEM block routes', () => {
 		it('succeeds when all fetches succeed (nemesis)', async () => {
 			// Arrange:
 			FetchStubHelper.stubLocalBlockAt(createBlocksResponse(1, NEMESIS_BLOCK_HASH, 0), true);
-			FetchStubHelper.stubMosaicResolution('magic', 'hat', 3);
+			FetchStubHelper.stubMosaicResolution('magic', 'hat', 3, 1);
 
 			// - create expected response
 			const expectedResponse = createMatchingRosettaBlock(
@@ -194,19 +194,18 @@ describe('NEM block routes', () => {
 
 		it('succeeds when all fetches succeed (other block)', async () => {
 			// Arrange:
-			FetchStubHelper.stubLocalBlockAt(createBlocksResponse(1, NEMESIS_BLOCK_HASH, 0), true);
-			FetchStubHelper.stubLocalBlockAt(createBlocksResponse(2, OTHER_BLOCK_HASH, 20), true);
-			FetchStubHelper.stubMosaicResolution('magic', 'hat', 3);
+			FetchStubHelper.stubLocalBlockAt(createBlocksResponse(TEST_BLOCK_HEIGHT, OTHER_BLOCK_HASH, 20), true);
+			FetchStubHelper.stubMosaicResolution('magic', 'hat', 3, TEST_BLOCK_HEIGHT);
 
 			// - create expected response
 			const expectedResponse = createMatchingRosettaBlock(
-				new BlockIdentifier(2, OTHER_BLOCK_HASH.toUpperCase()),
-				new BlockIdentifier(1, NEMESIS_BLOCK_HASH.toUpperCase()),
+				new BlockIdentifier(TEST_BLOCK_HEIGHT, OTHER_BLOCK_HASH.toUpperCase()),
+				new BlockIdentifier(TEST_BLOCK_HEIGHT - 1, NEMESIS_BLOCK_HASH.toUpperCase()),
 				20
 			);
 
 			// Act + Assert:
-			await assertRosettaSuccessBasic('/block', createValidRequest(2, OTHER_BLOCK_HASH), expectedResponse);
+			await assertRosettaSuccessBasic('/block', createValidRequest(TEST_BLOCK_HEIGHT, OTHER_BLOCK_HASH), expectedResponse);
 		});
 	});
 
@@ -257,7 +256,7 @@ describe('NEM block routes', () => {
 		it('succeeds when all fetches succeed', async () => {
 			// Arrange:
 			stubFetchResult(`transaction/get?hash=${TRANSACTION_HASH}`, true, createTransactionJson());
-			FetchStubHelper.stubMosaicResolution('magic', 'hat', 3);
+			FetchStubHelper.stubMosaicResolution('magic', 'hat', 3, TEST_BLOCK_HEIGHT);
 
 			// - create expected response
 			const transaction = createMatchingRosettaTransaction();

--- a/client/rest/test/plugins/rosetta/nem/constructionRoutes_spec.js
+++ b/client/rest/test/plugins/rosetta/nem/constructionRoutes_spec.js
@@ -53,7 +53,7 @@ describe('NEM rosetta construction routes', () => {
 	const { createRosettaNetworkIdentifier, createRosettaPublicKey } = RosettaObjectFactory;
 
 	const createRosettaCurrency = () => ({
-		symbol: 'nem.xem',
+		symbol: 'nem:xem',
 		decimals: 6
 	});
 

--- a/client/rest/test/plugins/rosetta/nem/mempoolRoutes_spec.js
+++ b/client/rest/test/plugins/rosetta/nem/mempoolRoutes_spec.js
@@ -188,8 +188,8 @@ describe('NEM rosetta mempool routes', () => {
 			FetchStubHelper.stubMosaicResolution('foo', 'bar', 3);
 
 			// - create expected response
-			const transferCurrencyProperties = ['foo.bar', 3];
-			const feeCurrencyProperties = ['nem.xem', 6];
+			const transferCurrencyProperties = ['foo:bar', 3];
+			const feeCurrencyProperties = ['nem:xem', 6];
 			const transaction = new Transaction(
 				new TransactionIdentifier(TRANSACTION_HASH),
 				[

--- a/client/rest/test/plugins/rosetta/nem/rosettaUtils_spec.js
+++ b/client/rest/test/plugins/rosetta/nem/rosettaUtils_spec.js
@@ -54,7 +54,7 @@ describe('NEM rosetta utils', () => {
 			const str = mosaicIdToString({ namespaceId: 'foo', name: 'bar' });
 
 			// Assert:
-			expect(str).to.equal('foo.bar');
+			expect(str).to.equal('foo:bar');
 		});
 	});
 
@@ -105,7 +105,7 @@ describe('NEM rosetta utils', () => {
 			const { currency, levy } = await lookupCurrency('currencyMosaicId');
 
 			// Assert:
-			const expectedCurrency = new Currency('nem.xem', 6);
+			const expectedCurrency = new Currency('nem:xem', 6);
 			expect(currency).to.deep.equal(expectedCurrency);
 			expect(levy).to.equal(undefined);
 		});
@@ -116,7 +116,7 @@ describe('NEM rosetta utils', () => {
 			const { currency, levy } = await lookupCurrency({ namespaceId: 'nem', name: 'xem' });
 
 			// Assert: bypasses mosaicProperties
-			const expectedCurrency = new Currency('nem.xem', 6);
+			const expectedCurrency = new Currency('nem:xem', 6);
 			expect(currency).to.deep.equal(expectedCurrency);
 			expect(levy).to.equal(undefined);
 		});
@@ -127,7 +127,7 @@ describe('NEM rosetta utils', () => {
 			const { currency, levy } = await lookupCurrency({ namespaceId: 'nem', name: 'other' }, { height: 2 });
 
 			// Assert: does not bypass mosaicProperties
-			const expectedCurrency = new Currency('nem.other', 2);
+			const expectedCurrency = new Currency('nem:other', 2);
 			expect(currency).to.deep.equal(expectedCurrency);
 			expect(levy).to.equal(undefined);
 		});
@@ -138,7 +138,7 @@ describe('NEM rosetta utils', () => {
 			const { currency, levy } = await lookupCurrency({ namespaceId: 'foo.bar', name: 'coins' }, { height: 3 });
 
 			// Assert:
-			const expectedCurrency = new Currency('foo.bar.coins', 3);
+			const expectedCurrency = new Currency('foo.bar:coins', 3);
 			expect(currency).to.deep.equal(expectedCurrency);
 			expect(levy).to.equal(undefined);
 		});
@@ -149,10 +149,10 @@ describe('NEM rosetta utils', () => {
 			const { currency, levy } = await lookupCurrency({ namespaceId: 'foo.bar', name: 'coupons' }, { height: 2 });
 
 			// Assert:
-			const expectedCurrency = new Currency('foo.bar.coupons', 4);
+			const expectedCurrency = new Currency('foo.bar:coupons', 4);
 			expect(currency).to.deep.equal(expectedCurrency);
 			expect(levy).to.deep.equal({
-				currency: new Currency('some.other.tax', 2),
+				currency: new Currency('some.other:tax', 2),
 				recipientAddress: 'TD3RXTHBLK6J3UD2BH2PXSOFLPWZOTR34WCG4HXH',
 				isAbsolute: true,
 				fee: 200

--- a/client/rest/test/plugins/rosetta/nem/utils/rosettaTestUtils.js
+++ b/client/rest/test/plugins/rosetta/nem/utils/rosettaTestUtils.js
@@ -31,13 +31,21 @@ import {
 export const FetchStubHelper = {
 	...BasicFetchStubHelper,
 
-	stubMosaicResolution: (namespaceId, name, divisibility) => {
-		FetchStubHelper.stubPost(`mosaic/definition/last?mosaicId=${namespaceId}:${name}`, true, {
-			id: { namespaceId, name },
-			properties: [
-				{ name: 'divisibility', value: divisibility.toString() }
-			],
-			levy: {}
+	stubMosaicResolution: (namespaceId, name, divisibility, height = undefined) => {
+		const heightQuery = undefined !== height ? `&height=${height}` : '';
+		FetchStubHelper.stubPost(`local/mosaic/definition/supply?mosaicId=${namespaceId}:${name}${heightQuery}`, true, {
+			data: [
+				{
+					mosaicDefinition: {
+						id: { namespaceId, name },
+						properties: [
+							{ name: 'divisibility', value: divisibility.toString() }
+						],
+						levy: {}
+					},
+					supply: 88664422
+				}
+			]
 		});
 	},
 

--- a/client/rest/test/plugins/rosetta/symbol/OperationParser_spec.js
+++ b/client/rest/test/plugins/rosetta/symbol/OperationParser_spec.js
@@ -52,7 +52,7 @@ describe('Symbol OperationParser', () => {
 
 	const encodeParitalDecodedAddress = address => new Address(utils.hexToUint8(address.padEnd(48, '0'))).toString();
 
-	const lookupCurrencyDefault = (mosaicId, transactionLocation) => {
+	const lookupCurrencySync = (mosaicId, transactionLocation) => {
 		if ('currencyMosaicId' === mosaicId)
 			return new Currency('currency.fee', 2);
 
@@ -88,7 +88,7 @@ describe('Symbol OperationParser', () => {
 	};
 
 	const createDefaultParser = (network, additionalOptions = {}) => new OperationParser(network, {
-		lookupCurrency: lookupCurrencyDefault,
+		lookupCurrency: (...args) => Promise.resolve(lookupCurrencySync(...args)),
 		resolveAddress: resolveAddressDefault,
 		...additionalOptions
 	});


### PR DESCRIPTION
    [client/rest]: update NEM rosetta to handle mosaic (re)definitions
    
     problem: NEM mosaic (re)definition behavior is dependent on current state
    solution: integrate 'mosaic/definition/supply' into mosaic definition creation
              transaction processing

    [client/rest]: in NEM rosetta use ':' as token separator to match NEM
    
     problem: NEM uses ':' as mosaic name separator but rosetta implementation is using '.'
    solution: use ':' as separator for consistency
