### PR TITLE
[client/rest]: fix supply endpoints to accept text/plain

### DIFF
--- a/client/rest/src/server/bootstrapper.js
+++ b/client/rest/src/server/bootstrapper.js
@@ -99,9 +99,11 @@ const catapultRestifyPlugins = {
 
 		if (req.accepts(accepts))
 			return next();
+
 		const error = isTextPlainPath
 			? new restifyErrors.NotAcceptableError('Endpoint accepts only text/plain')
 			: new restifyErrors.NotAcceptableError('Endpoint accepts only application/json');
+
 		return next(error);
 	}
 };

--- a/client/rest/src/server/bootstrapper.js
+++ b/client/rest/src/server/bootstrapper.js
@@ -62,7 +62,7 @@ const createCrossDomainHeaderAdder = crossDomainConfig => (req, res) => {
 	}
 };
 
-const TEXT_PLAIN_SUPPLY_PATHS = [
+const TEXT_PLAIN_PATHS = [
 	'/network/currency/supply/circulating',
 	'/network/currency/supply/max',
 	'/network/currency/supply/total'
@@ -94,14 +94,14 @@ const catapultRestifyPlugins = {
 		next();
 	},
 	acceptParser: () => (req, res, next) => {
-		const isSupplyPath = TEXT_PLAIN_SUPPLY_PATHS.includes(req.path());
-		const accepts = isSupplyPath ? ['text/plain'] : ['application/json'];
-		const error = isSupplyPath
-			? new restifyErrors.NotAcceptableError('Endpoint accepts only text/plain')
-			: new restifyErrors.NotAcceptableError('Endpoint accepts only application/json');
+		const isTextPlainPath = TEXT_PLAIN_PATHS.includes(req.path());
+		const accepts = isTextPlainPath ? ['text/plain'] : ['application/json'];
 
 		if (req.accepts(accepts))
 			return next();
+		const error = isTextPlainPath
+			? new restifyErrors.NotAcceptableError('Endpoint accepts only text/plain')
+			: new restifyErrors.NotAcceptableError('Endpoint accepts only application/json');
 		return next(error);
 	}
 };

--- a/client/rest/src/server/bootstrapper.js
+++ b/client/rest/src/server/bootstrapper.js
@@ -62,6 +62,12 @@ const createCrossDomainHeaderAdder = crossDomainConfig => (req, res) => {
 	}
 };
 
+const TEXT_PLAIN_SUPPLY_PATHS = [
+	'/network/currency/supply/circulating',
+	'/network/currency/supply/max',
+	'/network/currency/supply/total'
+];
+
 const catapultRestifyPlugins = {
 	crossDomain: addCrossDomainHeaders => (req, res, next) => {
 		addCrossDomainHeaders(req, res);
@@ -86,6 +92,17 @@ const catapultRestifyPlugins = {
 		}
 
 		next();
+	},
+	acceptParser: () => (req, res, next) => {
+		const isSupplyPath = TEXT_PLAIN_SUPPLY_PATHS.includes(req.path());
+		const accepts = isSupplyPath ? ['text/plain'] : ['application/json'];
+		const error = isSupplyPath
+			? new restifyErrors.NotAcceptableError('Endpoint accepts only text/plain')
+			: new restifyErrors.NotAcceptableError('Endpoint accepts only application/json');
+
+		if (req.accepts(accepts))
+			return next();
+		return next(error);
 	}
 };
 
@@ -153,7 +170,7 @@ export default {
 		const addCrossDomainHeaders = createCrossDomainHeaderAdder(config.crossDomain || {});
 
 		server.use(catapultRestifyPlugins.crossDomain(addCrossDomainHeaders));
-		server.use(restify.plugins.acceptParser('application/json'));
+		server.use(catapultRestifyPlugins.acceptParser());
 		server.use(restify.plugins.queryParser({ mapParams: true, parseArrays: false }));
 		server.use(restify.plugins.jsonBodyParser({ mapParams: true }));
 

--- a/client/rest/test/server/bootstrapper_spec.js
+++ b/client/rest/test/server/bootstrapper_spec.js
@@ -108,10 +108,10 @@ const addRestRoutes = server => {
 
 		// text/plain endpoints (e.g. supply)
 		server[method]('/network/currency/supply/circulating', (req, res, next) => {
-            res.setHeader('content-type', 'text/plain');
-            res.send('12345.678');
-            next();
-        });
+			res.setHeader('content-type', 'text/plain');
+			res.send('12345.678');
+			next();
+		});
 	});
 };
 

--- a/client/rest/test/server/bootstrapper_spec.js
+++ b/client/rest/test/server/bootstrapper_spec.js
@@ -105,13 +105,13 @@ const addRestRoutes = server => {
 			next();
 			return undefined;
 		});
-	});
 
-	// supply endpoints accept only text/plain
-	server.get('/network/currency/supply/circulating', (req, res, next) => {
-		res.setHeader('content-type', 'text/plain');
-		res.send('12345.678');
-		next();
+		// text/plain endpoints (e.g. supply)
+		server[method]('/network/currency/supply/circulating', (req, res, next) => {
+            res.setHeader('content-type', 'text/plain');
+            res.send('12345.678');
+            next();
+        });
 	});
 };
 
@@ -425,7 +425,7 @@ describe('server (bootstrapper)', () => {
 					expect(body).to.deep.equal({ code: 'ResourceNotFound', message: '/fake/valid does not exist' });
 				}));
 
-			it('rejects request with invalid accept header', () => makeWrappedJsonRequest(`/dummy/${dummyIds.valid}`, method)
+			it('rejects text/plain for application/json endpoint', () => makeWrappedJsonRequest(`/dummy/${dummyIds.valid}`, method)
 				.header('Accept', 'text/plain')
 				.expectStatus(406)
 				.end((headers, body) => {
@@ -434,21 +434,31 @@ describe('server (bootstrapper)', () => {
 					expect(body).to.deep.equal({ code: 'NotAcceptable', message: 'Endpoint accepts only application/json' });
 				}));
 
-			it('accepts text/plain for supply endpoints', () => makeWrappedJsonRequest('/network/currency/supply/circulating', 'get')
+			it('rejects application/json for text/plain endpoint', () => makeWrappedJsonRequest('/network/currency/supply/circulating', method)
+				.header('Accept', 'application/json')
+				.expectStatus(406)
+				.end((headers, body) => {
+					// Assert:
+					assertPayloadHeaders(headers, 69, methodOptions);
+					expect(body).to.deep.equal({ code: 'NotAcceptable', message: 'Endpoint accepts only text/plain' });
+				}));
+
+			it('rejects unsupported accept type', () => makeWrappedJsonRequest(`/dummy/${dummyIds.valid}`, method)
+				.header('Accept', 'application/xml')
+				.expectStatus(406)
+				.end((headers, body) => {
+					// Assert:
+					assertPayloadHeaders(headers, 75, methodOptions);
+					expect(body).to.deep.equal({ code: 'NotAcceptable', message: 'Endpoint accepts only application/json' });
+				}));
+
+			it('accepts text/plain for text/plain endpoint', () => makeWrappedJsonRequest('/network/currency/supply/circulating', method)
 				.header('Accept', 'text/plain')
 				.expectStatus(200)
 				.end((headers, body) => {
 					// Assert:
 					expect(headers['content-type']).to.include('text/plain');
-					expect(String(body)).to.equal('12345.678');
-				}));
-
-			it('rejects application/json for supply endpoints', () => makeWrappedJsonRequest('/network/currency/supply/circulating', 'get')
-				.header('Accept', 'application/json')
-				.expectStatus(406)
-				.end((headers, body) => {
-					// Assert:
-					expect(body).to.deep.equal({ code: 'NotAcceptable', message: 'Endpoint accepts only text/plain' });
+					expect(body).to.equal(12345.678);
 				}));
 
 			// endregion

--- a/client/rest/test/server/bootstrapper_spec.js
+++ b/client/rest/test/server/bootstrapper_spec.js
@@ -458,7 +458,7 @@ describe('server (bootstrapper)', () => {
 				.end((headers, body) => {
 					// Assert:
 					expect(headers['content-type']).to.include('text/plain');
-					expect(String(body)).to.equal('12345.678');
+					expect(body).to.equal(12345.678);
 				}));
 
 			// endregion

--- a/client/rest/test/server/bootstrapper_spec.js
+++ b/client/rest/test/server/bootstrapper_spec.js
@@ -106,6 +106,13 @@ const addRestRoutes = server => {
 			return undefined;
 		});
 	});
+
+	// supply endpoints accept only text/plain
+	server.get('/network/currency/supply/circulating', (req, res, next) => {
+		res.setHeader('content-type', 'text/plain');
+		res.send('12345.678');
+		next();
+	});
 };
 
 // endregion
@@ -423,8 +430,25 @@ describe('server (bootstrapper)', () => {
 				.expectStatus(406)
 				.end((headers, body) => {
 					// Assert:
-					assertPayloadHeaders(headers, 69, methodOptions);
-					expect(body).to.deep.equal({ code: 'NotAcceptable', message: 'Server accepts: application/json' });
+					assertPayloadHeaders(headers, 75, methodOptions);
+					expect(body).to.deep.equal({ code: 'NotAcceptable', message: 'Endpoint accepts only application/json' });
+				}));
+
+			it('accepts text/plain for supply endpoints', () => makeWrappedJsonRequest('/network/currency/supply/circulating', 'get')
+				.header('Accept', 'text/plain')
+				.expectStatus(200)
+				.end((headers, body) => {
+					// Assert:
+					expect(headers['content-type']).to.include('text/plain');
+					expect(String(body)).to.equal('12345.678');
+				}));
+
+			it('rejects application/json for supply endpoints', () => makeWrappedJsonRequest('/network/currency/supply/circulating', 'get')
+				.header('Accept', 'application/json')
+				.expectStatus(406)
+				.end((headers, body) => {
+					// Assert:
+					expect(body).to.deep.equal({ code: 'NotAcceptable', message: 'Endpoint accepts only text/plain' });
 				}));
 
 			// endregion

--- a/client/rest/test/server/bootstrapper_spec.js
+++ b/client/rest/test/server/bootstrapper_spec.js
@@ -458,7 +458,7 @@ describe('server (bootstrapper)', () => {
 				.end((headers, body) => {
 					// Assert:
 					expect(headers['content-type']).to.include('text/plain');
-					expect(body).to.equal(12345.678);
+					expect(String(body)).to.equal('12345.678');
 				}));
 
 			// endregion


### PR DESCRIPTION
## What is the current behavior?

- Endpoints /network/currency/supply/circulating, /network/currency/supply/max, /network/currency/supply/total return content-type: text/plain.
- Requests with Accept: text/plain receive 406 with "Server accepts: application/json".
- Requests with Accept: application/json succeed and return plain text, which is inconsistent.

## What's the issue?

- The API returns plain text, but the server only accepts Accept: application/json.
- Clients that send Accept: `text/plain` get 406.
- The response format and Accept handling are inconsistent.

## How have you changed the behavior?

- Added a path-specific accept parser in bootstrapper.js:
  - Supply endpoints accept only Accept: text/plain.
  - Other endpoints accept only Accept: application/json.

**Breaking change**: Supply endpoints no longer accept Accept: application/json; clients must send Accept: text/plain.