### PR TITLE
[client/catapult] fix: update catapult docs URL

### DIFF
--- a/client/catapult/README.md
+++ b/client/catapult/README.md
@@ -1,6 +1,6 @@
 # catapult-client
 
-[![docs](badges/docs--green.svg)](https://symbol.github.io)
+[![docs](badges/docs--green.svg)](https://docs.symbol.dev)
 [![build rel](https://jenkins.symbolsyndicate.us/buildStatus/icon?subject=build%20rel&job=Symbol%2Fserver-pipelines%2Fcatapult-client-release-build)](https://jenkins.symbolsyndicate.us/job/Symbol/server-pipelines/job/catapult-client-release-build/)
 [![build dev](https://jenkins.symbolsyndicate.us/buildStatus/icon?subject=build%20dev&job=Symbol%2Fserver-pipelines%2Fcatapult-client-build-catapult-project)](https://jenkins.symbolsyndicate.us/job/Symbol/server-pipelines/job/catapult-client-build-catapult-project/)
 [![docker](badges/docker-symbolplatform-brightgreen.svg)](https://hub.docker.com/u/symbolplatform)
@@ -49,7 +49,7 @@ catapult-client executable can be used either to run different types of nodes or
 
 Developers can deploy test net nodes to experiment with the offered transaction set in a live network without the loss of valuable assets.
 
-To run a test net node, follow [this guide](https://symbol.github.io/guides/network/running-a-test-net-node.html).
+To run a test net node, follow [this guide](https://docs.symbol.dev/guides/network/running-a-symbol-node.html).
 
 ### Main Network Node
 
@@ -59,7 +59,7 @@ At the time of writing, the main public network has not been launched. Follow th
 
 With Symbol, businesses can launch and extend private networks by developing custom plugins and extensions at the protocol level. The package [Service Bootstrap] contains the necessary setup scripts to deploy a network for testing and development purposes with just one command.
 
-To run a private test net, follow [this guide](https://symbol.github.io/guides/network/creating-a-private-test-net.html#creating-a-private-test-net).
+To run a private test net, follow [this guide](https://docs.symbol.dev/guides/network/creating-a-private-test-net.html#creating-a-private-test-net).
 
 ### Private Network
 
@@ -80,12 +80,11 @@ Before contributing please [read this](CONTRIBUTING.md).
 
 Copyright (c) 2018 Jaguar0625, gimre, BloodyRookie, Tech Bureau, Corp Licensed under the [GNU Lesser General Public License v3](LICENSE.txt)
 
-[developer documentation]: https://symbol.github.io
-[Forum]: https://forum.nem.io/c/announcement
-[issues]: https://github.com/symbol/catapult-client/issues
-[slack]: https://join.slack.com/t/nem2/shared_invite/enQtMzY4MDc2NTg0ODgyLWZmZWRiMjViYTVhZjEzOTA0MzUyMTA1NTA5OWQ0MWUzNTA4NjM5OTJhOGViOTBhNjkxYWVhMWRiZDRkOTE0YmU
-[catapult-client]: https://github.com/symbol/catapult-client
-[symbol-rest]: https://github.com/symbol/catapult-rest
+[developer documentation]: https://docs.symbol.dev
+[issues]: https://github.com/symbol/symbol/issues
+[discord]: https://discord.gg/NMA9YQ55td
+[catapult-client]: https://github.com/symbol/symbol/tree/dev/client/catapult
+[symbol-rest]: https://github.com/symbol/symbol/tree/dev/client/rest
 [Service Bootstrap]: https://github.com/symbol/symbol-bootstrap
 [nem]: https://nem.io
 [technical reference]: https://symbol.github.io/symbol-technicalref/main.pdf

--- a/client/catapult/docs/README.md
+++ b/client/catapult/docs/README.md
@@ -85,10 +85,10 @@ race:global_logger::get()
 
 * [How to create a new network](RUNNETWORKLIN.md)
 
-* [Network configuration](https://symbol.github.io/guides/network/configuring-network-properties.html)
+* [Network configuration](https://docs.symbol.dev/guides/network/configuring-network-properties.html)
 
 ## Running a peer node
 
 * [How to create a node and connect to an existing network](RUNPEERLIN.md)
 
-* [Node configuration](https://symbol.github.io/guides/network/configuring-node-properties.html)
+* [Node configuration](https://docs.symbol.dev/guides/network/configuring-node-properties.html)

--- a/client/catapult/docs/RUNNETWORKLIN.md
+++ b/client/catapult/docs/RUNNETWORKLIN.md
@@ -119,7 +119,7 @@ Replace at least one address in each list with an address from ``nemesis.address
 ## Edit the network properties
 
 The file ``resources/config-network.properties`` defines the network configuration.
-Learn more about each network property in [this guide](https://symbol.github.io/guides/network/configuring-network-properties.html#properties).
+Learn more about each network property in [this guide](https://docs.symbol.dev/guides/network/configuring-network-properties.html#properties).
 
 Edit the properties file to match the nemesis block with the desired network configuration. Important properties to check are:
 
@@ -137,7 +137,7 @@ Edit the properties file to match the nemesis block with the desired network con
 
 ## Append the VRF Keys to the nemesis block
 
-The process of creating new blocks is called [harvesting](https://symbol.github.io/concepts/harvesting.html).
+The process of creating new blocks is called [harvesting](https://docs.symbol.dev/concepts/harvesting.html).
 Each node of the network can host zero or more harvester accounts to create new blocks and get rewarded.
 
 In order to be an eligible harvester, the account must:

--- a/client/catapult/docs/RUNPEERLIN.md
+++ b/client/catapult/docs/RUNPEERLIN.md
@@ -1,6 +1,6 @@
 # Running a Peer Node on Ubuntu 18.04 (LTS)
 
-These instructions summarize the minimum number of steps to run a [peer node](https://symbol.github.io/concepts/node.html#id1) and connect it to an existing network using the catapult-client build.
+These instructions summarize the minimum number of steps to run a [peer node](https://docs.symbol.dev/concepts/node.html#id1) and connect it to an existing network using the catapult-client build.
 
 ## Prerequisites
 
@@ -31,7 +31,7 @@ If you have not launched a network yet, move directly to ["Edit the node propert
 ## Edit the node properties
 
 The file ``resources/config-node.properties`` defines the node configuration.
-Learn more about each network property in [this guide](https://symbol.github.io/guides/network/configuring-node-properties.html#properties).
+Learn more about each node property in [this guide](https://docs.symbol.dev/guides/network/configuring-node-properties.html#node-properties).
 
 Open ``resources/config-node.properties`` and search for the ``[localnode]`` section.
 Then, edit the properties with the node details. You will need at least these properties:
@@ -59,7 +59,7 @@ roles = IPv4,Peer
 
 ## Enable harvesting
 
-This step enables [harvesting](https://symbol.github.io/concepts/harvesting.html), which allows the node to produce new blocks.
+This step enables [harvesting](https://docs.symbol.dev/concepts/harvesting.html), which allows the node to produce new blocks.
 
 > **NOTE:**
 > At least one node of the network must have harvesting enabled to produce new blocks. If you don't want to enable harvesting, move directly to [Add other peer nodes](#add-other-peer-nodes).
@@ -83,7 +83,7 @@ This step enables [harvesting](https://symbol.github.io/concepts/harvesting.html
     ...
     ```
 
-   * Replace ``<HARVESTER_SIGNING_PRIVATE_KEY>`` with the private key of an [eligible account](https://symbol.github.io/concepts/harvesting.html#eligibility-criteria).
+   * Replace ``<HARVESTER_SIGNING_PRIVATE_KEY>`` with the private key of an [eligible account](https://docs.symbol.dev/concepts/harvesting.html#eligibility-criteria).
 
    * Replace ``<HARVESTER_VRF_PRIVATE_KEY>`` with the private key linked to the harvester account to randomize the block production. The link could be defined in the [nemesis block](RUNNETWORKLIN.md#append-the-vrf-keys-to-the-nemesis-block) or at a later point by announcing a **VRFKeyLinkTransaction** with the [CLI](https://github.com/nemtech/symbol-cli/blob/gh-pages/0.20.3.md#vrfkeylink) or [SDKs](https://github.com/nemtech/symbol-sdk-typescript-javascript).
 


### PR DESCRIPTION
problem: docs URL is outdated
solution: update the docs URL to https://docs.symbol.dev