### PR TITLE
[mkdocs] chore: review consistency between tutorials

### DIFF
--- a/mkdocs/overrides/devbook/accounts/account-metadata.log
+++ b/mkdocs/overrides/devbook/accounts/account-metadata.log
@@ -27,7 +27,7 @@ Waiting for aggregate transaction confirmation...
 aggregate transaction confirmed in 11 seconds
 
 --- Modifying existing metadata ---
-Fetching current metadata from /metadata?targetAddress=TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I&metadataType=0
+Fetching current metadata from /metadata?sourceAddress=TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I&targetAddress=TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I&scopedMetadataKey=E7F71DA42B54B310&metadataType=0
   Current value: alice
 Created embedded update transaction:
 {

--- a/mkdocs/overrides/devbook/mosaics/modify-mosaic-definition.mjs
+++ b/mkdocs/overrides/devbook/mosaics/modify-mosaic-definition.mjs
@@ -85,8 +85,7 @@ try {
 	console.log('  Response:', await announceResponse.text());
 
 	// Wait for confirmation
-	console.log(
-		'Waiting for mosaic modification confirmation...');
+	console.log('Waiting for mosaic modification confirmation...');
 	for (let attempt = 0; attempt < 60; attempt++) {
 		await new Promise(resolve => setTimeout(resolve, 1000));
 
@@ -104,16 +103,14 @@ try {
 			console.log('  Transaction status:', status.group);
 
 			if (status.group === 'confirmed') {
-				console.log(
-					'Mosaic modification confirmed in',
+				console.log('Mosaic modification confirmed in',
 					attempt, 'seconds');
 				break;
 			}
 
 			if (status.group === 'failed') {
 				throw new Error(
-					'Mosaic modification failed:'
-					+ ` ${status.code}`);
+					`Mosaic modification failed: ${status.code}`);
 			}
 		} catch (error) {
 			if (error.message.includes('failed:')) {

--- a/mkdocs/pages/en/devbook/accounts/account-metadata.md
+++ b/mkdocs/pages/en/devbook/accounts/account-metadata.md
@@ -6,7 +6,7 @@ title: Add Account Metadata
 
 <Accounts:|Accounts>, like <mosaics:> and <namespaces:>, can store <metadata:> as key-value pairs.
 
-This tutorial shows how to add metadata to an account, retrieve metadata from the network, and update existing values.
+This tutorial shows how to add metadata to an account, retrieve it from the network, and update existing values.
 
 In this example, the pair `username = alice` is attached to an account and then changed to `bob`.
 
@@ -38,8 +38,8 @@ Before you start, make sure to:
 
 Additionally, review the [Transfer transaction](../transactions/transfer.md) tutorial to understand how
 transactions are announced and confirmed, and the
-[Complete Aggregate transaction](../transactions/complete-aggregate.md) tutorial to understand how aggregate
-transactions work.
+[Complete Aggregate transaction](../transactions/complete-aggregate.md) tutorial to understand how
+<aggregate transactions:> work.
 
 ## Full Code
 
@@ -71,22 +71,35 @@ following the process described in the [Transfer Transaction](../transactions/tr
 
 ### Defining the Metadata
 
+Each account metadata entry is uniquely identified by:
+
+* The **signer's address**: the account adding the metadata
+* The **target account's address**: the account receiving the metadata, whose signature is required
+* A **scoped metadata key**: a 64-bit value chosen by the metadata creator
+
+    The SDK provides a <dy:Metadata.metadataGenerateKey> helper function that generates this key from a
+    human-readable string using SHA3-256 hashing.
+    This approach makes keys more meaningful and reduces the chance of collisions.
+
 {{ tutorial.code_snippet(['py:87:90', 'js:85:88']) }}
-
-Each metadata entry is uniquely identified by the signer's address, the target account's address, and a
-**scoped metadata key**: a 64-bit value chosen by the metadata creator.
-
-The SDK provides a <dy:Metadata.metadataGenerateKey> helper function that generates a key from a
-human-readable string using SHA3-256 hashing.
-This approach makes keys more meaningful and reduces the chance of collisions.
 
 In this example, the key is derived from the string `username`.
 For demonstration purposes, a timestamp is appended to the key string,
 so each time the code is executed a new entry is added to the account.
 In practice, you would use a fixed key that identifies the specific metadata entry you want to create or update.
 
-The metadata value can be any byte sequence.
+The metadata value can be any sequence of up to 1024 bytes.
 In this example, the value is the string `alice` encoded in UTF-8.
+
+!!! note "Multiple entries with the same key"
+
+    The key is only one of the 3 parts that identify a metadata entry,
+    so a change in any part produces a different entry.
+
+    For example, different accounts can use the same scoped metadata key on the same target account without conflict,
+    because the signer's address is different.
+
+    Each entry is independent and can only be updated by the account that originally created it.
 
 ### Creating the Embedded Account Metadata Transaction
 
@@ -132,9 +145,9 @@ The code adds the embedded account metadata transaction to an <aggregate transac
 Since the signer is modifying their own account, no <cosignatures:> are required and the aggregate can be created as
 <complete aggregate transaction:|complete>, allowing it to be signed and announced immediately.
 
-!!! note "Adding metadata to a different account"
+!!! note "Adding metadata by a different account"
 
-    If the target account is different from the signer, the target must cosign the aggregate transaction to approve the
+    If the signer is different from the account owner, the owner must cosign the aggregate transaction to approve the
     metadata entry.
 
     For details on collecting cosignatures on-chain, see the [Bonded Aggregate](../transactions/bonded-aggregate.md)
@@ -151,14 +164,17 @@ The aggregate transaction is signed and announced following the same process as 
 
 {{ tutorial.code_snippet(['py:132:149', 'js:133:150']) }}
 
-Updating an existing metadata entry requires the current value from the network.
+To retrieve the current value of a metadata entry, the code uses the <get:/metadata> endpoint
+with filters for `sourceAddress`, `targetAddress`, `scopedMetadataKey`, and `metadataType`
+(`0` for account metadata).
 
-The code queries the <get:/metadata> endpoint with filters for `sourceAddress`, `targetAddress`,
-`scopedMetadataKey`, and `metadataType` (`0` for account metadata) to retrieve the specific entry.
+The endpoint returns the list of entries matching the filters, which in this case contains a single item.
 
 ### Modifying Existing Metadata
 
 {{ tutorial.code_snippet(['py:151:165', 'js:152:167']) }}
+
+Updating an existing metadata entry requires the current value, retrieved from the network as previously shown.
 
 To demonstrate updating metadata, the code changes the username from `alice` to `bob` by creating another
 `account_metadata_transaction_v1` transaction with the same scoped metadata key.

--- a/mkdocs/pages/en/devbook/accounts/account-metadata.md
+++ b/mkdocs/pages/en/devbook/accounts/account-metadata.md
@@ -145,9 +145,9 @@ The code adds the embedded account metadata transaction to an <aggregate transac
 Since the signer is modifying their own account, no <cosignatures:> are required and the aggregate can be created as
 <complete aggregate transaction:|complete>, allowing it to be signed and announced immediately.
 
-!!! note "Adding metadata by a different account"
+!!! note "Adding metadata to a different account"
 
-    If the signer is different from the account owner, the owner must cosign the aggregate transaction to approve the
+    If the target account is different from the signer, the target must cosign the aggregate transaction to approve the
     metadata entry.
 
     For details on collecting cosignatures on-chain, see the [Bonded Aggregate](../transactions/bonded-aggregate.md)

--- a/mkdocs/pages/en/devbook/accounts/account-restrictions.md
+++ b/mkdocs/pages/en/devbook/accounts/account-restrictions.md
@@ -219,7 +219,8 @@ The output shown below corresponds to two typical runs of the program.
     - **Line 9** (`Response: [ ... ]`): Existing restrictions are detected.
     - **Line 21** (`restriction_flags`): Same flag value used when enabling the restriction.
     - **Line 23-25** (`restriction_deletions`): The previously configured address is removed.
-    - **Line 44** (`test transfer confirmed`): The transfer is confirmed successfully because the restriction has been lifted.
+    - **Line 44** (`test transfer confirmed`): The transfer is confirmed successfully because the restriction has been
+        lifted.
 
 The transaction hashes shown in the output can be used to look up the transactions in the
 [Symbol Testnet Explorer](https://testnet.symbol.fyi/).

--- a/mkdocs/pages/en/devbook/accounts/configure-multisig.md
+++ b/mkdocs/pages/en/devbook/accounts/configure-multisig.md
@@ -239,8 +239,10 @@ The output shown below corresponds to two typical runs of the program.
 
     - **Lines 2-4**: Addresses and public keys of all involved accounts.
     - **Line 10** (`Response: No cosignatories`): No cosignatories are currently configured.
-    - **Line 27** (`"min_approval_delta": 1`): The number of required signatures to approve transactions will be increased by one.
-    - **Line 28** (`"min_removal_delta": 1`): The number of required signatures to remove a cosignatory will be increased by one.
+    - **Line 27** (`"min_approval_delta": 1`): The number of required signatures to approve transactions will be
+        increased by one.
+    - **Line 28** (`"min_removal_delta": 1`): The number of required signatures to remove a cosignatory will be
+        increased by one.
     - **Line 29** (`"address_additions"`): List of addresses that will be added as cosignatories.
 
 === ":material-minus-thick: Disabling the Multisig"

--- a/mkdocs/pages/en/devbook/accounts/sign-multisig.md
+++ b/mkdocs/pages/en/devbook/accounts/sign-multisig.md
@@ -125,7 +125,8 @@ Finally, the aggregate transaction is signed by the cosignatory:
     In that case, they are attached using <dy:SymbolFacade.cosignTransaction> instead of
     <dy:SymbolFacade.signTransaction>.
 
-    See the [Configuring a Multisignature Account](./configure-multisig.md#enabling-the-multisig) tutorial for an example.
+    See the [Configuring a Multisignature Account](./configure-multisig.md#enabling-the-multisig) tutorial for an
+    example.
 
 ### Submitting the Aggregate Transaction
 

--- a/mkdocs/pages/en/devbook/mosaics/modify-mosaic-definition.md
+++ b/mkdocs/pages/en/devbook/mosaics/modify-mosaic-definition.md
@@ -126,14 +126,14 @@ duration.
 The modification transaction is signed and announced following the same process as in
 [Creating a Transfer Transaction](../transactions/transfer.md#announcing-the-transaction).
 
-{{ tutorial.code_snippet(['py:88:106', 'js:87:124']) }}
+{{ tutorial.code_snippet(['py:88:106', 'js:87:121']) }}
 
 The code then waits for the transaction to be confirmed by polling the <get:/transactionStatus/{hash}> endpoint
 until the status changes to `confirmed`.
 
 ### Retrieving the Mosaic
 
-{{ tutorial.code_snippet(['py:108:121', 'js:126:139']) }}
+{{ tutorial.code_snippet(['py:108:121', 'js:123:136']) }}
 
 To verify the modification was applied, the code retrieves the mosaic from the network using the
 <get:/mosaics/{mosaicId}> endpoint and displays its updated properties.

--- a/mkdocs/pages/en/devbook/namespaces/extend-root-namespace.md
+++ b/mkdocs/pages/en/devbook/namespaces/extend-root-namespace.md
@@ -12,9 +12,9 @@ This tutorial shows how to extend a root namespace.
 
 ## Prerequisites
 
-- An <account:> that owns an active root namespace.
+* An <account:> that owns an active root namespace.
     See [Registering a Root Namespace](./register-root-namespace.md).
-- <XYM:> to pay for the transaction and lease fees.
+* <XYM:> to pay for the transaction and lease fees.
 
 ## When to Extend
 

--- a/mkdocs/pages/en/devbook/namespaces/extend-root-namespace.md
+++ b/mkdocs/pages/en/devbook/namespaces/extend-root-namespace.md
@@ -23,8 +23,9 @@ You can extend a namespace in two situations:
 * **While active:** The specified duration is added to the current lease,
     pushing the expiration date further into the future.
 
-* **During the grace period:** The namespace has expired but is still within the [grace period](../../textbook/namespaces.md#duration),
-    extending it restores the namespace to active status immediately.
+* **During the grace period:** The namespace has expired but is still within the
+    [grace period](../../textbook/namespaces.md#duration), extending it restores the namespace to active status
+    immediately.
 
 !!! note "Extending Subnamespaces"
 

--- a/mkdocs/pages/en/devbook/namespaces/link-namespace-to-address.md
+++ b/mkdocs/pages/en/devbook/namespaces/link-namespace-to-address.md
@@ -97,7 +97,8 @@ The address alias transaction specifies:
     To unlink a namespace from an address, announce another `address_alias_transaction_v1` transaction with the same
     namespace ID and address, but set the `alias_action` field to `unlink`.
 
-    The unlinking process does not remove the namespace itself, only the association between the namespace and the address.
+    The unlinking process does not remove the namespace itself, only the association between the namespace and the
+    address.
     After unlinking, the namespace can be linked to a different address or mosaic.
 
 ### Submitting the Transaction

--- a/mkdocs/pages/en/devbook/namespaces/namespace-metadata.md
+++ b/mkdocs/pages/en/devbook/namespaces/namespace-metadata.md
@@ -8,7 +8,8 @@ title: Add Namespace Metadata
 
 This tutorial shows how to add metadata to a namespace, retrieve it from the network, and update existing values.
 
-In this example, the pair `description = My first namespace` is attached to a namespace and then changed to `Updated namespace`:
+In this example, the pair `description = My first namespace` is attached to a namespace and then changed to
+`Updated namespace`:
 
 ```dot
 digraph {
@@ -124,7 +125,7 @@ This prevents unwanted metadata from being attached to a namespace without its o
 
 In this tutorial, the signer is also the namespace owner so only one signature is needed.
 However, the transaction still needs to be inside an aggregate,
-so the code defines the mosaic metadata transaction as an <embedded transaction:> with these properties:
+so the code defines the namespace metadata transaction as an <embedded transaction:> with these properties:
 
 * **Type:** Use `namespace_metadata_transaction_v1`.
 

--- a/mkdocs/pages/en/devbook/namespaces/register-root-namespace.md
+++ b/mkdocs/pages/en/devbook/namespaces/register-root-namespace.md
@@ -7,7 +7,8 @@ title: Register Root Namespace
 <Namespaces:|Namespaces> provide human-readable aliases for <accounts:> and <mosaics:>,
 which can be used instead of long addresses and hexadecimal mosaic IDs.
 
-This tutorial shows how to register a <root namespace:> and set its lease [duration](../../textbook/namespaces.md#duration).
+This tutorial shows how to register a <root namespace:> and set its lease
+[duration](../../textbook/namespaces.md#duration).
 
 Once registered, additional steps are required to link the namespace to a mosaic or account,
 as explained in [Next Steps](#next-steps).
@@ -163,6 +164,7 @@ This tutorial showed how to:
 
 Now that you have a root namespace, you can:
 
-* [Link your namespace to a mosaic](./link-namespace-to-mosaic.md) or [to an account](./link-namespace-to-address.md) to create an alias
+* [Link your namespace to a mosaic](./link-namespace-to-mosaic.md) or [to an account](./link-namespace-to-address.md)
+    to create an alias
 * [Register a subnamespace](./register-subnamespace.md) to create a hierarchical structure
 * [Extend the namespace](./extend-root-namespace.md) before it expires to keep it active

--- a/mkdocs/pages/en/devbook/namespaces/register-subnamespace.md
+++ b/mkdocs/pages/en/devbook/namespaces/register-subnamespace.md
@@ -15,16 +15,16 @@ as explained in [Next Steps](#next-steps).
 
 Before you start, make sure to:
 
-- Set up your development environment.
+* Set up your development environment.
   See [Setting Up a Development Environment](../start/setup.md).
-- Have an <account:> with an existing root namespace.
+* Have an <account:> with an existing root namespace.
   See [Registering a Root Namespace](./register-root-namespace.md).
 
     !!! note
         The examples in this tutorial use a root namespace named `ns_root`.
         Make sure to update the code to use your own root namespace name.
 
-- Obtain <XYM:> to pay for the transaction and lease fees.
+* Obtain <XYM:> to pay for the transaction and lease fees.
   See [Getting Testnet Funds from the Faucet](../accounts/testnet-faucet.md).
 
 Additionally, review the [Transfer transaction](../transactions/transfer.md) tutorial to understand how
@@ -144,7 +144,6 @@ Some highlights from the output:
 The transaction hash printed in the output can also be used to search for the transaction
 in the [Symbol Testnet Explorer](https://testnet.symbol.fyi/).
 
-
 ## Conclusion
 
 This tutorial showed how to:
@@ -159,6 +158,6 @@ This tutorial showed how to:
 
 Now that you have a subnamespace, you can:
 
-- Register additional subnamespaces to expand your hierarchical structure
-- [Link your namespace to a mosaic](./link-namespace-to-mosaic.md) or
+* Register additional subnamespaces to expand your hierarchical structure
+* [Link your namespace to a mosaic](./link-namespace-to-mosaic.md) or
     [to an account](./link-namespace-to-address.md) to create an alias

--- a/mkdocs/pages/en/devbook/namespaces/register-subnamespace.md
+++ b/mkdocs/pages/en/devbook/namespaces/register-subnamespace.md
@@ -149,15 +149,16 @@ in the [Symbol Testnet Explorer](https://testnet.symbol.fyi/).
 
 This tutorial showed how to:
 
-| Step                                                           | Related documentation                 |
-| -------------------------------------------------------------- | ------------------------------------- |
-| [Generate namespace ID](#building-the-transaction)             | <dy:IdGenerator.generateNamespaceId>  |
+| Step                                                                       | Related documentation                 |
+| -------------------------------------------------------------------------  | ------------------------------------- |
+| [Generate namespace ID](#building-the-transaction)                         | <dy:IdGenerator.generateNamespaceId>  |
 | [Build a subnamespace registration transaction](#building-the-transaction) | <dy:SymbolTransactionFactory.create>  |
-| [Retrieve the subnamespace](#retrieving-the-subnamespace)      | <get:/namespaces/{namespaceId}>       |
+| [Retrieve the subnamespace](#retrieving-the-subnamespace)                  | <get:/namespaces/{namespaceId}>       |
 
 ## Next Steps
 
 Now that you have a subnamespace, you can:
 
 - Register additional subnamespaces to expand your hierarchical structure
-- [Link your namespace to a mosaic](./link-namespace-to-mosaic.md) or [to an account](./link-namespace-to-address.md) to create an alias
+- [Link your namespace to a mosaic](./link-namespace-to-mosaic.md) or
+    [to an account](./link-namespace-to-address.md) to create an alias

--- a/mkdocs/pages/en/devbook/start/hello-world.md
+++ b/mkdocs/pages/en/devbook/start/hello-world.md
@@ -1,6 +1,7 @@
 # Hello World
 
-This tutorial shows how to verify that your Symbol SDK installation is working correctly by writing a minimal program that:
+This tutorial shows how to verify that your Symbol SDK installation is working correctly by writing a minimal program
+that:
 
 * Retrieves the network name and launch date using the SDK.
 * Connects to a <node:> and prints the current blockchain height.

--- a/mkdocs/pages/en/devbook/transactions/bonded-aggregate.md
+++ b/mkdocs/pages/en/devbook/transactions/bonded-aggregate.md
@@ -300,15 +300,15 @@ Key points in the output:
 * **Line 18** (`"transactions"`): Contains the two embedded transfers that will execute atomically.
 * **Line 48** (`"cosignatures": []`): Initially empty. Cosignatures are submitted on-chain after announcement.
 * **Line 51** (`Bonded aggregate transaction hash:`): The hash of the bonded aggregate, required for creating the hash
-  lock and announcing the transaction.
+    lock and announcing the transaction.
 * **Line 54** (`Announcing Hash lock to /transactions`): A hash lock must be announced and confirmed before the bonded
-  aggregate.
+    aggregate.
 * **Line 63** (`Announcing Bonded aggregate transaction to /transactions/partial`): Bonded aggregates use a different
-  endpoint than regular transactions.
+    endpoint than regular transactions.
 * **Line 67** (`Bonded aggregate transaction partial in 1 seconds`): The bonded aggregate is now waiting for
-  cosignatures to be submitted on-chain.
+    cosignatures to be submitted on-chain.
 * **Line 71** (`[Account B] Verifying transaction: 2 embedded transactions`): Account B inspects the transaction content
-  before cosigning to ensure they agree with all operations.
+    before cosigning to ensure they agree with all operations.
 * **Line 73** (`Announcing cosignature to /transactions/cosignature`): The cosignature is submitted to the network.
 
 The aggregate transaction is treated as a single atomic unit by the network.

--- a/mkdocs/pages/en/devbook/transactions/bonded-aggregate.md
+++ b/mkdocs/pages/en/devbook/transactions/bonded-aggregate.md
@@ -268,7 +268,8 @@ The resulting detached cosignature payload includes:
 * **Signature:** The cryptographic signature computed from the transaction hash and Account B's private key.
 * **Parent hash:** The hash of the bonded transaction being cosigned.
 
-The cosignature payload is submitted using the `announce_transaction` helper function to <put:/transactions/cosignature>.
+The cosignature payload is submitted using the `announce_transaction` helper function to
+<put:/transactions/cosignature>.
 The network validates the cosignature and attaches it to the partial transaction.
 
 Once enough cosignatures are collected to satisfy all embedded transactions,
@@ -298,15 +299,16 @@ Key points in the output:
 * **Line 14** (`"type": 16961`): Indicates this is an `aggregate_bonded_transaction_v3`.
 * **Line 18** (`"transactions"`): Contains the two embedded transfers that will execute atomically.
 * **Line 48** (`"cosignatures": []`): Initially empty. Cosignatures are submitted on-chain after announcement.
-* **Line 51** (`Bonded aggregate transaction hash:`): The hash of the bonded aggregate, required for creating the hash lock and
-  announcing the transaction.
-* **Line 54** (`Announcing Hash lock to /transactions`): A hash lock must be announced and confirmed before the bonded aggregate.
-* **Line 63** (`Announcing Bonded aggregate transaction to /transactions/partial`): Bonded aggregates use a different endpoint than
-  regular transactions.
-* **Line 67** (`Bonded aggregate transaction partial in 1 seconds`): The bonded aggregate is now waiting for cosignatures to be
-  submitted on-chain.
-* **Line 71** (`[Account B] Verifying transaction: 2 embedded transactions`): Account B inspects the transaction content before cosigning to
-  ensure they agree with all operations.
+* **Line 51** (`Bonded aggregate transaction hash:`): The hash of the bonded aggregate, required for creating the hash
+  lock and announcing the transaction.
+* **Line 54** (`Announcing Hash lock to /transactions`): A hash lock must be announced and confirmed before the bonded
+  aggregate.
+* **Line 63** (`Announcing Bonded aggregate transaction to /transactions/partial`): Bonded aggregates use a different
+  endpoint than regular transactions.
+* **Line 67** (`Bonded aggregate transaction partial in 1 seconds`): The bonded aggregate is now waiting for
+  cosignatures to be submitted on-chain.
+* **Line 71** (`[Account B] Verifying transaction: 2 embedded transactions`): Account B inspects the transaction content
+  before cosigning to ensure they agree with all operations.
 * **Line 73** (`Announcing cosignature to /transactions/cosignature`): The cosignature is submitted to the network.
 
 The aggregate transaction is treated as a single atomic unit by the network.

--- a/mkdocs/pages/en/devbook/transactions/complete-aggregate.md
+++ b/mkdocs/pages/en/devbook/transactions/complete-aggregate.md
@@ -242,12 +242,13 @@ Key points in the output:
 * **Line 14** (`"type": 16705`): Indicates this is an `aggregate_complete_transaction_v3`.
 * **Line 18** (`"transactions"`): Contains the two embedded transfers that will execute atomically.
 * **Line 48** (`"cosignatures": []`): Initially empty. Account B's cosignature is added before announcement.
-  Note how Account A's signature is only needed once, even though it appears as signer in both the aggregate and the
-  first embedded transaction.
-* **Line 53** (`"payload": "6801..."`): The transaction payload computed from the aggregate transaction and its embedded transactions.
+    Note how Account A's signature is only needed once, even though it appears as signer in both the aggregate and the
+    first embedded transaction.
+* **Line 53** (`"payload": "6801..."`): The transaction payload computed from the aggregate transaction and its embedded
+    transactions.
 * **Line 60** (`"signature": "7037..."`): Account B's cosignature for the aggregate transaction.
-* **Line 66** (`Waiting for confirmation ...`): The hash shown in the confirmation check can be used to search for the transaction
-  in the [Symbol Testnet Explorer](https://testnet.symbol.fyi/).
+* **Line 66** (`Waiting for confirmation ...`): The hash shown in the confirmation check can be used to search for the
+    transaction in the [Symbol Testnet Explorer](https://testnet.symbol.fyi/).
 
 The aggregate transaction is treated as a single atomic unit by the network.
 The swap executes completely: Account A receives the custom mosaic and Account B receives the XYM,

--- a/mkdocs/pages/en/devbook/transactions/fee-sponsorship.md
+++ b/mkdocs/pages/en/devbook/transactions/fee-sponsorship.md
@@ -70,8 +70,8 @@ To ensure that the funds cannot misused, both the prefund transfer and the messa
 <aggregate transaction:>.
 The aggregate is signed by both the application account and the user, and announced by the latter.
 
-**Transaction fees are deducted after all embedded transactions are executed**, which makes the prefunded amount available
-to the message sender for paying all transaction fees.
+**Transaction fees are deducted after all embedded transactions are executed**, which makes the prefunded amount
+available to the message sender for paying all transaction fees.
 
 Note that the prefund amount must be sufficient to cover both embedded transactions' fees,
 and that the order of the embedded transactions does not matter in this case.
@@ -130,7 +130,8 @@ The sender of this transaction is the application account, and the recipient is 
 
 ### Aggregate Transaction
 
-The <complete aggregate transaction:> is built as usual, and its `fee` field is updated once the transaction size is known.
+The <complete aggregate transaction:> is built as usual, and its `fee` field is updated once the transaction size is
+known.
 
 The prefund transaction's amount is then set to match the calculated fee.
 
@@ -140,8 +141,8 @@ case it must be updated afterwards, once the prefund transaction has been modifi
 
 !!! caution
 
-    As shown in the code, when setting the `transactions_hash` field, use the model-specific type `sc.Hash256` (:simple-python:)
-    or `models.Hash256` (:simple-javascript:), and not the generic cryptography type `Hash256`.
+    As shown in the code, when setting the `transactions_hash` field, use the model-specific type `sc.Hash256`
+    (:simple-python:) or `models.Hash256` (:simple-javascript:), and not the generic cryptography type `Hash256`.
 
 {{ tutorial.code_snippet(['py:40:55', 'js:36:55']) }}
 

--- a/mkdocs/pages/en/devbook/transactions/messages.md
+++ b/mkdocs/pages/en/devbook/transactions/messages.md
@@ -15,13 +15,13 @@ This tutorial shows how to send both plain and encrypted messages and how to dec
 
 Before you start, make sure to:
 
-- Set up your development environment.
-  See [Setting Up a Development Environment](../start/setup.md).
-- Create an <account:> to send the transfer transaction, either
-  [from code](../accounts/create-from-private-key.md) or
-  [by using a wallet](../../userbook/wallet/create-account.md).
-- Obtain <XYM:> to pay for the transaction fee.
-  See [Getting Testnet Funds from the Faucet](../accounts/testnet-faucet.md).
+* Set up your development environment.
+    See [Setting Up a Development Environment](../start/setup.md).
+* Create an <account:> to send the transfer transaction, either
+    [from code](../accounts/create-from-private-key.md) or
+    [by using a wallet](../../userbook/wallet/create-account.md).
+* Obtain <XYM:> to pay for the transaction fee.
+    See [Getting Testnet Funds from the Faucet](../accounts/testnet-faucet.md).
 
 Additionally, check the [Transfer transaction](./transfer.md) tutorial to understand how fee
 calculation, network time, and transaction confirmation work.

--- a/mkdocs/pages/en/devbook/transactions/messages.md
+++ b/mkdocs/pages/en/devbook/transactions/messages.md
@@ -4,8 +4,8 @@ title: Messages
 
 # Sending Messages with Transfer Transactions
 
-<Transfer transactions:|Transfer transactions> can include an optional message field, which allows attaching up to 1,024 bytes of data to the
-transaction.
+<Transfer transactions:|Transfer transactions> can include an optional message field, which allows attaching up to 1,024
+bytes of data to the transaction.
 Messages can be sent as plain text or encrypted using the recipient's public key, ensuring only the intended recipient
 can read them.
 

--- a/mkdocs/pages/en/devbook/transactions/monitoring-status.md
+++ b/mkdocs/pages/en/devbook/transactions/monitoring-status.md
@@ -110,7 +110,8 @@ If the endpoint returns HTTP 404, the transaction status is not yet available.
 This can happen immediately after announcing a transaction, before the <node:> processes it, or if the hash is invalid.
 The function handles this case by logging the attempt and continuing to poll.
 
-For any other error (such as connectivity issues or failed transactions), the function re-raises the exception immediately.
+For any other error (such as connectivity issues or failed transactions), the function re-raises the exception
+immediately.
 
 ### Waiting Between Attempts
 

--- a/mkdocs/pages/en/devbook/transactions/transfer.md
+++ b/mkdocs/pages/en/devbook/transactions/transfer.md
@@ -16,13 +16,13 @@ up-to-date values.
 
 Before you start, make sure to:
 
-- Set up your development environment.
-  See [Setting Up a Development Environment](../start/setup.md).
-- Create an <account:> to send the transfer transaction, either
-  [from code](../accounts/create-from-private-key.md) or
-  [by using a wallet](../../userbook/wallet/create-account.md).
-- Obtain <XYM:> to pay for the transaction fee and transfer amount.
-  See [Getting Testnet Funds from the Faucet](../accounts/testnet-faucet.md).
+* Set up your development environment.
+    See [Setting Up a Development Environment](../start/setup.md).
+* Create an <account:> to send the transfer transaction, either
+    [from code](../accounts/create-from-private-key.md) or
+    [by using a wallet](../../userbook/wallet/create-account.md).
+* Obtain <XYM:> to pay for the transaction fee and transfer amount.
+    See [Getting Testnet Funds from the Faucet](../accounts/testnet-faucet.md).
 
 ## Full Code
 

--- a/mkdocs/pages/en/devbook/transactions/transfer.md
+++ b/mkdocs/pages/en/devbook/transactions/transfer.md
@@ -159,8 +159,8 @@ Signing ensures the transaction is authentic and authorized by the sender.
 
 <dy:SymbolFacade.signTransaction> returns a <signature:> encoded as a hexadecimal string.
 
-<dy:SymbolTransactionFactory.attachSignature> adds the signature to the transaction and serializes it into a JSON payload
-ready to be submitted directly to a node for announcement.
+<dy:SymbolTransactionFactory.attachSignature> adds the signature to the transaction and serializes it into a
+JSON payload ready to be submitted directly to a node for announcement.
 
 ### Announcing the Transaction
 
@@ -188,7 +188,8 @@ as shown in the next step.
     In addition, the logic for checking transaction status is reusable.
     It can be moved into a utility function or module, since it is needed after announcing every transaction.
 
-The snippet above repeatedly queries the <get:/transactionStatus/{hash}> endpoint using the hash of the submitted transaction.
+The snippet above repeatedly queries the <get:/transactionStatus/{hash}> endpoint using the hash of the submitted
+transaction.
 The response may take one of several forms:
 
 * An HTTP error, indicating that the node has not yet started processing the transaction.

--- a/mkdocs/pages/en/devbook/transactions/typed-descriptors.md
+++ b/mkdocs/pages/en/devbook/transactions/typed-descriptors.md
@@ -29,7 +29,8 @@ The rest of the process, including signing and announcing the transaction, remai
 
 ## Creation Process
 
-Transactions are created in a type-safe manner in two steps: creating a transaction descriptor and creating the transaction itself.
+Transactions are created in a type-safe manner in two steps: creating a transaction descriptor and creating the
+transaction itself.
 
 ### Creating the Descriptor
 
@@ -54,23 +55,26 @@ Whenever one such descriptor is available, tutorials will link to both the relev
     --8<-- "devbook/transactions/transfer.typed.mjs:53:55"
     ```
 
-Once the descriptor is ready, creating the transaction is straightforward: it simply involves passing the descriptor to the
-<js:SymbolFacade.createTransactionFromTypedDescriptor> method and provide the desired fees and deadline.
+Once the descriptor is ready, creating the transaction is straightforward: it simply involves passing the descriptor to
+the <js:SymbolFacade.createTransactionFromTypedDescriptor> method and provide the desired fees and deadline.
 
 Note that, as in the [Creating a Transfer Transaction](./transfer.md#building-the-transaction) tutorial,
 the transaction's fee must be calculated after construction because it depends on the transaction's size.
 
 !!! warning "Deadlines are provided differently in the typed and untyped versions"
 
-    Deadlines passed to <js:SymbolTransactionFactory.create> are specified in milliseconds and are relative to the _network time_.
+    Deadlines passed to <js:SymbolTransactionFactory.create> are specified in milliseconds and are relative to the
+    _network time_.
     In contrast, deadlines passed to <js:SymbolFacade.createTransactionFromTypedDescriptor> are specified in seconds
     and are relative to the _system time_, that is, the local clock of the machine running the code.
 
     This approach is convenient because it removes the need to fetch the current network time: for example,
-    to make a transaction expire in two hours, you only need to provide a deadline of `#!js 2 * 60 * 60` seconds as in the code above.
+    to make a transaction expire in two hours, you only need to provide a deadline of `#!js 2 * 60 * 60` seconds as in
+    the code above.
 
     However, if the system clock is not properly synchronized with the network time, transactions may expire earlier
-    than expected, or be rejected entirely if the provided deadline exceeds the network's maximum allowed offset of 2 hours.
+    than expected, or be rejected entirely if the provided deadline exceeds the network's maximum allowed offset of 2
+    hours.
 
     **Therefore, applications using the type-safe method should periodically check the network time to ensure the
     system clock is properly synchronized.**


### PR DESCRIPTION
Addresses some improvements added in the namespaces and mosaic metadata tutorials back to the account metadata tutorial: https://github.com/symbol/symbol/pull/1854

Additionally, makes sure tutorial lines lenght are 120 chars or less.