### PR TITLE
[jenkins] fix: conan fails to set home path on Windows

### DIFF
--- a/jenkins/catapult/runDockerBuildInnerBuild.py
+++ b/jenkins/catapult/runDockerBuildInnerBuild.py
@@ -29,7 +29,10 @@ class BuildEnvironment:
 	def _prepare_environment_variables(self):
 		if self.use_conan:
 			# conan cache directory
-			self.environment_manager.set_env_var('CONAN_HOME', '/conan')
+			self.environment_manager.set_env_var(
+				'CONAN_HOME',
+				'c:\\conan' if self.environment_manager.is_windows_platform() else '/conan'
+			)
 		else:
 			if self.environment_manager.is_windows_platform():
 				self.environment_manager.set_env_var('BOOST_ROOT', 'c:/usr/catapult/deps/boost')


### PR DESCRIPTION
problem: latest version of Conan fails to set home path on Windows
solution: Conan now requires absolute path in the format of ``c:\conan``