### PR TITLE
[client/catapult]: migrate boost asio usage to use non-deprecated APIs

### DIFF
--- a/client/catapult/CMakeGlobalSettings.cmake
+++ b/client/catapult/CMakeGlobalSettings.cmake
@@ -33,6 +33,7 @@ endif()
 ### set boost settings
 add_definitions(-DBOOST_ALL_DYN_LINK)
 add_definitions(-DBOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT)
+add_definitions(-DBOOST_ASIO_NO_DEPRECATED)
 
 if(Boost_VERSION VERSION_LESS 1.84)
 	# workaround for https://github.com/boostorg/phoenix/issues/111

--- a/client/catapult/CMakeGlobalSettings.cmake
+++ b/client/catapult/CMakeGlobalSettings.cmake
@@ -35,11 +35,6 @@ add_definitions(-DBOOST_ALL_DYN_LINK)
 add_definitions(-DBOOST_ASIO_USE_TS_EXECUTOR_AS_DEFAULT)
 add_definitions(-DBOOST_ASIO_NO_DEPRECATED)
 
-if(Boost_VERSION VERSION_LESS 1.84)
-	# workaround for https://github.com/boostorg/phoenix/issues/111
-	add_definitions(-DBOOST_PHOENIX_STL_TUPLE_H_)
-endif()
-
 set(Boost_USE_STATIC_LIBS OFF)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_USE_STATIC_RUNTIME OFF)

--- a/client/catapult/CMakeGlobalSettings.cmake
+++ b/client/catapult/CMakeGlobalSettings.cmake
@@ -125,7 +125,7 @@ if(MSVC)
 	add_compile_options(/MP)            # Enable parallel compilation
 	add_compile_options(/GA)            # Optimizes for Windows applications
 
-	add_definitions(-D_WIN32_WINNT=0x0601)
+	add_definitions(-D_WIN32_WINNT=0x0A00)
 
 	add_compile_options(/w44287)		# 'operator' : unsigned/negative constant mismatch
 	add_compile_options(/w44388)		# 'token' : signed/unsigned mismatch

--- a/client/catapult/CMakeLists.txt
+++ b/client/catapult/CMakeLists.txt
@@ -47,7 +47,7 @@ endfunction()
 
 ### setup boost
 message("--- locating boost dependencies ---")
-find_package(Boost 1.83.0 EXACT COMPONENTS ${CATAPULT_BOOST_COMPONENTS} REQUIRED)
+find_package(Boost 1.84.0 EXACT COMPONENTS ${CATAPULT_BOOST_COMPONENTS} REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIR})
 
 message("boost     ver: ${Boost_VERSION}")

--- a/client/catapult/CMakeLists.txt
+++ b/client/catapult/CMakeLists.txt
@@ -47,7 +47,7 @@ endfunction()
 
 ### setup boost
 message("--- locating boost dependencies ---")
-find_package(Boost 1.84.0 EXACT COMPONENTS ${CATAPULT_BOOST_COMPONENTS} REQUIRED)
+find_package(Boost 1.86.0 EXACT COMPONENTS ${CATAPULT_BOOST_COMPONENTS} REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIR})
 
 message("boost     ver: ${Boost_VERSION}")

--- a/client/catapult/CMakeLists.txt
+++ b/client/catapult/CMakeLists.txt
@@ -47,7 +47,7 @@ endfunction()
 
 ### setup boost
 message("--- locating boost dependencies ---")
-find_package(Boost 1.86.0 EXACT COMPONENTS ${CATAPULT_BOOST_COMPONENTS} REQUIRED)
+find_package(Boost 1.87.0 EXACT COMPONENTS ${CATAPULT_BOOST_COMPONENTS} REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIR})
 
 message("boost     ver: ${Boost_VERSION}")

--- a/client/catapult/CMakeLists.txt
+++ b/client/catapult/CMakeLists.txt
@@ -47,7 +47,7 @@ endfunction()
 
 ### setup boost
 message("--- locating boost dependencies ---")
-find_package(Boost 1.87.0 EXACT COMPONENTS ${CATAPULT_BOOST_COMPONENTS} REQUIRED)
+find_package(Boost 1.90.0 EXACT COMPONENTS ${CATAPULT_BOOST_COMPONENTS} REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIR})
 
 message("boost     ver: ${Boost_VERSION}")

--- a/client/catapult/conanfile.py
+++ b/client/catapult/conanfile.py
@@ -54,8 +54,8 @@ class CatapultConan(ConanFile):
 		self.options["boost*"].without_math = False
 		self.options["boost*"].without_mpi = True
 		self.options["boost*"].without_nowide = True
-		self.options["boost*"].without_program_options = False
 		self.options["boost*"].without_process = True
+		self.options["boost*"].without_program_options = False
 		self.options["boost*"].without_python = True
 		self.options["boost*"].without_random = False
 		self.options["boost*"].without_regex = False

--- a/client/catapult/conanfile.py
+++ b/client/catapult/conanfile.py
@@ -38,7 +38,7 @@ class CatapultConan(ConanFile):
 		self.options["boost*"].without_atomic = False
 		self.options["boost*"].without_chrono = False
 		self.options["boost*"].without_container = False
-		self.options["boost*"].without_context = True
+		self.options["boost*"].without_context = False
 		self.options["boost*"].without_contract = True
 		self.options["boost*"].without_coroutine = True
 		self.options["boost*"].without_date_time = False
@@ -58,7 +58,7 @@ class CatapultConan(ConanFile):
 		self.options["boost*"].without_python = True
 		self.options["boost*"].without_random = False
 		self.options["boost*"].without_regex = False
-		self.options["boost*"].without_serialization = True
+		self.options["boost*"].without_serialization = False  # due to this bug - https://github.com/conan-io/conan-center-index/issues/28801
 		self.options["boost*"].without_stacktrace = True
 		self.options["boost*"].without_system = False
 		self.options["boost*"].without_test = True

--- a/client/catapult/conanfile.py
+++ b/client/catapult/conanfile.py
@@ -9,7 +9,7 @@ class CatapultConan(ConanFile):
 	settings = "os", "compiler", "build_type", "arch"  # pylint: disable=invalid-name
 
 	def requirements(self):
-		self.requires("boost/1.83.0", run=True)
+		self.requires("boost/1.86.0", run=True)
 		self.requires("openssl/3.6.1", run=True)
 		self.requires("cppzmq/4.11.0@nemtech/stable", run=True)
 		self.requires("mongo-c-driver/2.2.1@nemtech/stable", run=True)

--- a/client/catapult/conanfile.py
+++ b/client/catapult/conanfile.py
@@ -9,7 +9,7 @@ class CatapultConan(ConanFile):
 	settings = "os", "compiler", "build_type", "arch"  # pylint: disable=invalid-name
 
 	def requirements(self):
-		self.requires("boost/1.86.0", run=True)
+		self.requires("boost/1.87.0", run=True)
 		self.requires("openssl/3.6.1", run=True)
 		self.requires("cppzmq/4.11.0@nemtech/stable", run=True)
 		self.requires("mongo-c-driver/2.2.1@nemtech/stable", run=True)

--- a/client/catapult/conanfile.py
+++ b/client/catapult/conanfile.py
@@ -38,7 +38,7 @@ class CatapultConan(ConanFile):
 		self.options["boost*"].without_atomic = False
 		self.options["boost*"].without_chrono = False
 		self.options["boost*"].without_container = False
-		self.options["boost*"].without_context = False
+		self.options["boost*"].without_context = True
 		self.options["boost*"].without_contract = True
 		self.options["boost*"].without_coroutine = True
 		self.options["boost*"].without_date_time = False
@@ -55,6 +55,7 @@ class CatapultConan(ConanFile):
 		self.options["boost*"].without_mpi = True
 		self.options["boost*"].without_nowide = True
 		self.options["boost*"].without_program_options = False
+		self.options["boost*"].without_process = True
 		self.options["boost*"].without_python = True
 		self.options["boost*"].without_random = False
 		self.options["boost*"].without_regex = False

--- a/client/catapult/conanfile.py
+++ b/client/catapult/conanfile.py
@@ -9,7 +9,7 @@ class CatapultConan(ConanFile):
 	settings = "os", "compiler", "build_type", "arch"  # pylint: disable=invalid-name
 
 	def requirements(self):
-		self.requires("boost/1.87.0", run=True)
+		self.requires("boost/1.90.0", run=True)
 		self.requires("openssl/3.6.1", run=True)
 		self.requires("cppzmq/4.11.0@nemtech/stable", run=True)
 		self.requires("mongo-c-driver/2.2.1@nemtech/stable", run=True)

--- a/client/catapult/extensions/finalization/src/FinalizationMessageProcessingService.cpp
+++ b/client/catapult/extensions/finalization/src/FinalizationMessageProcessingService.cpp
@@ -94,7 +94,7 @@ namespace catapult { namespace finalization {
 						if (!pRecentHashCache->add(messageHash))
 							continue;
 
-						messageProcessingPool.ioContext().dispatch([&messageAggregator, pMessage, messageHash]() {
+						boost::asio::dispatch(messageProcessingPool.ioContext(), [&messageAggregator, pMessage, messageHash]() {
 							auto addResult = messageAggregator.modifier().add(pMessage);
 							if (addResult < chain::RoundMessageAggregatorAddResult::Neutral_Redundant)
 								CATAPULT_LOG(warning) << "finalization message " << messageHash << " rejected due to " << addResult;

--- a/client/catapult/extensions/mongo/tests/mappers/MapperUtilsTests.cpp
+++ b/client/catapult/extensions/mongo/tests/mappers/MapperUtilsTests.cpp
@@ -35,7 +35,7 @@ namespace catapult { namespace mongo { namespace mappers {
 
 	TEST(TEST_CLASS, CanConvertRawPointerToBinary) {
 		// Arrange:
-		uint8_t data[10];
+		uint8_t data[10] = {};
 
 		// Act
 		auto bsonBinary = ToBinary(data, 10);

--- a/client/catapult/src/catapult/crypto/Sortition.cpp
+++ b/client/catapult/src/catapult/crypto/Sortition.cpp
@@ -21,8 +21,18 @@
 
 #include "Sortition.h"
 #include "catapult/utils/Casting.h"
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4714) // function marked as __forceinline not inlined
+#endif
+
 #include <boost/math/distributions/binomial.hpp>
 #include <boost/math/policies/policy.hpp>
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 namespace bm = boost::math;
 namespace bmp = boost::math::policies;

--- a/client/catapult/src/catapult/extensions/NetworkUtils.cpp
+++ b/client/catapult/src/catapult/extensions/NetworkUtils.cpp
@@ -101,7 +101,7 @@ namespace catapult { namespace extensions {
 			const supplier<Timestamp>& timeSupplier,
 			subscribers::NodeSubscriber& nodeSubscriber,
 			net::AcceptedConnectionContainer& acceptor) {
-		auto endpoint = boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(config.Node.ListenInterface), port);
+		auto endpoint = boost::asio::ip::tcp::endpoint(boost::asio::ip::make_address(config.Node.ListenInterface), port);
 		BootServerState bootServerState(port, serviceId, nodeSubscriber, acceptor);
 		auto rateMonitorSettings = GetRateMonitorSettings(config.Node.Banning);
 

--- a/client/catapult/src/catapult/ionet/AppendContext.cpp
+++ b/client/catapult/src/catapult/ionet/AppendContext.cpp
@@ -52,7 +52,7 @@ namespace catapult { namespace ionet {
 			m_data.resize(m_originalSize);
 	}
 
-	boost::asio::mutable_buffers_1 AppendContext::buffer() {
+	boost::asio::mutable_buffer AppendContext::buffer() {
 		assertNotCommitted();
 		return boost::asio::buffer(&m_data[m_originalSize], m_appendSize);
 	}

--- a/client/catapult/src/catapult/ionet/AppendContext.h
+++ b/client/catapult/src/catapult/ionet/AppendContext.h
@@ -39,7 +39,7 @@ namespace catapult { namespace ionet {
 
 	public:
 		/// Asio buffer that can be written to in place.
-		boost::asio::mutable_buffers_1 buffer();
+		boost::asio::mutable_buffer buffer();
 
 		/// Commits the write to the underlying buffer.
 		void commit(size_t size);

--- a/client/catapult/src/catapult/ionet/BufferedPacketIo.cpp
+++ b/client/catapult/src/catapult/ionet/BufferedPacketIo.cpp
@@ -92,10 +92,15 @@ namespace catapult { namespace ionet {
 
 		private:
 			void next() {
-				// note that it's very important to not call pop_front here - the request should only be popped
-				// after the callback is invoked (and the operation is complete)
+				// it's very important to not call pop_front here - the request should only be popped
+				// after the callback is invoked (and the operation is complete) - otherwise, the pending write data
+				// could be destroyed before the write is completed
 				auto& request = m_requests.front();
-				request.first.invoke(m_wrapper.wrap(WrappedWithRequests<TCallback>(request.second, *this)));
+
+				// currently, CreateBufferedPacketIo is only called from PacketSocket::buffered, where the underlying PacketSocket
+				// guarantees the read and write callbacks are called from within the appropriate strand, so no additional logic
+				// is needed here
+				request.first.invoke(WrappedWithRequests<TCallback>(request.second, *this));
 			}
 
 			template<typename THandler>

--- a/client/catapult/src/catapult/ionet/BufferedPacketIo.cpp
+++ b/client/catapult/src/catapult/ionet/BufferedPacketIo.cpp
@@ -141,7 +141,7 @@ namespace catapult { namespace ionet {
 		template<typename TRequest, typename TCallback>
 		class QueuedOperation {
 		public:
-			explicit QueuedOperation(boost::asio::io_context::strand& strand)
+			explicit QueuedOperation(Strand& strand)
 					: m_strand(strand)
 					, m_requests(m_strand)
 			{}
@@ -154,8 +154,8 @@ namespace catapult { namespace ionet {
 			}
 
 		private:
-			boost::asio::io_context::strand& m_strand;
-			RequestQueue<TRequest, TCallback, boost::asio::io_context::strand> m_requests;
+			Strand& m_strand;
+			RequestQueue<TRequest, TCallback, Strand> m_requests;
 		};
 
 		using QueuedWriteOperation = QueuedOperation<WriteRequest, PacketIo::WriteCallback>;
@@ -169,7 +169,7 @@ namespace catapult { namespace ionet {
 				: public PacketIo
 				, public std::enable_shared_from_this<BufferedPacketIo> {
 		public:
-			BufferedPacketIo(const std::shared_ptr<PacketIo>& pIo, boost::asio::io_context::strand& strand)
+			BufferedPacketIo(const std::shared_ptr<PacketIo>& pIo, Strand& strand)
 					: m_pIo(pIo)
 					, m_strand(strand)
 					, m_pWriteOperation(std::make_unique<QueuedWriteOperation>(m_strand))
@@ -193,7 +193,7 @@ namespace catapult { namespace ionet {
 
 		private:
 			std::shared_ptr<PacketIo> m_pIo;
-			boost::asio::io_context::strand& m_strand;
+			Strand& m_strand;
 			std::unique_ptr<QueuedWriteOperation> m_pWriteOperation;
 			std::unique_ptr<QueuedReadOperation> m_pReadOperation;
 		};
@@ -201,7 +201,7 @@ namespace catapult { namespace ionet {
 		// endregion
 	}
 
-	std::shared_ptr<PacketIo> CreateBufferedPacketIo(const std::shared_ptr<PacketIo>& pIo, boost::asio::io_context::strand& strand) {
+	std::shared_ptr<PacketIo> CreateBufferedPacketIo(const std::shared_ptr<PacketIo>& pIo, Strand& strand) {
 		return std::make_shared<BufferedPacketIo>(pIo, strand);
 	}
 }}

--- a/client/catapult/src/catapult/ionet/BufferedPacketIo.h
+++ b/client/catapult/src/catapult/ionet/BufferedPacketIo.h
@@ -27,5 +27,5 @@ namespace catapult { namespace ionet { class PacketIo; } }
 namespace catapult { namespace ionet {
 
 	/// Adds buffering to \a pIo using \a strand for synchronization.
-	std::shared_ptr<PacketIo> CreateBufferedPacketIo(const std::shared_ptr<PacketIo>& pIo, boost::asio::io_context::strand& strand);
+	std::shared_ptr<PacketIo> CreateBufferedPacketIo(const std::shared_ptr<PacketIo>& pIo, Strand& strand);
 }}

--- a/client/catapult/src/catapult/ionet/IoTypes.h
+++ b/client/catapult/src/catapult/ionet/IoTypes.h
@@ -40,4 +40,6 @@ namespace catapult { namespace ionet {
 	using NetworkSocket = boost::asio::ip::tcp::socket;
 
 	using Socket = boost::asio::ssl::stream<boost::asio::ip::tcp::socket>;
+
+	using Strand = boost::asio::strand<boost::asio::io_context::executor_type>;
 }}

--- a/client/catapult/src/catapult/ionet/PacketSocket.cpp
+++ b/client/catapult/src/catapult/ionet/PacketSocket.cpp
@@ -759,7 +759,7 @@ namespace catapult { namespace ionet {
 		template<typename TCallbackWrapper>
 		class BasicConnectHandler final {
 		private:
-			using Resolver = boost::asio::ip::tcp::resolver;
+			using ResolverType = boost::asio::ip::tcp::resolver;
 
 		public:
 			BasicConnectHandler(
@@ -775,15 +775,15 @@ namespace catapult { namespace ionet {
 							options))
 					, m_resolver(ioContext)
 					, m_host(endpoint.Host)
-					, m_query(m_host, std::to_string(endpoint.Port))
+					, m_port(std::to_string(endpoint.Port))
 					, m_protocols(options.OutgoingProtocols)
 					, m_isCancelled(false)
 			{}
 
 		public:
 			void start() {
-				m_resolver.async_resolve(m_query, m_wrapper.wrap([this](const auto& ec, auto iter) {
-					this->handleResolve(ec, std::move(iter));
+				m_resolver.async_resolve(m_host, m_port, m_wrapper.wrap([this](const auto& ec, const auto& results) {
+					this->handleResolve(ec, results);
 				}));
 			}
 
@@ -799,13 +799,13 @@ namespace catapult { namespace ionet {
 			}
 
 		private:
-			void handleResolve(const boost::system::error_code& ec, Resolver::iterator&& iter) {
+			void handleResolve(const boost::system::error_code& ec, const ResolverType::results_type& results) {
 				if (shouldAbort(ec, "resolving address"))
 					return invokeCallback(ConnectResult::Resolve_Error);
 
 				auto foundMatchingProtocol = false;
-				while (Resolver::iterator() != iter) {
-					auto endpoint = iter->endpoint();
+				for (const auto& result : results) {
+					const auto& endpoint = result.endpoint();
 					if (HasFlag(IpProtocol::IPv4, m_protocols) && boost::asio::ip::tcp::v4() == endpoint.protocol()) {
 						m_endpoint = endpoint;
 						foundMatchingProtocol = true;
@@ -823,8 +823,6 @@ namespace catapult { namespace ionet {
 						if (!HasFlag(IpProtocol::IPv4, m_protocols))
 							break;
 					}
-
-					++iter;
 				}
 
 				if (!foundMatchingProtocol)
@@ -879,9 +877,9 @@ namespace catapult { namespace ionet {
 			TCallbackWrapper& m_wrapper;
 
 			std::shared_ptr<StrandedPacketSocket> m_pSocket;
-			Resolver m_resolver;
+			ResolverType m_resolver;
 			std::string m_host;
-			Resolver::query m_query;
+			std::string m_port;
 			IpProtocol m_protocols;
 			bool m_isCancelled;
 			boost::asio::ip::tcp::endpoint m_endpoint;

--- a/client/catapult/src/catapult/ionet/PacketSocket.cpp
+++ b/client/catapult/src/catapult/ionet/PacketSocket.cpp
@@ -78,7 +78,7 @@ namespace catapult { namespace ionet {
 		class SocketGuard final : public std::enable_shared_from_this<SocketGuard> {
 		public:
 			SocketGuard(boost::asio::io_context& ioContext, boost::asio::ssl::context& sslContext)
-					: m_strand(ioContext)
+					: m_strand(boost::asio::make_strand(ioContext))
 					, m_strandWrapper(m_strand)
 					, m_socket(ioContext, sslContext)
 					, m_sentinelByte(0) {
@@ -87,7 +87,7 @@ namespace catapult { namespace ionet {
 			}
 
 			SocketGuard(NetworkSocket&& socket, boost::asio::io_context& ioContext, boost::asio::ssl::context& sslContext)
-					: m_strand(ioContext)
+					: m_strand(boost::asio::make_strand(ioContext))
 					, m_strandWrapper(m_strand)
 					, m_socket(std::move(socket), sslContext)
 					, m_sentinelByte(0) {
@@ -100,7 +100,7 @@ namespace catapult { namespace ionet {
 				return m_socket;
 			}
 
-			boost::asio::io_context::strand& strand() {
+			Strand& strand() {
 				return m_strand;
 			}
 
@@ -172,7 +172,7 @@ namespace catapult { namespace ionet {
 			}
 
 		private:
-			boost::asio::io_context::strand m_strand;
+			Strand m_strand;
 			thread::StrandOwnerLifetimeExtender<SocketGuard> m_strandWrapper;
 			Socket m_socket;
 			uint8_t m_sentinelByte;
@@ -456,7 +456,7 @@ namespace catapult { namespace ionet {
 				return m_publicKey;
 			}
 
-			boost::asio::io_context::strand& strand() {
+			Strand& strand() {
 				return m_pSocketGuard->strand();
 			}
 
@@ -585,7 +585,7 @@ namespace catapult { namespace ionet {
 				return m_socket.publicKey();
 			}
 
-			boost::asio::io_context::strand& strand() {
+			Strand& strand() {
 				return m_socket.strand();
 			}
 

--- a/client/catapult/src/catapult/net/AsyncTcpServer.cpp
+++ b/client/catapult/src/catapult/net/AsyncTcpServer.cpp
@@ -65,7 +65,7 @@ namespace catapult { namespace net {
 					const boost::asio::ip::tcp::endpoint& endpoint,
 					const AsyncTcpServerSettings& settings)
 					: m_ioContext(pool.ioContext())
-					, m_acceptorStrand(m_ioContext)
+					, m_acceptorStrand(boost::asio::make_strand(m_ioContext))
 					, m_acceptor(m_ioContext)
 					, m_settings(settings)
 					, m_isStopped(false)
@@ -204,7 +204,7 @@ namespace catapult { namespace net {
 
 		private:
 			boost::asio::io_context& m_ioContext;
-			boost::asio::io_context::strand m_acceptorStrand;
+			ionet::Strand m_acceptorStrand;
 			boost::asio::ip::tcp::acceptor m_acceptor;
 
 			const AsyncTcpServerSettings m_settings;

--- a/client/catapult/src/catapult/thread/IoThreadPool.cpp
+++ b/client/catapult/src/catapult/thread/IoThreadPool.cpp
@@ -34,7 +34,7 @@ namespace catapult { namespace thread {
 		class ThreadPoolContext {
 		public:
 			explicit ThreadPoolContext(boost::asio::io_context& ioContext) : m_work(boost::asio::make_work_guard(ioContext)) {
-				ioContext.reset();
+				ioContext.restart();
 			}
 
 			~ThreadPoolContext() {

--- a/client/catapult/src/catapult/thread/Scheduler.cpp
+++ b/client/catapult/src/catapult/thread/Scheduler.cpp
@@ -110,7 +110,7 @@ namespace catapult { namespace thread {
 		class StrandedTaskWrapper : public std::enable_shared_from_this<StrandedTaskWrapper> {
 		public:
 			StrandedTaskWrapper(boost::asio::io_context& ioContext, const Task& task)
-					: m_strand(ioContext)
+					: m_strand(boost::asio::make_strand(ioContext))
 					, m_strandWrapper(m_strand)
 					, m_impl(ioContext, task, *this)
 			{}
@@ -139,7 +139,7 @@ namespace catapult { namespace thread {
 			}
 
 		private:
-			boost::asio::io_context::strand m_strand;
+			ionet::Strand m_strand;
 			StrandOwnerLifetimeExtender<StrandedTaskWrapper> m_strandWrapper;
 			BasicTaskWrapper<StrandedTaskWrapper> m_impl;
 		};

--- a/client/catapult/src/catapult/thread/Scheduler.cpp
+++ b/client/catapult/src/catapult/thread/Scheduler.cpp
@@ -139,7 +139,7 @@ namespace catapult { namespace thread {
 			}
 
 		private:
-			ionet::Strand m_strand;
+			Strand m_strand;
 			StrandOwnerLifetimeExtender<StrandedTaskWrapper> m_strandWrapper;
 			BasicTaskWrapper<StrandedTaskWrapper> m_impl;
 		};

--- a/client/catapult/src/catapult/thread/Scheduler.cpp
+++ b/client/catapult/src/catapult/thread/Scheduler.cpp
@@ -139,7 +139,7 @@ namespace catapult { namespace thread {
 			}
 
 		private:
-			Strand m_strand;
+			StrandOwnerLifetimeExtender<StrandedTaskWrapper>::Strand m_strand;
 			StrandOwnerLifetimeExtender<StrandedTaskWrapper> m_strandWrapper;
 			BasicTaskWrapper<StrandedTaskWrapper> m_impl;
 		};

--- a/client/catapult/src/catapult/thread/StrandOwnerLifetimeExtender.h
+++ b/client/catapult/src/catapult/thread/StrandOwnerLifetimeExtender.h
@@ -21,6 +21,7 @@
 
 #pragma once
 #include "catapult/utils/WrappedWithOwnerDecorator.h"
+#include "catapult/exceptions.h"
 #include <boost/asio.hpp>
 
 namespace catapult { namespace thread {
@@ -28,6 +29,46 @@ namespace catapult { namespace thread {
 	/// Wraps a strand and automatically augments handlers to extend the lifetime of an owning object.
 	template<typename TOwner>
 	class StrandOwnerLifetimeExtender {
+	private:
+#ifdef ENABLE_CATAPULT_DIAGNOSTICS
+		class outside_strand_error : public catapult_runtime_error {
+		public:
+			using catapult_runtime_error::catapult_runtime_error;
+		};
+
+		template<typename THandler>
+		class StrandCheckHandler {
+		public:
+			StrandCheckHandler(const boost::asio::io_context::strand& strand, THandler handler)
+					: m_pStrand(&strand)
+					, m_handler(std::move(handler))
+			{}
+
+		public:
+			template<typename... TArgs>
+			auto operator()(TArgs&& ...args) const {
+				if (!m_pStrand->running_in_this_thread())
+					CATAPULT_THROW_AND_LOG_0(outside_strand_error, "wrapped function executing outside of strand");
+
+				return m_handler(std::forward<TArgs>(args)...);
+			}
+
+		protected:
+			const boost::asio::io_context::strand* m_pStrand;
+			THandler m_handler;
+		};
+
+		template<typename THandler>
+		static auto MakeStrandCheckHandler(const boost::asio::io_context::strand& strand, THandler handler) {
+			return StrandCheckHandler<THandler>(strand, std::move(handler));
+		}
+#else
+		template<typename THandler>
+		static auto MakeStrandCheckHandler(const boost::asio::io_context::strand&, THandler handler) {
+			return std::move(handler);
+		}
+#endif
+
 	public:
 		/// Creates a strand owner lifetime extender around \a strand.
 		explicit StrandOwnerLifetimeExtender(boost::asio::io_context::strand& strand) : m_strand(strand)
@@ -37,9 +78,14 @@ namespace catapult { namespace thread {
 		/// Wraps \a handler and attaches \a pOwner to it.
 		template<typename THandler>
 		auto wrap(const std::shared_ptr<TOwner>& pOwner, THandler handler) {
-			// when wrap is called the returned callback needs to extend the lifetime of pOwner
-			utils::WrappedWithOwnerDecorator<THandler> wrappedHandler(pOwner, std::move(handler));
-			return m_strand.wrap(wrappedHandler);
+			// 1. check in-strand execution (in diagnostic mode)
+			auto checkedHandler = MakeStrandCheckHandler<THandler>(m_strand, std::move(handler));
+
+			// 2. extend owner lifetime
+			utils::WrappedWithOwnerDecorator<decltype(checkedHandler)> wrappedWithOwnerHandler(pOwner, std::move(checkedHandler));
+
+			// 3. specify strand as executor for asio
+			return boost::asio::bind_executor(m_strand, std::move(wrappedWithOwnerHandler));
 		}
 
 	public:

--- a/client/catapult/src/catapult/thread/StrandOwnerLifetimeExtender.h
+++ b/client/catapult/src/catapult/thread/StrandOwnerLifetimeExtender.h
@@ -89,6 +89,15 @@ namespace catapult { namespace thread {
 		}
 
 	public:
+		/// Attaches \a pOwner to \a handler and dispatches it to the strand.
+		template<typename THandler>
+		void dispatch(const std::shared_ptr<TOwner>& pOwner, THandler handler) {
+			// ensure all handlers extend the lifetime of pOwner and dispatch to a strand
+			boost::asio::dispatch(m_strand, [pOwner, handler]() {
+				handler(pOwner);
+			});
+		}
+
 		/// Attaches \a pOwner to \a handler and posts it to the strand.
 		template<typename THandler>
 		void post(const std::shared_ptr<TOwner>& pOwner, THandler handler) {

--- a/client/catapult/src/catapult/thread/StrandOwnerLifetimeExtender.h
+++ b/client/catapult/src/catapult/thread/StrandOwnerLifetimeExtender.h
@@ -26,11 +26,12 @@
 
 namespace catapult { namespace thread {
 
-	using Strand = boost::asio::strand<boost::asio::io_context::executor_type>;
-
 	/// Wraps a strand and automatically augments handlers to extend the lifetime of an owning object.
 	template<typename TOwner>
 	class StrandOwnerLifetimeExtender {
+	public:
+		using Strand = boost::asio::strand<boost::asio::io_context::executor_type>;
+
 	private:
 #ifdef ENABLE_CATAPULT_DIAGNOSTICS
 		class outside_strand_error : public catapult_runtime_error {

--- a/client/catapult/src/catapult/thread/StrandOwnerLifetimeExtender.h
+++ b/client/catapult/src/catapult/thread/StrandOwnerLifetimeExtender.h
@@ -20,12 +20,13 @@
 **/
 
 #pragma once
-#include "catapult/ionet/IoTypes.h"
 #include "catapult/utils/WrappedWithOwnerDecorator.h"
 #include "catapult/exceptions.h"
 #include <boost/asio.hpp>
 
 namespace catapult { namespace thread {
+
+	using Strand = boost::asio::strand<boost::asio::io_context::executor_type>;
 
 	/// Wraps a strand and automatically augments handlers to extend the lifetime of an owning object.
 	template<typename TOwner>
@@ -40,7 +41,7 @@ namespace catapult { namespace thread {
 		template<typename THandler>
 		class StrandCheckHandler {
 		public:
-			StrandCheckHandler(const ionet::Strand& strand, THandler handler)
+			StrandCheckHandler(const Strand& strand, THandler handler)
 					: m_pStrand(&strand)
 					, m_handler(std::move(handler))
 			{}
@@ -55,24 +56,24 @@ namespace catapult { namespace thread {
 			}
 
 		protected:
-			const ionet::Strand* m_pStrand;
+			const Strand* m_pStrand;
 			THandler m_handler;
 		};
 
 		template<typename THandler>
-		static auto MakeStrandCheckHandler(const ionet::Strand& strand, THandler handler) {
+		static auto MakeStrandCheckHandler(const Strand& strand, THandler handler) {
 			return StrandCheckHandler<THandler>(strand, std::move(handler));
 		}
 #else
 		template<typename THandler>
-		static auto MakeStrandCheckHandler(const ionet::Strand&, THandler handler) {
+		static auto MakeStrandCheckHandler(const Strand&, THandler handler) {
 			return std::move(handler);
 		}
 #endif
 
 	public:
 		/// Creates a strand owner lifetime extender around \a strand.
-		explicit StrandOwnerLifetimeExtender(ionet::Strand& strand) : m_strand(strand)
+		explicit StrandOwnerLifetimeExtender(Strand& strand) : m_strand(strand)
 		{}
 
 	public:
@@ -109,6 +110,6 @@ namespace catapult { namespace thread {
 		}
 
 	private:
-		ionet::Strand& m_strand;
+		Strand& m_strand;
 	};
 }}

--- a/client/catapult/src/catapult/thread/StrandOwnerLifetimeExtender.h
+++ b/client/catapult/src/catapult/thread/StrandOwnerLifetimeExtender.h
@@ -20,6 +20,7 @@
 **/
 
 #pragma once
+#include "catapult/ionet/IoTypes.h"
 #include "catapult/utils/WrappedWithOwnerDecorator.h"
 #include "catapult/exceptions.h"
 #include <boost/asio.hpp>
@@ -39,7 +40,7 @@ namespace catapult { namespace thread {
 		template<typename THandler>
 		class StrandCheckHandler {
 		public:
-			StrandCheckHandler(const boost::asio::io_context::strand& strand, THandler handler)
+			StrandCheckHandler(const ionet::Strand& strand, THandler handler)
 					: m_pStrand(&strand)
 					, m_handler(std::move(handler))
 			{}
@@ -54,24 +55,24 @@ namespace catapult { namespace thread {
 			}
 
 		protected:
-			const boost::asio::io_context::strand* m_pStrand;
+			const ionet::Strand* m_pStrand;
 			THandler m_handler;
 		};
 
 		template<typename THandler>
-		static auto MakeStrandCheckHandler(const boost::asio::io_context::strand& strand, THandler handler) {
+		static auto MakeStrandCheckHandler(const ionet::Strand& strand, THandler handler) {
 			return StrandCheckHandler<THandler>(strand, std::move(handler));
 		}
 #else
 		template<typename THandler>
-		static auto MakeStrandCheckHandler(const boost::asio::io_context::strand&, THandler handler) {
+		static auto MakeStrandCheckHandler(const ionet::Strand&, THandler handler) {
 			return std::move(handler);
 		}
 #endif
 
 	public:
 		/// Creates a strand owner lifetime extender around \a strand.
-		explicit StrandOwnerLifetimeExtender(boost::asio::io_context::strand& strand) : m_strand(strand)
+		explicit StrandOwnerLifetimeExtender(ionet::Strand& strand) : m_strand(strand)
 		{}
 
 	public:
@@ -108,6 +109,6 @@ namespace catapult { namespace thread {
 		}
 
 	private:
-		boost::asio::io_context::strand& m_strand;
+		ionet::Strand& m_strand;
 	};
 }}

--- a/client/catapult/src/catapult/thread/TimedCallback.h
+++ b/client/catapult/src/catapult/thread/TimedCallback.h
@@ -56,7 +56,7 @@ namespace catapult { namespace thread {
 
 		public:
 			void setTimeout(const utils::TimeSpan& timeout) {
-				m_timer.expires_from_now(std::chrono::milliseconds(timeout.millis()));
+				m_timer.expires_after(std::chrono::milliseconds(timeout.millis()));
 				m_timer.async_wait(m_wrapper.wrap([this](const auto&) {
 					this->handleTimedOut();
 				}));

--- a/client/catapult/src/catapult/thread/TimedCallback.h
+++ b/client/catapult/src/catapult/thread/TimedCallback.h
@@ -161,7 +161,7 @@ namespace catapult { namespace thread {
 
 	private:
 		BasicTimedCallback<StrandedTimedCallback> m_impl;
-		Strand m_strand;
+		typename StrandOwnerLifetimeExtender<StrandedTimedCallback>::Strand m_strand;
 		StrandOwnerLifetimeExtender<StrandedTimedCallback> m_strandWrapper;
 	};
 

--- a/client/catapult/src/catapult/thread/TimedCallback.h
+++ b/client/catapult/src/catapult/thread/TimedCallback.h
@@ -161,7 +161,7 @@ namespace catapult { namespace thread {
 
 	private:
 		BasicTimedCallback<StrandedTimedCallback> m_impl;
-		ionet::Strand m_strand;
+		Strand m_strand;
 		StrandOwnerLifetimeExtender<StrandedTimedCallback> m_strandWrapper;
 	};
 

--- a/client/catapult/src/catapult/thread/TimedCallback.h
+++ b/client/catapult/src/catapult/thread/TimedCallback.h
@@ -119,7 +119,7 @@ namespace catapult { namespace thread {
 		/// On a timeout, the callback is invoked with \a timeoutArgs.
 		StrandedTimedCallback(boost::asio::io_context& ioContext, const TCallback& callback, TCallbackArgs&&... timeoutArgs)
 				: m_impl(*this, ioContext, callback, std::forward<TCallbackArgs>(timeoutArgs)...)
-				, m_strand(ioContext)
+				, m_strand(boost::asio::make_strand(ioContext))
 				, m_strandWrapper(m_strand)
 		{}
 
@@ -161,7 +161,7 @@ namespace catapult { namespace thread {
 
 	private:
 		BasicTimedCallback<StrandedTimedCallback> m_impl;
-		boost::asio::io_context::strand m_strand;
+		ionet::Strand m_strand;
 		StrandOwnerLifetimeExtender<StrandedTimedCallback> m_strandWrapper;
 	};
 

--- a/client/catapult/tests/catapult/ionet/AppendContextTests.cpp
+++ b/client/catapult/tests/catapult/ionet/AppendContextTests.cpp
@@ -65,7 +65,7 @@ namespace catapult { namespace ionet {
 		test::FillWithRandomData(buffer);
 
 		// Assert:
-		auto pContextBuffer = boost::asio::buffer_cast<uint8_t*>(context.buffer());
+		auto pContextBuffer = static_cast<const uint8_t*>(context.buffer().data());
 		auto contextBufferSize = boost::asio::buffer_size(context.buffer());
 		ASSERT_EQ(100u, contextBufferSize);
 		EXPECT_TRUE(std::equal(buffer.begin() + 12, buffer.end(), pContextBuffer, pContextBuffer + contextBufferSize));
@@ -79,7 +79,7 @@ namespace catapult { namespace ionet {
 		test::FillWithRandomData(buffer);
 
 		// Assert:
-		auto pContextBuffer = boost::asio::buffer_cast<uint8_t*>(context.buffer());
+		auto pContextBuffer = static_cast<const uint8_t*>(context.buffer().data());
 		auto contextBufferSize = boost::asio::buffer_size(context.buffer());
 		ASSERT_EQ(50u, contextBufferSize);
 		EXPECT_TRUE(std::equal(buffer.begin() + 8, buffer.end(), pContextBuffer, pContextBuffer + contextBufferSize));

--- a/client/catapult/tests/catapult/ionet/PacketSocketTests.cpp
+++ b/client/catapult/tests/catapult/ionet/PacketSocketTests.cpp
@@ -1262,7 +1262,7 @@ namespace catapult { namespace ionet {
 
 	namespace {
 		auto CreateEndpointForListenInterface(const std::string& listenInterface) {
-			return boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(listenInterface), test::GetLocalHostPort());
+			return boost::asio::ip::tcp::endpoint(boost::asio::ip::make_address(listenInterface), test::GetLocalHostPort());
 		}
 
 		void RunConnectionAcceptedTest(const std::string& listenInterface, const std::string& remoteHost, IpProtocol outgoingProtocols) {

--- a/client/catapult/tests/catapult/ionet/PacketSocketTests.cpp
+++ b/client/catapult/tests/catapult/ionet/PacketSocketTests.cpp
@@ -1155,7 +1155,7 @@ namespace catapult { namespace ionet {
 
 			CATAPULT_LOG(debug) << "starting async accept";
 			auto pAcceptor = test::CreateImplicitlyClosedLocalHostAcceptor(ioContext);
-			auto acceptorStrand = boost::asio::io_context::strand(ioContext);
+			auto acceptorStrand = boost::asio::make_strand(ioContext);
 			auto serverSocket = boost::asio::ip::tcp::socket(ioContext);
 
 			// - post an async server accept

--- a/client/catapult/tests/catapult/ionet/WorkingBufferTests.cpp
+++ b/client/catapult/tests/catapult/ionet/WorkingBufferTests.cpp
@@ -41,7 +41,7 @@ namespace catapult { namespace ionet {
 		std::array<uint8_t, N> AppendRandomBuffer(WorkingBuffer& buffer) {
 			auto appendBuffer = test::GenerateRandomArray<N>();
 			auto context = buffer.prepareAppend();
-			std::memcpy(boost::asio::buffer_cast<uint8_t*>(context.buffer()), appendBuffer.data(), appendBuffer.size());
+			std::memcpy(context.buffer().data(), appendBuffer.data(), appendBuffer.size());
 			context.commit(N);
 			return appendBuffer;
 		}
@@ -148,7 +148,7 @@ namespace catapult { namespace ionet {
 		{
 			auto appendBuffer = test::GenerateRandomArray<100>();
 			auto context = buffer.prepareAppend();
-			std::memcpy(boost::asio::buffer_cast<uint8_t*>(context.buffer()), &appendBuffer, appendBuffer.size());
+			std::memcpy(context.buffer().data(), &appendBuffer, appendBuffer.size());
 		}
 
 		// Assert:

--- a/client/catapult/tests/catapult/model/EmbeddedTransactionTests.cpp
+++ b/client/catapult/tests/catapult/model/EmbeddedTransactionTests.cpp
@@ -160,7 +160,17 @@ namespace catapult { namespace model {
 		// Arrange:
 		std::vector<uint8_t> buffer(sizeof(SizePrefixedEntity));
 		auto* pTransaction = reinterpret_cast<EmbeddedTransaction*>(&buffer[0]);
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds" // EmbeddedTransaction[0] is partly outside array bounds
+#endif
+
 		pTransaction->Size = sizeof(SizePrefixedEntity);
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 		// Act:
 		EXPECT_FALSE(IsSizeValid(*pTransaction));

--- a/client/catapult/tests/catapult/model/SizePrefixedEntityTests.cpp
+++ b/client/catapult/tests/catapult/model/SizePrefixedEntityTests.cpp
@@ -120,7 +120,7 @@ namespace catapult { namespace model {
 
 	BYTE_POINTER_TEST(ToBytePointerReturnsPointerToStartOfEntity) {
 		// Arrange:
-		CustomSizePrefixedEntity entity;
+		CustomSizePrefixedEntity entity = {};
 
 		// Act:
 		auto pEntityStart = test::AsVoidPointer(TTraits::ToStartPointer(entity));

--- a/client/catapult/tests/catapult/model/SizePrefixedEntityTests.cpp
+++ b/client/catapult/tests/catapult/model/SizePrefixedEntityTests.cpp
@@ -120,7 +120,7 @@ namespace catapult { namespace model {
 
 	BYTE_POINTER_TEST(ToBytePointerReturnsPointerToStartOfEntity) {
 		// Arrange:
-		CustomSizePrefixedEntity entity = {};
+		CustomSizePrefixedEntity entity{};
 
 		// Act:
 		auto pEntityStart = test::AsVoidPointer(TTraits::ToStartPointer(entity));

--- a/client/catapult/tests/catapult/net/AsyncTcpServerTests.cpp
+++ b/client/catapult/tests/catapult/net/AsyncTcpServerTests.cpp
@@ -198,7 +198,7 @@ namespace catapult { namespace net {
 
 			public:
 				void setDeadline(size_t millis, const ConnectionHandler& handler) {
-					m_deadline.expires_from_now(std::chrono::milliseconds(millis));
+					m_deadline.expires_after(std::chrono::milliseconds(millis));
 					m_deadline.async_wait([pThis = shared_from_this(), handler](const auto& ec) {
 						pThis->handleTimeout(ec, handler);
 					});
@@ -722,7 +722,7 @@ namespace catapult { namespace net {
 
 	namespace {
 		auto CreateEndpointForListenInterface(const std::string& listenInterface) {
-			return boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string(listenInterface), test::GetLocalHostPort());
+			return boost::asio::ip::tcp::endpoint(boost::asio::ip::make_address(listenInterface), test::GetLocalHostPort());
 		}
 
 		auto CreateServerForConnectionTests(

--- a/client/catapult/tests/catapult/thread/SchedulerTests.cpp
+++ b/client/catapult/tests/catapult/thread/SchedulerTests.cpp
@@ -490,7 +490,7 @@ namespace catapult { namespace thread {
 			auto pTimer = std::make_shared<boost::asio::steady_timer>(ioContext);
 			return CreateContinuousTaskWithCounterAndSleep(startDelayMs, repeatDelayMs, pCounter, [callbackDelayMs, pTimer]() {
 				auto pPromise = std::make_shared<promise<TaskResult>>();
-				pTimer->expires_from_now(std::chrono::milliseconds(callbackDelayMs));
+				pTimer->expires_after(std::chrono::milliseconds(callbackDelayMs));
 				pTimer->async_wait([pPromise](const auto&) {
 					pPromise->set_value(TaskResult::Continue);
 				});

--- a/client/catapult/tests/catapult/thread/StrandOwnerLifetimeExtenderTests.cpp
+++ b/client/catapult/tests/catapult/thread/StrandOwnerLifetimeExtenderTests.cpp
@@ -54,7 +54,7 @@ namespace catapult { namespace thread {
 		struct TestContext {
 		public:
 			std::unique_ptr<IoThreadPool> pPool;
-			boost::asio::io_context::strand Strand;
+			ionet::Strand Strand;
 			std::shared_ptr<Owner> pOwner;
 			ExtenderType Extender;
 			BreadcrumbsType Breadcrumbs;
@@ -62,7 +62,7 @@ namespace catapult { namespace thread {
 		public:
 			TestContext()
 					: pPool(test::CreateStartedIoThreadPool())
-					, Strand(boost::asio::io_context::strand(pPool->ioContext()))
+					, Strand(boost::asio::make_strand(pPool->ioContext()))
 					, pOwner(std::make_shared<Owner>(Breadcrumbs))
 					, Extender(Strand)
 			{}

--- a/client/catapult/tests/catapult/utils/CatapultExceptionTests.cpp
+++ b/client/catapult/tests/catapult/utils/CatapultExceptionTests.cpp
@@ -85,10 +85,6 @@ namespace catapult {
 		std::string ConvertToExceptionFunctionName(const std::string& functionFullName) {
 			CATAPULT_LOG(info) << "function: " << functionFullName;
 
-#ifdef _MSC_VER
-			return functionFullName;  // Boost 1.90 no transformation is needed.
-#endif
-
 			std::size_t functionNameEnd = functionFullName.find_first_of("<(");
 			if (std::string::npos == functionNameEnd)
 				return functionFullName;
@@ -132,8 +128,15 @@ namespace catapult {
 				exceptionFqn.replace(pos, toSearch.size(), ">>");
 #endif
 
+// For VS 2022 and greater with Boost 1.90 no transformation is needed.
+#if (defined(_MSC_VER) && _MSC_VER >= 1930)
+			auto thrownFunctionName = expected.FunctionName;
+#else
+			auto thrownFunctionName = ConvertToExceptionFunctionName(expected.FunctionName);
+#endif
+
 			std::vector<std::string> expectedDiagLines{
-				"Throw in function " + ConvertToExceptionFunctionName(expected.FunctionName),
+				"Throw in function " + thrownFunctionName,
 				"Dynamic exception type: " STRUCTPREFIX "boost::wrapexcept<" + exceptionFqn + endBrace,
 				"std::exception::what: " + expected.What
 			};

--- a/client/catapult/tests/catapult/utils/CatapultExceptionTests.cpp
+++ b/client/catapult/tests/catapult/utils/CatapultExceptionTests.cpp
@@ -85,6 +85,10 @@ namespace catapult {
 		std::string ConvertToExceptionFunctionName(const std::string& functionFullName) {
 			CATAPULT_LOG(info) << "function: " << functionFullName;
 
+#ifdef _MSC_VER
+			return functionFullName;  // Boost 1.90 no transformation is needed.
+#endif
+
 			std::size_t functionNameEnd = functionFullName.find_first_of("<(");
 			if (std::string::npos == functionNameEnd)
 				return functionFullName;

--- a/client/catapult/tests/test/core/WaitFunctions.cpp
+++ b/client/catapult/tests/test/core/WaitFunctions.cpp
@@ -39,7 +39,7 @@ namespace catapult { namespace test {
 				return;
 
 			auto pTimer = std::make_shared<boost::asio::steady_timer>(ioContext);
-			pTimer->expires_from_now(std::chrono::milliseconds(waitMillis));
+			pTimer->expires_after(std::chrono::milliseconds(waitMillis));
 			pTimer->async_wait([&ioContext, shouldWait, waitMillis](const auto&) {
 				WaitAsync(ioContext, shouldWait, waitMillis);
 			});

--- a/client/catapult/tests/test/net/ClientSocket.cpp
+++ b/client/catapult/tests/test/net/ClientSocket.cpp
@@ -258,7 +258,7 @@ namespace catapult { namespace test {
 
 				// otherwise, set a timer
 				CATAPULT_LOG(debug) << "delaying for " << delayMillis << "ms";
-				m_timer.expires_from_now(std::chrono::milliseconds(delayMillis));
+				m_timer.expires_after(std::chrono::milliseconds(delayMillis));
 				m_timer.async_wait([continuation](const auto& ec) {
 					CATAPULT_LOG(debug) << "resuming " << ToMessage(ec);
 					continuation();

--- a/client/catapult/tests/test/net/ClientSocket.cpp
+++ b/client/catapult/tests/test/net/ClientSocket.cpp
@@ -41,7 +41,7 @@ namespace catapult { namespace test {
 		class SocketGuard : public std::enable_shared_from_this<SocketGuard>{
 		public:
 			explicit SocketGuard(boost::asio::io_context& ioContext)
-					: m_strand(ioContext)
+					: m_strand(boost::asio::make_strand(ioContext))
 					, m_strandWrapper(m_strand)
 					, m_socket(ioContext, CreatePacketSocketSslOptions().ContextSupplier())
 					, m_sentinelByte(0) {
@@ -110,7 +110,7 @@ namespace catapult { namespace test {
 			}
 
 		private:
-			boost::asio::io_context::strand m_strand;
+			ionet::Strand m_strand;
 			thread::StrandOwnerLifetimeExtender<SocketGuard> m_strandWrapper;
 			ionet::Socket m_socket;
 			uint8_t m_sentinelByte;

--- a/client/catapult/tests/test/net/SocketTestUtils.cpp
+++ b/client/catapult/tests/test/net/SocketTestUtils.cpp
@@ -83,7 +83,7 @@ namespace catapult { namespace test {
 	public:
 		void init() {
 			// setup the timer
-			m_timer.expires_from_now(std::chrono::seconds(2 * detail::Default_Wait_Timeout));
+			m_timer.expires_after(std::chrono::seconds(2 * detail::Default_Wait_Timeout));
 			m_timer.async_wait([pThis = shared_from_this()](const auto& ec) {
 				if (boost::asio::error::operation_aborted == ec)
 					return;
@@ -202,11 +202,11 @@ namespace catapult { namespace test {
 	}
 
 	boost::asio::ip::tcp::endpoint CreateLocalHostEndpoint(unsigned short port) {
-		return boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string("127.0.0.1"), port);
+		return boost::asio::ip::tcp::endpoint(boost::asio::ip::make_address("127.0.0.1"), port);
 	}
 
 	boost::asio::ip::tcp::endpoint CreateLocalHostEndpointIPv6(unsigned short port) {
-		return boost::asio::ip::tcp::endpoint(boost::asio::ip::address::from_string("::1"), port);
+		return boost::asio::ip::tcp::endpoint(boost::asio::ip::make_address("::1"), port);
 	}
 
 	ionet::PacketSocketSslOptions CreatePacketSocketSslOptions() {

--- a/client/catapult/tests/test/net/SocketTestUtils.cpp
+++ b/client/catapult/tests/test/net/SocketTestUtils.cpp
@@ -57,7 +57,7 @@ namespace catapult { namespace test {
 		Impl(boost::asio::io_context& ioContext, const boost::asio::ip::tcp::endpoint& endpoint)
 				: m_ioContext(ioContext)
 				, m_endpoint(endpoint)
-				, m_acceptorStrand(m_ioContext)
+				, m_acceptorStrand(boost::asio::make_strand(m_ioContext))
 				, m_timer(m_ioContext)
 				, m_isClosed(false)
 				, m_pAcceptor(CreateLocalHostAcceptor(m_ioContext, m_endpoint))
@@ -144,7 +144,7 @@ namespace catapult { namespace test {
 		// this is now *properly* mitigated by wrapping acceptor operations in a strand
 		boost::asio::io_context& m_ioContext;
 		boost::asio::ip::tcp::endpoint m_endpoint;
-		boost::asio::io_context::strand m_acceptorStrand;
+		ionet::Strand m_acceptorStrand;
 		boost::asio::steady_timer m_timer;
 		std::atomic_bool m_isClosed;
 		std::unique_ptr<boost::asio::ip::tcp::acceptor> m_pAcceptor;
@@ -177,7 +177,7 @@ namespace catapult { namespace test {
 		return m_pImpl->acceptor();
 	}
 
-	boost::asio::io_context::strand& TcpAcceptor::strand() const {
+	ionet::Strand& TcpAcceptor::strand() const {
 		return m_pImpl->strand();
 	}
 

--- a/client/catapult/tests/test/net/SocketTestUtils.h
+++ b/client/catapult/tests/test/net/SocketTestUtils.h
@@ -68,7 +68,7 @@ namespace catapult { namespace test {
 		boost::asio::ip::tcp::acceptor& get() const;
 
 		/// Gets a strand that should be used when calling the acceptor.
-		boost::asio::io_context::strand& strand() const;
+		ionet::Strand& strand() const;
 
 		/// Returns \c true if the underlying acceptor is stopped.
 		bool isStopped() const;

--- a/client/catapult/tools/addressgen/main.cpp
+++ b/client/catapult/tools/addressgen/main.cpp
@@ -76,7 +76,7 @@ namespace catapult { namespace tools { namespace addressgen {
 				utils::SpinLock acceptLock;
 				auto pPool = CreateStartedThreadPool(m_numThreads);
 				for (auto i = 0u; i < pPool->numWorkerThreads(); ++i) {
-					pPool->ioContext().dispatch([acceptKeyPair, coinId, &acceptLock]() {
+					boost::asio::dispatch(pPool->ioContext(), [acceptKeyPair, coinId, &acceptLock]() {
 						auto randomGenerator = crypto::SecureRandomGenerator();
 
 						for (;;) {

--- a/client/catapult/tools/health/ApiNodeHealthUtils.cpp
+++ b/client/catapult/tools/health/ApiNodeHealthUtils.cpp
@@ -97,8 +97,8 @@ namespace catapult { namespace tools { namespace health {
 			SocketConnector(boost::asio::io_context& ioContext, const std::string& host, uint16_t port)
 					: m_socket(ioContext)
 					, m_resolver(ioContext)
-					, m_host(host + ":" + std::to_string(port))
-					, m_query(host, std::to_string(port))
+					, m_host(host)
+					, m_port(std::to_string(port))
 			{}
 
 		public:
@@ -116,17 +116,17 @@ namespace catapult { namespace tools { namespace health {
 
 		public:
 			void start() {
-				m_resolver.async_resolve(m_query, [this](const auto& ec, auto iterator) {
-					this->handleResolve(ec, iterator);
+				m_resolver.async_resolve(m_host, m_port, [this](const auto& ec, const auto& results) {
+					this->handleResolve(ec, results);
 				});
 			}
 
 		private:
-			void handleResolve(const boost::system::error_code& ec, const ResolverType::iterator& iterator) {
+			void handleResolve(const boost::system::error_code& ec, const ResolverType::results_type& results) {
 				if (ShouldAbort(ec, m_host, "resolving address"))
 					return complete(ionet::ConnectResult::Resolve_Error);
 
-				m_endpoint = iterator->endpoint();
+				m_endpoint = results.cbegin()->endpoint();
 				m_socket.async_connect(m_endpoint, [this](const auto& connectEc) {
 					this->handleConnect(connectEc);
 				});
@@ -149,7 +149,7 @@ namespace catapult { namespace tools { namespace health {
 			ResolverType m_resolver;
 
 			std::string m_host;
-			ResolverType::query m_query;
+			std::string m_port;
 
 			boost::asio::ip::tcp::endpoint m_endpoint;
 			thread::promise<ionet::ConnectResult> m_promise;

--- a/jenkins/catapult/baseImageDockerfileGenerator.py
+++ b/jenkins/catapult/baseImageDockerfileGenerator.py
@@ -3,32 +3,12 @@ import sys
 from pathlib import Path
 
 from configuration import load_compiler_configuration, load_versions_map
-from dependency_flags import get_dependency_flags
+from dependency_flags import get_boost_disabled_libraries, get_dependency_flags
 
 SINGLE_COMMAND_SEPARATOR = ' \\\n    && '
 LAYER_TO_IMAGE_TAG_MAP = {'os': 'preimage1', 'boost': 'preimage2', 'deps': 'preimage3', 'test': '', 'conan': 'conan'}
 VS_DEV_CMD = r'C:\BuildTools\VC\Auxiliary\Build\vcvars64.bat'
-BOOST_DISABLED_LIBS = map(lambda library_name: f'--without-{library_name}', [
-	'context',
-	'contract',
-	'coroutine',
-	'fiber',
-	'graph',
-	'graph_parallel',
-	'headers',
-	'iostreams',
-	'json',
-	'mpi',
-	'nowide',
-	'process',
-	'python',
-	'serialization',
-	'stacktrace',
-	'test',
-	'timer',
-	'type_erasure',
-	'wave'
-])
+BOOST_DISABLED_LIBS = map(lambda library_name: f'--without-{library_name}', get_boost_disabled_libraries())
 
 
 def print_line(lines, **kwargs):

--- a/jenkins/catapult/baseImageDockerfileGenerator.py
+++ b/jenkins/catapult/baseImageDockerfileGenerator.py
@@ -20,6 +20,7 @@ BOOST_DISABLED_LIBS = map(lambda library_name: f'--without-{library_name}', [
 	'json',
 	'mpi',
 	'nowide',
+	'process',
 	'python',
 	'serialization',
 	'stacktrace',

--- a/jenkins/catapult/dependency_flags.py
+++ b/jenkins/catapult/dependency_flags.py
@@ -51,3 +51,27 @@ def get_dependency_flags(dependency_name):
 		flags += WINDOWS_DEPENDENCY_FLAGS.get(dependency_name, [])
 
 	return flags
+
+
+def get_boost_disabled_libraries():
+	return [
+		'context',
+		'contract',
+		'coroutine',
+		'fiber',
+		'graph',
+		'graph_parallel',
+		'headers',
+		'iostreams',
+		'json',
+		'mpi',
+		'nowide',
+		'process',
+		'python',
+		'serialization',
+		'stacktrace',
+		'test',
+		'timer',
+		'type_erasure',
+		'wave'
+	]

--- a/jenkins/catapult/dependency_flags.py
+++ b/jenkins/catapult/dependency_flags.py
@@ -68,7 +68,6 @@ def get_boost_disabled_libraries():
 		'nowide',
 		'process',
 		'python',
-		'serialization',
 		'stacktrace',
 		'test',
 		'timer',

--- a/jenkins/catapult/installDepsLocal.py
+++ b/jenkins/catapult/installDepsLocal.py
@@ -2,7 +2,7 @@ import argparse
 from pathlib import Path
 
 from configuration import load_versions_map
-from dependency_flags import get_dependency_flags
+from dependency_flags import get_boost_disabled_libraries, get_dependency_flags
 from environment import EnvironmentManager
 from process import ProcessManager
 
@@ -64,27 +64,7 @@ class Builder:
 
 		boost_prefix_option = f'--prefix={self.target_directory / "boost"}'
 		bootstrap_options = [r'.\bootstrap.bat' if EnvironmentManager.is_windows_platform() else './bootstrap.sh']
-		bootstrap_options += [f'--without-libraries={",".join([
-			'context',
-			'contract',
-			'coroutine',
-			'fiber',
-			'graph',
-			'graph_parallel',
-			'headers',
-			'iostreams',
-			'json',
-			'mpi',
-			'nowide',
-			'process',
-			'python',
-			'serialization',
-			'stacktrace',
-			'test',
-			'timer',
-			'type_erasure',
-			'wave'
-		])}']
+		bootstrap_options += [f'--without-libraries={",".join(get_boost_disabled_libraries())}']
 		if self.is_clang:
 			bootstrap_options += ['with-toolset=clang']
 

--- a/jenkins/catapult/installDepsLocal.py
+++ b/jenkins/catapult/installDepsLocal.py
@@ -64,6 +64,7 @@ class Builder:
 
 		boost_prefix_option = f'--prefix={self.target_directory / "boost"}'
 		bootstrap_options = [r'.\bootstrap.bat' if EnvironmentManager.is_windows_platform() else './bootstrap.sh']
+		bootstrap_options += ['--without-libraries=python']
 		if self.is_clang:
 			bootstrap_options += ['with-toolset=clang']
 

--- a/jenkins/catapult/installDepsLocal.py
+++ b/jenkins/catapult/installDepsLocal.py
@@ -64,7 +64,27 @@ class Builder:
 
 		boost_prefix_option = f'--prefix={self.target_directory / "boost"}'
 		bootstrap_options = [r'.\bootstrap.bat' if EnvironmentManager.is_windows_platform() else './bootstrap.sh']
-		bootstrap_options += ['--without-libraries=python']
+		bootstrap_options += [f'--without-libraries={",".join([
+			'context',
+			'contract',
+			'coroutine',
+			'fiber',
+			'graph',
+			'graph_parallel',
+			'headers',
+			'iostreams',
+			'json',
+			'mpi',
+			'nowide',
+			'process',
+			'python',
+			'serialization',
+			'stacktrace',
+			'test',
+			'timer',
+			'type_erasure',
+			'wave'
+		])}']
 		if self.is_clang:
 			bootstrap_options += ['with-toolset=clang']
 

--- a/jenkins/catapult/runDockerBuildInnerBuild.py
+++ b/jenkins/catapult/runDockerBuildInnerBuild.py
@@ -166,7 +166,7 @@ class BuildManager(BasicBuildManager):
 
 			return
 
-		for name in ['atomic', 'chrono', 'date_time', 'filesystem', 'log', 'log_setup', 'program_options', 'regex', 'thread']:
+		for name in ['atomic', 'chrono', 'container', 'date_time', 'filesystem', 'log', 'log_setup', 'program_options', 'regex', 'serialization', 'thread']:
 			self.environment_manager.copy_glob_with_symlinks('/mybuild/lib', f'libboost_{name}.so*', destination)
 
 		for name in ['bson2', 'mongoc2', 'bsoncxx', 'mongocxx', 'zmq', 'rocksdb', 'snappy', 'gflags']:

--- a/jenkins/catapult/runDockerBuildInnerBuild.py
+++ b/jenkins/catapult/runDockerBuildInnerBuild.py
@@ -166,7 +166,18 @@ class BuildManager(BasicBuildManager):
 
 			return
 
-		for name in ['atomic', 'chrono', 'container', 'date_time', 'filesystem', 'log', 'log_setup', 'program_options', 'regex', 'serialization', 'thread']:
+		for name in [
+			'atomic',
+			'chrono',
+			'container',
+			'date_time',
+			'filesystem',
+			'log',
+			'log_setup',
+			'program_options',
+			'regex',
+			'serialization',
+			'thread']:
 			self.environment_manager.copy_glob_with_symlinks('/mybuild/lib', f'libboost_{name}.so*', destination)
 
 		for name in ['bson2', 'mongoc2', 'bsoncxx', 'mongocxx', 'zmq', 'rocksdb', 'snappy', 'gflags']:

--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -5,7 +5,7 @@ fedora = 43
 debian = 13
 windows = 2022
 
-boost = 1.84.0
+boost = 1.86.0
 cmake = 3.28.1
 gosu = 1.17
 

--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -5,7 +5,7 @@ fedora = 43
 debian = 13
 windows = 2022
 
-boost = 1.87.0
+boost = 1.90.0
 cmake = 3.28.1
 gosu = 1.17
 

--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -5,7 +5,7 @@ fedora = 43
 debian = 13
 windows = 2022
 
-boost = 1.86.0
+boost = 1.87.0
 cmake = 3.28.1
 gosu = 1.17
 

--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -5,7 +5,7 @@ fedora = 43
 debian = 13
 windows = 2022
 
-boost = 1.83.0
+boost = 1.84.0
 cmake = 3.28.1
 gosu = 1.17
 


### PR DESCRIPTION
problem: catapult is calling deprecated Boost functions
solution: disable deprecated functions by adding -DBOOST_ASIO_NO_DEPRECATED flag
                 update Boost to 1.90.0