### PR TITLE
[jenkins] fix: update Clang complier to 21

### DIFF
--- a/client/catapult/CMakeGlobalSettings.cmake
+++ b/client/catapult/CMakeGlobalSettings.cmake
@@ -160,7 +160,9 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 	# - Wno-switch-enum: do not require enum switch statements to list every value (this setting is also incompatible with GCC warnings)
 	# - Wno-weak-vtables: vtables are emitted in all translation units for virtual classes with no out-of-line virtual method definitions
 	# - Wno-unsafe-buffer-usage: allow unsafe buffer usage https://reviews.llvm.org/D137379
-	# = Wno-shadow-uncaptured-local: allow shadowing of local variables in lambdas https://github.com/llvm/llvm-project/issues/81307
+	# - Wno-shadow-uncaptured-local: allow shadowing of local variables in lambdas https://github.com/llvm/llvm-project/issues/81307
+	# - Wnrvo: error: not eliding copy on return
+	# - Wno-thread-safety-negative:
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
 		-stdlib=libc++ \
 		-Weverything \
@@ -173,7 +175,9 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 		-Wno-weak-vtables \
 		-Wno-unsafe-buffer-usage \
 		-Wno-shadow-uncaptured-local \
-		-Wno-switch-default")
+		-Wno-switch-default \
+		-Wno-nrvo \
+		-Wno-thread-safety-negative")
 
 	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -g1")
 
@@ -278,9 +282,11 @@ function(catapult_set_test_compiler_options)
 	elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 		# - Wno-global-constructors: required for GTEST test definition macros
 		# - Wno-zero-as-null-pointer-constant: workaround for GTEST NULL/nullptr mismatch https://github.com/google/googletest/issues/1323
+		# - Wno-missing-noreturn: test function FailToCreateSecondFuture does not return a value
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
 			-Wno-global-constructors \
-			-Wno-zero-as-null-pointer-constant"
+			-Wno-zero-as-null-pointer-constant \
+			-Wno-missing-noreturn"
 			PARENT_SCOPE)
 	endif()
 endfunction()

--- a/client/catapult/CMakeGlobalSettings.cmake
+++ b/client/catapult/CMakeGlobalSettings.cmake
@@ -161,8 +161,7 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 	# - Wno-weak-vtables: vtables are emitted in all translation units for virtual classes with no out-of-line virtual method definitions
 	# - Wno-unsafe-buffer-usage: allow unsafe buffer usage https://reviews.llvm.org/D137379
 	# - Wno-shadow-uncaptured-local: allow shadowing of local variables in lambdas https://github.com/llvm/llvm-project/issues/81307
-	# - Wnrvo: error: not eliding copy on return
-	# - Wno-thread-safety-negative:
+	# - Wno-thread-safety-negative: error: acquiring mutex 'm_mutex' requires negative capability '!m_mutex'
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
 		-stdlib=libc++ \
 		-Weverything \
@@ -176,8 +175,13 @@ elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 		-Wno-unsafe-buffer-usage \
 		-Wno-shadow-uncaptured-local \
 		-Wno-switch-default \
-		-Wno-nrvo \
 		-Wno-thread-safety-negative")
+
+	if("${CMAKE_CXX_COMPILER_VERSION}" MATCHES "^21.")
+		# - Wno-nrvo: error: not eliding copy on return
+		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
+			-Wno-nrvo")
+	endif()
 
 	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} -g1")
 
@@ -282,7 +286,7 @@ function(catapult_set_test_compiler_options)
 	elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
 		# - Wno-global-constructors: required for GTEST test definition macros
 		# - Wno-zero-as-null-pointer-constant: workaround for GTEST NULL/nullptr mismatch https://github.com/google/googletest/issues/1323
-		# - Wno-missing-noreturn: test function FailToCreateSecondFuture does not return a value
+		# - Wno-missing-noreturn: some test functions do not return a value
 		set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} \
 			-Wno-global-constructors \
 			-Wno-zero-as-null-pointer-constant \

--- a/client/catapult/CMakeLists.txt
+++ b/client/catapult/CMakeLists.txt
@@ -88,7 +88,7 @@ endfunction()
 
 ### setup rocksdb
 message("--- locating rocksdb dependencies ---")
-find_package(RocksDB 10.5.1 EXACT REQUIRED)
+find_package(RocksDB 10.6.2 EXACT REQUIRED)
 
 if(WIN32)
 	set(RocksDB_LIBRARY RocksDB::rocksdb)

--- a/client/catapult/conanfile.py
+++ b/client/catapult/conanfile.py
@@ -14,7 +14,7 @@ class CatapultConan(ConanFile):
 		self.requires("cppzmq/4.11.0@nemtech/stable", run=True)
 		self.requires("mongo-c-driver/1.30.3@nemtech/stable", run=True)
 		self.requires("mongo-cxx-driver/4.0.0@nemtech/stable", run=True)
-		self.requires("rocksdb/10.5.1@nemtech/stable", run=True)
+		self.requires("rocksdb/10.6.2@nemtech/stable", run=True)
 
 	def build_requirements(self):
 		# pylint: disable=not-callable

--- a/jenkins/catapult/baseImageDockerfileGenerator.py
+++ b/jenkins/catapult/baseImageDockerfileGenerator.py
@@ -127,6 +127,7 @@ class OptionsManager:
 		cxxflags = [self._arch_flag] if not self.is_msvc else []
 		if self.is_clang:
 			options += ['toolset=clang']
+			options += ['cxxflags=-Wno-deprecated-declarations']
 			options += [format_multivalue_options('linkflags', [f'-stdlib={self.stl.lib}'])]
 			cxxflags += self._stl_flags
 

--- a/jenkins/catapult/baseImageDockerfileGenerator.py
+++ b/jenkins/catapult/baseImageDockerfileGenerator.py
@@ -129,6 +129,9 @@ class OptionsManager:
 			options += ['toolset=clang']
 			options += ['cxxflags=-Wno-deprecated-declarations']
 			options += [format_multivalue_options('linkflags', [f'-stdlib={self.stl.lib}'])]
+			if 'arm64' == self.architecture:
+				options += ['cxxflags="--target=aarch64-linux-gnu"', 'linkflags="--target=aarch64-linux-gnu"']
+
 			cxxflags += self._stl_flags
 
 		options += get_dependency_flags('boost')

--- a/jenkins/catapult/compilers/clang-latest.yaml
+++ b/jenkins/catapult/compilers/clang-latest.yaml
@@ -1,15 +1,15 @@
 c: clang
 cpp: clang++
-version: 19
+version: 21
 
 stl:
   version: c++1y
   lib: libc++
 
 deps:
-  - /usr/lib/llvm-19/lib/libc++.so.*
-  - /usr/lib/llvm-19/lib/libc++abi.so.*
-  - /usr/lib/llvm-19/lib/libunwind.*
+  - /usr/lib/llvm-21/lib/libc++.so.*
+  - /usr/lib/llvm-21/lib/libc++abi.so.*
+  - /usr/lib/llvm-21/lib/libunwind.*
 
-  - /usr/lib/llvm-19/bin/llvm-symbolizer
+  - /usr/lib/llvm-21/bin/llvm-symbolizer
   - /usr/lib/x86_64-linux-gnu/libLLVM*

--- a/jenkins/catapult/compilers/clang-prior.yaml
+++ b/jenkins/catapult/compilers/clang-prior.yaml
@@ -1,15 +1,15 @@
 c: clang
 cpp: clang++
-version: 18
+version: 20
 
 stl:
   version: c++1y
   lib: libc++
 
 deps:
-  - /usr/lib/llvm-18/lib/libc++.so.*
-  - /usr/lib/llvm-18/lib/libc++abi.so.*
-  - /usr/lib/llvm-18/lib/libunwind.*
+  - /usr/lib/llvm-20/lib/libc++.so.*
+  - /usr/lib/llvm-20/lib/libc++abi.so.*
+  - /usr/lib/llvm-20/lib/libunwind.*
 
-  - /usr/lib/llvm-18/bin/llvm-symbolizer
-  - /usr/lib/x86_64-linux-gnu/libLLVM-18.*
+  - /usr/lib/llvm-20/bin/llvm-symbolizer
+  - /usr/lib/x86_64-linux-gnu/libLLVM*

--- a/jenkins/catapult/compilers/ubuntu-clang/Dockerfile
+++ b/jenkins/catapult/compilers/ubuntu-clang/Dockerfile
@@ -1,4 +1,4 @@
-ARG FROM_IMAGE=ubuntu:24.04
+ARG FROM_IMAGE=ubuntu:25.10
 FROM ${FROM_IMAGE}
 
 ARG DEBIAN_FRONTEND=noninteractive
@@ -11,11 +11,9 @@ RUN apt-get update >/dev/null && \
 	xz-utils \
 	wget 
 
-# Use the latest Clang version.
+# Use the latest Clang version from Ubuntu.
 ARG COMPILER_VERSION=21
-RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /etc/apt/trusted.gpg.d/clang.gpg  && \
-	echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${COMPILER_VERSION} main" > /etc/apt/sources.list.d/clang.list && \
-	apt-get update >/dev/null && \
+RUN apt-get update >/dev/null && \
 	apt-get install -y \
 	clang-${COMPILER_VERSION} \
 	clang-tools-${COMPILER_VERSION} \
@@ -26,7 +24,6 @@ RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /etc/
 	update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${COMPILER_VERSION} 100 && \
 	update-alternatives --install /usr/bin/cc cc /usr/bin/clang 100 && \
 	update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++ 100 && \
-	rm -rf /var/lib/apt/lists/* && \
 	clang --version
 
 # set default user (used by jenkins)

--- a/jenkins/catapult/compilers/ubuntu-clang/Dockerfile
+++ b/jenkins/catapult/compilers/ubuntu-clang/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update >/dev/null && \
 	wget 
 
 # Use the latest Clang version.
-ARG COMPILER_VERSION=18
+ARG COMPILER_VERSION=21
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | gpg --dearmor > /etc/apt/trusted.gpg.d/clang.gpg  && \
 	echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-${COMPILER_VERSION} main" > /etc/apt/sources.list.d/clang.list && \
 	apt-get update >/dev/null && \

--- a/jenkins/catapult/installDepsLocal.py
+++ b/jenkins/catapult/installDepsLocal.py
@@ -71,7 +71,7 @@ class Builder:
 
 		b2_options = [boost_prefix_option]
 		if self.is_clang:
-			b2_options += ['toolset=clang', 'cxxflags=--std=c++17', 'linkflags=\'-stdlib=libc++\'']
+			b2_options += ['toolset=clang', 'cxxflags=-Wno-deprecated-declarations', 'cxxflags=--std=c++17', 'linkflags=\'-stdlib=libc++\'']
 
 		b2_options += get_dependency_flags('boost')
 

--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -9,7 +9,7 @@ boost = 1.83.0
 cmake = 3.28.1
 gosu = 1.17
 
-facebook_rocksdb = v10.5.1
+facebook_rocksdb = v10.6.2
 
 google_googletest = v1.16.0
 google_benchmark = v1.9.4

--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -1,6 +1,6 @@
 [versions]
 
-ubuntu = 24.04
+ubuntu = 25.10
 fedora = 41
 debian = 12
 windows = 2022


### PR DESCRIPTION
problem: Catapult is not built with the latest Clang version
solution: Upgrade to the latest Clang in the Jenkins build