### PR TITLE
[jenkins] fix: ignore invalid chars during build

### DIFF
--- a/jenkins/catapult/process.py
+++ b/jenkins/catapult/process.py
@@ -18,14 +18,7 @@ class ProcessManager:
 		with Popen(command_line, stdout=PIPE, stderr=STDOUT) as process:
 			process_lines = []
 			for line_bin in iter(process.stdout.readline, b''):
-				try:
-					line = line_bin.decode('utf-8')
-				except UnicodeDecodeError:
-					if handle_error:
-						raise
-
-					print(f'failed to decode: {line_bin}')
-					continue
+				line = line_bin.decode('utf-8', 'strict' if handle_error else 'ignore')
 
 				if show_output:
 					sys.stdout.write(line)

--- a/jenkins/catapult/runDockerBuild.py
+++ b/jenkins/catapult/runDockerBuild.py
@@ -217,7 +217,7 @@ def main():
 
 	process_manager = ProcessManager(args.dry_run)
 
-	return_code = process_manager.dispatch_subprocess(docker_run)
+	return_code = process_manager.dispatch_subprocess(docker_run, handle_error=not environment_manager.is_windows_platform())
 	if return_code:
 		sys.exit(return_code)
 


### PR DESCRIPTION
problem: multiple level of dispatch_subprocess causing build to fail with invalid char.
                 set the decode() to ignore invalid chars and remove try..catch.
solution: ignore the invalid chars on decode error