### PR TITLE
[jenkins] fix: force pip to reinstall packages

### DIFF
--- a/jenkins/shared-library/vars/configureArtifactRepository.groovy
+++ b/jenkins/shared-library/vars/configureArtifactRepository.groovy
@@ -64,7 +64,8 @@ void configurePypi(Map info) {
 
 	env.PIP_INDEX_URL = "${info.url}simple"
 	env.PIP_TRUSTED_HOST = "${hostName} pypi.org"
-	env.PIP_EXTRA_INDEX_URL = 'https://pypi.org/simple'
+	env.PIP_NO_CACHE_DIR = 1
+	env.PIP_FORCE_REINSTALL = 1
 	if (null != info.userName && null != info.password) {
 		env.NETRC = pwd()
 		// groovylint-disable-next-line GStringExpressionWithinString


### PR DESCRIPTION
problem: internal Python packages with the same version are failing to install
         due to different hashes between Nexus and PyPi.
solution: for private builds, only use the Nexus registry and force pip to reinstall the package.