### PR TITLE
[client/catapult] fix: disable stringop-overread for GCC 14

### DIFF
--- a/client/catapult/tests/catapult/ionet/PacketEntityUtilsTests.cpp
+++ b/client/catapult/tests/catapult/ionet/PacketEntityUtilsTests.cpp
@@ -162,7 +162,7 @@ namespace catapult { namespace ionet {
 
 // disable this warning which happens only on GCC 14
 // error: reading 1 or more bytes from a Region of size 0 [-Werror=stringop-overread]
-#if 14 == __GNUC__ && !defined(__clang__)
+#if 14 <= __GNUC__ && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-overread"
 #endif

--- a/client/catapult/tests/catapult/ionet/PacketEntityUtilsTests.cpp
+++ b/client/catapult/tests/catapult/ionet/PacketEntityUtilsTests.cpp
@@ -181,7 +181,7 @@ namespace catapult { namespace ionet {
 			EXPECT_TRUE(TTraits::IsEmpty(extractResult)) << "packet size " << size;
 		}
 
-#if 14 == __GNUC__ && !defined(__clang__)
+#if 14 <= __GNUC__ && !defined(__clang__)
 #pragma GCC diagnostic pop
 #endif
 

--- a/client/catapult/tests/catapult/ionet/PacketEntityUtilsTests.cpp
+++ b/client/catapult/tests/catapult/ionet/PacketEntityUtilsTests.cpp
@@ -160,6 +160,13 @@ namespace catapult { namespace ionet {
 			}
 		};
 
+// disable this warning which happens only on GCC 14
+// error: ‘void* memcpy(void*, const void*, size_t)’ reading 1 or more bytes from a region of size 0 [-Werror=stringop-overread]
+#if 14 == __GNUC__ && !defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-overread"
+#endif
+
 		template<typename TTraits>
 		void AssertCannotExtractFromPacketHeaderWithNoData(uint32_t size) {
 			// Arrange:
@@ -173,6 +180,10 @@ namespace catapult { namespace ionet {
 			// Assert:
 			EXPECT_TRUE(TTraits::IsEmpty(extractResult)) << "packet size " << size;
 		}
+
+#if 14 == __GNUC__ && !defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 		template<typename TTraits>
 		void AssertCannotExtractEntitiesFromPacketWithSize(uint32_t size) {

--- a/client/catapult/tests/catapult/ionet/PacketEntityUtilsTests.cpp
+++ b/client/catapult/tests/catapult/ionet/PacketEntityUtilsTests.cpp
@@ -161,7 +161,7 @@ namespace catapult { namespace ionet {
 		};
 
 // disable this warning which happens only on GCC 14
-// error: ‘void* memcpy(void*, const void*, size_t)’ reading 1 or more bytes from a region of size 0 [-Werror=stringop-overread]
+// error: reading 1 or more bytes from a Region of size 0 [-Werror=stringop-overread]
 #if 14 == __GNUC__ && !defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-overread"


### PR DESCRIPTION
problem: GCC 14 FP on stringop-overread
solution: disable stringop-overread for GCC 14