### PR TITLE
[jenkins] fix: add twine to Python venv

### DIFF
--- a/jenkins/docker/ubuntu/python.Dockerfile
+++ b/jenkins/docker/ubuntu/python.Dockerfile
@@ -58,4 +58,4 @@ RUN python3 -m pip install poetry gitlint wheel setuptools
 
 # install common python packages
 RUN python3 -m pip install --upgrade aiohttp colorama coverage cryptography Jinja2 lark ply Pillow pynacl pytest PyYAML pyzbar requests \
-	ripemd-hash safe-pysha3 websockets zenlog
+	ripemd-hash safe-pysha3 twine websockets zenlog


### PR DESCRIPTION
problem: twine ships with Ubuntu is older version(v5.0) and does not support newer metadata
solution: install newer version of twine(v6.1) into Python venv