### PR TITLE
[jenkins]: fix ninja build dependencies

### DIFF
--- a/client/catapult/CMakeGlobalSettings.cmake
+++ b/client/catapult/CMakeGlobalSettings.cmake
@@ -503,6 +503,7 @@ function(catapult_define_tool TOOL_NAME)
 	target_link_libraries(${TARGET_NAME} catapult.tools)
 	catapult_target(${TARGET_NAME})
 
+	add_dependencies(${TARGET_NAME} catapult_sdk_publish)
 	add_dependencies(tools ${TARGET_NAME})
 
 	install(TARGETS ${TARGET_NAME})

--- a/client/catapult/docs/BUILD-conan.md
+++ b/client/catapult/docs/BUILD-conan.md
@@ -144,7 +144,6 @@ _where `build_type` argument value can be any of Release, RelWithDebInfo, Debug_
 
   ```sh
   cmake --preset conan-release -G Ninja -DUSE_CONAN=ON ../../
-  ninja publish
   ninja -j4
   ```
 

--- a/client/catapult/docs/BUILD-docker.md
+++ b/client/catapult/docs/BUILD-docker.md
@@ -79,7 +79,7 @@ The script that fires actual compilation is `runDockerBuildInnerBuild.py`. To un
 
 1. Sets up directories and ``ccache``.
 2. Fires up ``cmake``.
-3. Fires up the actual compilation using ``ninja publish`` followed by ``ninja``.
+3. Fires up the actual compilation using ``ninja``.
 4. Makes initial installation using ``ninja install`` (which installs to volume mounted in ``/binaries``).
 5. Copies the dependencies into directories inside ``/binaries``.
 

--- a/client/catapult/docs/BUILD-manual.md
+++ b/client/catapult/docs/BUILD-manual.md
@@ -57,7 +57,6 @@ BOOST_ROOT="$(realpath ../_deps/boost)" cmake .. \
 	-DCMAKE_BUILD_TYPE=RelWithDebInfo \
 	-DCMAKE_PREFIX_PATH="$(realpath ../_deps/facebook);$(realpath ../_deps/google);$(realpath ../_deps/mongodb);$(realpath ../_deps/zeromq)" \
 	-GNinja
-ninja publish
 ninja
 ```
 

--- a/client/catapult/sdk/src/CMakeLists.txt
+++ b/client/catapult/sdk/src/CMakeLists.txt
@@ -15,7 +15,7 @@ target_link_libraries(${TARGET_NAME}
 find_program(PYTHON_EXECUTABLE python3 python REQUIRED)
 
 add_custom_target(
-	publish ALL
+	catapult_sdk_publish ALL
 	COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/scripts/sdk/publishSdk.py -r ${PROJECT_SOURCE_DIR} -p ${CMAKE_BINARY_DIR}/inc
 	BYPRODUCTS ${CMAKE_BINARY_DIR}/inc/catapult/catapult.h
 )

--- a/jenkins/catapult/runDockerBuildInnerBuild.py
+++ b/jenkins/catapult/runDockerBuildInnerBuild.py
@@ -147,7 +147,6 @@ class BuildManager(BasicBuildManager):
 		else:
 			cpu_count = os.cpu_count()
 			cpu_count_str = str(cpu_count if cpu_count > 0 else 1)
-			self.dispatch_subprocess(['ninja', 'publish'])
 			self.dispatch_subprocess(['ninja', '-j', cpu_count_str])
 			self.dispatch_subprocess(['ninja', 'install'])
 


### PR DESCRIPTION
 problem: tools implicitly depend on the publishing of the Catapult SDK
                  With Ninja 1.12 and later, this causes the tool project to not find the catapult header file.
solution: add explicit dependency