### PR TITLE
[catbuffer/schemas]: fix NEM block previous_block_hash schema

### DIFF
--- a/catbuffer/schemas/nem/block.cats
+++ b/catbuffer/schemas/nem/block.cats
@@ -15,6 +15,9 @@ struct Block
 
 	inline EntityBody
 
+	# previous block hash outer size
+	previous_block_hash_outer_size = make_reserved(uint32, 36)
+
 	# previous block hash
 	previous_block_hash = inline SizePrefixedHash256
 

--- a/catbuffer/schemas/nem/block.cats
+++ b/catbuffer/schemas/nem/block.cats
@@ -16,7 +16,7 @@ struct Block
 	inline EntityBody
 
 	# previous block hash
-	previous_block_hash = Hash256
+	previous_block_hash = inline SizePrefixedHash256
 
 	# block height
 	height = Height


### PR DESCRIPTION
problem: previous_block_hash schema missing the object size
solution: update to type to SizePrefixedHash256