### PR TITLE
[client/rest] fix: catapultdb initialized with incorrect network

### DIFF
--- a/client/rest/src/db/CatapultDb.js
+++ b/client/rest/src/db/CatapultDb.js
@@ -25,7 +25,7 @@ import connector from './connector.js';
 import { buildOffsetCondition, convertToLong, uniqueLongList } from './dbUtils.js';
 import MultisigDb from '../plugins/multisig/MultisigDb.js';
 import MongoDb from 'mongodb';
-import { PublicKey } from 'symbol-sdk';
+import { NetworkLocator, PublicKey } from 'symbol-sdk';
 import { Network, models } from 'symbol-sdk/symbol';
 
 const { ObjectId } = MongoDb;
@@ -105,7 +105,7 @@ export default class CatapultDb {
 		if (!this.networkId)
 			throw Error('network id is required');
 
-		this.network = new Network(this.networkId);
+		this.network = NetworkLocator.findByIdentifier(Network.NETWORKS, this.networkId);
 		this.pagingOptions = {
 			pageSizeMin: options.pageSizeMin,
 			pageSizeMax: options.pageSizeMax,

--- a/client/rest/test/db/CatapultDb_spec.js
+++ b/client/rest/test/db/CatapultDb_spec.js
@@ -26,7 +26,7 @@ import { uniqueLongList } from '../../src/db/dbUtils.js';
 import { expect } from 'chai';
 import MongoDb from 'mongodb';
 import sinon from 'sinon';
-import { PublicKey, utils } from 'symbol-sdk';
+import { NetworkLocator, PublicKey, utils } from 'symbol-sdk';
 import { Address, Network, models } from 'symbol-sdk/symbol';
 
 const { TransactionType } = models;
@@ -63,7 +63,7 @@ describe('catapult db', () => {
 		return dbObject;
 	};
 
-	const network = new Network(Testnet_Network);
+	const network = NetworkLocator.findByIdentifier(Network.NETWORKS, Testnet_Network);
 	const keyToAddress = key => network.publicKeyToAddress(new PublicKey(key)).bytes;
 
 	const runDbTest = (dbEntities, issueDbCommand, assertDbCommandResult) => {
@@ -126,6 +126,14 @@ describe('catapult db', () => {
 
 			// Act + Assert: no exception
 			expect(() => db.close()).to.not.throw();
+		});
+
+		it('can create db with network id', () => {
+			// Arrange:
+			const db = new CatapultDb({ networkId: Testnet_Network });
+
+			// Act + Assert:
+			expect(db.network).to.equal(Network.TESTNET);
 		});
 	});
 

--- a/client/rest/test/db/utils/dbTestUtils.js
+++ b/client/rest/test/db/utils/dbTestUtils.js
@@ -24,7 +24,7 @@ import CatapultDb from '../../../src/db/CatapultDb.js';
 import { convertToLong } from '../../../src/db/dbUtils.js';
 import test from '../../testUtils.js';
 import MongoDb from 'mongodb';
-import { PublicKey } from 'symbol-sdk';
+import { NetworkLocator, PublicKey } from 'symbol-sdk';
 import { Network } from 'symbol-sdk/symbol';
 
 const { Binary, Long, ObjectId } = MongoDb;
@@ -63,7 +63,7 @@ const createImportances = count => {
 };
 
 const createAccount = (objectId, publicKey, savePublicKey, mosaics, importances) => {
-	const network = new Network(testDbOptions.networkId);
+	const network = NetworkLocator.findByIdentifier(Network.NETWORKS, testDbOptions.networkId);
 	const decoded = network.publicKeyToAddress(new PublicKey(publicKey)).bytes;
 	const account = {
 		address: new Binary(decoded),


### PR DESCRIPTION
problem: catapultDB created an incorrect network, which caused the address from publicKey to be incorrect
                 this caused search by publicKey to create an incorrect address, which would fail.
solution: create the network correctly