### PR TITLE
[jenkins] fix: boost download URI update

### DIFF
--- a/jenkins/catapult/baseImageDockerfileGenerator.py
+++ b/jenkins/catapult/baseImageDockerfileGenerator.py
@@ -451,7 +451,7 @@ class LinuxSystemGenerator:
 
 		print_args = {
 			'BOOST_ARCHIVE': f'boost_{boost_version.replace(".", "_")}',
-			'BOOST_URI': f'https://boostorg.jfrog.io/artifactory/main/release/{boost_version}/source',
+			'BOOST_URI': f'https://archives.boost.io/release/{boost_version}/source',
 			'BOOTSTRAP_OPTIONS': ' '.join(self.options.bootstrap()),
 			'B2_OPTIONS': ' '.join(self.options.b2()),
 			'BOOST_DISABLED_LIBS': ' '.join(BOOST_DISABLED_LIBS)
@@ -557,7 +557,7 @@ class WindowsSystemGenerator:
 		boost_version = self.options.versions['boost']
 		print_args = {
 			'BOOST_ARCHIVE': f'boost_{boost_version.replace(".", "_")}',
-			'BOOST_URI': f'https://boostorg.jfrog.io/artifactory/main/release/{boost_version}/source',
+			'BOOST_URI': f'https://archives.boost.io/release/{boost_version}/source',
 			'BOOTSTRAP_OPTIONS': ' '.join(self.options.bootstrap()),
 			'B2_OPTIONS': ' '.join(self.options.b2()),
 			'BOOST_DISABLED_LIBS': ' '.join(BOOST_DISABLED_LIBS),

--- a/jenkins/catapult/installDepsLocal.py
+++ b/jenkins/catapult/installDepsLocal.py
@@ -25,7 +25,7 @@ class Downloader:
 		version = self.versions['boost']
 		archive_name = f'boost_{version.replace(".", "_")}'
 		tar_filename = f'{archive_name}.tar.gz'
-		tar_source_path = f'https://boostorg.jfrog.io/artifactory/main/release/{version}/source/{tar_filename}'
+		tar_source_path = f'https://archives.boost.io/release/{version}/source/{tar_filename}'
 
 		self.process_manager.dispatch_subprocess(['curl', '-o', tar_filename, '-SL', tar_source_path])
 		self.process_manager.dispatch_subprocess(['tar', '-xzf', tar_filename])
@@ -35,7 +35,7 @@ class Downloader:
 		version = self.versions['boost']
 		archive_name = f'boost_{version.replace(".", "_")}'
 		zip_filename = f'{archive_name}.7z'
-		zip_source_path = f'https://boostorg.jfrog.io/artifactory/main/release/{version}/source/{zip_filename}'
+		zip_source_path = f'https://archives.boost.io/release/{version}/source/{zip_filename}'
 
 		self.process_manager.dispatch_subprocess(['powershell', '-Command', 'wget', zip_source_path, '-outfile', zip_filename])
 		self.process_manager.dispatch_subprocess(['powershell', '-Command', '7z', 'x', zip_filename])


### PR DESCRIPTION
problem: Boost update their download URI
solution: update the Boost URI for the image build

https://github.com/boostorg/boost/issues/843#issuecomment-2567034014