### PR TITLE
[mkdocs] feat: keep viewing path when switch language.

### DIFF
--- a/mkdocs/overrides/partials/alternate.html
+++ b/mkdocs/overrides/partials/alternate.html
@@ -1,0 +1,25 @@
+{#-
+	Custom language switcher template
+	Preserve the current page path when switching languages
+-#}
+<div class="md-header__option">
+	<div class="md-select">
+		{% set icon = config.theme.icon.alternate or "material/translate" %}
+		<button class="md-header__button md-icon" aria-label="{{ lang.t('select.language') }}">
+			{% include ".icons/" ~ icon ~ ".svg" %}
+		</button>
+		<div class="md-select__inner">
+			<ul class="md-select__list">
+				{% for alt in config.extra.alternate %}
+					<li class="md-select__item">
+						{% set current_path = page.url | default('', true) %}
+						{% set new_path = '/' ~ alt.lang ~ '/' ~ current_path %}
+						<a href="{{ new_path | url }}" hreflang="{{ alt.lang }}" class="md-select__link">
+							{{ alt.name }}
+						</a>
+					</li>
+				{% endfor %}
+			</ul>
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
[recording.webm](https://github.com/user-attachments/assets/66b48904-7e10-4d55-99c4-2c15723e5af6)
