### PR TITLE
[mkdocs] fix: update swagger dependency to remove deprecation warning

### DIFF
--- a/mkdocs/requirements.txt
+++ b/mkdocs/requirements.txt
@@ -10,4 +10,4 @@ mkdocstrings-python==1.16.7
 mkdocs-gen-files==0.5.0
 mkdocs-literate-nav==0.6.1
 mkdoxy==1.2.7
-mkdocs-swagger-ui-tag==0.6.11
+mkdocs-swagger-ui-tag==0.7.0


### PR DESCRIPTION
## What is the current behavior?
Building the docs site generates an ugly deprecation warning because the mkdocs-swagger-ui-tag dependency relies on an obsolete version of beautifulsoup4.

## What's the issue?
The warning is not critical, but it pollutes the output, making it harder to spot actual warnings.

## How have you changed the behavior?
Opened an issue on the mkdocs-swagger-ui-tag GitHub project, and they updated their dependency.
I changed `requirements.txt` to use the new version.

## How was this change tested?
Building the docs site does not produce any warning now, and the pages that use this plugin (the REST API pages) are still working as expected..

## Requirements

* [X] My pull request title is prefixed with the directory and subdirectory it affects.
* [X] My pull request contains a single change or feature.
* [X] My commits are clearly labeled with one of the following: **feat | bug | fix | build | perf | task**
* [X] My code has been linted.