### PR TITLE
[sdk/javascript] fix: update the rust edition to 2021

### DIFF
--- a/sdk/javascript/wasm/Cargo.toml
+++ b/sdk/javascript/wasm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "symbol-crypto-wasm"
 version = "0.1.0"
 authors = ["Symbol Contributors <contributors@symbol.dev>"]
-edition = "2018"
+edition = "2021"
 
 [lib]
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
problem: wasm-bindgen no longer works with feature resolver version 1
solution: update the edition to 2021 which uses resolver version 2

bug: ``https://github.com/rustwasm/wasm-bindgen/issues/4304``
resolution: https://doc.rust-lang.org/edition-guide/rust-2021/default-cargo-resolver.html