### PR TITLE
[sdk/javascript] fix: upgrade rustc to supports edition2024 feature

### DIFF
--- a/sdk/javascript/scripts/ci/build.sh
+++ b/sdk/javascript/scripts/ci/build.sh
@@ -7,10 +7,7 @@ bash scripts/run_catbuffer_generator_ts.sh dryrun
 
 # build wasm variants
 cd wasm
-# rustup default stable
-# stay with rustc 1.81.0 until wasm opt is fixed
-# https://github.com/rustwasm/wasm-pack/issues/1441
-rustup install 1.81.0
+rustup default stable
 wasm-pack build --release --no-typescript --target nodejs --out-dir ../_build/wasm/node
 wasm-pack build --release --no-typescript --target web --out-dir ../_build/wasm/web
 cd ..

--- a/sdk/javascript/wasm/Cargo.toml
+++ b/sdk/javascript/wasm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "symbol-crypto-wasm"
 version = "0.1.0"
 authors = ["Symbol Contributors <contributors@symbol.dev>"]
-edition = "2021"
+edition = "2024"
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -30,7 +30,7 @@ zeroize = "1.5.7"
 [dev-dependencies]
 wasm-bindgen-test = "0.3.13"
 clap = { version = "4.3.19", features = ["derive"] }
-hex-literal = "0.4.1"
+hex-literal = "1.0.0"
 serde = { version = "1.0.144", features = ["derive"] }
 serde-hex = "0.1.0"
 serde_json = "1.0.85"


### PR DESCRIPTION
problem: the latest version of hex-literal requires edition2024 feature
solution: upgrade to rustc 1.85, which supports edition2024 feature