### PR TITLE
[monorepo] fix: configure multi-directory for dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -2,13 +2,14 @@ version: 2
 updates:
 
   - package-ecosystem: github-actions
-    directory: /
     schedule:
       interval: weekly
       day: sunday
-    target-branch: dev
+    labels: ['dependencies']
     commit-message:
       prefix: '[dependency]'
+    target-branch: dev
+    directory: /
     groups:
       actions-dependencies:
         patterns:
@@ -18,179 +19,62 @@ updates:
           - patch
 
   - package-ecosystem: pip
-    directory: /catbuffer/parser
     schedule:
       interval: weekly
       day: sunday
-    target-branch: dev
-    labels: [catbuffer-parser]
-    versioning-strategy: increase-if-necessary
+    labels: ['dependencies']
     commit-message:
       prefix: '[dependency]'
+    target-branch: dev
+    versioning-strategy: increase-if-necessary
     groups:
-      catbuffer-dependencies:
+      pip-dependencies:
         patterns:
           - '*'
         update-types:
           - minor
           - patch
-
-  - package-ecosystem: pip
-    directory: /client/catapult/scripts
-    schedule:
-      interval: weekly
-      day: sunday
-    target-branch: dev
-    labels: [catapult]
-    versioning-strategy: increase-if-necessary
-    commit-message:
-      prefix: '[dependency]'
-    groups:
-      catapult-dependencies:
-        patterns:
-          - '*'
-        update-types:
-          - minor
-          - patch
+    directories:
+      - /catbuffer/parser
+      - /client/catapult/scripts
+      - /jenkins/catapult
+      - /linters/cpp
+      - /linters/python
+      - /sdk/javascript/generator
+      - /sdk/python
 
   - package-ecosystem: npm
-    directory: /client/rest
     schedule:
       interval: weekly
       day: sunday
-    target-branch: dev
-    labels: [rest]
-    versioning-strategy: increase-if-necessary
+    labels: ['dependencies']
     commit-message:
       prefix: '[dependency]'
+    target-branch: dev
+    versioning-strategy: increase-if-necessary
     groups:
-      rest-dependencies:
+      npm-dependencies:
         patterns:
           - '*'
         update-types:
           - minor
           - patch
-
-  - package-ecosystem: pip
-    directory: /jenkins/catapult
-    schedule:
-      interval: weekly
-      day: sunday
-    target-branch: dev
-    labels: [jenkins]
-    versioning-strategy: increase-if-necessary
-    commit-message:
-      prefix: '[dependency]'
-    groups:
-      jenkins-dependencies:
-        patterns:
-          - '*'
-        update-types:
-          - minor
-          - patch
-
-  - package-ecosystem: pip
-    directory: /linters/cpp
-    schedule:
-      interval: weekly
-      day: sunday
-    target-branch: dev
-    labels: [linters]
-    versioning-strategy: increase-if-necessary
-    commit-message:
-      prefix: '[dependency]'
-    groups:
-      linter-cpp-dependencies:
-        patterns:
-          - '*'
-        update-types:
-          - minor
-          - patch
-
-  - package-ecosystem: pip
-    directory: /linters/python
-    schedule:
-      interval: weekly
-      day: sunday
-    target-branch: dev
-    labels: [linters]
-    versioning-strategy: increase-if-necessary
-    commit-message:
-      prefix: '[dependency]'
-    groups:
-      linter-python-dependencies:
-        patterns:
-          - '*'
-        update-types:
-          - minor
-          - patch
-
-  - package-ecosystem: npm
-    directory: /sdk/javascript
-    schedule:
-      interval: weekly
-      day: sunday
-    target-branch: dev
-    labels: [sdk-javascript]
-    versioning-strategy: increase-if-necessary
-    commit-message:
-      prefix: '[dependency]'
-    groups:
-      sdk-javascript-dependencies:
-        patterns:
-          - '*'
-        update-types:
-          - minor
-          - patch
-
-  - package-ecosystem: pip
-    directory: /sdk/javascript/generator
-    schedule:
-      interval: weekly
-      day: sunday
-    target-branch: dev
-    labels: [sdk-javascript]
-    versioning-strategy: increase-if-necessary
-    commit-message:
-      prefix: '[dependency]'
-    groups:
-      sdk-javascript-generator-dependencies:
-        patterns:
-          - '*'
-        update-types:
-          - minor
-          - patch
+    directories:
+      - /client/rest
+      - /sdk/javascript
 
   - package-ecosystem: cargo
-    directory: /sdk/javascript/wasm
     schedule:
       interval: weekly
       day: sunday
-    target-branch: dev
-    labels: [sdk-javascript]
-    versioning-strategy: auto
-    commit-message:
-      prefix: '[sdk/javascript]'
-    groups:
-      sdk-javascript-wasm-dependencies:
-        patterns:
-          - '*'
-        update-types:
-          - minor
-          - patch
-
-  - package-ecosystem: pip
-    directory: /sdk/python
-    schedule:
-      interval: weekly
-      day: sunday
-    target-branch: dev
-    labels: [sdk-python]
-    versioning-strategy: increase-if-necessary
+    labels: ['dependencies']
     commit-message:
       prefix: '[dependency]'
+    target-branch: dev
+    directory: /sdk/javascript/wasm
+    versioning-strategy: auto
     groups:
-      sdk-python-dependencies:
+      wasm-dependencies:
         patterns:
           - '*'
         update-types:

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,6 +1,24 @@
 version: 2
 updates:
 
+  - package-ecosystem: cargo
+    schedule:
+      interval: weekly
+      day: sunday
+    labels: [dependencies]
+    commit-message:
+      prefix: '[dependency]'
+    target-branch: dev
+    directory: /sdk/javascript/wasm
+    versioning-strategy: auto
+    groups:
+      cargo-dependencies:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+
   - package-ecosystem: github-actions
     schedule:
       interval: weekly
@@ -11,12 +29,32 @@ updates:
     target-branch: dev
     directory: /
     groups:
-      actions-dependencies:
+      github-actions-dependencies:
         patterns:
           - '*'
         update-types:
           - minor
           - patch
+
+  - package-ecosystem: npm
+    schedule:
+      interval: weekly
+      day: sunday
+    labels: [dependencies]
+    commit-message:
+      prefix: '[dependency]'
+    target-branch: dev
+    versioning-strategy: increase-if-necessary
+    groups:
+      npm-dependencies:
+        patterns:
+          - '*'
+        update-types:
+          - minor
+          - patch
+    directories:
+      - /client/rest
+      - /sdk/javascript
 
   - package-ecosystem: pip
     schedule:
@@ -42,41 +80,3 @@ updates:
       - /linters/python
       - /sdk/javascript/generator
       - /sdk/python
-
-  - package-ecosystem: npm
-    schedule:
-      interval: weekly
-      day: sunday
-    labels: [dependencies]
-    commit-message:
-      prefix: '[dependency]'
-    target-branch: dev
-    versioning-strategy: increase-if-necessary
-    groups:
-      npm-dependencies:
-        patterns:
-          - '*'
-        update-types:
-          - minor
-          - patch
-    directories:
-      - /client/rest
-      - /sdk/javascript
-
-  - package-ecosystem: cargo
-    schedule:
-      interval: weekly
-      day: sunday
-    labels: [dependencies]
-    commit-message:
-      prefix: '[dependency]'
-    target-branch: dev
-    directory: /sdk/javascript/wasm
-    versioning-strategy: auto
-    groups:
-      wasm-dependencies:
-        patterns:
-          - '*'
-        update-types:
-          - minor
-          - patch

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: weekly
       day: sunday
-    labels: ['dependencies']
+    labels: [dependencies]
     commit-message:
       prefix: '[dependency]'
     target-branch: dev
@@ -22,7 +22,7 @@ updates:
     schedule:
       interval: weekly
       day: sunday
-    labels: ['dependencies']
+    labels: [dependencies]
     commit-message:
       prefix: '[dependency]'
     target-branch: dev
@@ -47,7 +47,7 @@ updates:
     schedule:
       interval: weekly
       day: sunday
-    labels: ['dependencies']
+    labels: [dependencies]
     commit-message:
       prefix: '[dependency]'
     target-branch: dev
@@ -67,7 +67,7 @@ updates:
     schedule:
       interval: weekly
       day: sunday
-    labels: ['dependencies']
+    labels: [dependencies]
     commit-message:
       prefix: '[dependency]'
     target-branch: dev


### PR DESCRIPTION
problem: currently, Dependabot creates a PR for each project, which leads to a lot of PRs
solution: configure multi-directory for Dependabot, that allows grouping of multiple projects with the same package manager