### PR TITLE
[jenkins] fix: pip upgrade fails with Python 3.13.0

### DIFF
--- a/jenkins/docker/windows/javascript.Dockerfile
+++ b/jenkins/docker/windows/javascript.Dockerfile
@@ -12,8 +12,7 @@ RUN Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser; `
 	$command='c:\scoop.ps1 -RunAsAdmin'; `
 	iex $command; `
 	del c:\scoop.ps1; `
-	scoop install git shellcheck nodejs-lts cygwin rustup python; `
-	python3 -m pip install --upgrade pip
+	scoop install git shellcheck nodejs-lts cygwin rustup python
 
 # Set VS tools first in the path so the correct link.exe is used.
 RUN Set-Content -Path c:\Users\ContainerAdministrator\.bash_profile  -Value 'export PATH=${VCToolsInstallDir}bin/Hostx64/x64:${PATH}'

--- a/jenkins/docker/windows/python.Dockerfile
+++ b/jenkins/docker/windows/python.Dockerfile
@@ -16,8 +16,7 @@ RUN Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser; `
 	$command='c:\scoop.ps1 -RunAsAdmin'; `
 	iex $command; `
 	del c:\scoop.ps1; `
-	scoop install git shellcheck openssl cmake cygwin python; `
-	python3 -m pip install --upgrade pip
+	scoop install git shellcheck openssl cmake cygwin python
 
 # Set VS tools first in the path so the correct link.exe is used.
 RUN Set-Content -Path c:\Users\ContainerAdministrator\.bash_profile  -Value 'export PATH=${VCToolsInstallDir}bin/Hostx64/x64:${PATH}'


### PR DESCRIPTION
problem: Windows docker image for Python and JavaScript is failing with Python 3.13.0
solution: Use the default pip installs with Python 3.13.0