### PR TITLE
[jenkins] fix: upgrade tests to use MongoDB 8

### DIFF
--- a/jenkins/catapult/templates/RunTest.yaml
+++ b/jenkins/catapult/templates/RunTest.yaml
@@ -1,7 +1,7 @@
 version: '2.4'
 services:
   db:
-    image: mongo:7.0
+    image: mongo:8.0
     user: {{USER}}
     networks:
       test_net:

--- a/jenkins/catapult/templates/RunTestWindows.yaml
+++ b/jenkins/catapult/templates/RunTestWindows.yaml
@@ -1,7 +1,7 @@
 version: '2.1'
 services:
   db:
-    image: mongo:7.0
+    image: mongo:8.0
     command: mongod --bind_ip_all --dbpath=c:\mongo --logpath c:\mongo\mongod.log
     volumes:
       - ./mongo/{{BUILD_NUMBER}}:c:\mongo:rw

--- a/jenkins/docker/ubuntu/cpp.Dockerfile
+++ b/jenkins/docker/ubuntu/cpp.Dockerfile
@@ -6,11 +6,11 @@ RUN apt-get install -y shellcheck
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Etc/UTC
 
-# mongodb 7.0
+# mongodb 8.0
 RUN apt-get install -y wget gnupg \
-	&& wget -qO - https://www.mongodb.org/static/pgp/server-7.0.asc |  gpg --dearmor | tee /usr/share/keyrings/mongodb.gpg > /dev/null \
-	&& echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse"  \
-	| tee /etc/apt/sources.list.d/mongodb-org-7.0.list \
+	&& wget -qO - https://www.mongodb.org/static/pgp/server-8.0.asc |  gpg --dearmor | tee /usr/share/keyrings/mongodb.gpg > /dev/null \
+	&& echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/8.0 multiverse"  \
+	| tee /etc/apt/sources.list.d/mongodb-org-8.0.list \
 	&& apt-get update \
 	&& apt-get install -y mongodb-org
 

--- a/jenkins/docker/ubuntu/javascript.Dockerfile
+++ b/jenkins/docker/ubuntu/javascript.Dockerfile
@@ -7,11 +7,11 @@ RUN apt-get update >/dev/null \
 	&& apt-get install -y tzdata \
 	&& apt-get install -y git curl zip unzip
 
-# mongodb 6.0
+# mongodb 8.0
 RUN apt-get install -y wget gnupg \
-	&& wget -qO - https://www.mongodb.org/static/pgp/server-6.0.asc |  gpg --dearmor | tee /usr/share/keyrings/mongodb.gpg > /dev/null \
-	&& echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/6.0 multiverse"  \
-	| tee /etc/apt/sources.list.d/mongodb-org-6.0.list \
+	&& wget -qO - https://www.mongodb.org/static/pgp/server-8.0.asc |  gpg --dearmor | tee /usr/share/keyrings/mongodb.gpg > /dev/null \
+	&& echo "deb [ arch=amd64,arm64 signed-by=/usr/share/keyrings/mongodb.gpg ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/8.0 multiverse"  \
+	| tee /etc/apt/sources.list.d/mongodb-org-8.0.list \
 	&& apt-get update \
 	&& apt-get install -y mongodb-org
 


### PR DESCRIPTION
problem: not using the latest MongoDB in testing
solution: upgrade to MongoDB 8