### PR TITLE
[mkdocs] fix: openapi-symbol.yml

### DIFF
--- a/openapi/openapi-symbol.yml
+++ b/openapi/openapi-symbol.yml
@@ -4001,7 +4001,7 @@ components:
           type: string
           description: Maximum number of blocks for which a hash lock can exist.
           example: 2d
-    LockHashAlgorithmEnum.:
+    LockHashAlgorithmEnum:
       type: integer
       enum:
         - 0
@@ -4049,7 +4049,7 @@ components:
         status:
           $ref: '#/components/schemas/LockStatus'
         hashAlgorithm:
-          $ref: '#/components/schemas/LockHashAlgorithmEnum.'
+          $ref: '#/components/schemas/LockHashAlgorithmEnum'
         secret:
           $ref: '#/components/schemas/Secret'
         recipientAddress:
@@ -4115,7 +4115,7 @@ components:
         duration:
           $ref: '#/components/schemas/BlockDuration'
         hashAlgorithm:
-          $ref: '#/components/schemas/LockHashAlgorithmEnum.'
+          $ref: '#/components/schemas/LockHashAlgorithmEnum'
     SecretLockTransactionDTO:
       type: object
       description: Transaction to sends mosaics to a recipient if the proof used is revealed. If the duration is reached, the locked
@@ -4136,7 +4136,7 @@ components:
         secret:
           $ref: '#/components/schemas/Hash256'
         hashAlgorithm:
-          $ref: '#/components/schemas/LockHashAlgorithmEnum.'
+          $ref: '#/components/schemas/LockHashAlgorithmEnum'
         proof:
           type: string
           description: Original random set of bytes.

--- a/openapi/openapi-symbol.yml
+++ b/openapi/openapi-symbol.yml
@@ -114,7 +114,7 @@ paths:
       tags:
         - Block routes
       summary: Search blocks
-      description: Gets an array of bocks.
+      description: Gets an array of blocks.
       operationId: searchBlocks
       parameters:
         - $ref: '#/components/parameters/signerPublicKeyQuery'


### PR DESCRIPTION
- fix typo "bocks" -> "blocks".
- fix invalid key name "LockHashAlgorithmEnum." -> "LockHashAlgorithmEnum"