### PR TITLE
[client/rest]: NEM rosetta should only credit LAST unique mosaic definition in block

### DIFF
--- a/client/rest/src/plugins/rosetta/nem/rosettaUtils.js
+++ b/client/rest/src/plugins/rosetta/nem/rosettaUtils.js
@@ -90,6 +90,14 @@ export const createLookupCurrencyFunction = proxy => async (mosaicId, transactio
 };
 
 /**
+ * Checks if two mosaic ids (REST JSON model) are equal.
+ * @param {object} lhs First mosaic id.
+ * @param {object} rhs Second mosaic id.
+ * @returns {boolean} \c true if mosaic ids are equal.
+ */
+export const areMosaicIdsEqual = (lhs, rhs) => lhs.namespaceId === rhs.namespaceId && lhs.name === rhs.name;
+
+/**
  * Checks if two mosaic definitions (REST JSON model) are equal at specified height.
  * @param {object} lhs First mosaic definition.
  * @param {object} rhs Second mosaic definition.
@@ -121,6 +129,5 @@ export const areMosaicDefinitionsEqual = (lhs, rhs, isDescriptionSignificant) =>
 		&& lhsLevy.fee === rhsLevy.fee
 		&& lhsLevy.recipient === rhsLevy.recipient
 		&& lhsLevy.type === rhsLevy.type
-		&& lhsLevyMosaicId.namespaceId === rhsLevyMosaicId.namespaceId
-		&& lhsLevyMosaicId.name === rhsLevyMosaicId.name;
+		&& areMosaicIdsEqual(lhsLevyMosaicId, rhsLevyMosaicId);
 };

--- a/client/rest/test/plugins/rosetta/nem/rosettaUtils_spec.js
+++ b/client/rest/test/plugins/rosetta/nem/rosettaUtils_spec.js
@@ -21,6 +21,7 @@
 
 import {
 	areMosaicDefinitionsEqual,
+	areMosaicIdsEqual,
 	calculateXemTransferFee,
 	createLookupCurrencyFunction,
 	getBlockchainDescriptor,
@@ -182,6 +183,37 @@ describe('NEM rosetta utils', () => {
 
 	// endregion
 
+	// region areMosaicIdsEqual
+
+	describe('areMosaicIdsEqual', () => {
+		const createMosaicIdJson = () => ({ namespaceId: 'foo', name: 'bar' });
+
+		const runAreEqualTest = (expectedAreEqual, transform) => {
+			// Arrange:
+			const mosaicId1 = createMosaicIdJson();
+			const mosaicId2 = createMosaicIdJson();
+			transform(mosaicId2);
+
+			// Act:
+			const areEqual = areMosaicIdsEqual(mosaicId1, mosaicId2);
+
+			// Assert:
+			expect(areEqual).to.equal(expectedAreEqual);
+		};
+
+		it('is true when everything matches', () => runAreEqualTest(true, () => {}));
+
+		it('is false when namespaceId does not match', () => runAreEqualTest(false, mosaicId => {
+			mosaicId.namespaceId = 'baz';
+		}));
+
+		it('is false when name does not match', () => runAreEqualTest(false, mosaicId => {
+			mosaicId.name = 'baz';
+		}));
+	});
+
+	// endregion
+
 	// region areMosaicDefinitionsEqual
 
 	describe('areMosaicDefinitionsEqual', () => {
@@ -258,12 +290,8 @@ describe('NEM rosetta utils', () => {
 			mosaicDefinition.levy.type += 1;
 		}));
 
-		it('is false when levy does not match (mosaicId.namespaceId)', () => runAreEqualTest(false, false, mosaicDefinition => {
+		it('is false when levy does not match (mosaicId)', () => runAreEqualTest(false, false, mosaicDefinition => {
 			mosaicDefinition.levy.mosaicId.namespaceId = 'bar';
-		}));
-
-		it('is false when levy does not match (mosaicId.name)', () => runAreEqualTest(false, false, mosaicDefinition => {
-			mosaicDefinition.levy.mosaicId.name = 'tokens';
 		}));
 
 		it('is false when one levy is empty', () => runAreEqualTest(false, false, mosaicDefinition => {


### PR DESCRIPTION
 problem: NEM allows multiple definitions of same mosaic in block, but only last one is relevant
solution: add postprocessing in parseBlock to debit earlier duplicate mosaic definitions
