### PR TITLE
[mkdocs] add namespace and mosaic metadata tutorials

### DIFF
--- a/mkdocs/config/mkdocs.en.yml
+++ b/mkdocs/config/mkdocs.en.yml
@@ -86,15 +86,19 @@ nav:
               - devbook/transactions/complete-aggregate.md
               - devbook/transactions/bonded-aggregate.md
               - devbook/transactions/fee-sponsorship.md
+          - Mosaics:
+              - devbook/mosaics/mosaic-metadata.md
           - Namespaces:
               - devbook/namespaces/register-root-namespace.md
               - devbook/namespaces/register-subnamespace.md
               - devbook/namespaces/extend-root-namespace.md
               - devbook/namespaces/link-namespace-to-address.md
               - devbook/namespaces/link-namespace-to-mosaic.md
+              - devbook/namespaces/namespace-metadata.md
           - Mosaics:
               - devbook/mosaics/create-mosaic.md
               - devbook/mosaics/change-mosaic-supply.md
+              - devbook/mosaics/mosaic-metadata.md
       - Reference Guides:
           - Python SDK: devbook/reference/py/
           - TypeScript SDK: devbook/reference/ts/

--- a/mkdocs/config/mkdocs.en.yml
+++ b/mkdocs/config/mkdocs.en.yml
@@ -86,8 +86,6 @@ nav:
               - devbook/transactions/complete-aggregate.md
               - devbook/transactions/bonded-aggregate.md
               - devbook/transactions/fee-sponsorship.md
-          - Mosaics:
-              - devbook/mosaics/mosaic-metadata.md
           - Namespaces:
               - devbook/namespaces/register-root-namespace.md
               - devbook/namespaces/register-subnamespace.md

--- a/mkdocs/overrides/assets/stylesheets/extra.css
+++ b/mkdocs/overrides/assets/stylesheets/extra.css
@@ -28,6 +28,8 @@
 [data-md-color-scheme=slate][data-md-color-primary=indigo] {
 	--md-typeset-a-color: var(--md-primary-fg-color--light);
 	--md-accent-fg-color: var(--md-primary-fg-color);
+	--md-accent-fg-color--light: var(--md-primary-fg-color--dark);
+	--md-accent-fg-color--dark: var(--md-primary-fg-color--light);
 	--md-default-bg-color--light: #333;
 	--md-footer-bg-color--dark: var(--md-primary-fg-color--dark);
 	--md-footer-fg-color: var(--md-primary-fg-color);
@@ -43,6 +45,8 @@
 [data-md-color-scheme=default][data-md-color-primary=indigo] {
 	--md-typeset-a-color: var(--md-primary-fg-color--light);
 	--md-accent-fg-color: var(--md-primary-fg-color);
+	--md-accent-fg-color--light: var(--md-primary-fg-color--light);
+	--md-accent-fg-color--dark: var(--md-primary-fg-color--dark);
 	--md-default-bg-color--light: #DDD;
 	--md-footer-bg-color--dark: var(--md-primary-fg-color--dark);
 	--md-footer-fg-color: var(--md-primary-fg-color);
@@ -567,21 +571,25 @@ code.doc-symbol-interface::after {
 .graphviz .node path:not([fill="transparent"]),
 .graphviz .node polygon:not([fill="transparent"]),
 .graphviz .node ellipse:not([fill="transparent"]) {
-	stroke: var(--md-primary-fg-color--light);
+	stroke: var(--md-accent-fg-color--dark);
 	fill: var(--md-accent-fg-color--transparent);
 	transition: fill 0.25s;
 }
 
-.graphviz .node:hover a path,
-.graphviz .node:hover a polygon,
-.graphviz .node:hover a ellipse,
-.graphviz .edge:hover a text {
+.graphviz .node:hover a:any-link path,
+.graphviz .node:hover a:any-link polygon,
+.graphviz .node:hover a:any-link ellipse,
+.graphviz .edge:hover a:any-link text {
 	fill: var(--md-primary-fg-color--light);
 	transition: fill 0.25s;
 }
 
 .graphviz .cluster polygon {
 	stroke: var(--md-primary-fg-color--light);
+}
+
+.graphviz .node.metadata polygon {
+	fill: var(--md-accent-fg-color--light);
 }
 
 /* General tables customization */

--- a/mkdocs/overrides/devbook/mosaics/mosaic-metadata.log
+++ b/mkdocs/overrides/devbook/mosaics/mosaic-metadata.log
@@ -1,0 +1,59 @@
+Using node https://reference.symboltest.net:3001
+Signer address: TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I
+Mosaic ID: 7859648582932718274 (0x6d1314be751b62c2)
+Fetching current network time from /node/time
+  Network time: 103372272508 ms since nemesis
+Fetching recommended fees from /network/fees/transaction
+  Fee multiplier: 100
+
+--- Adding new metadata ---
+Created embedded metadata transaction:
+{
+  "signer_public_key": "3B6A27BCCEB6A42D62A3A8D02A6F0D73653215771DE243A63AC048A18B59DA29",
+  "version": 1,
+  "network": 152,
+  "type": 16964,
+  "target_address": "988E1191A25A88142C2FB3F69787576E3DC713EFC1CE4DE9",
+  "scoped_metadata_key": "15731601119740876263",
+  "target_mosaic_id": "7859648582932718274",
+  "value_size_delta": 15,
+  "value": "4d79206669727374206d6f73616963"
+}
+Built aggregate transaction with hash: 900741B895CD8CA31F969C8929BBDE1331F1B93565CEA276283FD0122EAC77C9
+Announcing aggregate transaction to /transactions
+  Response: {"message":"packet 9 was pushed to the network via /transactions"}
+Waiting for aggregate transaction confirmation...
+  Transaction status: unconfirmed
+  Transaction status: unconfirmed
+  Transaction status: unconfirmed
+  Transaction status: unconfirmed
+  Transaction status: unconfirmed
+  Transaction status: confirmed
+aggregate transaction confirmed in 21 seconds
+
+--- Modifying existing metadata ---
+Fetching current metadata from /metadata?targetAddress=TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I&scopedMetadataKey=DA51DFDE6A4AD5E7&targetId=6D1314BE751B62C2&metadataType=1
+  Current value: My first mosaic
+Created embedded update transaction:
+{
+  "signer_public_key": "3B6A27BCCEB6A42D62A3A8D02A6F0D73653215771DE243A63AC048A18B59DA29",
+  "version": 1,
+  "network": 152,
+  "type": 16964,
+  "target_address": "988E1191A25A88142C2FB3F69787576E3DC713EFC1CE4DE9",
+  "scoped_metadata_key": "15731601119740876263",
+  "target_mosaic_id": "7859648582932718274",
+  "value_size_delta": -1,
+  "value": "180944071d1717544d021c12080a63"
+}
+Built aggregate transaction with hash: A05078F485403FAEC0F740EFAA997241C26E2C25DFFD9E023113C861943ACB92
+Announcing aggregate transaction to /transactions
+  Response: {"message":"packet 9 was pushed to the network via /transactions"}
+Waiting for aggregate transaction confirmation...
+  Transaction status: unconfirmed
+  Transaction status: unconfirmed
+  Transaction status: unconfirmed
+  Transaction status: unconfirmed
+  Transaction status: unconfirmed
+  Transaction status: confirmed
+aggregate transaction confirmed in 26 seconds

--- a/mkdocs/overrides/devbook/mosaics/mosaic-metadata.mjs
+++ b/mkdocs/overrides/devbook/mosaics/mosaic-metadata.mjs
@@ -142,8 +142,8 @@ try {
 		.toUpperCase().padStart(16, '0');
 	const mosaicIdHex = mosaicId.toString(16)
 		.toUpperCase().padStart(16, '0');
-	const metadataPath = `/metadata?sourceAddress=${signerAddress}`
-		+ `&targetAddress=${signerAddress}`
+	const metadataPath = `/metadata`
+		+ `?targetAddress=${signerAddress}`
 		+ `&scopedMetadataKey=${scopedKeyHex}`
 		+ `&targetId=${mosaicIdHex}`
 		+ '&metadataType=1';

--- a/mkdocs/overrides/devbook/mosaics/mosaic-metadata.mjs
+++ b/mkdocs/overrides/devbook/mosaics/mosaic-metadata.mjs
@@ -1,0 +1,211 @@
+import { PrivateKey } from 'symbol-sdk';
+import {
+	metadataGenerateKey,
+	metadataUpdateValue,
+	models,
+	NetworkTimestamp,
+	SymbolFacade
+} from 'symbol-sdk/symbol';
+
+const NODE_URL = process.env.NODE_URL ||
+	'https://reference.symboltest.net:3001';
+console.log('Using node', NODE_URL);
+
+// Helper function to announce a transaction
+async function announceTransaction(payload, label) {
+	console.log(`Announcing ${label} to /transactions`);
+	const response = await fetch(`${NODE_URL}/transactions`, {
+		method: 'PUT',
+		headers: { 'Content-Type': 'application/json' },
+		body: payload
+	});
+	console.log('  Response:', await response.text());
+}
+
+// Helper function to wait for transaction confirmation
+async function waitForConfirmation(transactionHash, label) {
+	console.log(`Waiting for ${label} confirmation...`);
+	for (let attempt = 0; attempt < 60; attempt++) {
+		await new Promise(resolve => setTimeout(resolve, 1000));
+		try {
+			const response = await fetch(
+				`${NODE_URL}/transactionStatus/${transactionHash}`);
+			const status = await response.json();
+			console.log('  Transaction status:', status.group);
+			if (status.group === 'confirmed') {
+				console.log(`${label} confirmed in`, attempt, 'seconds');
+				return;
+			}
+			if (status.group === 'failed') {
+				throw new Error(`${label} failed: ${status.code}`);
+			}
+		} catch (e) {
+			if (e.message.includes('failed'))
+				throw e;
+			console.log('  Transaction status: unknown');
+		}
+	}
+	throw new Error(`${label} not confirmed after 60 seconds`);
+}
+
+const SIGNER_PRIVATE_KEY = process.env.SIGNER_PRIVATE_KEY || (
+	'0000000000000000000000000000000000000000000000000000000000000000');
+const signerKeyPair = new SymbolFacade.KeyPair(
+	new PrivateKey(SIGNER_PRIVATE_KEY));
+
+const facade = new SymbolFacade('testnet');
+const signerAddress = facade.network.publicKeyToAddress(
+	signerKeyPair.publicKey);
+console.log('Signer address:', signerAddress.toString());
+
+// Get mosaic ID from environment
+const MOSAIC_ID = process.env.MOSAIC_ID || '6D1314BE751B62C2';
+const mosaicId = BigInt(`0x${MOSAIC_ID}`);
+console.log('Mosaic ID:',
+	mosaicId.toString(), `(0x${mosaicId.toString(16)})`);
+
+try {
+	// Fetch current network time
+	const timePath = '/node/time';
+	console.log('Fetching current network time from', timePath);
+	const timeResponse = await fetch(`${NODE_URL}${timePath}`);
+	const timeJSON = await timeResponse.json();
+	const timestamp = new NetworkTimestamp(
+		timeJSON.communicationTimestamps.receiveTimestamp);
+	console.log('  Network time:', timestamp.timestamp,
+		'ms since nemesis');
+
+	// Fetch recommended fees
+	const feePath = '/network/fees/transaction';
+	console.log('Fetching recommended fees from', feePath);
+	const feeResponse = await fetch(`${NODE_URL}${feePath}`);
+	const feeJSON = await feeResponse.json();
+	const medianMult = feeJSON.medianFeeMultiplier;
+	const minimumMult = feeJSON.minFeeMultiplier;
+	const feeMult = Math.max(medianMult, minimumMult);
+	console.log('  Fee multiplier:', feeMult);
+
+	// --- ADDING NEW METADATA ---
+	console.log('\n--- Adding new metadata ---');
+
+	// Define metadata key and value
+	const keyString = `description_${Date.now()}`;
+	const scopedMetadataKey = metadataGenerateKey(keyString);
+	const metadataValue = new TextEncoder().encode('My first mosaic');
+
+	// Create the embedded metadata transaction
+	const embeddedTransaction = facade.transactionFactory
+		.createEmbedded({
+			type: 'mosaic_metadata_transaction_v1',
+			signerPublicKey: signerKeyPair.publicKey.toString(),
+			targetAddress: signerAddress.toString(),
+			targetMosaicId: mosaicId,
+			scopedMetadataKey,
+			// When creating new metadata, valueSizeDelta
+			// equals value length
+			valueSizeDelta: metadataValue.length,
+			value: metadataValue
+		});
+	console.log('Created embedded metadata transaction:');
+	console.log(JSON.stringify(embeddedTransaction.toJson(), null, 2));
+
+	// Build the aggregate transaction
+	const embeddedTransactions = [embeddedTransaction];
+	const transaction = facade.transactionFactory.create({
+		type: 'aggregate_complete_transaction_v3',
+		signerPublicKey: signerKeyPair.publicKey.toString(),
+		deadline: timestamp.addHours(2).timestamp,
+		transactionsHash: facade.static.hashEmbeddedTransactions(
+			embeddedTransactions),
+		transactions: embeddedTransactions
+	});
+	transaction.fee = new models.Amount(feeMult * transaction.size);
+
+	// Sign and generate final payload
+	const signature = facade.signTransaction(signerKeyPair, transaction);
+	const jsonPayload = facade.transactionFactory.static.attachSignature(
+		transaction, signature);
+
+	// Announce and wait for confirmation
+	const transactionHash =
+		facade.hashTransaction(transaction).toString();
+	console.log(
+		'Built aggregate transaction with hash:', transactionHash);
+	await announceTransaction(jsonPayload, 'aggregate transaction');
+	await waitForConfirmation(transactionHash, 'aggregate transaction');
+
+	// --- MODIFYING EXISTING METADATA ---
+	console.log('\n--- Modifying existing metadata ---');
+
+	// Fetch current metadata value from network
+	const scopedKeyHex = scopedMetadataKey.toString(16)
+		.toUpperCase().padStart(16, '0');
+	const mosaicIdHex = mosaicId.toString(16)
+		.toUpperCase().padStart(16, '0');
+	const metadataPath = `/metadata?sourceAddress=${signerAddress}`
+		+ `&targetAddress=${signerAddress}`
+		+ `&scopedMetadataKey=${scopedKeyHex}`
+		+ `&targetId=${mosaicIdHex}`
+		+ '&metadataType=1';
+	console.log('Fetching current metadata from', metadataPath);
+	const metadataResponse = await fetch(`${NODE_URL}${metadataPath}`);
+	const metadataJSON = await metadataResponse.json();
+
+	// Get the metadata entry
+	if (!metadataJSON.data.length) {
+		throw new Error('Metadata entry not found');
+	}
+	const metadataEntry = metadataJSON.data[0].metadataEntry;
+	const currentValue = Buffer.from(metadataEntry.value, 'hex');
+	console.log('  Current value:', currentValue.toString('utf8'));
+
+	// XOR the current and new values
+	const newValue = new TextEncoder().encode('Updated mosaic');
+	const updateValue = metadataUpdateValue(currentValue, newValue);
+
+	// Create the update transaction with XOR'd value
+	const embeddedUpdate = facade.transactionFactory
+		.createEmbedded({
+			type: 'mosaic_metadata_transaction_v1',
+			signerPublicKey: signerKeyPair.publicKey.toString(),
+			targetAddress: signerAddress.toString(),
+			targetMosaicId: mosaicId,
+			scopedMetadataKey,
+			// valueSizeDelta is the difference in length
+			// (can be negative)
+			valueSizeDelta: newValue.length - currentValue.length,
+			value: updateValue
+		});
+	console.log('Created embedded update transaction:');
+	console.log(JSON.stringify(embeddedUpdate.toJson(), null, 2));
+
+	// Build the aggregate for the update
+	const updateEmbedded = [embeddedUpdate];
+	const updateTransaction = facade.transactionFactory.create({
+		type: 'aggregate_complete_transaction_v3',
+		signerPublicKey: signerKeyPair.publicKey.toString(),
+		deadline: timestamp.addHours(2).timestamp,
+		transactionsHash: facade.static.hashEmbeddedTransactions(
+			updateEmbedded),
+		transactions: updateEmbedded
+	});
+	updateTransaction.fee = new models.Amount(
+		feeMult * updateTransaction.size);
+
+	// Sign and announce the update
+	const updateSignature = facade.signTransaction(
+		signerKeyPair, updateTransaction);
+	const updatePayload = facade.transactionFactory.static
+		.attachSignature(updateTransaction, updateSignature);
+
+	// Announce and wait for confirmation
+	const updateHash =
+		facade.hashTransaction(updateTransaction).toString();
+	console.log(
+		'Built aggregate transaction with hash:', updateHash);
+	await announceTransaction(updatePayload, 'aggregate transaction');
+	await waitForConfirmation(updateHash, 'aggregate transaction');
+
+} catch (e) {
+	console.error(e.message, '| Cause:', e.cause?.code ?? 'unknown');
+}

--- a/mkdocs/overrides/devbook/mosaics/mosaic-metadata.py
+++ b/mkdocs/overrides/devbook/mosaics/mosaic-metadata.py
@@ -60,6 +60,11 @@ signer_address = facade.network.public_key_to_address(
 	signer_key_pair.public_key)
 print(f'Signer address: {signer_address}')
 
+# Get mosaic ID from environment
+MOSAIC_ID = os.getenv('MOSAIC_ID', '6D1314BE751B62C2')
+mosaic_id = int(MOSAIC_ID, 16)
+print(f'Mosaic ID: {mosaic_id} ({hex(mosaic_id)})')
+
 try:
 	# Fetch current network time
 	time_path = '/node/time'
@@ -85,15 +90,16 @@ try:
 	print('\n--- Adding new metadata ---')
 
 	# Define metadata key and value
-	key_string = f'username_{int(time.time())}'
+	key_string = f'description_{int(time.time())}'
 	scoped_metadata_key = metadata_generate_key(key_string)
-	metadata_value = 'alice'.encode('utf8')
+	metadata_value = 'My first mosaic'.encode('utf8')
 
 	# Create the embedded metadata transaction
 	embedded_transaction = facade.transaction_factory.create_embedded({
-		'type': 'account_metadata_transaction_v1',
+		'type': 'mosaic_metadata_transaction_v1',
 		'signer_public_key': signer_key_pair.public_key,
 		'target_address': signer_address,
+		'target_mosaic_id': mosaic_id,
 		'scoped_metadata_key': scoped_metadata_key,
 		# When creating new metadata, value_size_delta
 		# equals the value length
@@ -131,10 +137,10 @@ try:
 
 	# Fetch current metadata value from network
 	metadata_path = (
-		f'/metadata?sourceAddress={signer_address}'
-		f'&targetAddress={signer_address}'
+		f'/metadata?targetAddress={signer_address}'
 		f'&scopedMetadataKey={scoped_metadata_key:016X}'
-		'&metadataType=0'
+		f'&targetId={mosaic_id:016X}'
+		'&metadataType=1'
 	)
 	print(f'Fetching current metadata from {metadata_path}')
 	with urllib.request.urlopen(
@@ -149,20 +155,23 @@ try:
 	print(f'  Current value: {current_value.decode("utf8")}')
 
 	# XOR the current and new values
-	new_value = 'bob'.encode('utf8')
+	new_value = 'Updated mosaic'.encode('utf8')
 	update_value = metadata_update_value(current_value, new_value)
 
 	# Create the update transaction with XOR'd value
 	embedded_update = facade.transaction_factory.create_embedded({
-		'type': 'account_metadata_transaction_v1',
+		'type': 'mosaic_metadata_transaction_v1',
 		'signer_public_key': signer_key_pair.public_key,
 		'target_address': signer_address,
+		'target_mosaic_id': mosaic_id,
 		'scoped_metadata_key': scoped_metadata_key,
 		# value_size_delta is the difference in length
 		# (can be negative)
 		'value_size_delta': len(new_value) - len(current_value),
 		'value': update_value
 	})
+	print('Created embedded update transaction:')
+	print(json.dumps(embedded_update.to_json(), indent=2))
 
 	# Build the aggregate for the update
 	embedded_transactions = [embedded_update]

--- a/mkdocs/overrides/devbook/namespaces/namespace-metadata.log
+++ b/mkdocs/overrides/devbook/namespaces/namespace-metadata.log
@@ -1,0 +1,60 @@
+Using node https://reference.symboltest.net:3001
+Signer address: TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I
+Namespace name: ns_1768809538
+Namespace ID: 13058489397075111804 (0xb53912eb77ddef7c)
+Fetching current network time from /node/time
+  Network time: 103372720119 ms since nemesis
+Fetching recommended fees from /network/fees/transaction
+  Fee multiplier: 100
+
+--- Adding new metadata ---
+Created embedded metadata transaction:
+{
+  "signer_public_key": "3B6A27BCCEB6A42D62A3A8D02A6F0D73653215771DE243A63AC048A18B59DA29",
+  "version": 1,
+  "network": 152,
+  "type": 17220,
+  "target_address": "988E1191A25A88142C2FB3F69787576E3DC713EFC1CE4DE9",
+  "scoped_metadata_key": "14762970678993106057",
+  "target_namespace_id": "13058489397075111804",
+  "value_size_delta": 18,
+  "value": "4d79206669727374206e616d657370616365"
+}
+Built aggregate transaction with hash: C435EE593381F459F59F2651C900273AA4FE54B9D8C14812872B736F9FABEB16
+Announcing aggregate transaction to /transactions
+  Response: {"message":"packet 9 was pushed to the network via /transactions"}
+Waiting for aggregate transaction confirmation...
+  Transaction status: unconfirmed
+  Transaction status: unconfirmed
+  Transaction status: unconfirmed
+  Transaction status: unconfirmed
+  Transaction status: unconfirmed
+  Transaction status: confirmed
+aggregate transaction confirmed in 20 seconds
+
+--- Modifying existing metadata ---
+Fetching current metadata from /metadata?targetAddress=TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I&scopedMetadataKey=CCE09B9D6EE43489&targetId=B53912EB77DDEF7C&metadataType=2
+  Current value: My first namespace
+Created embedded update transaction:
+{
+  "signer_public_key": "3B6A27BCCEB6A42D62A3A8D02A6F0D73653215771DE243A63AC048A18B59DA29",
+  "version": 1,
+  "network": 152,
+  "type": 17220,
+  "target_address": "988E1191A25A88142C2FB3F69787576E3DC713EFC1CE4DE9",
+  "scoped_metadata_key": "14762970678993106057",
+  "target_namespace_id": "13058489397075111804",
+  "value_size_delta": -1,
+  "value": "180944071d1717544e0f0c08160311020665"
+}
+Built aggregate transaction with hash: 28D0C39811C1C4907DCB6C2DFB52B5B2207053DBBB14B52F807FC4B417D8D368
+Announcing aggregate transaction to /transactions
+  Response: {"message":"packet 9 was pushed to the network via /transactions"}
+Waiting for aggregate transaction confirmation...
+  Transaction status: unconfirmed
+  Transaction status: unconfirmed
+  Transaction status: unconfirmed
+  Transaction status: unconfirmed
+  Transaction status: unconfirmed
+  Transaction status: confirmed
+aggregate transaction confirmed in 8 seconds

--- a/mkdocs/overrides/devbook/namespaces/namespace-metadata.mjs
+++ b/mkdocs/overrides/devbook/namespaces/namespace-metadata.mjs
@@ -144,8 +144,8 @@ try {
 		.toUpperCase().padStart(16, '0');
 	const namespaceIdHex = namespaceId.toString(16)
 		.toUpperCase().padStart(16, '0');
-	const metadataPath = `/metadata?sourceAddress=${signerAddress}`
-		+ `&targetAddress=${signerAddress}`
+	const metadataPath = `/metadata`
+		+ `?targetAddress=${signerAddress}`
 		+ `&scopedMetadataKey=${scopedKeyHex}`
 		+ `&targetId=${namespaceIdHex}`
 		+ '&metadataType=2';

--- a/mkdocs/overrides/devbook/namespaces/namespace-metadata.mjs
+++ b/mkdocs/overrides/devbook/namespaces/namespace-metadata.mjs
@@ -1,0 +1,213 @@
+import { PrivateKey } from 'symbol-sdk';
+import {
+	generateNamespaceId,
+	metadataGenerateKey,
+	metadataUpdateValue,
+	models,
+	NetworkTimestamp,
+	SymbolFacade
+} from 'symbol-sdk/symbol';
+
+const NODE_URL = process.env.NODE_URL ||
+	'https://reference.symboltest.net:3001';
+console.log('Using node', NODE_URL);
+
+// Helper function to announce a transaction
+async function announceTransaction(payload, label) {
+	console.log(`Announcing ${label} to /transactions`);
+	const response = await fetch(`${NODE_URL}/transactions`, {
+		method: 'PUT',
+		headers: { 'Content-Type': 'application/json' },
+		body: payload
+	});
+	console.log('  Response:', await response.text());
+}
+
+// Helper function to wait for transaction confirmation
+async function waitForConfirmation(transactionHash, label) {
+	console.log(`Waiting for ${label} confirmation...`);
+	for (let attempt = 0; attempt < 60; attempt++) {
+		await new Promise(resolve => setTimeout(resolve, 1000));
+		try {
+			const response = await fetch(
+				`${NODE_URL}/transactionStatus/${transactionHash}`);
+			const status = await response.json();
+			console.log('  Transaction status:', status.group);
+			if (status.group === 'confirmed') {
+				console.log(`${label} confirmed in`, attempt, 'seconds');
+				return;
+			}
+			if (status.group === 'failed') {
+				throw new Error(`${label} failed: ${status.code}`);
+			}
+		} catch (e) {
+			if (e.message.includes('failed'))
+				throw e;
+			console.log('  Transaction status: unknown');
+		}
+	}
+	throw new Error(`${label} not confirmed after 60 seconds`);
+}
+
+const SIGNER_PRIVATE_KEY = process.env.SIGNER_PRIVATE_KEY || (
+	'0000000000000000000000000000000000000000000000000000000000000000');
+const signerKeyPair = new SymbolFacade.KeyPair(
+	new PrivateKey(SIGNER_PRIVATE_KEY));
+
+const facade = new SymbolFacade('testnet');
+const signerAddress = facade.network.publicKeyToAddress(
+	signerKeyPair.publicKey);
+console.log('Signer address:', signerAddress.toString());
+
+// Get namespace name from environment or use default
+const NAMESPACE_NAME = process.env.NAMESPACE_NAME || 'testnamespace';
+const namespaceId = generateNamespaceId(NAMESPACE_NAME);
+console.log('Namespace name:', NAMESPACE_NAME);
+console.log('Namespace ID:',
+	namespaceId.toString(), `(0x${namespaceId.toString(16)})`);
+
+try {
+	// Fetch current network time
+	const timePath = '/node/time';
+	console.log('Fetching current network time from', timePath);
+	const timeResponse = await fetch(`${NODE_URL}${timePath}`);
+	const timeJSON = await timeResponse.json();
+	const timestamp = new NetworkTimestamp(
+		timeJSON.communicationTimestamps.receiveTimestamp);
+	console.log('  Network time:', timestamp.timestamp,
+		'ms since nemesis');
+
+	// Fetch recommended fees
+	const feePath = '/network/fees/transaction';
+	console.log('Fetching recommended fees from', feePath);
+	const feeResponse = await fetch(`${NODE_URL}${feePath}`);
+	const feeJSON = await feeResponse.json();
+	const medianMult = feeJSON.medianFeeMultiplier;
+	const minimumMult = feeJSON.minFeeMultiplier;
+	const feeMult = Math.max(medianMult, minimumMult);
+	console.log('  Fee multiplier:', feeMult);
+
+	// --- ADDING NEW METADATA ---
+	console.log('\n--- Adding new metadata ---');
+
+	// Define metadata key and value
+	const keyString = `description_${Date.now()}`;
+	const scopedMetadataKey = metadataGenerateKey(keyString);
+	const metadataValue = new TextEncoder().encode('My first namespace');
+
+	// Create the embedded metadata transaction
+	const embeddedTransaction = facade.transactionFactory
+		.createEmbedded({
+			type: 'namespace_metadata_transaction_v1',
+			signerPublicKey: signerKeyPair.publicKey.toString(),
+			targetAddress: signerAddress.toString(),
+			targetNamespaceId: namespaceId,
+			scopedMetadataKey,
+			// When creating new metadata, valueSizeDelta
+			// equals value length
+			valueSizeDelta: metadataValue.length,
+			value: metadataValue
+		});
+	console.log('Created embedded metadata transaction:');
+	console.log(JSON.stringify(embeddedTransaction.toJson(), null, 2));
+
+	// Build the aggregate transaction
+	const embeddedTransactions = [embeddedTransaction];
+	const transaction = facade.transactionFactory.create({
+		type: 'aggregate_complete_transaction_v3',
+		signerPublicKey: signerKeyPair.publicKey.toString(),
+		deadline: timestamp.addHours(2).timestamp,
+		transactionsHash: facade.static.hashEmbeddedTransactions(
+			embeddedTransactions),
+		transactions: embeddedTransactions
+	});
+	transaction.fee = new models.Amount(feeMult * transaction.size);
+
+	// Sign and generate final payload
+	const signature = facade.signTransaction(signerKeyPair, transaction);
+	const jsonPayload = facade.transactionFactory.static.attachSignature(
+		transaction, signature);
+
+	// Announce and wait for confirmation
+	const transactionHash =
+		facade.hashTransaction(transaction).toString();
+	console.log(
+		'Built aggregate transaction with hash:', transactionHash);
+	await announceTransaction(jsonPayload, 'aggregate transaction');
+	await waitForConfirmation(transactionHash, 'aggregate transaction');
+
+	// --- MODIFYING EXISTING METADATA ---
+	console.log('\n--- Modifying existing metadata ---');
+
+	// Fetch current metadata value from network
+	const scopedKeyHex = scopedMetadataKey.toString(16)
+		.toUpperCase().padStart(16, '0');
+	const namespaceIdHex = namespaceId.toString(16)
+		.toUpperCase().padStart(16, '0');
+	const metadataPath = `/metadata?sourceAddress=${signerAddress}`
+		+ `&targetAddress=${signerAddress}`
+		+ `&scopedMetadataKey=${scopedKeyHex}`
+		+ `&targetId=${namespaceIdHex}`
+		+ '&metadataType=2';
+	console.log('Fetching current metadata from', metadataPath);
+	const metadataResponse = await fetch(`${NODE_URL}${metadataPath}`);
+	const metadataJSON = await metadataResponse.json();
+
+	// Get the metadata entry
+	if (!metadataJSON.data.length) {
+		throw new Error('Metadata entry not found');
+	}
+	const metadataEntry = metadataJSON.data[0].metadataEntry;
+	const currentValue = Buffer.from(metadataEntry.value, 'hex');
+	console.log('  Current value:', currentValue.toString('utf8'));
+
+	// XOR the current and new values
+	const newValue = new TextEncoder().encode('Updated namespace');
+	const updateValue = metadataUpdateValue(currentValue, newValue);
+
+	// Create the update transaction with XOR'd value
+	const embeddedUpdate = facade.transactionFactory
+		.createEmbedded({
+			type: 'namespace_metadata_transaction_v1',
+			signerPublicKey: signerKeyPair.publicKey.toString(),
+			targetAddress: signerAddress.toString(),
+			targetNamespaceId: namespaceId,
+			scopedMetadataKey,
+			// valueSizeDelta is the difference in length
+			// (can be negative)
+			valueSizeDelta: newValue.length - currentValue.length,
+			value: updateValue
+		});
+	console.log('Created embedded update transaction:');
+	console.log(JSON.stringify(embeddedUpdate.toJson(), null, 2));
+
+	// Build the aggregate for the update
+	const updateEmbedded = [embeddedUpdate];
+	const updateTransaction = facade.transactionFactory.create({
+		type: 'aggregate_complete_transaction_v3',
+		signerPublicKey: signerKeyPair.publicKey.toString(),
+		deadline: timestamp.addHours(2).timestamp,
+		transactionsHash: facade.static.hashEmbeddedTransactions(
+			updateEmbedded),
+		transactions: updateEmbedded
+	});
+	updateTransaction.fee = new models.Amount(
+		feeMult * updateTransaction.size);
+
+	// Sign and announce the update
+	const updateSignature = facade.signTransaction(
+		signerKeyPair, updateTransaction);
+	const updatePayload = facade.transactionFactory.static
+		.attachSignature(updateTransaction, updateSignature);
+
+	// Announce and wait for confirmation
+	const updateHash =
+		facade.hashTransaction(updateTransaction).toString();
+	console.log(
+		'Built aggregate transaction with hash:', updateHash);
+	await announceTransaction(updatePayload, 'aggregate transaction');
+	await waitForConfirmation(updateHash, 'aggregate transaction');
+
+} catch (e) {
+	console.error(e.message, '| Cause:', e.cause?.code ?? 'unknown');
+}

--- a/mkdocs/overrides/devbook/namespaces/namespace-metadata.py
+++ b/mkdocs/overrides/devbook/namespaces/namespace-metadata.py
@@ -11,6 +11,7 @@ from symbolchain.symbol.Metadata import (
 	metadata_update_value
 )
 from symbolchain.symbol.Network import NetworkTimestamp
+from symbolchain.symbol.IdGenerator import generate_namespace_id
 
 NODE_URL = os.getenv(
 	'NODE_URL', 'https://reference.symboltest.net:3001')
@@ -60,6 +61,12 @@ signer_address = facade.network.public_key_to_address(
 	signer_key_pair.public_key)
 print(f'Signer address: {signer_address}')
 
+# Get namespace name from environment or use default
+NAMESPACE_NAME = os.getenv('NAMESPACE_NAME', 'testnamespace')
+namespace_id = generate_namespace_id(NAMESPACE_NAME)
+print(f'Namespace name: {NAMESPACE_NAME}')
+print(f'Namespace ID: {namespace_id} ({hex(namespace_id)})')
+
 try:
 	# Fetch current network time
 	time_path = '/node/time'
@@ -85,15 +92,16 @@ try:
 	print('\n--- Adding new metadata ---')
 
 	# Define metadata key and value
-	key_string = f'username_{int(time.time())}'
+	key_string = f'description_{int(time.time())}'
 	scoped_metadata_key = metadata_generate_key(key_string)
-	metadata_value = 'alice'.encode('utf8')
+	metadata_value = 'My first namespace'.encode('utf8')
 
 	# Create the embedded metadata transaction
 	embedded_transaction = facade.transaction_factory.create_embedded({
-		'type': 'account_metadata_transaction_v1',
+		'type': 'namespace_metadata_transaction_v1',
 		'signer_public_key': signer_key_pair.public_key,
 		'target_address': signer_address,
+		'target_namespace_id': namespace_id,
 		'scoped_metadata_key': scoped_metadata_key,
 		# When creating new metadata, value_size_delta
 		# equals the value length
@@ -131,10 +139,10 @@ try:
 
 	# Fetch current metadata value from network
 	metadata_path = (
-		f'/metadata?sourceAddress={signer_address}'
-		f'&targetAddress={signer_address}'
+		f'/metadata?targetAddress={signer_address}'
 		f'&scopedMetadataKey={scoped_metadata_key:016X}'
-		'&metadataType=0'
+		f'&targetId={namespace_id:016X}'
+		'&metadataType=2'
 	)
 	print(f'Fetching current metadata from {metadata_path}')
 	with urllib.request.urlopen(
@@ -149,20 +157,23 @@ try:
 	print(f'  Current value: {current_value.decode("utf8")}')
 
 	# XOR the current and new values
-	new_value = 'bob'.encode('utf8')
+	new_value = 'Updated namespace'.encode('utf8')
 	update_value = metadata_update_value(current_value, new_value)
 
 	# Create the update transaction with XOR'd value
 	embedded_update = facade.transaction_factory.create_embedded({
-		'type': 'account_metadata_transaction_v1',
+		'type': 'namespace_metadata_transaction_v1',
 		'signer_public_key': signer_key_pair.public_key,
 		'target_address': signer_address,
+		'target_namespace_id': namespace_id,
 		'scoped_metadata_key': scoped_metadata_key,
 		# value_size_delta is the difference in length
 		# (can be negative)
 		'value_size_delta': len(new_value) - len(current_value),
 		'value': update_value
 	})
+	print('Created embedded update transaction:')
+	print(json.dumps(embedded_update.to_json(), indent=2))
 
 	# Build the aggregate for the update
 	embedded_transactions = [embedded_update]

--- a/mkdocs/pages/en/devbook/accounts/account-metadata.md
+++ b/mkdocs/pages/en/devbook/accounts/account-metadata.md
@@ -1,21 +1,26 @@
 ---
-title: Add Metadata
+title: Add Account Metadata
 ---
 
 # Adding Metadata to an Account
 
-<Accounts:|Accounts> - like <mosaics:> and <namespaces:> - can store <metadata:> as key-value pairs.
+<Accounts:|Accounts>, like <mosaics:> and <namespaces:>, can store <metadata:> as key-value pairs.
 
 This tutorial shows how to add metadata to an account, retrieve metadata from the network, and update existing values.
 
-In this example, the string `alice` is attached to an account and then changed to `bob`:
+In this example, the pair `username = alice` is attached to an account and then changed to `bob`.
 
 ```dot
 digraph {
-    rankdir="LR";
-    Account [label="Account A" tooltip="Account"];
-    Metadata [label="username: alice" tooltip="Metadata entry" shape=note];
-    Account -> Metadata [label="metadata"];
+    layout="neato";
+    Account [label="Account\nTCHBDE...HHE32I" tooltip="Account" pos="0,0!"];
+    Metadata [
+        style=filled
+        class=metadata
+        label=<<table border="0"><tr><td><b>Key</b></td><td><b>Value</b></td></tr><tr><td>username</td><td>alice</td></tr></table>>
+        tooltip="Metadata entry"
+        shape=note
+        pos="2.0,0.5!"];
 }
 ```
 
@@ -23,12 +28,12 @@ digraph {
 
 Before you start, make sure to:
 
-- Set up your development environment.
+* Set up your development environment.
     See [Setting Up a Development Environment](../start/setup.md).
-- Create an <account:> to add metadata to, either
+* Create an <account:> to add metadata to, either
     [from code](./create-from-private-key.md) or
     [by using a wallet](../../userbook/wallet/create-account.md).
-- Obtain <XYM:> to pay for the transaction fee.
+* Obtain <XYM:> to pay for the transaction fee.
     See [Getting Testnet Funds from the Faucet](./testnet-faucet.md).
 
 Additionally, review the [Transfer transaction](../transactions/transfer.md) tutorial to understand how
@@ -82,7 +87,6 @@ In practice, you would use a fixed key that identifies the specific metadata ent
 
 The metadata value can be any byte sequence.
 In this example, the value is the string `alice` encoded in UTF-8.
-
 
 ### Creating the Embedded Account Metadata Transaction
 
@@ -159,16 +163,16 @@ The code queries the <get:/metadata> endpoint with filters for `sourceAddress`, 
 To demonstrate updating metadata, the code changes the username from `alice` to `bob` by creating another
 `account_metadata_transaction_v1` transaction with the same scoped metadata key.
 
-Modifying an existing metadata value in Symbol differs from creating one.
-Instead of sending the new value directly, the transaction must include:
+Modifying an existing metadata value differs from creating a new one in that the updated value must be defined
+in terms of the current value, using the following fields:
 
 * **`value_size_delta`:** The difference in length between the new and current values.
-    In this example, the delta is `-2` because `bob` (3 bytes) is shorter than `alice` (5 bytes).
+    In this example, the delta is `-2` because `bob` (3 bytes) is two bytes shorter than `alice` (5 bytes).
 
 * **`value`:** The XOR'd bytes computed by comparing the current and new values byte-by-byte.
 
-The SDK provides a <dy:Metadata.metadataUpdateValue> helper function that handles the XOR calculation.
-The XOR operation compares each byte: matching bytes become zero, and differing bytes capture the change.
+    The SDK provides a <dy:Metadata.metadataUpdateValue> helper function that handles the XOR calculation.
+    The XOR operation compares each byte: matching bytes become zero, and differing bytes capture the change.
 
 Note that `value_size_delta` represents the difference in final value lengths (new vs current),
 not the length of the XOR'd bytes themselves.
@@ -178,12 +182,10 @@ not the length of the XOR'd bytes themselves.
     To delete a metadata entry, set `value_size_delta` to the negative of the current value length and provide the
     current value as `value`. The XOR produces an empty result, which removes the entry from the network.
 
-{{ tutorial.code_snippet(['py:167:189', 'js:169:194']) }}
-
 As with the [initial metadata creation](#building-the-aggregate-transaction), this metadata modification is wrapped
-in an aggregate transaction.
-The aggregate transaction is then signed and announced as in
-[Creating a Complete Aggregate Transaction](../transactions/complete-aggregate.md#building-the-aggregate-transaction).
+in an aggregate transaction and then signed and announced.
+
+{{ tutorial.code_snippet(['py:167:189', 'js:169:194']) }}
 
 ## Output
 
@@ -214,9 +216,9 @@ The transaction hashes can be used to search for the transactions in the
 
 This tutorial showed how to:
 
-| Step                                                                                  | Related documentation                                |
-| ------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| [Define metadata key and value](#defining-the-metadata)                               | <dy:Metadata.metadataGenerateKey>                    |
+| Step                                                                                          | Related documentation                        |
+|-----------------------------------------------------------------------------------------------|----------------------------------------------|
+| [Define metadata key and value](#defining-the-metadata)                                       | <dy:Metadata.metadataGenerateKey>            |
 | [Create an account metadata transaction](#creating-the-embedded-account-metadata-transaction) | <dy:SymbolTransactionFactory.createEmbedded> |
-| [Retrieve metadata](#retrieving-metadata)                                             | <get:/metadata>                                      |
-| [Modify existing metadata](#modifying-existing-metadata)                              | <dy:Metadata.metadataUpdateValue>                    |
+| [Retrieve metadata](#retrieving-metadata)                                                     | <get:/metadata>                              |
+| [Modify existing metadata](#modifying-existing-metadata)                                      | <dy:Metadata.metadataUpdateValue>            |

--- a/mkdocs/pages/en/devbook/accounts/account-metadata.md
+++ b/mkdocs/pages/en/devbook/accounts/account-metadata.md
@@ -4,11 +4,20 @@ title: Add Metadata
 
 # Adding Metadata to an Account
 
-<Accounts:> can store <metadata:> as key-value pairs.
+<Accounts:|Accounts> - like <mosaics:> and <namespaces:> - can store <metadata:> as key-value pairs.
 
 This tutorial shows how to add metadata to an account, retrieve metadata from the network, and update existing values.
 
-In this example, the string `alice` is attached to an account and then changed to `bob`.
+In this example, the string `alice` is attached to an account and then changed to `bob`:
+
+```dot
+digraph {
+    rankdir="LR";
+    Account [label="Account A" tooltip="Account"];
+    Metadata [label="username: alice" tooltip="Metadata entry" shape=note];
+    Account -> Metadata [label="metadata"];
+}
+```
 
 ## Prerequisites
 
@@ -62,16 +71,6 @@ following the process described in the [Transfer Transaction](../transactions/tr
 Each metadata entry is uniquely identified by the signer's address, the target account's address, and a
 **scoped metadata key**: a 64-bit value chosen by the metadata creator.
 
-!!! note "Multiple entries with the same key"
-
-    Because the signer's address is part of the unique identifier, different accounts can use the same scoped metadata
-    key on the same target account without conflict.
-
-    For example, Account A and Account B can both use the key `username` when adding metadata to Account C,
-    resulting in two distinct metadata entries.
-
-    Each entry is independent and can only be updated by the account that originally created it.
-
 The SDK provides a <dy:Metadata.metadataGenerateKey> helper function that generates a key from a
 human-readable string using SHA3-256 hashing.
 This approach makes keys more meaningful and reduces the chance of collisions.
@@ -83,6 +82,7 @@ In practice, you would use a fixed key that identifies the specific metadata ent
 
 The metadata value can be any byte sequence.
 In this example, the value is the string `alice` encoded in UTF-8.
+
 
 ### Creating the Embedded Account Metadata Transaction
 
@@ -154,12 +154,13 @@ The code queries the <get:/metadata> endpoint with filters for `sourceAddress`, 
 
 ### Modifying Existing Metadata
 
-{{ tutorial.code_snippet(['py:151:177', 'js:152:180']) }}
+{{ tutorial.code_snippet(['py:151:165', 'js:152:167']) }}
 
-To demonstrate updating metadata, the code changes the username from `alice` to `bob` using another account
-metadata transaction.
+To demonstrate updating metadata, the code changes the username from `alice` to `bob` by creating another
+`account_metadata_transaction_v1` transaction with the same scoped metadata key.
 
-Updating metadata in Symbol requires:
+Modifying an existing metadata value in Symbol differs from creating one.
+Instead of sending the new value directly, the transaction must include:
 
 * **`value_size_delta`:** The difference in length between the new and current values.
     In this example, the delta is `-2` because `bob` (3 bytes) is shorter than `alice` (5 bytes).
@@ -172,8 +173,15 @@ The XOR operation compares each byte: matching bytes become zero, and differing 
 Note that `value_size_delta` represents the difference in final value lengths (new vs current),
 not the length of the XOR'd bytes themselves.
 
-{{ tutorial.code_snippet(['py:179:189', 'js:182:194']) }}
+!!! tip "Deleting a metadata entry"
 
+    To delete a metadata entry, set `value_size_delta` to the negative of the current value length and provide the
+    current value as `value`. The XOR produces an empty result, which removes the entry from the network.
+
+{{ tutorial.code_snippet(['py:167:189', 'js:169:194']) }}
+
+As with the [initial metadata creation](#building-the-aggregate-transaction), this metadata modification is wrapped
+in an aggregate transaction.
 The aggregate transaction is then signed and announced as in
 [Creating a Complete Aggregate Transaction](../transactions/complete-aggregate.md#building-the-aggregate-transaction).
 
@@ -206,9 +214,9 @@ The transaction hashes can be used to search for the transactions in the
 
 This tutorial showed how to:
 
-| Step                                                                                  | Related documentation                              |
-| ------------------------------------------------------------------------------------- | -------------------------------------------------- |
-| [Define metadata key and value](#defining-the-metadata)                               | <dy:Metadata.metadataGenerateKey>                  |
-| [Create an account metadata transaction](#creating-the-embedded-account-metadata-transaction) | <dy:SymbolTransactionFactory.createEmbedded>       |
-| [Retrieve metadata](#retrieving-metadata)                                             | <get:/metadata>                                    |
-| [Modify existing metadata](#modifying-existing-metadata)                              | <dy:Metadata.metadataUpdateValue>                  |
+| Step                                                                                  | Related documentation                                |
+| ------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| [Define metadata key and value](#defining-the-metadata)                               | <dy:Metadata.metadataGenerateKey>                    |
+| [Create an account metadata transaction](#creating-the-embedded-account-metadata-transaction) | <dy:SymbolTransactionFactory.createEmbedded> |
+| [Retrieve metadata](#retrieving-metadata)                                             | <get:/metadata>                                      |
+| [Modify existing metadata](#modifying-existing-metadata)                              | <dy:Metadata.metadataUpdateValue>                    |

--- a/mkdocs/pages/en/devbook/mosaics/mosaic-metadata.md
+++ b/mkdocs/pages/en/devbook/mosaics/mosaic-metadata.md
@@ -1,0 +1,237 @@
+---
+title: Add Metadata
+---
+
+# Adding Metadata to a Mosaic
+
+<Mosaics:|Mosaics> - like <accounts:> and <namespaces:> - can store <metadata:> as key-value pairs.
+
+This tutorial shows how to add metadata to a mosaic, retrieve metadata from the network, and update existing values.
+
+In this example, the string `My first mosaic` is attached to a mosaic and then changed to `Updated mosaic`:
+
+```dot
+digraph {
+    rankdir="LR";
+    Mosaic [label="Mosaic\n0x6D13...62C2" tooltip="Mosaic"];
+    Metadata [label="description:\nMy first mosaic" tooltip="Metadata entry" shape=note];
+    Mosaic -> Metadata [label="metadata"];
+}
+```
+
+## Prerequisites
+
+Before you start, make sure to:
+
+- Set up your development environment.
+    See [Setting Up a Development Environment](../start/setup.md).
+- Create an <account:> to own the mosaic, either
+    [from code](../accounts/create-from-private-key.md) or
+    [by using a wallet](../../userbook/wallet/create-account.md).
+- Create a mosaic owned by the signer account.
+- Obtain <XYM:> to pay for the transaction fee.
+    See [Getting Testnet Funds from the Faucet](../accounts/testnet-faucet.md).
+
+Additionally, review the [Transfer transaction](../transactions/transfer.md) tutorial to understand how
+transactions are announced and confirmed, and the
+[Complete Aggregate transaction](../transactions/complete-aggregate.md) tutorial to understand how aggregate
+transactions work.
+
+## Full Code
+
+{% import 'tutorial.jinja2' as tutorial with context %}
+
+{{ tutorial.code_full('devbook/mosaics/mosaic-metadata', ['py', 'js']) }}
+
+## Code Explanation
+
+This tutorial demonstrates adding new metadata to a mosaic and then updating that metadata.
+
+### Setting Up the Account and Mosaic
+
+{{ tutorial.code_snippet(['py:53:66', 'js:51:65']) }}
+
+The snippet reads the signer's private key from the `SIGNER_PRIVATE_KEY` environment variable, which defaults to a
+test key if not set.
+The signer's address is derived from the public key.
+
+The mosaic ID is read from the `MOSAIC_ID` environment variable as a hexadecimal string, which defaults to
+`6D1314BE751B62C2` if not set.
+
+!!! note "Mosaic must exist"
+
+    The mosaic must already be created and owned by the signer account.
+    See [Creating a Mosaic](./create-mosaic.md) for how to create one.
+
+### Fetching Network Time and Fees
+
+{{ tutorial.code_snippet(['py:69:87', 'js:68:86']) }}
+
+Network time and recommended fees are fetched from <get:/node/time> and <get:/network/fees/transaction> respectively,
+following the process described in the [Transfer Transaction](../transactions/transfer.md) tutorial.
+
+### Defining the Metadata
+
+{{ tutorial.code_snippet(['py:92:95', 'js:91:94']) }}
+
+Each mosaic metadata entry is uniquely identified by the signer's address, the target account's address (mosaic owner),
+the target mosaic ID, and a **scoped metadata key**: a 64-bit value chosen by the metadata creator.
+
+The SDK provides a <dy:Metadata.metadataGenerateKey> helper function that generates a key from a
+human-readable string using SHA3-256 hashing.
+This approach makes keys more meaningful and reduces the chance of collisions.
+
+In this example, the key is derived from the string `description`.
+For demonstration purposes, a timestamp is appended to the key string,
+so each time the code is executed a new entry is added to the mosaic.
+In practice, you would use a fixed key that identifies the specific metadata entry you want to create or update.
+
+The metadata value can be any byte sequence.
+In this example, the value is the string `My first mosaic` encoded in UTF-8.
+
+!!! note "Multiple entries with the same key"
+
+    Because the signer's address is part of the unique identifier, different accounts can use the same scoped metadata
+    key on the same mosaic without conflict.
+
+    For example, Account A and Account B can both use the key `description` when adding metadata to a mosaic,
+    resulting in two distinct metadata entries.
+
+    Each entry is independent and can only be updated by the account that originally created it.
+
+### Creating the Embedded Mosaic Metadata Transaction
+
+{{ tutorial.code_snippet(['py:97:110', 'js:96:110']) }}
+
+A mosaic metadata transaction attaches a key-value pair to a mosaic on the blockchain.
+The same transaction type handles both adding new metadata entries and updating existing ones.
+
+Symbol requires these transactions to be inside an <aggregate transaction:> that includes the mosaic owner's
+signature.
+This prevents unwanted metadata from being attached to a mosaic without its owner's permission.
+
+For this reason, the code defines the mosaic metadata transaction as an <embedded transaction:>.
+
+This transaction specifies:
+
+* **Type:** Use `mosaic_metadata_transaction_v1`.
+
+* **Signer public key:** The account creating the metadata entry.
+
+* **Target address:** The mosaic owner's address.
+    When the signer differs from the mosaic owner, the owner must cosign the aggregate transaction.
+
+* **Target mosaic ID:** The mosaic to attach the metadata to.
+
+* **Scoped metadata key:** The 64-bit key used to identify this metadata entry.
+
+* **Value size delta:** When creating new metadata, set this to the byte length of the value.
+    When updating existing metadata, set this to the difference between the new and current value lengths.
+
+* **Value:** The metadata content as bytes.
+    When creating new metadata, provide the raw value.
+    When updating, provide a computed value (explained in the
+    [Modifying Existing Metadata](#modifying-existing-metadata) section).
+
+### Building the Aggregate Transaction
+
+{{ tutorial.code_snippet(['py:112:122', 'js:112:122']) }}
+
+The code adds the embedded mosaic metadata transaction to an <aggregate transaction:>.
+
+Since the signer is the mosaic owner, no <cosignatures:> are required and the aggregate can be created as
+<complete aggregate transaction:|complete>, allowing it to be signed and announced immediately.
+
+!!! note "Adding metadata by a different account"
+
+    If the signer is different from the mosaic owner, the owner must cosign the aggregate transaction to approve the
+    metadata entry.
+
+    For details on collecting cosignatures on-chain, see the [Bonded Aggregate](../transactions/bonded-aggregate.md)
+    tutorial.
+
+### Submitting the Aggregate Transaction
+
+{{ tutorial.code_snippet(['py:124:133', 'js:124:135']) }}
+
+The aggregate transaction is signed and announced following the same process as in
+[Creating a Complete Aggregate Transaction](../transactions/complete-aggregate.md#building-the-aggregate-transaction).
+
+### Retrieving Metadata
+
+{{ tutorial.code_snippet(['py:138:155', 'js:140:160']) }}
+
+Updating an existing metadata entry requires the current value from the network.
+
+The code queries the <get:/metadata> endpoint with filters for `targetAddress`, `scopedMetadataKey`,
+`targetId` (the mosaic ID), and `metadataType` (`1` for mosaic metadata) to retrieve the specific entry.
+
+### Modifying Existing Metadata
+
+{{ tutorial.code_snippet(['py:157:174', 'js:162:180']) }}
+
+To demonstrate updating metadata, the code changes the description from `My first mosaic` to `Updated mosaic`
+by creating another `mosaic_metadata_transaction_v1` transaction with the same scoped metadata key.
+
+Modifying an existing metadata value in Symbol differs from creating one.
+Instead of sending the new value directly, the transaction must include:
+
+* **`value_size_delta`:** The difference in length between the new and current values.
+    In this example, the delta is `-1` because `Updated mosaic` (14 bytes) is shorter than
+    `My first mosaic` (15 bytes).
+
+* **`value`:** The XOR'd bytes computed by comparing the current and new values byte-by-byte.
+
+The SDK provides a <dy:Metadata.metadataUpdateValue> helper function that handles the XOR calculation.
+The XOR operation compares each byte: matching bytes become zero, and differing bytes capture the change.
+
+Note that `value_size_delta` represents the difference in final value lengths (new vs current),
+not the length of the XOR'd bytes themselves.
+
+!!! tip "Deleting a metadata entry"
+
+    To delete a metadata entry, set `value_size_delta` to the negative of the current value length and provide the
+    current value as `value`. The XOR produces an empty result, which removes the entry from the network.
+
+{{ tutorial.code_snippet(['py:176:198', 'js:182:210']) }}
+
+As with the [initial metadata creation](#building-the-aggregate-transaction), this metadata modification is wrapped
+in an aggregate transaction.
+The aggregate transaction is then signed and announced as in
+[Creating a Complete Aggregate Transaction](../transactions/complete-aggregate.md#building-the-aggregate-transaction).
+
+## Output
+
+The output shown below corresponds to a typical run of the program.
+
+```text linenums="1" hl_lines="3 17 18 19 22 36 46 47 49"
+--8<-- 'devbook/mosaics/mosaic-metadata.log'
+```
+
+Key points in the output:
+
+* **Line 3** (`Mosaic ID`): The mosaic ID read from the environment variable, in decimal and hexadecimal formats.
+* **Line 17** (`"scoped_metadata_key"`): The 64-bit key generated from the input string using SHA3-256 hashing.
+* **Line 18** (`"target_mosaic_id"`): The mosaic receiving the metadata.
+* **Line 19** (`"value_size_delta": 15`): When creating new metadata, this equals the byte length of the value
+    (`"My first mosaic"` = 15 bytes).
+* **Line 22**: The transaction hash for looking up the metadata creation in the explorer.
+* **Line 36** (`Current value: My first mosaic`): Retrieved from the network before updating.
+* **Line 46** (`"value_size_delta": -1`): Negative because the new value (`"Updated mosaic"` = 14 bytes) is shorter
+    than the current value (15 bytes).
+* **Line 47** (`"value"`): The XOR'd value computed from the current and new values, not the raw new value.
+* **Line 49**: The transaction hash for looking up the metadata update in the explorer.
+
+The transaction hashes can be used to search for the transactions in the
+[Symbol Testnet Explorer](https://testnet.symbol.fyi/).
+
+## Conclusion
+
+This tutorial showed how to:
+
+| Step                                                                                       | Related documentation                              |
+| ------------------------------------------------------------------------------------------ | -------------------------------------------------- |
+| [Define metadata key and value](#defining-the-metadata)                                    | <dy:Metadata.metadataGenerateKey>                  |
+| [Create a mosaic metadata transaction](#creating-the-embedded-mosaic-metadata-transaction) | <dy:SymbolTransactionFactory.createEmbedded>  |
+| [Retrieve metadata](#retrieving-metadata)                                                  | <get:/metadata>                                    |
+| [Modify existing metadata](#modifying-existing-metadata)                                   | <dy:Metadata.metadataUpdateValue>                  |

--- a/mkdocs/pages/en/devbook/mosaics/mosaic-metadata.md
+++ b/mkdocs/pages/en/devbook/mosaics/mosaic-metadata.md
@@ -173,7 +173,7 @@ The aggregate transaction is signed and announced following the same process as 
 
 {{ tutorial.code_snippet(['py:138:155', 'js:140:160']) }}
 
-The retrieve the current value of a metadata entry, the code uses the <get:/metadata> endpoint
+To retrieve the current value of a metadata entry, the code uses the <get:/metadata> endpoint
 with filters for `targetAddress`, `scopedMetadataKey`, `targetId` (the mosaic ID), and `metadataType`
 (`1` for mosaic metadata).
 

--- a/mkdocs/pages/en/devbook/mosaics/mosaic-metadata.md
+++ b/mkdocs/pages/en/devbook/mosaics/mosaic-metadata.md
@@ -1,21 +1,26 @@
 ---
-title: Add Metadata
+title: Add Mosaic Metadata
 ---
 
 # Adding Metadata to a Mosaic
 
-<Mosaics:|Mosaics> - like <accounts:> and <namespaces:> - can store <metadata:> as key-value pairs.
+<Mosaics:|Mosaics>, like <accounts:> and <namespaces:>, can store <metadata:> as key-value pairs.
 
-This tutorial shows how to add metadata to a mosaic, retrieve metadata from the network, and update existing values.
+This tutorial shows how to add metadata to a mosaic, retrieve it from the network, and update existing values.
 
-In this example, the string `My first mosaic` is attached to a mosaic and then changed to `Updated mosaic`:
+In this example, the pair `description = My first mosaic` is attached to a mosaic and then changed to `Updated mosaic`.
 
 ```dot
 digraph {
-    rankdir="LR";
-    Mosaic [label="Mosaic\n0x6D13...62C2" tooltip="Mosaic"];
-    Metadata [label="description:\nMy first mosaic" tooltip="Metadata entry" shape=note];
-    Mosaic -> Metadata [label="metadata"];
+    layout="neato";
+    Mosaic [label="Mosaic\n0x6D13...62C2" tooltip="Mosaic" pos="0,0!"];
+    Metadata [
+        style=filled
+        class=metadata
+        label=<<table border="0"><tr><td><b>Key</b></td><td><b>Value</b></td></tr><tr><td>description</td><td>My first mosaic</td></tr></table>>
+        tooltip="Metadata entry"
+        shape=note
+        pos="2.5,0.5!"];
 }
 ```
 
@@ -23,19 +28,20 @@ digraph {
 
 Before you start, make sure to:
 
-- Set up your development environment.
+* Set up your development environment.
     See [Setting Up a Development Environment](../start/setup.md).
-- Create an <account:> to own the mosaic, either
+* Create an <account:> to own the mosaic, either
     [from code](../accounts/create-from-private-key.md) or
     [by using a wallet](../../userbook/wallet/create-account.md).
-- Create a mosaic owned by the signer account.
-- Obtain <XYM:> to pay for the transaction fee.
+* Create a mosaic owned by the signer account.
+    See [Creating a Mosaic](./create-mosaic.md).
+* Obtain <XYM:> to pay for the transaction fee.
     See [Getting Testnet Funds from the Faucet](../accounts/testnet-faucet.md).
 
 Additionally, review the [Transfer transaction](../transactions/transfer.md) tutorial to understand how
 transactions are announced and confirmed, and the
-[Complete Aggregate transaction](../transactions/complete-aggregate.md) tutorial to understand how aggregate
-transactions work.
+[Complete Aggregate transaction](../transactions/complete-aggregate.md) tutorial to understand how
+<aggregate transactions:> work.
 
 ## Full Code
 
@@ -55,13 +61,15 @@ The snippet reads the signer's private key from the `SIGNER_PRIVATE_KEY` environ
 test key if not set.
 The signer's address is derived from the public key.
 
-The mosaic ID is read from the `MOSAIC_ID` environment variable as a hexadecimal string, which defaults to
-`6D1314BE751B62C2` if not set.
+The ID of the mosaic to which the metadata will be attached is read from the `MOSAIC_ID` environment variable.
+This is as an unprefixed hexadecimal string, which defaults to a test value if not set.
 
 !!! note "Mosaic must exist"
 
-    The mosaic must already be created and owned by the signer account.
-    See [Creating a Mosaic](./create-mosaic.md) for how to create one.
+    The mosaic must already be created and owned by the signer account,
+    or the transaction adding the metadata will be rejected.
+
+    See the [Creating a Mosaic](./create-mosaic.md) tutorial to learn how to create one.
 
 ### Fetching Network Time and Fees
 
@@ -72,30 +80,34 @@ following the process described in the [Transfer Transaction](../transactions/tr
 
 ### Defining the Metadata
 
+Each mosaic metadata entry is uniquely identified by:
+
+* The **signer's address**: the account adding the metadata
+* The **target account's address**: the mosaic owner, whose signature is required
+* The **target mosaic ID**
+* A **scoped metadata key**: a 64-bit value chosen by the metadata creator
+
+    The SDK provides a <dy:Metadata.metadataGenerateKey> helper function that generates this key from a
+    human-readable string using SHA3-256 hashing.
+    This approach makes keys more meaningful and reduces the chance of collisions.
+
 {{ tutorial.code_snippet(['py:92:95', 'js:91:94']) }}
-
-Each mosaic metadata entry is uniquely identified by the signer's address, the target account's address (mosaic owner),
-the target mosaic ID, and a **scoped metadata key**: a 64-bit value chosen by the metadata creator.
-
-The SDK provides a <dy:Metadata.metadataGenerateKey> helper function that generates a key from a
-human-readable string using SHA3-256 hashing.
-This approach makes keys more meaningful and reduces the chance of collisions.
 
 In this example, the key is derived from the string `description`.
 For demonstration purposes, a timestamp is appended to the key string,
 so each time the code is executed a new entry is added to the mosaic.
 In practice, you would use a fixed key that identifies the specific metadata entry you want to create or update.
 
-The metadata value can be any byte sequence.
+The metadata value can be any sequence of up to 1024 bytes.
 In this example, the value is the string `My first mosaic` encoded in UTF-8.
 
 !!! note "Multiple entries with the same key"
 
-    Because the signer's address is part of the unique identifier, different accounts can use the same scoped metadata
-    key on the same mosaic without conflict.
+    The key is only one of the 4 parts that identify a metadata entry,
+    so a change in any part produces a different entry.
 
-    For example, Account A and Account B can both use the key `description` when adding metadata to a mosaic,
-    resulting in two distinct metadata entries.
+    For example, different accounts can use the same scoped metadata key on the same mosaic without conflict,
+    because the signer's address is different.
 
     Each entry is independent and can only be updated by the account that originally created it.
 
@@ -106,20 +118,20 @@ In this example, the value is the string `My first mosaic` encoded in UTF-8.
 A mosaic metadata transaction attaches a key-value pair to a mosaic on the blockchain.
 The same transaction type handles both adding new metadata entries and updating existing ones.
 
-Symbol requires these transactions to be inside an <aggregate transaction:> that includes the mosaic owner's
-signature.
+Symbol requires these transactions to be inside an <aggregate transaction:> that includes both
+the signer account and the mosaic owner's signature.
 This prevents unwanted metadata from being attached to a mosaic without its owner's permission.
 
-For this reason, the code defines the mosaic metadata transaction as an <embedded transaction:>.
-
-This transaction specifies:
+In this tutorial, the signer is also the mosaic owner so only one signature is needed.
+However, the transaction still needs to be inside an aggregate,
+so the code defines the mosaic metadata transaction as an <embedded transaction:> with these properties:
 
 * **Type:** Use `mosaic_metadata_transaction_v1`.
 
 * **Signer public key:** The account creating the metadata entry.
 
 * **Target address:** The mosaic owner's address.
-    When the signer differs from the mosaic owner, the owner must cosign the aggregate transaction.
+    When the signer differs from the mosaic owner, the owner must <cosignature:|cosign> the aggregate transaction.
 
 * **Target mosaic ID:** The mosaic to attach the metadata to.
 
@@ -161,29 +173,32 @@ The aggregate transaction is signed and announced following the same process as 
 
 {{ tutorial.code_snippet(['py:138:155', 'js:140:160']) }}
 
-Updating an existing metadata entry requires the current value from the network.
+The retrieve the current value of a metadata entry, the code uses the <get:/metadata> endpoint
+with filters for `targetAddress`, `scopedMetadataKey`, `targetId` (the mosaic ID), and `metadataType`
+(`1` for mosaic metadata).
 
-The code queries the <get:/metadata> endpoint with filters for `targetAddress`, `scopedMetadataKey`,
-`targetId` (the mosaic ID), and `metadataType` (`1` for mosaic metadata) to retrieve the specific entry.
+The endpoint returns the list of entries matching the filters, which in this case contains a single item.
 
 ### Modifying Existing Metadata
 
 {{ tutorial.code_snippet(['py:157:174', 'js:162:180']) }}
 
+Updating an existing metadata entry requires the current value, retrieved from the network as previously shown.
+
 To demonstrate updating metadata, the code changes the description from `My first mosaic` to `Updated mosaic`
 by creating another `mosaic_metadata_transaction_v1` transaction with the same scoped metadata key.
 
-Modifying an existing metadata value in Symbol differs from creating one.
-Instead of sending the new value directly, the transaction must include:
+Modifying an existing metadata value differs from creating a new one in that the updated value must be defined
+in terms of the current value, using the following fields:
 
-* **`value_size_delta`:** The difference in length between the new and current values.
-    In this example, the delta is `-1` because `Updated mosaic` (14 bytes) is shorter than
+* `value_size_delta`: The difference in length between the new and current values.
+    In this example, the delta is `-1` because the string `Updated mosaic` (14 bytes) is one byte shorter than
     `My first mosaic` (15 bytes).
 
-* **`value`:** The XOR'd bytes computed by comparing the current and new values byte-by-byte.
+* `value`: The XOR'd bytes computed by comparing the current and new values byte-by-byte.
 
-The SDK provides a <dy:Metadata.metadataUpdateValue> helper function that handles the XOR calculation.
-The XOR operation compares each byte: matching bytes become zero, and differing bytes capture the change.
+    The SDK provides a <dy:Metadata.metadataUpdateValue> helper function that handles the XOR calculation.
+    The XOR operation compares each byte: matching bytes become zero, and differing bytes capture the change.
 
 Note that `value_size_delta` represents the difference in final value lengths (new vs current),
 not the length of the XOR'd bytes themselves.
@@ -193,12 +208,10 @@ not the length of the XOR'd bytes themselves.
     To delete a metadata entry, set `value_size_delta` to the negative of the current value length and provide the
     current value as `value`. The XOR produces an empty result, which removes the entry from the network.
 
-{{ tutorial.code_snippet(['py:176:198', 'js:182:210']) }}
-
 As with the [initial metadata creation](#building-the-aggregate-transaction), this metadata modification is wrapped
-in an aggregate transaction.
-The aggregate transaction is then signed and announced as in
-[Creating a Complete Aggregate Transaction](../transactions/complete-aggregate.md#building-the-aggregate-transaction).
+in an aggregate transaction and then signed and announced.
+
+{{ tutorial.code_snippet(['py:176:198', 'js:182:210']) }}
 
 ## Output
 
@@ -210,7 +223,7 @@ The output shown below corresponds to a typical run of the program.
 
 Key points in the output:
 
-* **Line 3** (`Mosaic ID`): The mosaic ID read from the environment variable, in decimal and hexadecimal formats.
+* **Line 3** (`Mosaic ID`): The mosaic ID used, in decimal and hexadecimal formats.
 * **Line 17** (`"scoped_metadata_key"`): The 64-bit key generated from the input string using SHA3-256 hashing.
 * **Line 18** (`"target_mosaic_id"`): The mosaic receiving the metadata.
 * **Line 19** (`"value_size_delta": 15`): When creating new metadata, this equals the byte length of the value
@@ -232,6 +245,6 @@ This tutorial showed how to:
 | Step                                                                                       | Related documentation                              |
 | ------------------------------------------------------------------------------------------ | -------------------------------------------------- |
 | [Define metadata key and value](#defining-the-metadata)                                    | <dy:Metadata.metadataGenerateKey>                  |
-| [Create a mosaic metadata transaction](#creating-the-embedded-mosaic-metadata-transaction) | <dy:SymbolTransactionFactory.createEmbedded>  |
+| [Create a mosaic metadata transaction](#creating-the-embedded-mosaic-metadata-transaction) | <dy:SymbolTransactionFactory.createEmbedded>       |
 | [Retrieve metadata](#retrieving-metadata)                                                  | <get:/metadata>                                    |
 | [Modify existing metadata](#modifying-existing-metadata)                                   | <dy:Metadata.metadataUpdateValue>                  |

--- a/mkdocs/pages/en/devbook/namespaces/namespace-metadata.md
+++ b/mkdocs/pages/en/devbook/namespaces/namespace-metadata.md
@@ -1,21 +1,26 @@
 ---
-title: Add Metadata
+title: Add Namespace Metadata
 ---
 
 # Adding Metadata to a Namespace
 
-<Namespaces:|Namespaces> - like <accounts:> and <mosaics:> - can store <metadata:> as key-value pairs.
+<Namespaces:|Namespaces>, like <accounts:> and <mosaics:>, can store <metadata:> as key-value pairs.
 
-This tutorial shows how to add metadata to a namespace, retrieve metadata from the network, and update existing values.
+This tutorial shows how to add metadata to a namespace, retrieve it from the network, and update existing values.
 
-In this example, the string `My first namespace` is attached to a namespace and then changed to `Updated namespace`:
+In this example, the pair `description = My first namespace` is attached to a namespace and then changed to `Updated namespace`:
 
 ```dot
 digraph {
-    rankdir="LR";
-    NS [label="Namespace\ntestnamespace" tooltip="Namespace"];
-    Metadata [label="description:\nMy first namespace" tooltip="Metadata entry" shape=note];
-    NS -> Metadata [label="metadata"];
+    layout="neato";
+    Namespace [label="Namespace\ntestnamespace" tooltip="Namespace" pos="0,0!"];
+    Metadata [
+        style=filled
+        class=metadata
+        label=<<table border="0"><tr><td><b>Key</b></td><td><b>Value</b></td></tr><tr><td>description</td><td>My first namespace</td></tr></table>>
+        tooltip="Metadata entry"
+        shape=note
+        pos="2.5,0.5!"];
 }
 ```
 
@@ -23,19 +28,19 @@ digraph {
 
 Before you start, make sure to:
 
-- Set up your development environment.
+* Set up your development environment.
     See [Setting Up a Development Environment](../start/setup.md).
-- Create an <account:> to own the namespace, either
+* Create an <account:> to own the namespace, either
     [from code](../accounts/create-from-private-key.md) or
     [by using a wallet](../../userbook/wallet/create-account.md).
-- [Register a namespace](./register-root-namespace.md) owned by the signer account.
-- Obtain <XYM:> to pay for the transaction fee.
+* [Register a namespace](./register-root-namespace.md) owned by the signer account.
+* Obtain <XYM:> to pay for the transaction fee.
     See [Getting Testnet Funds from the Faucet](../accounts/testnet-faucet.md).
 
 Additionally, review the [Transfer transaction](../transactions/transfer.md) tutorial to understand how
 transactions are announced and confirmed, and the
-[Complete Aggregate transaction](../transactions/complete-aggregate.md) tutorial to understand how aggregate
-transactions work.
+[Complete Aggregate transaction](../transactions/complete-aggregate.md) tutorial to understand how
+<aggregate transactions:> work.
 
 ## Full Code
 
@@ -61,8 +66,10 @@ The namespace ID is computed from the name using <dy:IdGenerator.generateNamespa
 
 !!! note "Namespace must exist"
 
-    The namespace must already be registered and owned by the signer account.
-    See [Registering a Root Namespace](./register-root-namespace.md) for how to create one.
+    The namespace must already be registered and owned by the signer account,
+    or the transaction adding the metadata will be rejected.
+
+    See [Registering a Root Namespace](./register-root-namespace.md) to learn how to do it.
 
 ### Fetching Network Time and Fees
 
@@ -73,30 +80,34 @@ following the process described in the [Transfer Transaction](../transactions/tr
 
 ### Defining the Metadata
 
+Each namespace metadata entry is uniquely identified by:
+
+* The **signer's address**: the account adding the metadata
+* The **target account's address**: the namespace owner, whose signature is required
+* The **target namespace ID**
+* A **scoped metadata key**: a 64-bit value chosen by the metadata creator
+
+    The SDK provides a <dy:Metadata.metadataGenerateKey> helper function that generates this key from a
+    human-readable string using SHA3-256 hashing.
+    This approach makes keys more meaningful and reduces the chance of collisions.
+
 {{ tutorial.code_snippet(['py:94:97', 'js:93:96']) }}
-
-Each namespace metadata entry is uniquely identified by the signer's address, the target account's address,
-the target namespace ID, and a **scoped metadata key**: a 64-bit value chosen by the metadata creator.
-
-The SDK provides a <dy:Metadata.metadataGenerateKey> helper function that generates a key from a
-human-readable string using SHA3-256 hashing.
-This approach makes keys more meaningful and reduces the chance of collisions.
 
 In this example, the key is derived from the string `description`.
 For demonstration purposes, a timestamp is appended to the key string,
 so each time the code is executed a new entry is added to the namespace.
 In practice, you would use a fixed key that identifies the specific metadata entry you want to create or update.
 
-The metadata value can be any byte sequence.
+The metadata value can be any sequence of up to 1024 bytes.
 In this example, the value is the string `My first namespace` encoded in UTF-8.
 
 !!! note "Multiple entries with the same key"
 
-    Because the signer's address is part of the unique identifier, different accounts can use the same scoped metadata
-    key on the same namespace without conflict.
+    The key is only one of the 4 parts that identify a metadata entry,
+    so a change in any part produces a different entry.
 
-    For example, Account A and Account B can both use the key `description` when adding metadata to a namespace,
-    resulting in two distinct metadata entries.
+    For example, different accounts can use the same scoped metadata key on the same namespace without conflict,
+    because the signer's address is different.
 
     Each entry is independent and can only be updated by the account that originally created it.
 
@@ -107,20 +118,20 @@ In this example, the value is the string `My first namespace` encoded in UTF-8.
 A namespace metadata transaction attaches a key-value pair to a namespace on the blockchain.
 The same transaction type handles both adding new metadata entries and updating existing ones.
 
-Symbol requires these transactions to be inside an <aggregate transaction:> that includes the namespace owner's
-signature.
+Symbol requires these transactions to be inside an <aggregate transaction:> that includes both
+the signer account and the namespace owner's signature.
 This prevents unwanted metadata from being attached to a namespace without its owner's permission.
 
-For this reason, the code defines the namespace metadata transaction as an <embedded transaction:>.
-
-This transaction specifies:
+In this tutorial, the signer is also the namespace owner so only one signature is needed.
+However, the transaction still needs to be inside an aggregate,
+so the code defines the mosaic metadata transaction as an <embedded transaction:> with these properties:
 
 * **Type:** Use `namespace_metadata_transaction_v1`.
 
 * **Signer public key:** The account creating the metadata entry.
 
 * **Target address:** The namespace owner's address.
-    When the signer differs from the namespace owner, the owner must cosign the aggregate transaction.
+    When the signer differs from the namespace owner, the owner must <cosignature:|cosign> the aggregate transaction.
 
 * **Target namespace ID:** The namespace to attach the metadata to.
 
@@ -162,29 +173,32 @@ The aggregate transaction is signed and announced following the same process as 
 
 {{ tutorial.code_snippet(['py:140:157', 'js:142:162']) }}
 
-Updating an existing metadata entry requires the current value from the network.
+To retrieve the current value of a metadata entry, the code uses the <get:/metadata> endpoint
+with filters for `targetAddress`, `scopedMetadataKey`, `targetId` (the namespace ID), and `metadataType`
+(`2` for namespace metadata).
 
-The code queries the <get:/metadata> endpoint with filters for `targetAddress`, `scopedMetadataKey`,
-`targetId` (the namespace ID), and `metadataType` (`2` for namespace metadata) to retrieve the specific entry.
+The endpoint returns the list of entries matching the filters, which in this case contains a single item.
 
 ### Modifying Existing Metadata
 
 {{ tutorial.code_snippet(['py:159:176', 'js:164:182']) }}
 
+Updating an existing metadata entry requires the current value, retrieved from the network as previously shown.
+
 To demonstrate updating metadata, the code changes the description from `My first namespace` to `Updated namespace`
 by creating another `namespace_metadata_transaction_v1` transaction with the same scoped metadata key.
 
-Modifying an existing metadata value in Symbol differs from creating one.
-Instead of sending the new value directly, the transaction must include:
+Modifying an existing metadata value differs from creating a new one in that the updated value must be defined
+in terms of the current value, using the following fields:
 
-* **`value_size_delta`:** The difference in length between the new and current values.
-    In this example, the delta is `-1` because `Updated namespace` (17 bytes) is shorter than
+* `value_size_delta`: The difference in length between the new and current values.
+    In this example, the delta is `-1` because `Updated namespace` (17 bytes) is one byte shorter than
     `My first namespace` (18 bytes).
 
-* **`value`:** The XOR'd bytes computed by comparing the current and new values byte-by-byte.
+* `value`: The XOR'd bytes computed by comparing the current and new values byte-by-byte.
 
-The SDK provides a <dy:Metadata.metadataUpdateValue> helper function that handles the XOR calculation.
-The XOR operation compares each byte: matching bytes become zero, and differing bytes capture the change.
+    The SDK provides a <dy:Metadata.metadataUpdateValue> helper function that handles the XOR calculation.
+    The XOR operation compares each byte: matching bytes become zero, and differing bytes capture the change.
 
 Note that `value_size_delta` represents the difference in final value lengths (new vs current),
 not the length of the XOR'd bytes themselves.
@@ -194,12 +208,10 @@ not the length of the XOR'd bytes themselves.
     To delete a metadata entry, set `value_size_delta` to the negative of the current value length and provide the
     current value as `value`. The XOR produces an empty result, which removes the entry from the network.
 
-{{ tutorial.code_snippet(['py:178:200', 'js:184:209']) }}
-
 As with the [initial metadata creation](#building-the-aggregate-transaction), this metadata modification is wrapped
-in an aggregate transaction.
-The aggregate transaction is then signed and announced as in
-[Creating a Complete Aggregate Transaction](../transactions/complete-aggregate.md#building-the-aggregate-transaction).
+in an aggregate transaction and then signed and announced.
+
+{{ tutorial.code_snippet(['py:178:200', 'js:184:209']) }}
 
 ## Output
 
@@ -231,9 +243,9 @@ The transaction hashes can be used to search for the transactions in the
 
 This tutorial showed how to:
 
-| Step                                                                                             | Related documentation                              |
-| ------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
-| [Define metadata key and value](#defining-the-metadata)                                          | <dy:Metadata.metadataGenerateKey>                  |
-| [Create a namespace metadata transaction](#creating-the-embedded-namespace-metadata-transaction) | <dy:SymbolTransactionFactory.createEmbedded>       |
-| [Retrieve metadata](#retrieving-metadata)                                                        | <get:/metadata>                                    |
-| [Modify existing metadata](#modifying-existing-metadata)                                         | <dy:Metadata.metadataUpdateValue>                  |
+| Step                                                                                             | Related documentation                        |
+|--------------------------------------------------------------------------------------------------|----------------------------------------------|
+| [Define metadata key and value](#defining-the-metadata)                                          | <dy:Metadata.metadataGenerateKey>            |
+| [Create a namespace metadata transaction](#creating-the-embedded-namespace-metadata-transaction) | <dy:SymbolTransactionFactory.createEmbedded> |
+| [Retrieve metadata](#retrieving-metadata)                                                        | <get:/metadata>                              |
+| [Modify existing metadata](#modifying-existing-metadata)                                         | <dy:Metadata.metadataUpdateValue>            |

--- a/mkdocs/pages/en/devbook/namespaces/namespace-metadata.md
+++ b/mkdocs/pages/en/devbook/namespaces/namespace-metadata.md
@@ -1,0 +1,239 @@
+---
+title: Add Metadata
+---
+
+# Adding Metadata to a Namespace
+
+<Namespaces:|Namespaces> - like <accounts:> and <mosaics:> - can store <metadata:> as key-value pairs.
+
+This tutorial shows how to add metadata to a namespace, retrieve metadata from the network, and update existing values.
+
+In this example, the string `My first namespace` is attached to a namespace and then changed to `Updated namespace`:
+
+```dot
+digraph {
+    rankdir="LR";
+    NS [label="Namespace\ntestnamespace" tooltip="Namespace"];
+    Metadata [label="description:\nMy first namespace" tooltip="Metadata entry" shape=note];
+    NS -> Metadata [label="metadata"];
+}
+```
+
+## Prerequisites
+
+Before you start, make sure to:
+
+- Set up your development environment.
+    See [Setting Up a Development Environment](../start/setup.md).
+- Create an <account:> to own the namespace, either
+    [from code](../accounts/create-from-private-key.md) or
+    [by using a wallet](../../userbook/wallet/create-account.md).
+- [Register a namespace](./register-root-namespace.md) owned by the signer account.
+- Obtain <XYM:> to pay for the transaction fee.
+    See [Getting Testnet Funds from the Faucet](../accounts/testnet-faucet.md).
+
+Additionally, review the [Transfer transaction](../transactions/transfer.md) tutorial to understand how
+transactions are announced and confirmed, and the
+[Complete Aggregate transaction](../transactions/complete-aggregate.md) tutorial to understand how aggregate
+transactions work.
+
+## Full Code
+
+{% import 'tutorial.jinja2' as tutorial with context %}
+
+{{ tutorial.code_full('devbook/namespaces/namespace-metadata', ['py', 'js']) }}
+
+## Code Explanation
+
+This tutorial demonstrates adding new metadata to a namespace and then updating that metadata.
+
+### Setting Up the Account and Namespace
+
+{{ tutorial.code_snippet(['py:54:68', 'js:52:67']) }}
+
+The snippet reads the signer's private key from the `SIGNER_PRIVATE_KEY` environment variable, which defaults to a
+test key if not set.
+The signer's address is derived from the public key.
+
+The namespace name is read from the `NAMESPACE_NAME` environment variable,
+which defaults to `testnamespace` if not set.
+The namespace ID is computed from the name using <dy:IdGenerator.generateNamespaceId>.
+
+!!! note "Namespace must exist"
+
+    The namespace must already be registered and owned by the signer account.
+    See [Registering a Root Namespace](./register-root-namespace.md) for how to create one.
+
+### Fetching Network Time and Fees
+
+{{ tutorial.code_snippet(['py:71:89', 'js:70:88']) }}
+
+Network time and recommended fees are fetched from <get:/node/time> and <get:/network/fees/transaction> respectively,
+following the process described in the [Transfer Transaction](../transactions/transfer.md) tutorial.
+
+### Defining the Metadata
+
+{{ tutorial.code_snippet(['py:94:97', 'js:93:96']) }}
+
+Each namespace metadata entry is uniquely identified by the signer's address, the target account's address,
+the target namespace ID, and a **scoped metadata key**: a 64-bit value chosen by the metadata creator.
+
+The SDK provides a <dy:Metadata.metadataGenerateKey> helper function that generates a key from a
+human-readable string using SHA3-256 hashing.
+This approach makes keys more meaningful and reduces the chance of collisions.
+
+In this example, the key is derived from the string `description`.
+For demonstration purposes, a timestamp is appended to the key string,
+so each time the code is executed a new entry is added to the namespace.
+In practice, you would use a fixed key that identifies the specific metadata entry you want to create or update.
+
+The metadata value can be any byte sequence.
+In this example, the value is the string `My first namespace` encoded in UTF-8.
+
+!!! note "Multiple entries with the same key"
+
+    Because the signer's address is part of the unique identifier, different accounts can use the same scoped metadata
+    key on the same namespace without conflict.
+
+    For example, Account A and Account B can both use the key `description` when adding metadata to a namespace,
+    resulting in two distinct metadata entries.
+
+    Each entry is independent and can only be updated by the account that originally created it.
+
+### Creating the Embedded Namespace Metadata Transaction
+
+{{ tutorial.code_snippet(['py:99:112', 'js:98:112']) }}
+
+A namespace metadata transaction attaches a key-value pair to a namespace on the blockchain.
+The same transaction type handles both adding new metadata entries and updating existing ones.
+
+Symbol requires these transactions to be inside an <aggregate transaction:> that includes the namespace owner's
+signature.
+This prevents unwanted metadata from being attached to a namespace without its owner's permission.
+
+For this reason, the code defines the namespace metadata transaction as an <embedded transaction:>.
+
+This transaction specifies:
+
+* **Type:** Use `namespace_metadata_transaction_v1`.
+
+* **Signer public key:** The account creating the metadata entry.
+
+* **Target address:** The namespace owner's address.
+    When the signer differs from the namespace owner, the owner must cosign the aggregate transaction.
+
+* **Target namespace ID:** The namespace to attach the metadata to.
+
+* **Scoped metadata key:** The 64-bit key used to identify this metadata entry.
+
+* **Value size delta:** When creating new metadata, set this to the byte length of the value.
+    When updating existing metadata, set this to the difference between the new and current value lengths.
+
+* **Value:** The metadata content as bytes.
+    When creating new metadata, provide the raw value.
+    When updating, provide a computed value (explained in the
+    [Modifying Existing Metadata](#modifying-existing-metadata) section).
+
+### Building the Aggregate Transaction
+
+{{ tutorial.code_snippet(['py:114:124', 'js:114:124']) }}
+
+The code adds the embedded namespace metadata transaction to an <aggregate transaction:>.
+
+Since the signer is the namespace owner, no <cosignatures:> are required and the aggregate can be created as
+<complete aggregate transaction:|complete>, allowing it to be signed and announced immediately.
+
+!!! note "Adding metadata by a different account"
+
+    If the signer is different from the namespace owner, the owner must cosign the aggregate transaction to approve the
+    metadata entry.
+
+    For details on collecting cosignatures on-chain, see the [Bonded Aggregate](../transactions/bonded-aggregate.md)
+    tutorial.
+
+### Submitting the Aggregate Transaction
+
+{{ tutorial.code_snippet(['py:126:135', 'js:126:137']) }}
+
+The aggregate transaction is signed and announced following the same process as in
+[Creating a Complete Aggregate Transaction](../transactions/complete-aggregate.md#building-the-aggregate-transaction).
+
+### Retrieving Metadata
+
+{{ tutorial.code_snippet(['py:140:157', 'js:142:162']) }}
+
+Updating an existing metadata entry requires the current value from the network.
+
+The code queries the <get:/metadata> endpoint with filters for `targetAddress`, `scopedMetadataKey`,
+`targetId` (the namespace ID), and `metadataType` (`2` for namespace metadata) to retrieve the specific entry.
+
+### Modifying Existing Metadata
+
+{{ tutorial.code_snippet(['py:159:176', 'js:164:182']) }}
+
+To demonstrate updating metadata, the code changes the description from `My first namespace` to `Updated namespace`
+by creating another `namespace_metadata_transaction_v1` transaction with the same scoped metadata key.
+
+Modifying an existing metadata value in Symbol differs from creating one.
+Instead of sending the new value directly, the transaction must include:
+
+* **`value_size_delta`:** The difference in length between the new and current values.
+    In this example, the delta is `-1` because `Updated namespace` (17 bytes) is shorter than
+    `My first namespace` (18 bytes).
+
+* **`value`:** The XOR'd bytes computed by comparing the current and new values byte-by-byte.
+
+The SDK provides a <dy:Metadata.metadataUpdateValue> helper function that handles the XOR calculation.
+The XOR operation compares each byte: matching bytes become zero, and differing bytes capture the change.
+
+Note that `value_size_delta` represents the difference in final value lengths (new vs current),
+not the length of the XOR'd bytes themselves.
+
+!!! tip "Deleting a metadata entry"
+
+    To delete a metadata entry, set `value_size_delta` to the negative of the current value length and provide the
+    current value as `value`. The XOR produces an empty result, which removes the entry from the network.
+
+{{ tutorial.code_snippet(['py:178:200', 'js:184:209']) }}
+
+As with the [initial metadata creation](#building-the-aggregate-transaction), this metadata modification is wrapped
+in an aggregate transaction.
+The aggregate transaction is then signed and announced as in
+[Creating a Complete Aggregate Transaction](../transactions/complete-aggregate.md#building-the-aggregate-transaction).
+
+## Output
+
+The output shown below corresponds to a typical run of the program.
+
+```text linenums="1" hl_lines="3 4 18 19 20 23 37 47 48 50"
+--8<-- 'devbook/namespaces/namespace-metadata.log'
+```
+
+Key points in the output:
+
+* **Line 3** (`Namespace name`): The namespace receiving the metadata.
+* **Line 4** (`Namespace ID`): The computed namespace ID in decimal and hexadecimal formats.
+* **Line 18** (`"scoped_metadata_key"`): The 64-bit key generated from the input string using SHA3-256 hashing.
+* **Line 19** (`"target_namespace_id"`): The namespace receiving the metadata.
+* **Line 20** (`"value_size_delta": 18`): When creating new metadata, this equals the byte length of the value
+    (`"My first namespace"` = 18 bytes).
+* **Line 23**: The transaction hash for looking up the metadata creation in the explorer.
+* **Line 37** (`Current value: My first namespace`): Retrieved from the network before updating.
+* **Line 47** (`"value_size_delta": -1`): Negative because the new value (`"Updated namespace"` = 17 bytes) is shorter
+    than the current value (18 bytes).
+* **Line 48** (`"value"`): The XOR'd value computed from the current and new values, not the raw new value.
+* **Line 50**: The transaction hash for looking up the metadata update in the explorer.
+
+The transaction hashes can be used to search for the transactions in the
+[Symbol Testnet Explorer](https://testnet.symbol.fyi/).
+
+## Conclusion
+
+This tutorial showed how to:
+
+| Step                                                                                             | Related documentation                              |
+| ------------------------------------------------------------------------------------------------ | -------------------------------------------------- |
+| [Define metadata key and value](#defining-the-metadata)                                          | <dy:Metadata.metadataGenerateKey>                  |
+| [Create a namespace metadata transaction](#creating-the-embedded-namespace-metadata-transaction) | <dy:SymbolTransactionFactory.createEmbedded>       |
+| [Retrieve metadata](#retrieving-metadata)                                                        | <get:/metadata>                                    |
+| [Modify existing metadata](#modifying-existing-metadata)                                         | <dy:Metadata.metadataUpdateValue>                  |

--- a/mkdocs/pages/en/devbook/namespaces/register-root-namespace.md
+++ b/mkdocs/pages/en/devbook/namespaces/register-root-namespace.md
@@ -16,12 +16,12 @@ as explained in [Next Steps](#next-steps).
 
 Before you start, make sure to:
 
-- Set up your development environment.
+* Set up your development environment.
   See [Setting Up a Development Environment](../start/setup.md).
-- Create an <account:> to register the namespace, either
+* Create an <account:> to register the namespace, either
   [from code](../accounts/create-from-private-key.md) or
   [by using a wallet](../../userbook/wallet/create-account.md).
-- Obtain <XYM:> to pay for the transaction and lease fees.
+* Obtain <XYM:> to pay for the transaction and lease fees.
   See [Getting Testnet Funds from the Faucet](../accounts/testnet-faucet.md).
 
 Additionally, review the [Transfer transaction](../transactions/transfer.md) tutorial to understand how
@@ -153,16 +153,16 @@ in the [Symbol Testnet Explorer](https://testnet.symbol.fyi/).
 
 This tutorial showed how to:
 
-| Step                                                          | Related documentation                              |
-| ------------------------------------------------------------- | -------------------------------------------------- |
-| [Generate namespace ID](#building-the-transaction)            | <dy:IdGenerator.generateNamespaceId>               |
-| [Build a namespace registration transaction](#building-the-transaction)   | <dy:SymbolTransactionFactory.create>   |
-| [Retrieve the namespace](#retrieving-the-namespace)           | <get:/namespaces/{namespaceId}>                    |
+| Step                                                                    | Related documentation                |
+|-------------------------------------------------------------------------|--------------------------------------|
+| [Generate namespace ID](#building-the-transaction)                      | <dy:IdGenerator.generateNamespaceId> |
+| [Build a namespace registration transaction](#building-the-transaction) | <dy:SymbolTransactionFactory.create> |
+| [Retrieve the namespace](#retrieving-the-namespace)                     | <get:/namespaces/{namespaceId}>      |
 
 ## Next Steps
 
 Now that you have a root namespace, you can:
 
-- [Link your namespace to a mosaic](./link-namespace-to-mosaic.md) or [to an account](./link-namespace-to-address.md) to create an alias
-- [Register a subnamespace](./register-subnamespace.md) to create a hierarchical structure
-- [Extend the namespace](./extend-root-namespace.md) before it expires to keep it active
+* [Link your namespace to a mosaic](./link-namespace-to-mosaic.md) or [to an account](./link-namespace-to-address.md) to create an alias
+* [Register a subnamespace](./register-subnamespace.md) to create a hierarchical structure
+* [Extend the namespace](./extend-root-namespace.md) before it expires to keep it active

--- a/mkdocs/pages/en/devbook/namespaces/register-root-namespace.md
+++ b/mkdocs/pages/en/devbook/namespaces/register-root-namespace.md
@@ -4,7 +4,7 @@ title: Register Root Namespace
 
 # Registering a Root Namespace
 
-<Namespaces:> provide human-readable aliases for <accounts:> and <mosaics:>,
+<Namespaces:|Namespaces> provide human-readable aliases for <accounts:> and <mosaics:>,
 which can be used instead of long addresses and hexadecimal mosaic IDs.
 
 This tutorial shows how to register a <root namespace:> and set its lease [duration](../../textbook/namespaces.md#duration).


### PR DESCRIPTION
Add tutorials for namespace metadata and mosaic metadata.

Appplies the latest improvements from those tutorials to the former account metadata tutorial.

**Note:** It could make sense to review  the mosaic metadata tutorial after I submit the PR that includes the creation tutorial.