### PR TITLE
[jenkins] fix: remove invalid chars

### DIFF
--- a/jenkins/docker/windows/javascript.Dockerfile
+++ b/jenkins/docker/windows/javascript.Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-ht
+
 ARG FROM_IMAGE=symbolplatform/symbol-server-compiler:windows-msvc-17
 
 FROM ${FROM_IMAGE}


### PR DESCRIPTION
problem: Javascript docker build fails on Windows
solution: remove invalid chars