### PR TITLE
[jenkins] fix: fail to decode line on Windows

### DIFF
--- a/jenkins/catapult/process.py
+++ b/jenkins/catapult/process.py
@@ -18,7 +18,11 @@ class ProcessManager:
 		with Popen(command_line, stdout=PIPE, stderr=STDOUT) as process:
 			process_lines = []
 			for line_bin in iter(process.stdout.readline, b''):
-				line = line_bin.decode('utf-8')
+				try:
+					line = line_bin.decode('utf-8')
+				except UnicodeDecodeError:
+					print(f'failed to decode: {line_bin}')
+					continue
 
 				if show_output:
 					sys.stdout.write(line)

--- a/jenkins/catapult/process.py
+++ b/jenkins/catapult/process.py
@@ -21,6 +21,9 @@ class ProcessManager:
 				try:
 					line = line_bin.decode('utf-8')
 				except UnicodeDecodeError:
+					if handle_error:
+						raise
+
 					print(f'failed to decode: {line_bin}')
 					continue
 

--- a/jenkins/catapult/runDockerBuildInnerBuild.py
+++ b/jenkins/catapult/runDockerBuildInnerBuild.py
@@ -52,12 +52,15 @@ class BuildEnvironment:
 		for key, value in settings.items():
 			setting_overrides += ['-s', f'compiler.{key}={value}']
 		self.dispatch_subprocess(['conan', 'profile', 'show', '--profile', 'default'])
-		self.dispatch_subprocess([
+		conan_install_rc = self.dispatch_subprocess([
 			'conan', 'install', source_path,
 			'--build', 'missing',
 			'--output-folder', build_path,
-			'-s', f'build_type={build_type}',
-		] + setting_overrides)
+			'-s', f'build_type={build_type}'
+		] + setting_overrides,
+			handle_error=not self.environment_manager.is_windows_platform())
+		if 0 != conan_install_rc:
+			raise RuntimeError(f'conan install failed: {conan_install_rc}')
 
 
 class BuildManager(BasicBuildManager):


### PR DESCRIPTION
problem: building catapult deps fails on Windows due to an invalid UTF-8 character
solution: add exception handling
