### PR TITLE
[jenkins] fix: cpp ci images fails due to permissions

### DIFF
--- a/jenkins/docker/ubuntu/cpp.Dockerfile
+++ b/jenkins/docker/ubuntu/cpp.Dockerfile
@@ -1,4 +1,5 @@
 FROM symbolplatform/symbol-server-build-base:ubuntu-gcc-13-conan
+USER root
 
 # install shellcheck
 RUN apt-get install -y shellcheck


### PR DESCRIPTION
problem: cpp ci image fails to build due to permissions
solution: change to root user before installing apps