### PR TITLE
[jenkins] fix: supply chain attestations for docker builds

### DIFF
--- a/jenkins/infra/jenkins/build-ci-image.groovy
+++ b/jenkins/infra/jenkins/build-ci-image.groovy
@@ -80,10 +80,14 @@ pipeline {
 						{
 							String versionArg = getVersionArg(params.CI_IMAGE, buildEnvironment)
 							String buildArg = "-f ${CI_IMAGE}.Dockerfile ${versionArg} --build-arg FROM_IMAGE=${dockerFromImage} ."
-							docker.withRegistry(DOCKER_URL, DOCKER_CREDENTIALS_ID) {
-								docker.build(archImageName, buildArg).push()
-							}
 
+							dockerHelper.dockerBuildAndPushImage(
+								params.OPERATING_SYSTEM,
+								"${env.DOCKER_URL}",
+								"${env.DOCKER_CREDENTIALS_ID}",
+								archImageName,
+								buildArg
+							)
 							dockerHelper.tagDockerImage(
 								params.OPERATING_SYSTEM,
 								"${env.DOCKER_URL}",

--- a/jenkins/shared-library/vars/dockerHelper.groovy
+++ b/jenkins/shared-library/vars/dockerHelper.groovy
@@ -97,7 +97,7 @@ void tagDockerImage(String operatingSystem, String dockerUrl, String dockerCrede
 	}
 }
 
-void dockerBuildAndPushImage(String operatingSystem, String dockerUrl, String dockerCredentialsId,  String imageName, String buildArgs='.') {
+void dockerBuildAndPushImage(String operatingSystem, String dockerUrl, String dockerCredentialsId, String imageName, String buildArgs='.') {
 	if ('windows' == operatingSystem) {
 		// Windows does not support docker buildx
 		dockerImage = docker.build(imageName, buildArgs)

--- a/jenkins/shared-library/vars/dockerHelper.groovy
+++ b/jenkins/shared-library/vars/dockerHelper.groovy
@@ -68,8 +68,7 @@ List<String> resolveDockerImageDigests(Object packageJson, String latestImageNam
 }
 
 void dockerBuildAndPushImage(String imageName, String buildArgs='.') {
-	runScript("docker build -t ${imageName} ${buildArgs}")
-	runScript("docker push ${imageName}")
+	runScript("docker buildx build --builder=container --provenance=true --sbom=true --push -t ${imageName} ${buildArgs}")
 }
 
 void loginAndRunCommand(String dockerCredentialsId, String hostName, Closure command) {
@@ -94,6 +93,22 @@ void tagDockerImage(String operatingSystem, String dockerUrl, String dockerCrede
 		loginAndRunCommand(dockerCredentialsId, dockerUrl) {
 			final String hostName = helper.resolveUrlHostName(dockerUrl)
 			updateDockerImage("${hostName}/${destImageName}", "${hostName}/${imageName}", "${ARCHITECTURE}")
+		}
+	}
+}
+
+void dockerBuildAndPushImage(String operatingSystem, String dockerUrl, String dockerCredentialsId,  String imageName, String buildArgs='.') {
+	if ('windows' == operatingSystem) {
+		// Windows does not support docker buildx
+		dockerImage = docker.build(imageName, buildArgs)
+		docker.withRegistry(dockerUrl, dockerCredentialsId) {
+			dockerImage.push()
+		}
+	} else {
+		final String dockerHost = helper.resolveUrlHostName(dockerUrl)
+		final String fullImageName = "${dockerHost}/${imageName}"
+		loginAndRunCommand(dockerCredentialsId, dockerHost) {
+			dockerBuildAndPushImage(fullImageName, buildArgs)
 		}
 	}
 }


### PR DESCRIPTION
problem: Docker images do not have supply chain attestations
solution: add docker buildx with supply chain attestations enabled by default
