### PR TITLE
[jenkins] fix: openssl fails on Ubuntu 24.10

### DIFF
--- a/jenkins/docker/ubuntu/python.Dockerfile
+++ b/jenkins/docker/ubuntu/python.Dockerfile
@@ -10,6 +10,10 @@ RUN apt-get update >/dev/null \
 # install python
 ARG FROM_IMAGE
 ARG PYTHON_VERSION='3.11'
+# Adding the Deadsnakes PPA
+RUN apt-get install -y software-properties-common && \
+	add-apt-repository ppa:deadsnakes/ppa && \
+	apt-get update
 RUN apt-get install -y python${PYTHON_VERSION} python3-pip python${PYTHON_VERSION}-venv python${PYTHON_VERSION}-dev  \
 		&& update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 10
 

--- a/jenkins/shared-library/resources/buildEnvironment/baseImages.yaml
+++ b/jenkins/shared-library/resources/buildEnvironment/baseImages.yaml
@@ -9,7 +9,7 @@ ubuntu-base:
   python: 3.9
   nodejs: 18
 ubuntu-latest:
-  image: ubuntu:24.10
+  image: ubuntu:24.04
   python: 3.13
   nodejs: 21
 windows-lts:


### PR DESCRIPTION
problem: openssl command is failing on Ubuntu 24.10
solution: revert to Ubuntu 24.04 LTS and install Python 3.13 from Deadsnakes PPA
