### PR TITLE
[sdk/javascript] fix: noble imports and prohibit string in hash functions

### DIFF
--- a/sdk/javascript/package-lock.json
+++ b/sdk/javascript/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "~1.8.0",
+        "@noble/hashes": "~2.0.1",
         "@types/node": "^24.2.0",
         "bitcore-mnemonic": "~11.4.0",
         "ripemd160": "~2.0.2"
@@ -337,12 +337,12 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.0.1.tgz",
+      "integrity": "sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==",
       "license": "MIT",
       "engines": {
-        "node": "^14.21.3 || >=16"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"

--- a/sdk/javascript/package.json
+++ b/sdk/javascript/package.json
@@ -71,7 +71,7 @@
     "yargs": "~18.0.0"
   },
   "dependencies": {
-    "@noble/hashes": "~1.8.0",
+    "@noble/hashes": "~2.0.1",
     "@types/node": "^24.2.0",
     "bitcore-mnemonic": "~11.4.0",
     "ripemd160": "~2.0.2"

--- a/sdk/javascript/src/SharedKey.js
+++ b/sdk/javascript/src/SharedKey.js
@@ -7,8 +7,8 @@ import {
 	SharedKey256
 } from './CryptoTypes.js';
 import tweetnacl from './impl/external/tweetnacl-nacl-fast-symbol.js';
-import { hkdf } from '@noble/hashes/hkdf';
-import { sha256 } from '@noble/hashes/sha256.js';
+import { hkdf } from '@noble/hashes/hkdf.js';
+import { sha256 } from '@noble/hashes/sha2.js';
 
 // order matches order of exported methods
 const tweetnacl_lowlevel = (/** @type {any} */ (tweetnacl)).lowlevel;

--- a/sdk/javascript/src/SharedKey.js
+++ b/sdk/javascript/src/SharedKey.js
@@ -9,6 +9,7 @@ import {
 import tweetnacl from './impl/external/tweetnacl-nacl-fast-symbol.js';
 import { hkdf } from '@noble/hashes/hkdf.js';
 import { sha256 } from '@noble/hashes/sha2.js';
+import { utf8ToBytes } from '@noble/hashes/utils.js';
 
 // order matches order of exported methods
 const tweetnacl_lowlevel = (/** @type {any} */ (tweetnacl)).lowlevel;
@@ -87,7 +88,7 @@ const deriveSharedKeyFactory = (info, hasher) => {
 	const deriveSharedSecret = deriveSharedSecretFactory(hasher);
 	return (privateKeyBytes, otherPublicKey) => {
 		const sharedSecret = deriveSharedSecret(privateKeyBytes, otherPublicKey);
-		return new SharedKey256(hkdf(sha256, sharedSecret, undefined, info, 32));
+		return new SharedKey256(hkdf(sha256, sharedSecret, undefined, utf8ToBytes(info), 32));
 	};
 };
 

--- a/sdk/javascript/src/impl/ed25519_js.js
+++ b/sdk/javascript/src/impl/ed25519_js.js
@@ -2,8 +2,8 @@
 
 import tweetnacl from './external/tweetnacl-nacl-fast-symbol.js';
 import { deepCompare } from '../utils/arrayHelpers.js';
+import { sha512 } from '@noble/hashes/sha2.js';
 import { keccak_512 } from '@noble/hashes/sha3.js';
-import { sha512 } from '@noble/hashes/sha512.js';
 
 const getHasher = hashMode => ('Keccak' === hashMode ? keccak_512 : sha512);
 

--- a/sdk/javascript/src/symbol/SharedKey.js
+++ b/sdk/javascript/src/symbol/SharedKey.js
@@ -3,7 +3,7 @@ import { KeyPair } from './KeyPair.js';
 import { PublicKey, SharedKey256 } from '../CryptoTypes.js';
 /* eslint-enable no-unused-vars */
 import { deriveSharedKeyFactory } from '../SharedKey.js';
-import { sha512 } from '@noble/hashes/sha512.js';
+import { sha512 } from '@noble/hashes/sha2.js';
 
 const deriveSharedKeyImpl = deriveSharedKeyFactory('catapult', sha512);
 

--- a/sdk/javascript/src/symbol/idGenerator.js
+++ b/sdk/javascript/src/symbol/idGenerator.js
@@ -2,6 +2,7 @@
 import { Address } from './Network.js';
 /* eslint-enable no-unused-vars */
 import { sha3_256 } from '@noble/hashes/sha3.js';
+import { utf8ToBytes } from '@noble/hashes/utils.js';
 
 const NAMESPACE_FLAG = 1n << 63n;
 
@@ -49,7 +50,7 @@ const generateNamespaceId = (name, parentNamespaceId = 0n) => {
 	const hasher = sha3_256.create();
 	hasher.update(uint32ToBytes(Number(parentNamespaceId & 0xFFFFFFFFn)));
 	hasher.update(uint32ToBytes(Number((parentNamespaceId >> 32n) & 0xFFFFFFFFn)));
-	hasher.update(name);
+	hasher.update(utf8ToBytes(name));
 	const digest = new Uint8Array(hasher.digest());
 
 	const result = digestToBigInt(digest);

--- a/sdk/javascript/src/symbol/metadata.js
+++ b/sdk/javascript/src/symbol/metadata.js
@@ -1,4 +1,5 @@
 import { sha3_256 } from '@noble/hashes/sha3.js';
+import { utf8ToBytes } from '@noble/hashes/utils.js';
 
 /**
  * Generates a metadata key from a string.
@@ -6,7 +7,7 @@ import { sha3_256 } from '@noble/hashes/sha3.js';
  * @returns {bigint} Metadata key.
  */
 const metadataGenerateKey = seed => {
-	const hashResult = sha3_256(seed);
+	const hashResult = sha3_256(utf8ToBytes(seed));
 
 	const keyBytes = hashResult.subarray(0, 8);
 	keyBytes[7] |= 0x80; // set high bit to match SDK V2 implementation


### PR DESCRIPTION
problem: @noble/hashes 2.0.1 enforces the correct import path, plus prohibits strings in hash functions
solution: update imports of sha256 and sha512 to sha2.js
                convert all strings to byte array for hashes