### PR TITLE
[mkdocs] docs: add create from mnemonic tutorial

### DIFF
--- a/mkdocs/config/mkdocs.en.yml
+++ b/mkdocs/config/mkdocs.en.yml
@@ -72,6 +72,7 @@ nav:
       - Tutorials:
           - Accounts:
               - devbook/accounts/create-from-private-key.md
+              - devbook/accounts/create-from-mnemonic.md
               - devbook/accounts/query-balance.md
           - Transactions:
               - devbook/transactions/transfer.md

--- a/mkdocs/overrides/devbook/accounts/create-from-mnemonic.log
+++ b/mkdocs/overrides/devbook/accounts/create-from-mnemonic.log
@@ -1,0 +1,6 @@
+Generating random mnemonic...
+Mnemonic: east actual egg series spot express addict always human swallow decrease turn surround direct place burst million curious dish divorce net nephew allow *****
+Password: correcthorsebatterystaple
+Address: TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I
+Public key: 3B6A27BCCEB6A42D62A3A8D02A6F0D73653215771DE243A63AC048A18B59DA29
+Private key: 0000000000000000000000000000000000000000000000000000000000000000

--- a/mkdocs/overrides/devbook/accounts/create-from-mnemonic.log
+++ b/mkdocs/overrides/devbook/accounts/create-from-mnemonic.log
@@ -1,5 +1,5 @@
-Generating random mnemonic...
-Mnemonic: east actual egg series spot express addict always human swallow decrease turn surround direct place burst million curious dish divorce net nephew allow *****
+Generating random mnemonic phrase...
+Mnemonic phrase: east actual egg series spot express addict always human swallow decrease turn surround direct place burst million curious dish divorce net nephew allow *****
 Password: correcthorsebatterystaple
 Address: TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I
 Public key: 3B6A27BCCEB6A42D62A3A8D02A6F0D73653215771DE243A63AC048A18B59DA29

--- a/mkdocs/overrides/devbook/accounts/create-from-mnemonic.mjs
+++ b/mkdocs/overrides/devbook/accounts/create-from-mnemonic.mjs
@@ -9,12 +9,12 @@ const facade = new SymbolFacade('testnet');
 const bip32 = new Bip32(facade.constructor.BIP32_CURVE_NAME);
 let mnemonic = process.env.MNEMONIC;
 if (mnemonic) {
-	console.log('Loading mnemonic from environment variable...');
+	console.log('Loading mnemonic phrase from environment variable...');
 } else {
-	console.log('Generating random mnemonic...');
+	console.log('Generating random mnemonic phrase...');
 	mnemonic = bip32.random();
 }
-console.log('Mnemonic:', mnemonic);
+console.log('Mnemonic phrase:', mnemonic);
 
 // Load password from environment variable or use default
 const password = process.env.PASSWORD || 'correcthorsebatterystaple';

--- a/mkdocs/overrides/devbook/accounts/create-from-mnemonic.mjs
+++ b/mkdocs/overrides/devbook/accounts/create-from-mnemonic.mjs
@@ -1,0 +1,39 @@
+import { Bip32 } from 'symbol-sdk';
+import { SymbolFacade } from 'symbol-sdk/symbol';
+import process from 'process';
+
+// Initialize the facade for the testnet network
+const facade = new SymbolFacade('testnet');
+
+// Use an existing mnemonic if provided, otherwise generate a random one
+const bip32 = new Bip32(facade.constructor.BIP32_CURVE_NAME);
+let mnemonic = process.env.MNEMONIC;
+if (mnemonic) {
+	console.log('Loading mnemonic from environment variable...');
+} else {
+	console.log('Generating random mnemonic...');
+	mnemonic = bip32.random();
+}
+console.log('Mnemonic:', mnemonic);
+
+// Load password from environment variable or use default
+const password = process.env.PASSWORD || 'correcthorsebatterystaple';
+console.log('Password:', password);
+
+// Derive a root Bip32 node from the mnemonic and a password
+const rootNode = bip32.fromMnemonic(mnemonic, password);
+
+// Derive a child Bip32 node for the account at index 0
+const accountIndex = 0;
+const childNode = rootNode.derivePath(facade.bip32Path(accountIndex));
+
+// Convert the Bip32 node to a signing key pair
+const keyPair = facade.constructor.bip32NodeToKeyPair(childNode);
+
+// Derive the address from the public key
+const address = facade.network.publicKeyToAddress(keyPair.publicKey);
+
+// Output the account details
+console.log('Address:', address.toString());
+console.log('Public key:', keyPair.publicKey.toString());
+console.log('Private key:', keyPair.privateKey.toString());

--- a/mkdocs/overrides/devbook/accounts/create-from-mnemonic.py
+++ b/mkdocs/overrides/devbook/accounts/create-from-mnemonic.py
@@ -1,0 +1,38 @@
+import os
+from symbolchain.Bip32 import Bip32
+from symbolchain.facade.SymbolFacade import SymbolFacade
+
+# Initialize the facade for the testnet network
+facade = SymbolFacade('testnet')
+
+# Use an existing mnemonic if provided, otherwise generate a random one
+bip32 = Bip32()
+mnemonic = os.environ.get('MNEMONIC')
+if mnemonic:
+	print("Loading mnemonic from environment variable...")
+else:
+	print("Generating random mnemonic...")
+	mnemonic = bip32.random()
+print(f'Mnemonic: {mnemonic}')
+
+# Load password from environment variable or use default
+password = os.environ.get('PASSWORD', 'correcthorsebatterystaple')
+print(f'Password: {password}')
+
+# Derive a root Bip32 node from the mnemonic and a password
+root_node = bip32.from_mnemonic(mnemonic, password)
+
+# Derive a child Bip32 node for the account at index 0
+account_index = 0
+child_node = root_node.derive_path(facade.bip32_path(account_index))
+
+# Convert the Bip32 node to a signing key pair
+key_pair = facade.bip32_node_to_key_pair(child_node)
+
+# Derive the address from the public key
+address = facade.network.public_key_to_address(key_pair.public_key)
+
+# Output the account details
+print(f'Address: {address}')
+print(f'Public key: {key_pair.public_key}')
+print(f'Private key: {key_pair.private_key}')

--- a/mkdocs/overrides/devbook/accounts/create-from-mnemonic.py
+++ b/mkdocs/overrides/devbook/accounts/create-from-mnemonic.py
@@ -9,11 +9,11 @@ facade = SymbolFacade('testnet')
 bip32 = Bip32()
 mnemonic = os.environ.get('MNEMONIC')
 if mnemonic:
-	print("Loading mnemonic from environment variable...")
+	print("Loading mnemonic phrase from environment variable...")
 else:
-	print("Generating random mnemonic...")
+	print("Generating random mnemonic phrase...")
 	mnemonic = bip32.random()
-print(f'Mnemonic: {mnemonic}')
+print(f'Mnemonic phrase: {mnemonic}')
 
 # Load password from environment variable or use default
 password = os.environ.get('PASSWORD', 'correcthorsebatterystaple')

--- a/mkdocs/pages/en/devbook/accounts/create-from-mnemonic.md
+++ b/mkdocs/pages/en/devbook/accounts/create-from-mnemonic.md
@@ -4,7 +4,8 @@ title: Create from Mnemonic
 
 # Creating Accounts from Mnemonics
 
-This tutorial shows how to create <accounts:> for the Symbol blockchain using a <mnemonic phrase:>.
+This tutorial shows how to create <accounts:> for the Symbol blockchain using a <mnemonic phrase:>,
+also known simply as _mnemonic_.
 
 This approach is commonly used by <HD wallets:> to manage multiple accounts from a single seed.
 
@@ -27,7 +28,7 @@ development environment is set up correctly.
 
 The <dy:SymbolFacade> provides access to Symbol's cryptographic operations and network utilities.
 It is initialized with a network name (`testnet` or `mainnet`) to ensure that network-specific values,
-such as <address:>, are generated correctly.
+such as <addresses:>, are generated correctly.
 
 ### Defining a Mnemonic
 
@@ -39,10 +40,10 @@ Otherwise, a new random mnemonic is generated using <dy:Bip32.random>.
 
 Symbol uses the [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) standard, which represents
 mnemonics as 24 English words selected from a standardized word list.
-These words encode entropy that serves as the foundation for deriving private keys.
+These words encode the entropy (randomness) used to create all derived private keys.
 
-!!! warning "Store your mnemonic securely"
-    The mnemonic can be used to regenerate all derived accounts and private keys.
+!!! warning "Store your mnemonic phrase securely"
+    The mnemonic phrase can be used to regenerate all derived accounts and private keys.
     Anyone with access to it can control your accounts, and losing it means losing access permanently.
 
     Never share your mnemonic with anyone, and always store it in a secure location.
@@ -56,30 +57,32 @@ which serves as the starting point for deriving child accounts.
 
 The password (sometimes called a "25th word") is an optional string that extends the mnemonic seed.
 It can be left empty or set to any value.
-When used, it adds another layer of security. Different passwords with the same mnemonic produce completely different
-accounts.
+When used, it adds another layer of security.
+Different passwords with the same mnemonic produce completely different accounts.
 
 !!! note "Password security"
     The password is part of the account derivation.
     Both the mnemonic and password are required to regenerate the accounts.
-    If you lose or forget either one, you lose access to all derived accounts.
+    If you lose either one, you lose access to all derived accounts.
 
 In this example, the password is loaded from the `PASSWORD` environment variable.
-If not set, the snippet defaults to `correcthorsebatterystaple` for demonstration purposes only.
+If not set, the snippet uses a default one.
 
 ### Deriving the Child Account
 
 {{ tutorial.code_snippet(['py:25:27', 'js:26:28']) }}
 
-The root node can derive multiple child accounts using a hierarchical path.
+The root node can generate multiple accounts, each with its own unique keys and address.
 This allows a single mnemonic to manage many accounts while keeping them cryptographically isolated.
 
-<dy:SymbolFacade.bip32Path> generates the derivation path for a specific account index.
-In this example, the account at index `0` is derived, but you can derive additional accounts by using different
-indices (e.g., `1`, `2`, `3`).
+Deriving an account requires specifying an account index.
+<dy:SymbolFacade.bip32Path> generates the derivation path
+(a standardized string that specifies which account to derive) for that index,
+and <dy:Bip32Node.derivePath> follows that path to create the account.
 
-<dy:Bip32Node.derivePath> follows the specified path from the root node to produce a child node that represents
-the account.
+In this example, the account at index `0` is derived.
+Additional accounts can be derived by using different indices (e.g., `1`, `2`, `3`, ...).
+Each index produces a completely different account.
 
 ### Creating the Account
 
@@ -109,10 +112,8 @@ If the same mnemonic and password are provided, the same account is always deriv
 
 This tutorial showed how to:
 
-| Step                                                       | Related documentation                    |
-| ---------------------------------------------------------- | ---------------------------------------- |
-| [Define a mnemonic](#defining-a-mnemonic)                  | <dy:Bip32.random>                        |
-| [Derive a root node](#deriving-the-root-node)              | <dy:Bip32.fromMnemonic>                  |
-| [Derive a child account](#deriving-the-child-account)      | <dy:Bip32Node.derivePath>                |
-| [Get the key pair](#creating-the-key-pair-and-address)     | <dy:SymbolFacade.bip32NodeToKeyPair>     |
-| [Get the address](#creating-the-key-pair-and-address)      | <dy:network.publicKeyToAddress>          |
+| Step                                                         | Related documentation                                                                           |
+| -----------------------------------------------------------  | ----------------------------------------------------------------------------------------------- |
+| [Create a random mnemonic](#defining-a-mnemonic)             | <dy:Bip32.random>                                                                               |
+| [Derive an account from a mnemonic](#deriving-the-root-node) | <dy:Bip32.fromMnemonic>, <dy:SymbolFacade.bip32Path>, and <dy:Bip32Node.derivePath>             |
+| [Get the key pair of the account](#creating-the-account)     | <dy:SymbolFacade.bip32NodeToKeyPair>, <dy:network.publicKeyToAddress>                           |

--- a/mkdocs/pages/en/devbook/accounts/create-from-mnemonic.md
+++ b/mkdocs/pages/en/devbook/accounts/create-from-mnemonic.md
@@ -1,0 +1,118 @@
+---
+title: Create from Mnemonic
+---
+
+# Creating Accounts from Mnemonics
+
+This tutorial shows how to create <accounts:> for the Symbol blockchain using a <mnemonic phrase:>.
+
+This approach is commonly used by <HD wallets:> to manage multiple accounts from a single seed.
+
+## Prerequisites
+
+If you have not done so already, start with the [Hello World](../start/hello-world.md) tutorial to make sure your
+development environment is set up correctly.
+
+## Full Code
+
+{% import 'tutorial.jinja2' as tutorial with context %}
+
+{{ tutorial.code_full('devbook/accounts/create-from-mnemonic', ['py', 'js']) }}
+
+## Code Explanation
+
+### Initializing the Facade
+
+{{ tutorial.code_snippet(['py:5:6', 'js:5:6']) }}
+
+The <dy:SymbolFacade> provides access to Symbol's cryptographic operations and network utilities.
+It is initialized with a network name (`testnet` or `mainnet`) to ensure that network-specific values,
+such as <address:>, are generated correctly.
+
+### Defining a Mnemonic
+
+{{ tutorial.code_snippet(['py:8:16', 'js:8:17']) }}
+
+The example checks for an existing mnemonic in the `MNEMONIC` environment variable.
+If the variable is set, the mnemonic is loaded from it.
+Otherwise, a new random mnemonic is generated using <dy:Bip32.random>.
+
+Symbol uses the [BIP39](https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki) standard, which represents
+mnemonics as 24 English words selected from a standardized word list.
+These words encode entropy that serves as the foundation for deriving private keys.
+
+!!! warning "Store your mnemonic securely"
+    The mnemonic can be used to regenerate all derived accounts and private keys.
+    Anyone with access to it can control your accounts, and losing it means losing access permanently.
+
+    Never share your mnemonic with anyone, and always store it in a secure location.
+
+### Deriving the Root Node
+
+{{ tutorial.code_snippet(['py:18:23', 'js:19:24']) }}
+
+After defining the mnemonic, <dy:Bip32.fromMnemonic> converts the mnemonic and a password into a root node,
+which serves as the starting point for deriving child accounts.
+
+The password (sometimes called a "25th word") is an optional string that extends the mnemonic seed.
+It can be left empty or set to any value.
+When used, it adds another layer of security. Different passwords with the same mnemonic produce completely different
+accounts.
+
+!!! note "Password security"
+    The password is part of the account derivation.
+    Both the mnemonic and password are required to regenerate the accounts.
+    If you lose or forget either one, you lose access to all derived accounts.
+
+In this example, the password is loaded from the `PASSWORD` environment variable.
+If not set, the snippet defaults to `correcthorsebatterystaple` for demonstration purposes only.
+
+### Deriving the Child Account
+
+{{ tutorial.code_snippet(['py:25:27', 'js:26:28']) }}
+
+The root node can derive multiple child accounts using a hierarchical path.
+This allows a single mnemonic to manage many accounts while keeping them cryptographically isolated.
+
+<dy:SymbolFacade.bip32Path> generates the derivation path for a specific account index.
+In this example, the account at index `0` is derived, but you can derive additional accounts by using different
+indices (e.g., `1`, `2`, `3`).
+
+<dy:Bip32Node.derivePath> follows the specified path from the root node to produce a child node that represents
+the account.
+
+### Creating the Account
+
+{{ tutorial.code_snippet(['py:29:38', 'js:30:39']) }}
+
+Once the child node is derived, it is converted into a usable key pair and address.
+
+1. **Key pair creation:** <dy:SymbolFacade.bip32NodeToKeyPair> extracts the <private key:> and <public key:> from the
+   child node.
+   The private key must remain secret, while the public key can be safely shared.
+
+2. **Address derivation:** <dy:network.publicKeyToAddress> converts the public key into an <address:>, a shorter,
+   human-readable, network-specific identifier for the account.
+
+## Output
+
+The output shown below corresponds to a typical run of the program.
+
+```text
+--8<-- 'devbook/accounts/create-from-mnemonic.log'
+```
+
+Each time the code runs without environment variables, it generates a different random mnemonic and account.
+If the same mnemonic and password are provided, the same account is always derived for the given account index.
+
+## Conclusion
+
+This tutorial showed how to:
+
+| Step                                                       | Related documentation                    |
+| ---------------------------------------------------------- | ---------------------------------------- |
+| [Define a mnemonic](#defining-a-mnemonic)                  | <dy:Bip32.random>                        |
+| [Derive a root node](#deriving-the-root-node)              | <dy:Bip32.fromMnemonic>                  |
+| [Derive a child account](#deriving-the-child-account)      | <dy:Bip32Node.derivePath>                |
+| [Get the key pair](#creating-the-key-pair-and-address)     | <dy:SymbolFacade.bip32NodeToKeyPair>     |
+| [Get the address](#creating-the-key-pair-and-address)      | <dy:network.publicKeyToAddress>          |

--- a/mkdocs/pages/en/devbook/accounts/create-from-private-key.md
+++ b/mkdocs/pages/en/devbook/accounts/create-from-private-key.md
@@ -26,7 +26,7 @@ development environment is set up correctly.
 
 The <dy:SymbolFacade> provides access to Symbol’s cryptographic operations and network utilities.
 It is initialized with a network name (`testnet` or `mainnet`) to ensure that network-specific values,
-such as <address:>, are generated correctly.
+such as <addresses:>, are generated correctly.
 
 ### Defining a Private Key
 


### PR DESCRIPTION
Adds a tutorial for creating an account from mnemonic, based on [Create an account](https://github.com/symbol/symbol/blob/main/docs/index.md#tutorial-creating-an-account) snippet.