### PR TITLE
[sdk/python] fix: update Python minimum version requirements to 3.9.2

### DIFF
--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -17,4 +17,4 @@ keywords = ['symbol', 'sdk', 'Symbol SDK']
 classifiers = ['Programming Language :: Python :: 3.9', 'Programming Language :: Python :: 3.10', 'Programming Language :: Python :: 3.11']
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.9.2"


### PR DESCRIPTION
problem: cryptography 44.0.0 does not support python 3.9.0 and 3.9.1
         Poetry fails to published the package.
solution: update Python minimum version requirements to 3.9.2

```
13:45:00  + poetry add cryptography~=44.0.0
13:45:10  Creating virtualenv symbol-sdk-python-Q2sVR_aH-py3.10 in /home/ubuntu/.cache/pypoetry/virtualenvs
13:45:13  
13:45:13  Updating dependencies
13:45:13  Resolving dependencies...
13:45:13  
13:45:13  The current project's Python requirement (>=3.9,<4.0) is not compatible with some of the required packages Python requirement:
13:45:13    - cryptography requires Python !=3.9.0,!=3.9.1,>=3.7, so it will not be satisfied for Python 3.9 || 3.9.1
13:45:13  
13:45:13  Because no versions of cryptography match >44.0.0,<44.1.0
13:45:13   and cryptography (44.0.0) requires Python !=3.9.0,!=3.9.1,>=3.7, cryptography is forbidden.
13:45:13  So, because symbol-sdk-python depends on cryptography (>=44.0.0,<44.1.0), version solving failed.
13:45:13  
13:45:13    • Check your dependencies Python requirement: The Python requirement can be specified via the `python` or `markers` properties
13:45:13      
13:45:13      For cryptography, a possible solution would be to set the `python` property to ">3.9.0,<3.9.1 || >3.9.1,<4.0"
```