### PR TITLE
[jenkins] fix: add Python 3.13 to build

### DIFF
--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -1,7 +1,7 @@
 [versions]
 
 ubuntu = 24.04
-fedora = 40
+fedora = 41
 debian = 12
 windows = 2022
 

--- a/jenkins/shared-library/resources/buildEnvironment/baseImages.yaml
+++ b/jenkins/shared-library/resources/buildEnvironment/baseImages.yaml
@@ -1,5 +1,5 @@
 fedora-lts:
-  image: fedora:40
+  image: fedora:41
 ubuntu-lts:
   image: ubuntu:22.04
   python: 3.11
@@ -9,8 +9,8 @@ ubuntu-base:
   python: 3.9
   nodejs: 18
 ubuntu-latest:
-  image: ubuntu:24.04
-  python: 3.12
+  image: ubuntu:24.10
+  python: 3.13
   nodejs: 21
 windows-lts:
   image: symbolplatform/symbol-server-compiler:windows-msvc-17


### PR DESCRIPTION
problem: automation is not using the latest Python release
solution: update the automation to use Python 3.13 for Ubuntu latest release