### PR TITLE
[sdk/javascript] fix: pin rustc to 1.86.0

### DIFF
--- a/sdk/javascript/scripts/ci/build.sh
+++ b/sdk/javascript/scripts/ci/build.sh
@@ -7,7 +7,10 @@ bash scripts/run_catbuffer_generator_ts.sh dryrun
 
 # build wasm variants
 cd wasm
-rustup default stable
+# rustup default stable
+# stay with rustc 1.86.0 until wasm opt is fixed
+# https://github.com/rustwasm/wasm-pack/issues/1441#issuecomment-2933318080
+rustup install 1.86.0
 wasm-pack build --release --no-typescript --target nodejs --out-dir ../_build/wasm/node
 wasm-pack build --release --no-typescript --target web --out-dir ../_build/wasm/web
 cd ..


### PR DESCRIPTION
problem: JS SDK fails to build with Rustc 1.87.0
solution: pin the Rustc version to 1.86.0