### PR TITLE
[monorepo]: update Jenkins url to TSS domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,52 +25,52 @@ Detailed version can be seen on [codecov.io][symbol-cov-link].
 [symbol-cov]: https://codecov.io/gh/symbol/symbol/branch/dev/graphs/tree.svg
 [symbol-cov-link]: https://codecov.io/gh/symbol/symbol/tree/dev
 
-[catbuffer-job]: https://jenkins.symboldev.com/blue/organizations/jenkins/Symbol%2Fgenerated%2Fsymbol%2Fcatbuffer-parser/activity/?branch=dev
-[catbuffer-parser-lint]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fcatbuffer-parser%2Fdev%2F&config=catbuffer-parser-lint
-[catbuffer-parser-test]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fcatbuffer-parser%2Fdev%2F&config=catbuffer-parser-test
-[catbuffer-parser-vectors]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fcatbuffer-parser%2Fdev%2F&config=catbuffer-parser-vectors
+[catbuffer-job]: https://jenkins.symbolsyndicate.us/blue/organizations/jenkins/Symbol%2Fgenerated%2Fsymbol%2Fcatbuffer-parser/activity/?branch=dev
+[catbuffer-parser-lint]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fcatbuffer-parser%2Fdev%2F&config=catbuffer-parser-lint
+[catbuffer-parser-test]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fcatbuffer-parser%2Fdev%2F&config=catbuffer-parser-test
+[catbuffer-parser-vectors]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fcatbuffer-parser%2Fdev%2F&config=catbuffer-parser-vectors
 [catbuffer-parser-cov]: https://codecov.io/gh/symbol/symbol/branch/dev/graph/badge.svg?token=SSYYBMK0M7&flag=catbuffer-parser
 [catbuffer-parser-cov-link]: https://codecov.io/gh/symbol/symbol/tree/dev/catbuffer/parser
 [catbuffer-package]: https://img.shields.io/pypi/v/catparser
 [catbuffer-package-link]: https://pypi.org/project/catparser
 
-[client-catapult-job]: https://jenkins.symboldev.com/blue/organizations/jenkins/Symbol%2Fgenerated%2Fsymbol%2Fclient-catapult/activity?branch=dev
-[client-catapult-lint]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fclient-catapult%2Fdev%2F&config=client-catapult-lint
-[client-catapult-build]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fclient-catapult%2Fdev%2F&config=client-catapult-build
-[client-catapult-test]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fclient-catapult%2Fdev%2F&config=client-catapult-test
+[client-catapult-job]: https://jenkins.symbolsyndicate.us/blue/organizations/jenkins/Symbol%2Fgenerated%2Fsymbol%2Fclient-catapult/activity?branch=dev
+[client-catapult-lint]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fclient-catapult%2Fdev%2F&config=client-catapult-lint
+[client-catapult-build]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fclient-catapult%2Fdev%2F&config=client-catapult-build
+[client-catapult-test]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fclient-catapult%2Fdev%2F&config=client-catapult-test
 [client-catapult-cov]: https://codecov.io/gh/symbol/symbol/branch/dev/graph/badge.svg?token=SSYYBMK0M7&flag=client-catapult
 [client-catapult-cov-link]: https://codecov.io/gh/symbol/symbol/tree/dev/client/catapult
 
-[client-rest-job]: https://jenkins.symboldev.com/blue/organizations/jenkins/Symbol%2Fgenerated%2Fsymbol%2Fclient-rest/activity?branch=dev
-[client-rest-lint]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fclient-rest%2Fdev%2F&config=client-rest-lint
-[client-rest-test]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fclient-rest%2Fdev%2F&config=client-rest-test
+[client-rest-job]: https://jenkins.symbolsyndicate.us/blue/organizations/jenkins/Symbol%2Fgenerated%2Fsymbol%2Fclient-rest/activity?branch=dev
+[client-rest-lint]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fclient-rest%2Fdev%2F&config=client-rest-lint
+[client-rest-test]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fclient-rest%2Fdev%2F&config=client-rest-test
 [client-rest-cov]: https://codecov.io/gh/symbol/symbol/branch/dev/graph/badge.svg?token=SSYYBMK0M7&flag=client-rest
 [client-rest-cov-link]: https://codecov.io/gh/symbol/symbol/tree/dev/client/rest
 
-[sdk-javascript-job]: https://jenkins.symboldev.com/blue/organizations/jenkins/Symbol%2Fgenerated%2Fsymbol%2Fsdk-javascript/activity?branch=dev
-[sdk-javascript-lint]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fsdk-javascript%2Fdev%2F&config=sdk-javascript-lint
-[sdk-javascript-build]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fsdk-javascript%2Fdev%2F&config=sdk-javascript-build
-[sdk-javascript-test]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fsdk-javascript%2Fdev%2F&config=sdk-javascript-test
-[sdk-javascript-examples]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fsdk-javascript%2Fdev%2F&config=sdk-javascript-examples
-[sdk-javascript-vectors]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fsdk-javascript%2Fdev%2F&config=sdk-javascript-vectors
+[sdk-javascript-job]: https://jenkins.symbolsyndicate.us/blue/organizations/jenkins/Symbol%2Fgenerated%2Fsymbol%2Fsdk-javascript/activity?branch=dev
+[sdk-javascript-lint]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fsdk-javascript%2Fdev%2F&config=sdk-javascript-lint
+[sdk-javascript-build]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fsdk-javascript%2Fdev%2F&config=sdk-javascript-build
+[sdk-javascript-test]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fsdk-javascript%2Fdev%2F&config=sdk-javascript-test
+[sdk-javascript-examples]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fsdk-javascript%2Fdev%2F&config=sdk-javascript-examples
+[sdk-javascript-vectors]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fsdk-javascript%2Fdev%2F&config=sdk-javascript-vectors
 [sdk-javascript-cov]: https://codecov.io/gh/symbol/symbol/branch/dev/graph/badge.svg?token=SSYYBMK0M7&flag=sdk-javascript
 [sdk-javascript-cov-link]: https://codecov.io/gh/symbol/symbol/tree/dev/sdk/javascript
 [sdk-javascript-package]: https://img.shields.io/npm/v/symbol-sdk-javascript
 [sdk-javascript-package-link]: https://www.npmjs.com/package/symbol-sdk-javascript
 
-[sdk-python-job]: https://jenkins.symboldev.com/blue/organizations/jenkins/Symbol%2Fgenerated%2Fsymbol%2Fsdk-python/activity?branch=dev
-[sdk-python-lint]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fsdk-python%2Fdev%2F&config=sdk-python-lint
-[sdk-python-build]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fsdk-python%2Fdev%2F&config=sdk-python-build
-[sdk-python-test]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fsdk-python%2Fdev%2F&config=sdk-python-test
-[sdk-python-examples]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fsdk-python%2Fdev%2F&config=sdk-python-examples
-[sdk-python-vectors]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fsdk-python%2Fdev%2F&config=sdk-python-vectors
+[sdk-python-job]: https://jenkins.symbolsyndicate.us/blue/organizations/jenkins/Symbol%2Fgenerated%2Fsymbol%2Fsdk-python/activity?branch=dev
+[sdk-python-lint]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fsdk-python%2Fdev%2F&config=sdk-python-lint
+[sdk-python-build]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fsdk-python%2Fdev%2F&config=sdk-python-build
+[sdk-python-test]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fsdk-python%2Fdev%2F&config=sdk-python-test
+[sdk-python-examples]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fsdk-python%2Fdev%2F&config=sdk-python-examples
+[sdk-python-vectors]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fsdk-python%2Fdev%2F&config=sdk-python-vectors
 [sdk-python-cov]: https://codecov.io/gh/symbol/symbol/branch/dev/graph/badge.svg?token=SSYYBMK0M7&flag=sdk-python
 [sdk-python-cov-link]: https://codecov.io/gh/symbol/symbol/tree/dev/sdk/python
 [sdk-python-package]: https://img.shields.io/pypi/v/symbol-sdk-python
 [sdk-python-package-link]: https://pypi.org/project/symbol-sdk-python
 
-[jenkins-job]: https://jenkins.symboldev.com/blue/organizations/jenkins/Symbol%2Fgenerated%2Fsymbol%2Fjenkins/activity?branch=dev
-[jenkins-lint]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fjenkins%2Fdev%2F&config=jenkins-lint
+[jenkins-job]: https://jenkins.symbolsyndicate.us/blue/organizations/jenkins/Symbol%2Fgenerated%2Fsymbol%2Fjenkins/activity?branch=dev
+[jenkins-lint]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fjenkins%2Fdev%2F&config=jenkins-lint
 
-[linters-job]: https://jenkins.symboldev.com/blue/organizations/jenkins/Symbol%2Fgenerated%2Fsymbol%2Flinters/activity?branch=dev
-[linters-lint]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Flinters%2Fdev%2F&config=linters-lint
+[linters-job]: https://jenkins.symbolsyndicate.us/blue/organizations/jenkins/Symbol%2Fgenerated%2Fsymbol%2Flinters/activity?branch=dev
+[linters-lint]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Flinters%2Fdev%2F&config=linters-lint

--- a/client/catapult/README.md
+++ b/client/catapult/README.md
@@ -1,8 +1,8 @@
 # catapult-client
 
 [![docs](badges/docs--green.svg)](https://symbol.github.io)
-[![build rel](https://jenkins.symboldev.com/buildStatus/icon?subject=build%20rel&job=Symbol%2Fserver-pipelines%2Fcatapult-client-release-build)](https://jenkins.symboldev.com/job/Symbol/server-pipelines/job/catapult-client-release-build/)
-[![build dev](https://jenkins.symboldev.com/buildStatus/icon?subject=build%20dev&job=Symbol%2Fserver-pipelines%2Fcatapult-client-build-catapult-project)](https://jenkins.symboldev.com/job/Symbol/server-pipelines/job/catapult-client-build-catapult-project/)
+[![build rel](https://jenkins.symbolsyndicate.us/buildStatus/icon?subject=build%20rel&job=Symbol%2Fserver-pipelines%2Fcatapult-client-release-build)](https://jenkins.symbolsyndicate.us/job/Symbol/server-pipelines/job/catapult-client-release-build/)
+[![build dev](https://jenkins.symbolsyndicate.us/buildStatus/icon?subject=build%20dev&job=Symbol%2Fserver-pipelines%2Fcatapult-client-build-catapult-project)](https://jenkins.symbolsyndicate.us/job/Symbol/server-pipelines/job/catapult-client-build-catapult-project/)
 [![docker](badges/docker-symbolplatform-brightgreen.svg)](https://hub.docker.com/u/symbolplatform)
 
 Symbol-based networks rely on nodes to provide a trustless, high-performance, and secure blockchain platform.

--- a/sdk/javascript/README.md
+++ b/sdk/javascript/README.md
@@ -2,10 +2,10 @@
 
 [![lint][sdk-javascript-lint]][sdk-javascript-job] [![test][sdk-javascript-test]][sdk-javascript-job] [![vectors][sdk-javascript-vectors]][sdk-javascript-job] [![][sdk-javascript-cov]][sdk-javascript-cov-link] [![][sdk-javascript-package]][sdk-javascript-package-link]
 
-[sdk-javascript-job]: https://jenkins.symboldev.com/blue/organizations/jenkins/Symbol%2Fgenerated%2Fsymbol%2Fjavascript/activity?branch=dev
-[sdk-javascript-lint]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fjavascript%2Fdev%2F&config=sdk-javascript-lint
-[sdk-javascript-test]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fjavascript%2Fdev%2F&config=sdk-javascript-test
-[sdk-javascript-vectors]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fjavascript%2Fdev%2F&config=sdk-javascript-vectors
+[sdk-javascript-job]: https://jenkins.symbolsyndicate.us/blue/organizations/jenkins/Symbol%2Fgenerated%2Fsymbol%2Fjavascript/activity?branch=dev
+[sdk-javascript-lint]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fjavascript%2Fdev%2F&config=sdk-javascript-lint
+[sdk-javascript-test]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fjavascript%2Fdev%2F&config=sdk-javascript-test
+[sdk-javascript-vectors]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fjavascript%2Fdev%2F&config=sdk-javascript-vectors
 [sdk-javascript-cov]: https://codecov.io/gh/symbol/symbol/branch/dev/graph/badge.svg?token=SSYYBMK0M7&flag=sdk-javascript
 [sdk-javascript-cov-link]: https://codecov.io/gh/symbol/symbol/tree/dev/sdk/javascript
 [sdk-javascript-package]: https://img.shields.io/npm/v/symbol-sdk

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -2,12 +2,12 @@
 
 [![lint][sdk-python-lint]][sdk-python-job] [![test][sdk-python-test]][sdk-python-job] [![vectors][sdk-python-vectors]][sdk-python-job] [![][sdk-python-cov]][sdk-python-cov-link] [![][sdk-python-package]][sdk-python-package-link]
 
-[sdk-python-job]: https://jenkins.symboldev.com/blue/organizations/jenkins/Symbol%2Fgenerated%2Fsymbol%2Fpython/activity?branch=dev
-[sdk-python-lint]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fpython%2Fdev%2F&config=sdk-python-lint
-[sdk-python-build]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fpython%2Fdev%2F&config=sdk-python-build
-[sdk-python-test]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fpython%2Fdev%2F&config=sdk-python-test
-[sdk-python-examples]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fpython%2Fdev%2F&config=sdk-python-examples
-[sdk-python-vectors]: https://jenkins.symboldev.com/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fpython%2Fdev%2F&config=sdk-python-vectors
+[sdk-python-job]: https://jenkins.symbolsyndicate.us/blue/organizations/jenkins/Symbol%2Fgenerated%2Fsymbol%2Fpython/activity?branch=dev
+[sdk-python-lint]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fpython%2Fdev%2F&config=sdk-python-lint
+[sdk-python-build]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fpython%2Fdev%2F&config=sdk-python-build
+[sdk-python-test]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fpython%2Fdev%2F&config=sdk-python-test
+[sdk-python-examples]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fpython%2Fdev%2F&config=sdk-python-examples
+[sdk-python-vectors]: https://jenkins.symbolsyndicate.us/buildStatus/icon?job=Symbol%2Fgenerated%2Fsymbol%2Fpython%2Fdev%2F&config=sdk-python-vectors
 [sdk-python-cov]: https://codecov.io/gh/symbol/symbol/branch/dev/graph/badge.svg?token=SSYYBMK0M7&flag=sdk-python
 [sdk-python-cov-link]: https://codecov.io/gh/symbol/symbol/tree/dev/sdk/python
 [sdk-python-package]: https://img.shields.io/pypi/v/symbol-sdk-python


### PR DESCRIPTION
problem: Jenkins domain has been updated to https://jenkins.symbolsyndicate.us, and the README needs to be updated
solution: update the README files