### PR TITLE
[jenkins] fix: mongo-cxx-driver libraries name change in r3.10

### DIFF
--- a/jenkins/catapult/baseImageDockerfileGenerator.py
+++ b/jenkins/catapult/baseImageDockerfileGenerator.py
@@ -167,6 +167,9 @@ class OptionsManager:
 			# https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
 			descriptor.cxxflags += ['/Zc:__cplusplus']
 
+			# https://www.mongodb.com/docs/languages/cpp/cpp-driver/upcoming/api-abi-versioning/#shared-libraries--msvc-only-
+			descriptor.options += ['-DENABLE_ABI_TAG_IN_LIBRARY_FILENAMES=OFF']
+
 		return self._cmake(descriptor)
 
 	def libzmq(self):

--- a/jenkins/catapult/installDepsLocal.py
+++ b/jenkins/catapult/installDepsLocal.py
@@ -96,6 +96,10 @@ class Builder:
 			# https://devblogs.microsoft.com/cppblog/msvc-now-correctly-reports-__cplusplus/
 			cmake_options += ['-DCMAKE_CXX_FLAGS="/Zc:__cplusplus"', f'-DCMAKE_PREFIX_PATH={self.target_directory / organization}']
 
+			version = self.versions[f'{organization}_{project}']
+			if 'r3.10.0' <= version:
+				cmake_options += ['-DENABLE_ABI_TAG_IN_LIBRARY_FILENAMES=OFF']
+
 		if 'mongodb' == organization:
 			cmake_options += [f'-DOPENSSL_ROOT_DIR={self.target_directory / "openssl"}']
 


### PR DESCRIPTION
problem: starting with mongocxx r3.10.0, MSVC toolchain on Windows generates different library names
solution: disable this feature by setting ENABLE_ABI_TAG_IN_LIBRARY_FILENAMES=OFF
