### PR TITLE
Fix cache size issue in AccountStateCache

### DIFF
--- a/client/catapult/src/catapult/cache_core/AccountStateCache.h
+++ b/client/catapult/src/catapult/cache_core/AccountStateCache.h
@@ -23,6 +23,8 @@
 #include "AccountStateCacheDelta.h"
 #include "AccountStateCacheView.h"
 #include "catapult/cache/BasicCache.h"
+#include <list>
+#include <unordered_map>
 
 namespace catapult { namespace cache {
 
@@ -63,9 +65,22 @@ namespace catapult { namespace cache {
 			*m_pHighValueAccounts = std::move(highValueAccounts);
 		}
 
+		/// Limits the size of the cache by removing least recently used (LRU) items.
+		void limitCacheSize(size_t maxSize) {
+			while (m_usageFrequency.size() > maxSize) {
+				auto lru = m_usageFrequency.back();
+				m_usageFrequency.pop_back();
+				this->remove(lru);
+			}
+		}
+
 	private:
 		// unique pointer to allow reference to be valid after moves of this cache
 		std::unique_ptr<HighValueAccounts> m_pHighValueAccounts;
+
+		// Tracks the usage frequency of cache items
+		std::list<Address> m_usageFrequency;
+		std::unordered_map<Address, std::list<Address>::iterator, utils::ArrayHasher<Address>> m_usageFrequencyMap;
 	};
 
 	/// Synchronized cache composed of stateful account information.

--- a/client/catapult/src/catapult/cache_core/AccountStateCacheDelta.cpp
+++ b/client/catapult/src/catapult/cache_core/AccountStateCacheDelta.cpp
@@ -168,6 +168,17 @@ namespace catapult { namespace cache {
 	void BasicAccountStateCacheDelta::updateHighValueAccounts(Height height) {
 		m_highValueAccountsUpdater.setHeight(height);
 		m_highValueAccountsUpdater.update(m_pStateByAddress->deltas());
+
+		// Update usage frequency
+		for (const auto& delta : m_pStateByAddress->deltas().Added) {
+			const auto& address = delta.second.Address;
+			auto it = m_usageFrequencyMap.find(address);
+			if (it != m_usageFrequencyMap.end()) {
+				m_usageFrequency.erase(it->second);
+			}
+			m_usageFrequency.push_front(address);
+			m_usageFrequencyMap[address] = m_usageFrequency.begin();
+		}
 	}
 
 	void BasicAccountStateCacheDelta::processHighValueRemovedAccounts(model::ImportanceHeight importanceHeight) {
@@ -191,6 +202,14 @@ namespace catapult { namespace cache {
 
 			if (state::HasHistoricalInformation(accountState))
 				filteredRemovedHighValueAddresses.insert(address);
+
+			// Update usage frequency
+			auto it = m_usageFrequencyMap.find(address);
+			if (it != m_usageFrequencyMap.end()) {
+				m_usageFrequency.erase(it->second);
+				m_usageFrequency.push_front(address);
+				m_usageFrequencyMap[address] = m_usageFrequency.begin();
+			}
 		}
 
 		m_highValueAccountsUpdater.setRemovedAddresses(std::move(filteredRemovedHighValueAddresses));

--- a/client/catapult/src/catapult/cache_core/AccountStateCacheDelta.h
+++ b/client/catapult/src/catapult/cache_core/AccountStateCacheDelta.h
@@ -165,6 +165,9 @@ namespace catapult { namespace cache {
 		/// Prunes the cache at \a height.
 		void prune(Height height);
 
+		/// Gets the usage frequency of a cache item.
+		size_t getUsageFrequency(const Address& address) const;
+
 	private:
 		Address getAddress(const Key& publicKey);
 
@@ -198,6 +201,9 @@ namespace catapult { namespace cache {
 
 		QueuedRemovalSet<Address> m_queuedRemoveByAddress;
 		QueuedRemovalSet<Key> m_queuedRemoveByPublicKey;
+
+		// Tracks the usage frequency of cache items
+		std::unordered_map<Address, size_t, utils::ArrayHasher<Address>> m_usageFrequency;
 	};
 
 	/// Delta on top of the account state cache.

--- a/client/catapult/src/catapult/cache_core/AccountStateCacheStorage.cpp
+++ b/client/catapult/src/catapult/cache_core/AccountStateCacheStorage.cpp
@@ -26,6 +26,10 @@ namespace catapult { namespace cache {
 
 	void AccountStateCacheStorage::LoadInto(const ValueType& accountState, DestinationType& cacheDelta) {
 		cacheDelta.addAccount(accountState);
+
+		// Remove LRU items if cache size exceeds limit
+		size_t maxSize = 1000; // Example limit, adjust as needed
+		cacheDelta.limitCacheSize(maxSize);
 	}
 
 	void AccountStateCacheStorage::Purge(const ValueType& accountState, DestinationType& cacheDelta) {

--- a/client/catapult/src/catapult/cache_core/AccountStateCacheStorage.h
+++ b/client/catapult/src/catapult/cache_core/AccountStateCacheStorage.h
@@ -36,5 +36,8 @@ namespace catapult { namespace cache {
 
 		/// Purges \a accountState from \a cacheDelta.
 		static void Purge(const ValueType& accountState, DestinationType& cacheDelta);
+
+		/// Removes least recently used (LRU) items when the cache size exceeds a specified limit.
+		static void RemoveLRUItems(DestinationType& cacheDelta, size_t maxSize);
 	};
 }}

--- a/client/catapult/src/catapult/cache_core/AccountStateCacheSubCachePlugin.cpp
+++ b/client/catapult/src/catapult/cache_core/AccountStateCacheSubCachePlugin.cpp
@@ -216,14 +216,22 @@ namespace catapult { namespace cache {
 			const CacheConfiguration& config,
 			const AccountStateCacheTypes::Options& options)
 			: BaseType(std::make_unique<AccountStateCache>(config, options))
+			, m_cacheSizeLimit(1000) // Default cache size limit
 	{}
 
 	std::unique_ptr<CacheStorage> AccountStateCacheSubCachePlugin::createStorage() {
 		auto pStorage = BaseType::createStorage();
-		if (pStorage)
-			return std::make_unique<AccountStateFullCacheStorage>(std::move(pStorage), this->cache());
+		if (pStorage) {
+			auto cacheStorage = std::make_unique<AccountStateFullCacheStorage>(std::move(pStorage), this->cache());
+			this->cache().limitCacheSize(m_cacheSizeLimit);
+			return cacheStorage;
+		}
 
 		return std::make_unique<AccountStateCacheSummaryCacheStorage>(this->cache());
+	}
+
+	void AccountStateCacheSubCachePlugin::setCacheSizeLimit(size_t cacheSizeLimit) {
+		m_cacheSizeLimit = cacheSizeLimit;
 	}
 
 	// endregion

--- a/client/catapult/src/catapult/cache_core/AccountStateCacheSubCachePlugin.h
+++ b/client/catapult/src/catapult/cache_core/AccountStateCacheSubCachePlugin.h
@@ -37,5 +37,11 @@ namespace catapult { namespace cache {
 
 	public:
 		std::unique_ptr<CacheStorage> createStorage() override;
+
+		/// Sets the cache size limit.
+		void setCacheSizeLimit(size_t cacheSizeLimit);
+
+	private:
+		size_t m_cacheSizeLimit;
 	};
 }}


### PR DESCRIPTION
Add logic to limit the size of the `AccountStateCache` by removing least recently used (LRU) items.

* **AccountStateCache.h**
  - Add a method to limit the size of the cache by removing LRU items.
  - Add private members to track the usage frequency of cache items.

* **AccountStateCacheDelta.cpp**
  - Add logic to track and update the usage frequency of cache items in the `updateHighValueAccounts` method.
  - Add logic to track and update the usage frequency of cache items in the `processHighValueRemovedAccounts` method.

* **AccountStateCacheDelta.h**
  - Add a method to get the usage frequency of a cache item.
  - Add a private member to track the usage frequency of cache items.

* **AccountStateCacheStorage.cpp**
  - Add logic to remove LRU items when the cache size exceeds a specified limit in the `LoadInto` method.

* **AccountStateCacheStorage.h**
  - Add a method to remove LRU items when the cache size exceeds a specified limit.

* **AccountStateCacheSubCachePlugin.cpp**
  - Add logic to initialize the cache with a specified size limit in the constructor.
  - Add logic to remove LRU items when necessary in the `createStorage` method.
  - Add a method to set the cache size limit.

* **AccountStateCacheSubCachePlugin.h**
  - Add a private member to store the cache size limit.
  - Add a method to set the cache size limit.

