### PR TITLE
[jenkins] fix: libzmq build fails with CMake 4

### DIFF
--- a/jenkins/catapult/dependency_flags.py
+++ b/jenkins/catapult/dependency_flags.py
@@ -41,7 +41,8 @@ WINDOWS_DEPENDENCY_FLAGS = {
 	'google_googletest': ['-Dgtest_force_shared_crt=on'],
 
 	'mongodb_mongo-c-driver': ['-DENABLE_EXTRA_ALIGNMENT=0'],
-	'mongodb_mongo-cxx-driver': ['-DENABLE_TESTS=OFF']
+	'mongodb_mongo-cxx-driver': ['-DENABLE_TESTS=OFF'],
+	'zeromq_libzmq': ['-DCMAKE_POLICY_VERSION_MINIMUM=3.5']
 }
 
 


### PR DESCRIPTION
problem: libzmq CMake version requirement is not compatible with CMake 4
solution: disable the CMake requirement by adding -DCMAKE_POLICY_VERSION_MINIMUM=3.5