### PR TITLE
[jenkins] fix: deps and macOS build failing

### DIFF
--- a/client/catapult/CMakeGlobalSettings.cmake
+++ b/client/catapult/CMakeGlobalSettings.cmake
@@ -177,7 +177,7 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 
 	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -g1")
 
-    # fix -Wpoison-system-directories: error: include location '/usr/local/include' is "unsafe for cross-compilation"
+	# fix -Wpoison-system-directories: error: include location '/usr/local/include' is "unsafe for cross-compilation"
 	if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 		find_program(XCODE_SELECT xcode-select)
 		if (XCODE_SELECT)

--- a/client/catapult/CMakeGlobalSettings.cmake
+++ b/client/catapult/CMakeGlobalSettings.cmake
@@ -176,6 +176,17 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 		-Wno-switch-default")
 
 	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -g1")
+
+    # fix -Wpoison-system-directories: error: include location '/usr/local/include' is "unsafe for cross-compilation"
+	if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+		find_program(XCODE_SELECT xcode-select)
+		if (XCODE_SELECT)
+			execute_process(COMMAND xcode-select --print-path OUTPUT_VARIABLE XCODE_PATH OUTPUT_STRIP_TRAILING_WHITESPACE)
+			set(CMAKE_OSX_SYSROOT "${XCODE_PATH}/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk")
+		else()
+			message(WARNING "xcode-select not found, cannot automatically set CMAKE_OSX_SYSROOT.")
+		endif()
+	endif()
 endif()
 
 if(NOT MSVC)

--- a/jenkins/catapult/installDepsLocal.py
+++ b/jenkins/catapult/installDepsLocal.py
@@ -103,6 +103,9 @@ class Builder:
 		if 'mongodb' == organization:
 			cmake_options += [f'-DOPENSSL_ROOT_DIR={self.target_directory / "openssl"}']
 
+		if 'zeromq' == organization:
+			cmake_options += ['-DCMAKE_POLICY_VERSION_MINIMUM=3.5']
+
 		additional_cmake_options = get_dependency_flags(f'{organization}_{project}')
 		if additional_cmake_options:
 			cmake_options += additional_cmake_options
@@ -129,9 +132,8 @@ class Builder:
 		self.process_manager.dispatch_subprocess(['nmake', 'install_sw', 'install_ssldirs'])
 
 	def build_openssl_unix(self):
-		compiler = 'linux-x86_64-clang' if self.is_clang else ''
 		openssl_destinations = [f'--{key}={self.target_directory / "openssl"}' for key in ('prefix', 'openssldir', 'libdir')]
-		self.process_manager.dispatch_subprocess(['perl', './Configure', compiler] + openssl_destinations)
+		self.process_manager.dispatch_subprocess(['perl', './Configure'] + openssl_destinations)
 		self.process_manager.dispatch_subprocess(['make'])
 		self.process_manager.dispatch_subprocess(['make', 'install_sw', 'install_ssldirs'])
 


### PR DESCRIPTION
problem: OpenSSL and ZeroMQ are failing to build on macOS with CMake 4.
solution: ZeroMQ set the CMAKE_POLICY_VERSION_MINIMUM=3.5
          MacOS build set the CMAKE_OSX_SYSROOT so as not to use the system include
          OpenSSL Configure scripts now autodetect OS correctly