### PR TITLE
[client/rest]: use 64-bit arithmetic when calculating transfer amounts

### DIFF
--- a/client/rest/src/plugins/rosetta/nem/OperationParser.js
+++ b/client/rest/src/plugins/rosetta/nem/OperationParser.js
@@ -365,8 +365,10 @@ export class OperationParser {
 
 				pushTransferOperations(amount, currency);
 			} else {
+				const toAtomicUnits = (amount, quantity, divisor) => Number(BigInt(amount) * BigInt(quantity) / BigInt(divisor));
+
 				await Promise.all(transaction.mosaics.map(async mosaic => {
-					const amount = Math.trunc((transaction.amount * mosaic.quantity) / 1000000);
+					const amount = toAtomicUnits(transaction.amount, mosaic.quantity, 1000000);
 					const { currency, levy } = await lookupCurrency(mosaic.mosaicId);
 
 					pushTransferOperations(amount, currency);
@@ -374,7 +376,7 @@ export class OperationParser {
 					if (levy) {
 						const levyAmount = levy.isAbsolute
 							? levy.fee
-							: Math.trunc(amount * levy.fee / 10000);
+							: toAtomicUnits(amount, levy.fee, 10000);
 						pushDebitCreditOperations(transaction.signer, levy.recipientAddress, levyAmount, levy.currency);
 					}
 				}));

--- a/client/rest/test/plugins/rosetta/nem/OperationParser_spec.js
+++ b/client/rest/test/plugins/rosetta/nem/OperationParser_spec.js
@@ -248,6 +248,13 @@ describe('NEM OperationParser', () => {
 				expectedAmount: '24690000000'
 			}));
 
+			it('can parse with single mosaic in bag [large amount]', () => assertCanParseSingleMosaicInBagXem({
+				// notice that amount * mosaicAmount > Number.MAX_SAFE_INTEGER
+				amount: 14570747_490000,
+				mosaicAmount: 1_000000,
+				expectedAmount: '14570747490000'
+			}));
+
 			it('can parse with single mosaic in fractional bag', () => assertCanParseSingleMosaicInBagXem({
 				amount: 50000,
 				mosaicAmount: 34_152375,


### PR DESCRIPTION
 problem: some intermediate values can exceed Number.MAX_SAFE_INTEGER, leading to loss of precision
solution: use BitInt math and convert result to Number