### PR TITLE
[jenkins] fix: Jenkins no jobs run

### DIFF
--- a/jenkins/shared-library/vars/monorepoControllerPipeline.groovy
+++ b/jenkins/shared-library/vars/monorepoControllerPipeline.groovy
@@ -117,7 +117,11 @@ void triggerJobs(String branchName) {
 	Map<String, String> siblingNameMap = jobHelper.siblingJobNames(jenkinsfilesJobToRun, currentJobName)
 
 	if (siblingNameMap.size() == 0) {
-		return
+		// In some cases Jenkins think there is no changes, so run all the jobs to be safe.
+		println "no build projects found for path:${currentJobName} ${jenkinsfilesJobToRun}"
+		println "Trigger files: ${triggeredJenkinsfile}"
+		println 'defaulting to all jobs'
+		siblingNameMap = allJenkinsfiles
 	}
 
 	Map<String, Closure> buildJobs = [:]

--- a/jenkins/shared-library/vars/monorepoControllerPipeline.groovy
+++ b/jenkins/shared-library/vars/monorepoControllerPipeline.groovy
@@ -121,7 +121,7 @@ void triggerJobs(String branchName) {
 		println "no build projects found for path:${currentJobName} ${jenkinsfilesJobToRun}"
 		println "Trigger files: ${triggeredJenkinsfile}"
 		println 'defaulting to all jobs'
-		siblingNameMap = allJenkinsfiles
+		siblingNameMap = jobHelper.siblingJobNames(allJenkinsfiles, currentJobName)
 	}
 
 	Map<String, Closure> buildJobs = [:]

--- a/jenkins/shared-library/vars/monorepoControllerPipeline.groovy
+++ b/jenkins/shared-library/vars/monorepoControllerPipeline.groovy
@@ -113,7 +113,7 @@ void triggerJobs(String branchName) {
 	final Map<String, String> dependencyJenkinsfile = findDependencyMultibranchPipelinesToRun(triggeredJenkinsfile, buildConfiguration)
 	final Map<String, String> requiredJenkinsfile = findRequiredMultibranchPipelinesToRun(buildConfiguration)
 	final String currentJobName = Paths.get(currentBuild.fullProjectName).parent
-	final Map<String, String> jenkinsfilesJobToRun = triggeredJenkinsfile + dependencyJenkinsfile + requiredJenkinsfile
+	Map<String, String> jenkinsfilesJobToRun = triggeredJenkinsfile + dependencyJenkinsfile + requiredJenkinsfile
 	Map<String, String> siblingNameMap = jobHelper.siblingJobNames(jenkinsfilesJobToRun, currentJobName)
 
 	if (siblingNameMap.size() == 0) {
@@ -121,7 +121,8 @@ void triggerJobs(String branchName) {
 		println "no build projects found for path:${currentJobName} ${jenkinsfilesJobToRun}"
 		println "Trigger files: ${triggeredJenkinsfile}"
 		println 'defaulting to all jobs'
-		siblingNameMap = jobHelper.siblingJobNames(allJenkinsfiles, currentJobName)
+		jenkinsfilesJobToRun = allJenkinsfiles
+		siblingNameMap = jobHelper.siblingJobNames(jenkinsfilesJobToRun, currentJobName)
 	}
 
 	Map<String, Closure> buildJobs = [:]

--- a/jenkins/shared-library/vars/monorepoControllerPipeline.groovy
+++ b/jenkins/shared-library/vars/monorepoControllerPipeline.groovy
@@ -116,7 +116,7 @@ void triggerJobs(String branchName) {
 	Map<String, String> jenkinsfilesJobToRun = triggeredJenkinsfile + dependencyJenkinsfile + requiredJenkinsfile
 	Map<String, String> siblingNameMap = jobHelper.siblingJobNames(jenkinsfilesJobToRun, currentJobName)
 
-	if (siblingNameMap.size() == 0) {
+	if (0 == triggeredJenkinsfile.size()) {
 		// In some cases Jenkins think there is no changes, so run all the jobs to be safe.
 		println "no build projects found for path:${currentJobName} ${jenkinsfilesJobToRun}"
 		println "Trigger files: ${triggeredJenkinsfile}"


### PR DESCRIPTION
problem: in some instances, Jenkin(controller) thinks no job needs to be run
         this seems to be the case, especially on rebase.
solution: run all jobs when none is found.