### PR TITLE
[sdk]: add a cosign transaction hash

### DIFF
--- a/sdk/javascript/src/facade/SymbolFacade.js
+++ b/sdk/javascript/src/facade/SymbolFacade.js
@@ -134,6 +134,17 @@ export class SymbolAccount extends SymbolPublicAccount {
 	cosignTransaction(transaction, detached = false) {
 		return this._facade.cosignTransaction(this.keyPair, transaction, detached);
 	}
+
+	/**
+	 * Cosigns a Symbol transaction hash.
+	 * @param {Hash256} transactionHash Transaction hash.
+	 * @param {boolean} detached \c true if resulting cosignature is appropriate for network propagation.
+	 *                           \c false if resulting cosignature is appropriate for attaching to an aggregate.
+	 * @returns {sc.Cosignature|sc.DetachedCosignature} Signed cosignature.
+	 */
+	cosignTransactionHash(transactionHash, detached = false) {
+		return this._facade.static.cosignTransactionHash(this.keyPair, transactionHash, detached);
+	}
 }
 
 // endregion
@@ -320,16 +331,14 @@ export class SymbolFacade {
 	}
 
 	/**
-	 * Cosigns a Symbol transaction.
+	 * Cosigns a Symbol transaction hash.
 	 * @param {KeyPair} keyPair Key pair of the cosignatory.
-	 * @param {sc.Transaction} transaction Transaction object.
+	 * @param {Hash256} transactionHash Transaction hash.
 	 * @param {boolean} detached \c true if resulting cosignature is appropriate for network propagation.
 	 *                           \c false if resulting cosignature is appropriate for attaching to an aggregate.
 	 * @returns {sc.Cosignature|sc.DetachedCosignature} Signed cosignature.
 	 */
-	cosignTransaction(keyPair, transaction, detached = false) {
-		const transactionHash = this.hashTransaction(transaction);
-
+	static cosignTransactionHash(keyPair, transactionHash, detached = false) {
 		const initializeCosignature = cosignature => {
 			cosignature.version = 0n;
 			cosignature.signerPublicKey = new sc.PublicKey(keyPair.publicKey.bytes);
@@ -346,6 +355,20 @@ export class SymbolFacade {
 		const cosignature = new sc.Cosignature();
 		initializeCosignature(cosignature);
 		return cosignature;
+	}
+
+	/**
+	 * Cosigns a Symbol transaction.
+	 * @param {KeyPair} keyPair Key pair of the cosignatory.
+	 * @param {sc.Transaction} transaction Transaction object.
+	 * @param {boolean} detached \c true if resulting cosignature is appropriate for network propagation.
+	 *                           \c false if resulting cosignature is appropriate for attaching to an aggregate.
+	 * @returns {sc.Cosignature|sc.DetachedCosignature} Signed cosignature.
+	 */
+	cosignTransaction(keyPair, transaction, detached = false) {
+		const transactionHash = this.hashTransaction(transaction);
+
+		return SymbolFacade.cosignTransactionHash(keyPair, transactionHash, detached);
 	}
 
 	/**

--- a/sdk/javascript/test/facade/SymbolFacade_spec.js
+++ b/sdk/javascript/test/facade/SymbolFacade_spec.js
@@ -334,6 +334,15 @@ describe('Symbol Facade', () => {
 			cosignTransaction: (facade, privateKey, transaction, detached) =>
 				facade.createAccount(privateKey).cosignTransaction(transaction, detached)
 		});
+
+		addCosignTransactionTests({
+			testNamePrefix: 'can cosign transaction hash ',
+			signTransaction: (facade, privateKey, transaction) => facade.createAccount(privateKey).signTransaction(transaction),
+			cosignTransaction: (facade, privateKey, transaction, detached) => {
+				const transactionHash = facade.hashTransaction(transaction);
+				return facade.createAccount(privateKey).cosignTransactionHash(transactionHash, detached);
+			}
+		});
 	});
 
 	// endregion
@@ -553,12 +562,21 @@ describe('Symbol Facade', () => {
 
 	// region cosignTransaction
 
-	describe('can cosign transactions', () => {
+	describe('can cosign transaction', () => {
 		addCosignTransactionTests({
 			testNamePrefix: '',
 			signTransaction: (facade, privateKey, transaction) => facade.signTransaction(new SymbolFacade.KeyPair(privateKey), transaction),
 			cosignTransaction: (facade, privateKey, transaction, detached) =>
 				facade.cosignTransaction(new SymbolFacade.KeyPair(privateKey), transaction, detached)
+		});
+
+		addCosignTransactionTests({
+			testNamePrefix: 'hash ',
+			signTransaction: (facade, privateKey, transaction) => facade.signTransaction(new SymbolFacade.KeyPair(privateKey), transaction),
+			cosignTransaction: (facade, privateKey, transaction, detached) => {
+				const transactionHash = facade.hashTransaction(transaction);
+				return facade.static.cosignTransactionHash(new SymbolFacade.KeyPair(privateKey), transactionHash, detached);
+			}
 		});
 	});
 

--- a/sdk/python/symbolchain/facade/SymbolFacade.py
+++ b/sdk/python/symbolchain/facade/SymbolFacade.py
@@ -59,6 +59,10 @@ class SymbolAccount(SymbolPublicAccount):
 		"""Cosigns a Symbol transaction."""
 		return self._facade.cosign_transaction(self.key_pair, transaction, detached)
 
+	def cosign_transaction_hash(self, transaction_hash, detached=False):
+		"""Cosigns a Symbol transaction hash."""
+		return self._facade.cosign_transaction_hash(self.key_pair, transaction_hash, detached)
+
 # endregion
 
 
@@ -130,10 +134,9 @@ class SymbolFacade:
 		"""Verifies a Symbol transaction."""
 		return Verifier(transaction.signer_public_key).verify(self.extract_signing_payload(transaction), signature)
 
-	def cosign_transaction(self, key_pair, transaction, detached=False):
-		"""Cosigns a Symbol transaction."""
-		transaction_hash = self.hash_transaction(transaction)
-
+	@staticmethod
+	def cosign_transaction_hash(key_pair, transaction_hash, detached=False):
+		"""Cosigns a Symbol transaction hash."""
 		cosignature = sc.DetachedCosignature() if detached else sc.Cosignature()
 		if detached:
 			cosignature.parent_hash = sc.Hash256(transaction_hash.bytes)
@@ -142,6 +145,11 @@ class SymbolFacade:
 		cosignature.signer_public_key = sc.PublicKey(key_pair.public_key.bytes)
 		cosignature.signature = sc.Signature(key_pair.sign(transaction_hash.bytes).bytes)
 		return cosignature
+
+	def cosign_transaction(self, key_pair, transaction, detached=False):
+		"""Cosigns a Symbol transaction."""
+		transaction_hash = self.hash_transaction(transaction)
+		return self.cosign_transaction_hash(key_pair, transaction_hash, detached)
 
 	@staticmethod
 	def hash_embedded_transactions(embedded_transactions):

--- a/sdk/python/tests/facade/test_SymbolFacade.py
+++ b/sdk/python/tests/facade/test_SymbolFacade.py
@@ -345,6 +345,23 @@ class SymbolFacadeTest(unittest.TestCase):
 	def test_can_cosign_transaction_detached_with_account_wrappers(self):
 		self._run_test_can_cosign_transaction_detached(self._get_cosign_transaction_test_descriptor_for_account_wrappers())
 
+	@staticmethod
+	def _get_cosign_transaction_hash_test_descriptor_for_account_wrappers():
+		def _cosign_transaction_hash_for_account_wrappers(facade, private_key, transaction, detached):
+			transaction_hash = facade.hash_transaction(transaction)
+			return facade.create_account(private_key).cosign_transaction_hash(transaction_hash, detached)
+
+		return CosignTransactionTestDescriptor(
+			lambda facade, private_key, transaction: facade.create_account(private_key).sign_transaction(transaction),
+			_cosign_transaction_hash_for_account_wrappers
+		)
+
+	def test_can_cosign_transaction_hash_with_account_wrappers(self):
+		self._run_test_can_cosign_transaction(self._get_cosign_transaction_hash_test_descriptor_for_account_wrappers())
+
+	def test_can_cosign_transaction_hash_detached_with_account_wrappers(self):
+		self._run_test_can_cosign_transaction_detached(self._get_cosign_transaction_hash_test_descriptor_for_account_wrappers())
+
 	# endregion
 
 	# region hash_transaction / sign_transaction
@@ -456,6 +473,23 @@ class SymbolFacadeTest(unittest.TestCase):
 
 	def test_can_cosign_transaction_detached(self):
 		self._run_test_can_cosign_transaction_detached(self._get_cosign_transaction_test_descriptor_for_facade())
+
+	@staticmethod
+	def _get_cosign_transaction_hash_test_descriptor_for_facade():
+		def _cosign_transaction_hash_for_facade(facade, private_key, transaction, detached):
+			transaction_hash = facade.hash_transaction(transaction)
+			return facade.cosign_transaction_hash(facade.KeyPair(private_key), transaction_hash, detached)
+
+		return CosignTransactionTestDescriptor(
+			lambda facade, private_key, transaction: facade.sign_transaction(facade.KeyPair(private_key), transaction),
+			_cosign_transaction_hash_for_facade
+		)
+
+	def test_can_cosign_transaction_hash(self):
+		self._run_test_can_cosign_transaction(self._get_cosign_transaction_hash_test_descriptor_for_facade())
+
+	def test_can_cosign_transaction_hash_detached(self):
+		self._run_test_can_cosign_transaction_detached(self._get_cosign_transaction_hash_test_descriptor_for_facade())
 
 	# endregion
 


### PR DESCRIPTION
[sdk/python] fix: add a cosign_transaction_hash
problem: no capability to sign the transaction hash
solution: add a cosign_transaction_hash()

[sdk/javascript] fix: add a cosignTransactionHash
problem: no capability to sign the transaction hash
solution: add a cosignTransactionHash()