### PR TITLE
[jenkins] fix: latest Transifex CLI requires a token

### DIFF
--- a/jenkins/shared-library/vars/publish.groovy
+++ b/jenkins/shared-library/vars/publish.groovy
@@ -144,7 +144,7 @@ void gitHubPagesPublisher(Map config, String phase) {
 	}
 
 	githubHelper.executeGitAuthenticatedCommand {
-		withCredentials([string(credentialsId: TRANSIFEX_TOKEN_ID, variable: 'TRANSIFEX_TOKEN')]) {
+		withCredentials([string(credentialsId: 'TRANSIFEX_TOKEN_ID', variable: 'TRANSIFEX_TOKEN')]) {
 			runScript(env.GITHUB_PAGES_PUBLISH_SCRIPT_FILEPATH)
 		}
 	}

--- a/jenkins/shared-library/vars/publish.groovy
+++ b/jenkins/shared-library/vars/publish.groovy
@@ -144,9 +144,7 @@ void gitHubPagesPublisher(Map config, String phase) {
 	}
 
 	githubHelper.executeGitAuthenticatedCommand {
-		withCredentials([usernamePassword(credentialsId: 'TRANSIFEX_LOGIN_ID',
-			usernameVariable: 'TRANSIFEX_USER',
-			passwordVariable: 'TRANSIFEX_PASSWORD')]) {
+		withCredentials([string(credentialsId: TRANSIFEX_TOKEN_ID, variable: 'TRANSIFEX_TOKEN')]) {
 			runScript(env.GITHUB_PAGES_PUBLISH_SCRIPT_FILEPATH)
 		}
 	}


### PR DESCRIPTION
problem: The latest Transifex CLI uses a token instead of a username/password
solution: update the publish to get an API token