### PR TITLE
[sdk/javascript] fix: wasm-opt failing with rustc 1.82.0

### DIFF
--- a/sdk/javascript/scripts/ci/build.sh
+++ b/sdk/javascript/scripts/ci/build.sh
@@ -7,7 +7,10 @@ bash scripts/run_catbuffer_generator_ts.sh dryrun
 
 # build wasm variants
 cd wasm
-rustup default stable
+# rustup default stable
+# stay with rustc 1.81.0 until wasm opt is fixed
+# https://github.com/rustwasm/wasm-pack/issues/1441
+rustup install 1.81.0
 wasm-pack build --release --no-typescript --target nodejs --out-dir ../_build/wasm/node
 wasm-pack build --release --no-typescript --target web --out-dir ../_build/wasm/web
 cd ..


### PR DESCRIPTION
problem: rustc 1.82.0 seems to break wasm-opt
solution: downgrade to rustc 1.81.0 for now.