### PR TITLE
[client/catapult] fix: disable globals variablie san for macOS

### DIFF
--- a/client/catapult/CMakeGlobalSettings.cmake
+++ b/client/catapult/CMakeGlobalSettings.cmake
@@ -97,8 +97,11 @@ if(USE_SANITIZER)
 		endif()
 
 		if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
-			# disable vptr on M1
+			# -fno-sanitize=vptr: disable vptr on Apple MX processors to avoid false positives
 			set(SANITIZATION_FLAGS "${SANITIZATION_FLAGS} -fno-sanitize=vptr")
+
+			# revert to clang 15 behavior due to false positives around unterminated constant strings
+			add_compile_options(-mllvm -asan-globals=0)
 		endif()
 	endif()
 


### PR DESCRIPTION
problem: for Clang 16 and 17 on macOS, AddressSanitizer failed due to false positive detection of ODR and global buffer overflow
solution: disable the global variable in AddressSanitizer on macOS
https://maskray.me/blog/2023-10-15-address-sanitizer-global-variable-instrumentation