### PR TITLE
[jenkins]: add catapult image supply chain attestations for docker build

### DIFF
--- a/jenkins/catapult/baseImageDockerfileGenerator.py
+++ b/jenkins/catapult/baseImageDockerfileGenerator.py
@@ -437,11 +437,14 @@ class LinuxSystemGenerator:
 			'ENV PATH="$VIRTUAL_ENV/bin:$PATH"',
 		])
 
-	def generate_phase_boost(self):
+	def _print_dockerfile_image_layer_header(self, layer):
 		print_lines([
-			f'FROM {self.options.layer_image_name("os")}',
+			f'FROM {self.options.layer_image_name(layer)}',
 			'USER root'
 		])
+
+	def generate_phase_boost(self):
+		self._print_dockerfile_image_layer_header("os")
 		gosu_version = self.options.versions['gosu']
 		gosu_target = '/usr/local/bin/gosu'
 		gosu_uri = f'https://github.com/tianon/gosu/releases/download/{gosu_version}'
@@ -506,10 +509,7 @@ class LinuxSystemGenerator:
 			COMPILER=compiler)
 
 	def generate_phase_deps(self):
-		print_lines([
-			f'FROM {self.options.layer_image_name("boost")}',
-			'USER root'
-		])
+		self._print_dockerfile_image_layer_header("boost")
 
 		self.add_openssl(self.options, [])
 
@@ -523,10 +523,7 @@ class LinuxSystemGenerator:
 		print(f'USER {self.system.user()}')
 
 	def generate_phase_test(self):
-		print_lines([
-			f'FROM {self.options.layer_image_name("deps")}',
-			'USER root'
-		])
+		self._print_dockerfile_image_layer_header("deps")
 
 		self.add_git_dependency('google', 'googletest', self.options.googletest())
 		self.add_git_dependency('google', 'benchmark', self.options.googlebench())
@@ -542,10 +539,7 @@ class LinuxSystemGenerator:
 		])
 
 	def generate_phase_conan(self):
-		print_lines([
-			f'FROM {self.options.layer_image_name("os")}',
-			'USER root'
-		])
+		self._print_dockerfile_image_layer_header("os")
 
 		self.system.add_conan_packages(['python3-pip'])
 		install_pip_package(self.system.user(), 'conan')

--- a/jenkins/catapult/baseImageDockerfileGenerator.py
+++ b/jenkins/catapult/baseImageDockerfileGenerator.py
@@ -444,7 +444,7 @@ class LinuxSystemGenerator:
 		])
 
 	def generate_phase_boost(self):
-		self._print_dockerfile_image_layer_header("os")
+		self._print_dockerfile_image_layer_header('os')
 		gosu_version = self.options.versions['gosu']
 		gosu_target = '/usr/local/bin/gosu'
 		gosu_uri = f'https://github.com/tianon/gosu/releases/download/{gosu_version}'
@@ -509,7 +509,7 @@ class LinuxSystemGenerator:
 			COMPILER=compiler)
 
 	def generate_phase_deps(self):
-		self._print_dockerfile_image_layer_header("boost")
+		self._print_dockerfile_image_layer_header('boost')
 
 		self.add_openssl(self.options, [])
 
@@ -523,7 +523,7 @@ class LinuxSystemGenerator:
 		print(f'USER {self.system.user()}')
 
 	def generate_phase_test(self):
-		self._print_dockerfile_image_layer_header("deps")
+		self._print_dockerfile_image_layer_header('deps')
 
 		self.add_git_dependency('google', 'googletest', self.options.googletest())
 		self.add_git_dependency('google', 'benchmark', self.options.googlebench())
@@ -539,7 +539,7 @@ class LinuxSystemGenerator:
 		])
 
 	def generate_phase_conan(self):
-		self._print_dockerfile_image_layer_header("os")
+		self._print_dockerfile_image_layer_header('os')
 
 		self.system.add_conan_packages(['python3-pip'])
 		install_pip_package(self.system.user(), 'conan')

--- a/jenkins/catapult/compilers/debian-gcc/Dockerfile
+++ b/jenkins/catapult/compilers/debian-gcc/Dockerfile
@@ -15,3 +15,13 @@ RUN apt-get update >/dev/null && \
 	gcc g++ \
 	>/dev/null && \
 	rm -rf /var/lib/apt/lists/*
+
+# add ubuntu user (used by jenkins)
+ARG HOME_DIR=/home/ubuntu
+RUN groupadd -g 1000 ubuntu && \
+	useradd -m -u 1000 -g ubuntu -d ${HOME_DIR} ubuntu
+USER ubuntu
+WORKDIR ${HOME_DIR}
+ENV VIRTUAL_ENV=${HOME_DIR}/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/jenkins/catapult/compilers/debian-gcc/Dockerfile
+++ b/jenkins/catapult/compilers/debian-gcc/Dockerfile
@@ -22,6 +22,3 @@ RUN groupadd -g 1000 ubuntu && \
 	useradd -m -u 1000 -g ubuntu -d ${HOME_DIR} ubuntu
 USER ubuntu
 WORKDIR ${HOME_DIR}
-ENV VIRTUAL_ENV=${HOME_DIR}/venv
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/jenkins/catapult/compilers/fedora-gcc/Dockerfile
+++ b/jenkins/catapult/compilers/fedora-gcc/Dockerfile
@@ -18,6 +18,3 @@ RUN groupadd -g 1000 fedora && \
 	useradd -m -u 1000 -g fedora -d ${HOME_DIR} fedora
 USER fedora
 WORKDIR ${HOME_DIR}
-ENV VIRTUAL_ENV=${HOME_DIR}/venv
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/jenkins/catapult/compilers/fedora-gcc/Dockerfile
+++ b/jenkins/catapult/compilers/fedora-gcc/Dockerfile
@@ -1,4 +1,4 @@
-ARG FROM_IMAGE=fedora:40
+ARG FROM_IMAGE=fedora:41
 FROM ${FROM_IMAGE}
 
 RUN dnf update --assumeyes >/dev/null && \
@@ -11,3 +11,13 @@ RUN dnf update --assumeyes >/dev/null && \
 	>/dev/null && \
 	dnf clean all && \
 	rm -rf /var/cache/yum
+
+# add fedora user (used by jenkins)
+ARG HOME_DIR=/home/fedora
+RUN groupadd -g 1000 fedora && \
+	useradd -m -u 1000 -g fedora -d ${HOME_DIR} fedora
+USER fedora
+WORKDIR ${HOME_DIR}
+ENV VIRTUAL_ENV=${HOME_DIR}/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/jenkins/catapult/compilers/ubuntu-clang/Dockerfile
+++ b/jenkins/catapult/compilers/ubuntu-clang/Dockerfile
@@ -33,6 +33,3 @@ RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /etc/
 ARG HOME_DIR=/home/ubuntu
 USER ubuntu
 WORKDIR ${HOME_DIR}
-ENV VIRTUAL_ENV=${HOME_DIR}/venv
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/jenkins/catapult/compilers/ubuntu-clang/Dockerfile
+++ b/jenkins/catapult/compilers/ubuntu-clang/Dockerfile
@@ -28,3 +28,11 @@ RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /etc/
 	update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100 && \
 	rm -rf /var/lib/apt/lists/* && \
 	clang --version
+
+# set default user (used by jenkins)
+ARG HOME_DIR=/home/ubuntu
+USER ubuntu
+WORKDIR ${HOME_DIR}
+ENV VIRTUAL_ENV=${HOME_DIR}/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/jenkins/catapult/compilers/ubuntu-gcc/Dockerfile
+++ b/jenkins/catapult/compilers/ubuntu-gcc/Dockerfile
@@ -31,6 +31,3 @@ RUN apt-get update >/dev/null && \
 ARG HOME_DIR=/home/ubuntu
 USER ubuntu
 WORKDIR ${HOME_DIR}
-ENV VIRTUAL_ENV=${HOME_DIR}/venv
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/jenkins/catapult/compilers/ubuntu-gcc/Dockerfile
+++ b/jenkins/catapult/compilers/ubuntu-gcc/Dockerfile
@@ -26,3 +26,11 @@ RUN apt-get update >/dev/null && \
 	update-alternatives --install /usr/bin/gcov-dump gcov-dump /usr/bin/gcov-dump-${COMPILER_VERSION} 100 && \
 	update-alternatives --install /usr/bin/gcov-tool gcov-tool /usr/bin/gcov-tool-${COMPILER_VERSION} 100 && \
 	rm -rf /var/lib/apt/lists/*
+
+# set default user (used by jenkins)
+ARG HOME_DIR=/home/ubuntu
+USER ubuntu
+WORKDIR ${HOME_DIR}
+ENV VIRTUAL_ENV=${HOME_DIR}/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/jenkins/catapult/jenkins/catapult-client-build-base-image.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-base-image.groovy
@@ -168,10 +168,10 @@ void dockerBuildAndPushLayer(String layer, String baseImageDockerfileGeneratorCo
 			"""
 
 		dockerHelper.dockerBuildAndPushImage(
-				"${env.OPERATING_SYSTEM}",
-				"${env.DOCKER_URL}",
-				"${env.DOCKER_CREDENTIALS_ID}",
-				destImageName
+			"${env.OPERATING_SYSTEM}",
+			"${env.DOCKER_URL}",
+			"${env.DOCKER_CREDENTIALS_ID}",
+			destImageName
 		)
 	}
 }

--- a/jenkins/catapult/jenkins/catapult-client-build-base-image.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-base-image.groovy
@@ -167,9 +167,12 @@ void dockerBuildAndPushLayer(String layer, String baseImageDockerfileGeneratorCo
 				cat Dockerfile
 			"""
 
-		docker.withRegistry(DOCKER_URL, DOCKER_CREDENTIALS_ID) {
-			docker.build(destImageName).push()
-		}
+		dockerHelper.dockerBuildAndPushImage(
+				"${env.OPERATING_SYSTEM}",
+				"${env.DOCKER_URL}",
+				"${env.DOCKER_CREDENTIALS_ID}",
+				destImageName
+		)
 	}
 }
 

--- a/jenkins/catapult/jenkins/catapult-client-build-compiler-image.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-compiler-image.groovy
@@ -90,9 +90,14 @@ pipeline {
 									? 'mcr.microsoft.com/powershell:latest'
 									: "${params.OPERATING_SYSTEM}:${osVersion}"
 							String buildArg = "--build-arg COMPILER_VERSION=${compilerVersion} --build-arg FROM_IMAGE=${fromImage} ."
-							docker.withRegistry(DOCKER_URL, DOCKER_CREDENTIALS_ID) {
-								docker.build(archImageName, buildArg).push()
-							}
+
+							dockerHelper.dockerBuildAndPushImage(
+									params.OPERATING_SYSTEM,
+									"${env.DOCKER_URL}",
+									"${env.DOCKER_CREDENTIALS_ID}",
+									archImageName,
+									buildArg
+							)
 							dockerHelper.tagDockerImage("${OPERATING_SYSTEM}", "${DOCKER_URL}", "${DOCKER_CREDENTIALS_ID}", archImageName, destImageName)
 						}
 					}

--- a/jenkins/catapult/jenkins/catapult-client-build-compiler-image.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-build-compiler-image.groovy
@@ -92,13 +92,19 @@ pipeline {
 							String buildArg = "--build-arg COMPILER_VERSION=${compilerVersion} --build-arg FROM_IMAGE=${fromImage} ."
 
 							dockerHelper.dockerBuildAndPushImage(
-									params.OPERATING_SYSTEM,
-									"${env.DOCKER_URL}",
-									"${env.DOCKER_CREDENTIALS_ID}",
-									archImageName,
-									buildArg
+								params.OPERATING_SYSTEM,
+								"${env.DOCKER_URL}",
+								"${env.DOCKER_CREDENTIALS_ID}",
+								archImageName,
+								buildArg
 							)
-							dockerHelper.tagDockerImage("${OPERATING_SYSTEM}", "${DOCKER_URL}", "${DOCKER_CREDENTIALS_ID}", archImageName, destImageName)
+							dockerHelper.tagDockerImage(
+								"${OPERATING_SYSTEM}",
+								"${DOCKER_URL}",
+								"${DOCKER_CREDENTIALS_ID}",
+								archImageName,
+								destImageName
+							)
 						}
 					}
 				}

--- a/jenkins/catapult/jenkins/catapult-client-prepare-base-image.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-prepare-base-image.groovy
@@ -106,10 +106,14 @@ pipeline {
 						echo "Dockerfile name: ${dockerfile}"
 						echo "Base image name: ${baseImage}"
 
-						dockerImage = docker.build(archImageName, "--file ${dockerfile} --build-arg FROM_IMAGE=${baseImage} .")
-						docker.withRegistry(DOCKER_URL, DOCKER_CREDENTIALS_ID) {
-							dockerImage.push()
-						}
+						final String buildArg = "--file ${dockerfile} --build-arg FROM_IMAGE=${baseImage} ."
+						dockerHelper.dockerBuildAndPushImage(
+								params.OPERATING_SYSTEM,
+								"${env.DOCKER_URL}",
+								"${env.DOCKER_CREDENTIALS_ID}",
+								archImageName,
+								buildArg
+						)
 						dockerHelper.tagDockerImage("${OPERATING_SYSTEM}", "${DOCKER_URL}", "${DOCKER_CREDENTIALS_ID}", archImageName, destImageName)
 					}
 				}

--- a/jenkins/catapult/jenkins/catapult-client-prepare-base-image.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-prepare-base-image.groovy
@@ -108,13 +108,19 @@ pipeline {
 
 						final String buildArg = "--file ${dockerfile} --build-arg FROM_IMAGE=${baseImage} ."
 						dockerHelper.dockerBuildAndPushImage(
-								params.OPERATING_SYSTEM,
-								"${env.DOCKER_URL}",
-								"${env.DOCKER_CREDENTIALS_ID}",
-								archImageName,
-								buildArg
+							params.OPERATING_SYSTEM,
+							"${env.DOCKER_URL}",
+							"${env.DOCKER_CREDENTIALS_ID}",
+							archImageName,
+							buildArg
 						)
-						dockerHelper.tagDockerImage("${OPERATING_SYSTEM}", "${DOCKER_URL}", "${DOCKER_CREDENTIALS_ID}", archImageName, destImageName)
+						dockerHelper.tagDockerImage(
+							"${OPERATING_SYSTEM}",
+							"${DOCKER_URL}",
+							"${DOCKER_CREDENTIALS_ID}",
+							archImageName,
+							destImageName
+						)
 					}
 				}
 			}

--- a/jenkins/catapult/jenkins/catapult-client-release-build.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-release-build.groovy
@@ -126,28 +126,26 @@ pipeline {
 				stage('build and push image') {
 					steps {
 						script {
-							final String hostName = helper.resolveUrlHostName(dockerUrl)
 							final String defaultUser = 'fedora' == "${params.OPERATING_SYSTEM}" ? 'fedora' : 'ubuntu'
-							final String buildArg = "-f symbol-mono/jenkins/catapult/templates/release.Dockerfile " +
+							final String buildArg = '-f symbol-mono/jenkins/catapult/templates/release.Dockerfile ' +
 								"--build-arg BUILD_IMAGE=${baseImageNames[0]} " +
 								"--build-arg RELEASE_BASE_IMAGE=${baseImageNames[1]} " +
 								"--build-arg BUILD_CONFIGURATION=${BUILD_CONFIGURATION} " +
 								"--build-arg COMPILER_CONFIGURATION=${COMPILER_CONFIGURATION} " +
 								"--build-arg USER_NAME=${defaultUser} symbol-mono/"
-							final String archImageName = "${hostName}/${dockerRepoName}:${resolveShortArchitectureImageLabel(compilerConfigurationFilepath)}"
+							final String archImageName = "${dockerRepoName}:${resolveShortArchitectureImageLabel(compilerConfigurationFilepath)}"
 
 							dockerHelper.dockerBuildAndPushImage(
 								params.OPERATING_SYSTEM,
-								"${env.DOCKER_URL}",
-								"${env.DOCKER_CREDENTIALS_ID}",
+								dockerUrl,
+								dockerCredentialId,
 								archImageName,
 								buildArg,
 								SHOULD_PUBLISH_BUILD_IMAGE.toBoolean()
 							)
-							dockerHelper.loginAndRunCommand(dockerCredentialId, dockerUrl) {
-								String multiArchImageName = "${hostName}/${dockerRepoName}:${resolveShortImageLabel()}"
-								dockerHelper.updateDockerImage(multiArchImageName, archImageName, "${ARCHITECTURE}")
-							}
+
+							final String multiArchImageName = "${dockerRepoName}:${resolveShortImageLabel()}"
+							dockerHelper.tagDockerImage("${OPERATING_SYSTEM}", dockerUrl, dockerCredentialId, archImageName, multiArchImageName)
 						}
 					}
 				}

--- a/jenkins/catapult/jenkins/catapult-client-release-build.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-release-build.groovy
@@ -128,11 +128,11 @@ pipeline {
 						script {
 							final String hostName = helper.resolveUrlHostName(dockerUrl)
 							final String defaultUser = 'fedora' == "${params.OPERATING_SYSTEM}" ? 'fedora' : 'ubuntu'
-							final String buildArg = "-f release.Dockerfile ${versionArg}" +
-								"--build-arg BUILD_IMAGE=${baseImageNames[0]}" +
-								"--build-arg RELEASE_BASE_IMAGE=${baseImageNames[1]}" +
-								"--build-arg BUILD_CONFIGURATION=${BUILD_CONFIGURATION}" +
-								"--build-arg COMPILER_CONFIGURATION=${COMPILER_CONFIGURATION}" +
+							final String buildArg = "-f release.Dockerfile " +
+								"--build-arg BUILD_IMAGE=${baseImageNames[0]} " +
+								"--build-arg RELEASE_BASE_IMAGE=${baseImageNames[1]} " +
+								"--build-arg BUILD_CONFIGURATION=${BUILD_CONFIGURATION} " +
+								"--build-arg COMPILER_CONFIGURATION=${COMPILER_CONFIGURATION} " +
 								"--build-arg USER_NAME=${defaultUser} ."
 							final String archImageName = "${hostName}/${dockerRepoName}:${resolveShortArchitectureImageLabel(compilerConfigurationFilepath)}"
 

--- a/jenkins/catapult/jenkins/catapult-client-release-build.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-release-build.groovy
@@ -123,23 +123,28 @@ pipeline {
 						}
 					}
 				}
-				stage('build') {
-					steps {
-						sh "${runDockerBuildCommand}"
-					}
-				}
-				stage('push built image') {
-					when {
-						expression { SHOULD_PUBLISH_BUILD_IMAGE.toBoolean() }
-					}
+				stage('build and push image') {
 					steps {
 						script {
-							dockerHelper.loginAndRunCommand(dockerCredentialId, dockerUrl) {
-								final String hostName = helper.resolveUrlHostName(dockerUrl)
+							final String hostName = helper.resolveUrlHostName(dockerUrl)
+							final String defaultUser = 'fedora' == "${params.OPERATING_SYSTEM}" ? 'fedora' : 'ubuntu'
+							final String buildArg = "-f release.Dockerfile ${versionArg}" +
+								"--build-arg BUILD_IMAGE=${baseImageNames[0]}" +
+								"--build-arg RELEASE_BASE_IMAGE=${baseImageNames[1]}" +
+								"--build-arg BUILD_CONFIGURATION=${BUILD_CONFIGURATION}" +
+								"--build-arg COMPILER_CONFIGURATION=${COMPILER_CONFIGURATION}" +
+								"--build-arg USER_NAME=${defaultUser} ."
+							final String archImageName = "${hostName}/${dockerRepoName}:${resolveShortArchitectureImageLabel(compilerConfigurationFilepath)}"
 
-								dockerHelper.pushImage(buildImageFullName, "${hostName}/${buildImageFullName}")
-								String archImageName = "${hostName}/${dockerRepoName}:${resolveShortArchitectureImageLabel(compilerConfigurationFilepath)}"
-								dockerHelper.pushImage(buildImageFullName, archImageName)
+							dockerHelper.dockerBuildAndPushImage(
+								params.OPERATING_SYSTEM,
+								"${env.DOCKER_URL}",
+								"${env.DOCKER_CREDENTIALS_ID}",
+								archImageName,
+								buildArg,
+								SHOULD_PUBLISH_BUILD_IMAGE.toBoolean()
+							)
+							dockerHelper.loginAndRunCommand(dockerCredentialId, dockerUrl) {
 								String multiArchImageName = "${hostName}/${dockerRepoName}:${resolveShortImageLabel()}"
 								dockerHelper.updateDockerImage(multiArchImageName, archImageName, "${ARCHITECTURE}")
 							}

--- a/jenkins/catapult/jenkins/catapult-client-release-build.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-release-build.groovy
@@ -128,7 +128,7 @@ pipeline {
 						script {
 							final String hostName = helper.resolveUrlHostName(dockerUrl)
 							final String defaultUser = 'fedora' == "${params.OPERATING_SYSTEM}" ? 'fedora' : 'ubuntu'
-							final String buildArg = "-f release.Dockerfile " +
+							final String buildArg = "-f jenkins/catapult/templates/release.Dockerfile " +
 								"--build-arg BUILD_IMAGE=${baseImageNames[0]} " +
 								"--build-arg RELEASE_BASE_IMAGE=${baseImageNames[1]} " +
 								"--build-arg BUILD_CONFIGURATION=${BUILD_CONFIGURATION} " +

--- a/jenkins/catapult/jenkins/catapult-client-release-build.groovy
+++ b/jenkins/catapult/jenkins/catapult-client-release-build.groovy
@@ -128,12 +128,12 @@ pipeline {
 						script {
 							final String hostName = helper.resolveUrlHostName(dockerUrl)
 							final String defaultUser = 'fedora' == "${params.OPERATING_SYSTEM}" ? 'fedora' : 'ubuntu'
-							final String buildArg = "-f jenkins/catapult/templates/release.Dockerfile " +
+							final String buildArg = "-f symbol-mono/jenkins/catapult/templates/release.Dockerfile " +
 								"--build-arg BUILD_IMAGE=${baseImageNames[0]} " +
 								"--build-arg RELEASE_BASE_IMAGE=${baseImageNames[1]} " +
 								"--build-arg BUILD_CONFIGURATION=${BUILD_CONFIGURATION} " +
 								"--build-arg COMPILER_CONFIGURATION=${COMPILER_CONFIGURATION} " +
-								"--build-arg USER_NAME=${defaultUser} ."
+								"--build-arg USER_NAME=${defaultUser} symbol-mono/"
 							final String archImageName = "${hostName}/${dockerRepoName}:${resolveShortArchitectureImageLabel(compilerConfigurationFilepath)}"
 
 							dockerHelper.dockerBuildAndPushImage(

--- a/jenkins/catapult/runDockerBuild.py
+++ b/jenkins/catapult/runDockerBuild.py
@@ -148,6 +148,7 @@ def prepare_docker_image(process_manager, container_id, prepare_replacements):
 	script_path = prepare_replacements['script_path']
 	process_manager.dispatch_subprocess([
 		'docker', 'run',
+		'--user=root',
 		f'--cidfile={cid_filepath}',
 		f'--volume={script_path}:{EnvironmentManager.root_directory("scripts")}',
 		f'--volume={OUTPUT_DIR}:{EnvironmentManager.root_directory("data")}',

--- a/jenkins/catapult/runDockerBuild.py
+++ b/jenkins/catapult/runDockerBuild.py
@@ -148,7 +148,7 @@ def prepare_docker_image(process_manager, container_id, prepare_replacements):
 	script_path = prepare_replacements['script_path']
 	process_manager.dispatch_subprocess([
 		'docker', 'run',
-		f'--user={"ContainerAdministrator" if "windows" == prepare_replacements["os"] else "root"}',
+		f'--user={prepare_replacements["user"]}',
 		f'--cidfile={cid_filepath}',
 		f'--volume={script_path}:{EnvironmentManager.root_directory("scripts")}',
 		f'--volume={OUTPUT_DIR}:{EnvironmentManager.root_directory("data")}',
@@ -240,7 +240,7 @@ def main():
 		'build_disposition': options.build_disposition,
 		'source_path': source_path,
 		'script_path': script_path,
-		"os": args.operating_system
+		'user': 'ContainerAdministrator' if 'windows' == args.operating_system else 'root'
 	})
 
 

--- a/jenkins/catapult/runDockerBuild.py
+++ b/jenkins/catapult/runDockerBuild.py
@@ -148,7 +148,7 @@ def prepare_docker_image(process_manager, container_id, prepare_replacements):
 	script_path = prepare_replacements['script_path']
 	process_manager.dispatch_subprocess([
 		'docker', 'run',
-		'--user=root',
+		f'--user={"ContainerAdministrator" if "windows" == prepare_replacements["os"] else "root"}',
 		f'--cidfile={cid_filepath}',
 		f'--volume={script_path}:{EnvironmentManager.root_directory("scripts")}',
 		f'--volume={OUTPUT_DIR}:{EnvironmentManager.root_directory("data")}',
@@ -239,7 +239,8 @@ def main():
 		'destination_image_label': args.destination_image_label,
 		'build_disposition': options.build_disposition,
 		'source_path': source_path,
-		'script_path': script_path
+		'script_path': script_path,
+		"os": args.operating_system
 	})
 
 

--- a/jenkins/catapult/templates/FedoraTestBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/FedoraTestBaseImage.Dockerfile
@@ -1,5 +1,5 @@
 # image name required as ARG
-ARG FROM_IMAGE=''
+ARG FROM_IMAGE='fedora:41'
 ARG DEBIAN_FRONTEND=noninteractive
 
 FROM ${FROM_IMAGE}
@@ -21,3 +21,13 @@ RUN dnf update --assumeyes && dnf install --assumeyes \
 	dnf clean all && \
 	rm -rf /var/cache/yum && \
 	pip3 install -U colorama conan cryptography gitpython pycodestyle pylint PyYAML
+
+# add fedora user (used by jenkins)
+ARG HOME_DIR=/home/fedora
+RUN groupadd -g 1000 fedora && \
+	useradd -m -u 1000 -g fedora -d ${HOME_DIR} fedora
+USER fedora
+WORKDIR ${HOME_DIR}
+ENV VIRTUAL_ENV=${HOME_DIR}/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/jenkins/catapult/templates/UbuntuReleaseBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuReleaseBaseImage.Dockerfile
@@ -10,12 +10,7 @@ RUN apt-get -y update && apt-get install -y \
 	&& \
 	rm -rf /var/lib/apt/lists/*
 
-# add catapult user (used by jenkins)
+# add ubuntu user (used by jenkins)
 ARG HOME_DIR=/home/catapult
-RUN groupadd -g 1000 catapult && \
-	useradd -m -u 1000 -g catapult -d ${HOME_DIR} catapult
-USER catapult
+USER ubuntu
 WORKDIR ${HOME_DIR}
-ENV VIRTUAL_ENV=${HOME_DIR}/venv
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/jenkins/catapult/templates/UbuntuReleaseBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuReleaseBaseImage.Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get -y update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # add ubuntu user (used by jenkins)
+# create the user for debian image
+RUN id -u "ubuntu" || useradd --uid 1000 -ms /bin/bash ubuntu
 ARG HOME_DIR=/home/catapult
 USER ubuntu
 WORKDIR ${HOME_DIR}

--- a/jenkins/catapult/templates/UbuntuReleaseBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuReleaseBaseImage.Dockerfile
@@ -11,7 +11,6 @@ RUN apt-get -y update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # add ubuntu user (used by jenkins)
-# create the user for debian image
 RUN id -u "ubuntu" || useradd --uid 1000 -ms /bin/bash ubuntu
 ARG HOME_DIR=/home/ubuntu
 USER ubuntu

--- a/jenkins/catapult/templates/UbuntuReleaseBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuReleaseBaseImage.Dockerfile
@@ -1,5 +1,5 @@
 # image name required as ARG
-ARG FROM_IMAGE=''
+ARG FROM_IMAGE='ubuntu:24.04'
 ARG DEBIAN_FRONTEND=noninteractive
 
 FROM ${FROM_IMAGE}
@@ -9,3 +9,13 @@ RUN apt-get -y update && apt-get install -y \
 	openssl \
 	&& \
 	rm -rf /var/lib/apt/lists/*
+
+# add catapult user (used by jenkins)
+ARG HOME_DIR=/home/catapult
+RUN groupadd -g 1000 catapult && \
+	useradd -m -u 1000 -g catapult -d ${HOME_DIR} catapult
+USER catapult
+WORKDIR ${HOME_DIR}
+ENV VIRTUAL_ENV=${HOME_DIR}/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"

--- a/jenkins/catapult/templates/UbuntuReleaseBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuReleaseBaseImage.Dockerfile
@@ -13,6 +13,6 @@ RUN apt-get -y update && apt-get install -y \
 # add ubuntu user (used by jenkins)
 # create the user for debian image
 RUN id -u "ubuntu" || useradd --uid 1000 -ms /bin/bash ubuntu
-ARG HOME_DIR=/home/catapult
+ARG HOME_DIR=/home/ubuntu
 USER ubuntu
 WORKDIR ${HOME_DIR}

--- a/jenkins/catapult/templates/UbuntuTestBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuTestBaseImage.Dockerfile
@@ -29,7 +29,6 @@ RUN git clone https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
 	rm -rf linux.git
 
 # add ubuntu user (used by jenkins)
-# create the user for debian image
 RUN id -u "ubuntu" || useradd --uid 1000 -ms /bin/bash ubuntu
 ARG HOME_DIR=/home/ubuntu
 USER ubuntu

--- a/jenkins/catapult/templates/UbuntuTestBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuTestBaseImage.Dockerfile
@@ -1,5 +1,5 @@
 # image name required as ARG
-ARG FROM_IMAGE=''
+ARG FROM_IMAGE='ubuntu:24.04'
 ARG DEBIAN_FRONTEND=noninteractive
 
 FROM ${FROM_IMAGE}
@@ -21,20 +21,22 @@ RUN apt-get -y update && apt-get install -y \
 	&& \
 	rm -rf /var/lib/apt/lists/*
 
-# add ubuntu user (used by jenkins)
-RUN id -u "ubuntu" || useradd --uid 1000 -ms /bin/bash ubuntu
-USER ubuntu
-WORKDIR /home/ubuntu
-ENV VIRTUAL_ENV=/home/ubuntu/venv
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-
-RUN pip3 install -U colorama conan cryptography gitpython pycodestyle pylint ply PyYAML
-
-USER root
 RUN git clone https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git linux.git && \
 	cd linux.git/tools/perf && \
 	NO_LIBTRACEEVENT=1 make && \
 	cp perf /usr/bin && \
 	cd ../../.. && \
 	rm -rf linux.git
+
+# add catapult user (used by jenkins)
+ARG HOME_DIR=/home/catapult
+RUN groupadd -g 1000 catapult && \
+	useradd -m -u 1000 -g catapult -d ${HOME_DIR} catapult
+USER catapult
+WORKDIR ${HOME_DIR}
+ENV VIRTUAL_ENV=${HOME_DIR}/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+RUN pip3 install -U colorama conan cryptography gitpython pycodestyle pylint ply PyYAML
+

--- a/jenkins/catapult/templates/UbuntuTestBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuTestBaseImage.Dockerfile
@@ -28,11 +28,9 @@ RUN git clone https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
 	cd ../../.. && \
 	rm -rf linux.git
 
-# add catapult user (used by jenkins)
-ARG HOME_DIR=/home/catapult
-RUN groupadd -g 1000 catapult && \
-	useradd -m -u 1000 -g catapult -d ${HOME_DIR} catapult
-USER catapult
+# add ubuntu user (used by jenkins)
+ARG HOME_DIR=/home/ubuntu
+USER ubuntu
 WORKDIR ${HOME_DIR}
 ENV VIRTUAL_ENV=${HOME_DIR}/venv
 RUN python3 -m venv $VIRTUAL_ENV

--- a/jenkins/catapult/templates/UbuntuTestBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuTestBaseImage.Dockerfile
@@ -29,6 +29,8 @@ RUN git clone https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
 	rm -rf linux.git
 
 # add ubuntu user (used by jenkins)
+# create the user for debian image
+RUN id -u "ubuntu" || useradd --uid 1000 -ms /bin/bash ubuntu
 ARG HOME_DIR=/home/ubuntu
 USER ubuntu
 WORKDIR ${HOME_DIR}

--- a/jenkins/catapult/templates/UbuntuTestSanitizerBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuTestSanitizerBaseImage.Dockerfile
@@ -1,5 +1,5 @@
 # image name required as ARG
-ARG FROM_IMAGE=''
+ARG FROM_IMAGE='ubuntu:24.04'
 ARG DEBIAN_FRONTEND=noninteractive
 
 FROM ${FROM_IMAGE}
@@ -21,14 +21,14 @@ RUN apt-get -y update && apt-get install -y \
 	&& \
 	rm -rf /var/lib/apt/lists/*
 
-# add ubuntu user (used by jenkins)
-RUN id -u "ubuntu" || useradd --uid 1000 -ms /bin/bash ubuntu
-USER ubuntu
-WORKDIR /home/ubuntu
-ENV VIRTUAL_ENV=/home/ubuntu/venv
+# add catapult user (used by jenkins)
+ARG HOME_DIR=/home/catapult
+RUN groupadd -g 1000 catapult && \
+	useradd -m -u 1000 -g catapult -d ${HOME_DIR} catapult
+USER catapult
+WORKDIR ${HOME_DIR}
+ENV VIRTUAL_ENV=${HOME_DIR}/venv
 RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 RUN pip3 install -U colorama conan cryptography gitpython pycodestyle pylint ply PyYAML
-
-USER root

--- a/jenkins/catapult/templates/UbuntuTestSanitizerBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuTestSanitizerBaseImage.Dockerfile
@@ -4,6 +4,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 FROM ${FROM_IMAGE}
 LABEL maintainer="Catapult Development Team"
+USER root
 RUN apt-get -y update && apt-get install -y \
 	bison \
 	gdb \

--- a/jenkins/catapult/templates/UbuntuTestSanitizerBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuTestSanitizerBaseImage.Dockerfile
@@ -21,11 +21,9 @@ RUN apt-get -y update && apt-get install -y \
 	&& \
 	rm -rf /var/lib/apt/lists/*
 
-# add catapult user (used by jenkins)
-ARG HOME_DIR=/home/catapult
-RUN groupadd -g 1000 catapult && \
-	useradd -m -u 1000 -g catapult -d ${HOME_DIR} catapult
-USER catapult
+# add ubuntu user (used by jenkins)
+ARG HOME_DIR=/home/ubuntu
+USER ubuntu
 WORKDIR ${HOME_DIR}
 ENV VIRTUAL_ENV=${HOME_DIR}/venv
 RUN python3 -m venv $VIRTUAL_ENV

--- a/jenkins/catapult/templates/UbuntuTestSanitizerBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuTestSanitizerBaseImage.Dockerfile
@@ -22,6 +22,8 @@ RUN apt-get -y update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # add ubuntu user (used by jenkins)
+# create the user for debian image
+RUN id -u "ubuntu" || useradd --uid 1000 -ms /bin/bash ubuntu
 ARG HOME_DIR=/home/ubuntu
 USER ubuntu
 WORKDIR ${HOME_DIR}

--- a/jenkins/catapult/templates/UbuntuTestSanitizerBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuTestSanitizerBaseImage.Dockerfile
@@ -23,7 +23,6 @@ RUN apt-get -y update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # add ubuntu user (used by jenkins)
-# create the user for debian image
 RUN id -u "ubuntu" || useradd --uid 1000 -ms /bin/bash ubuntu
 ARG HOME_DIR=/home/ubuntu
 USER ubuntu

--- a/jenkins/catapult/templates/release.Dockerfile
+++ b/jenkins/catapult/templates/release.Dockerfile
@@ -1,0 +1,29 @@
+# image name required as ARG
+ARG BUILD_IMAGE='symbolplatform/symbol-server-build-base:ubuntu-gcc-13'
+ARG RELEASE_BASE_IMAGE='symbolplatform/symbol-server-build-base:ubuntu-gcc-13'
+ARG DEBIAN_FRONTEND=noninteractive
+
+FROM ${BUILD_IMAGE} AS builder
+LABEL maintainer="Catapult Development Team"
+
+WORKDIR /tmp/build
+COPY . src/
+
+ARG COMPILER_CONFIGURATION='gcc-latest'
+ARG BUILD_CONFIGURATION='release-public'
+RUN ARCH=$([ "$(uname -m)" = "x86_64" ] && echo "amd64" || echo "arm64")  \
+    && python3 /tmp/build/src/jenkins/catapult/runDockerBuildInnerBuild.py \
+    --compiler-configuration=/tmp/build/src/jenkins/catapult/configurations/${ARCH}/${COMPILER_CONFIGURATION}.yaml \
+    --build-configuration=/tmp/build/src/jenkins/catapult/configurations/${BUILD_CONFIGURATION}.yaml \
+    --source-path=/tmp/build/src/client/catapult \
+    --out-dir=/tmp/build/binaries
+
+FROM ${RELEASE_BASE_IMAGE}
+LABEL maintainer="Catapult Development Team"
+
+ARG CATAPULT_HOME=/usr/catapult
+COPY --chown=1000:1000 --from=builder /tmp/build/binaries ${CATAPULT_HOME}
+WORKDIR ${CATAPULT_HOME}
+ENV LD_LIBRARY_PATH="${CATAPULT_HOME}/lib:${CATAPULT_HOME}/deps"
+ARG USER_NAME='ubuntu'
+USER ${USER_NAME}

--- a/jenkins/catapult/templates/release.Dockerfile
+++ b/jenkins/catapult/templates/release.Dockerfile
@@ -12,11 +12,11 @@ COPY . src/
 ARG COMPILER_CONFIGURATION='gcc-latest'
 ARG BUILD_CONFIGURATION='release-public'
 RUN ARCH=$([ "$(uname -m)" = "x86_64" ] && echo "amd64" || echo "arm64")  \
-    && python3 /tmp/build/src/jenkins/catapult/runDockerBuildInnerBuild.py \
-    --compiler-configuration=/tmp/build/src/jenkins/catapult/configurations/${ARCH}/${COMPILER_CONFIGURATION}.yaml \
-    --build-configuration=/tmp/build/src/jenkins/catapult/configurations/${BUILD_CONFIGURATION}.yaml \
-    --source-path=/tmp/build/src/client/catapult \
-    --out-dir=/tmp/build/binaries
+	&& python3 /tmp/build/src/jenkins/catapult/runDockerBuildInnerBuild.py \
+	--compiler-configuration=/tmp/build/src/jenkins/catapult/configurations/${ARCH}/${COMPILER_CONFIGURATION}.yaml \
+	--build-configuration=/tmp/build/src/jenkins/catapult/configurations/${BUILD_CONFIGURATION}.yaml \
+	--source-path=/tmp/build/src/client/catapult \
+	--out-dir=/tmp/build/binaries
 
 FROM ${RELEASE_BASE_IMAGE}
 LABEL maintainer="Catapult Development Team"

--- a/jenkins/catapult/templates/release.Dockerfile
+++ b/jenkins/catapult/templates/release.Dockerfile
@@ -4,7 +4,6 @@ ARG RELEASE_BASE_IMAGE='symbolplatform/symbol-server-build-base:ubuntu-gcc-13'
 ARG DEBIAN_FRONTEND=noninteractive
 
 FROM ${BUILD_IMAGE} AS builder
-LABEL maintainer="Catapult Development Team"
 
 WORKDIR /tmp/build
 COPY . src/

--- a/jenkins/shared-library/vars/dockerHelper.groovy
+++ b/jenkins/shared-library/vars/dockerHelper.groovy
@@ -70,8 +70,10 @@ List<String> resolveDockerImageDigests(Object packageJson, String latestImageNam
 void dockerBuildAndPushImage(String imageName, String buildArgs='.', Boolean pushImage=true) {
 	String dockerBuildCommand = "docker buildx build --builder=container --provenance=true --load --sbom=true -t ${imageName}"
 
-	if (pushImage)
+	if (pushImage) {
 		dockerBuildCommand += ' --push'
+	}
+
 	runScript("${dockerBuildCommand} ${buildArgs}")
 }
 
@@ -101,7 +103,14 @@ void tagDockerImage(String operatingSystem, String dockerUrl, String dockerCrede
 	}
 }
 
-void dockerBuildAndPushImage(String operatingSystem, String dockerUrl, String dockerCredentialsId, String imageName, String buildArgs='.', Boolean pushImage=true) {
+void dockerBuildAndPushImage(
+	String operatingSystem,
+	String dockerUrl,
+	String dockerCredentialsId,
+	String imageName,
+	String buildArgs='.',
+	Boolean pushImage=true
+) {
 	if ('windows' == operatingSystem) {
 		// Windows does not support docker buildx
 		dockerImage = docker.build(imageName, buildArgs)


### PR DESCRIPTION
problem: catapult docker images do not have supply chain attestations
solution: add docker buildx with supply chain attestations enabled by default
          create a release Dockerfile to build a release image