### PR TITLE
[monorepo]: update the min python version for packages

### DIFF
--- a/catbuffer/parser/pyproject.toml
+++ b/catbuffer/parser/pyproject.toml
@@ -14,7 +14,7 @@ repository = 'https://github.com/symbol/symbol/tree/main/catbuffer/parser'
 
 keywords = ['symbol', 'catbuffer', 'catparser', 'parser', 'catbuffer-parser']
 
-classifiers = ['Programming Language :: Python :: 3.7']
+classifiers = ['Programming Language :: Python :: 3.10']
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.10"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -14,7 +14,7 @@ repository = 'https://github.com/symbol/symbol/tree/main/sdk/python'
 
 keywords = ['symbol', 'sdk', 'Symbol SDK']
 
-classifiers = ['Programming Language :: Python :: 3.9', 'Programming Language :: Python :: 3.10', 'Programming Language :: Python :: 3.11']
+classifiers = ['Programming Language :: Python :: 3.10', 'Programming Language :: Python :: 3.11',  'Programming Language :: Python :: 3.12',  'Programming Language :: Python :: 3.13']
 
 [tool.poetry.dependencies]
-python = "^3.9.2"
+python = "^3.10.0"

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -14,7 +14,7 @@ repository = 'https://github.com/symbol/symbol/tree/main/sdk/python'
 
 keywords = ['symbol', 'sdk', 'Symbol SDK']
 
-classifiers = ['Programming Language :: Python :: 3.10', 'Programming Language :: Python :: 3.11',  'Programming Language :: Python :: 3.12',  'Programming Language :: Python :: 3.13']
+classifiers = ['Programming Language :: Python :: 3.10', 'Programming Language :: Python :: 3.11', 'Programming Language :: Python :: 3.12', 'Programming Language :: Python :: 3.13']
 
 [tool.poetry.dependencies]
-python = "^3.10.0"
+python = "^3.10"


### PR DESCRIPTION
[sdk/python] fix: bump minimum Python version for SDK
problem: Python 9 eol in Oct
solution: Bump the minimum Python version to 3.10

[catbuffer/parser] fix: bump minimum Python version
problem: Python version 7-9 reaches EOL
solution: Bump the minimum Python version to 3.10