### PR TITLE
[catapult/client] fix: add mongo-c-driver as a requirement

### DIFF
--- a/client/catapult/conanfile.py
+++ b/client/catapult/conanfile.py
@@ -12,6 +12,7 @@ class CatapultConan(ConanFile):
 		self.requires("boost/1.83.0", run=True)
 		self.requires("openssl/3.4.1", run=True)
 		self.requires("cppzmq/4.10.0@nemtech/stable", run=True)
+		self.requires("mongo-c-driver/1.30.3@nemtech/stable", run=True)
 		self.requires("mongo-cxx-driver/4.0.0@nemtech/stable", run=True)
 		self.requires("rocksdb/10.1.3@nemtech/stable", run=True)
 


### PR DESCRIPTION
problem: catapult build will fail when mongo-c-driver is updated without mongo-cxx-driver.
         This is because the Conanfile only has a mongo-cxx-driver dependency, so the correct version of mongo-c-driver is not pulled.
solution: add a requirement on mongo-c-driver, which will match CMake