### PR TITLE
[mkdocs] fix: add source address back to metadata tutorials

### DIFF
--- a/mkdocs/overrides/devbook/mosaics/mosaic-metadata.log
+++ b/mkdocs/overrides/devbook/mosaics/mosaic-metadata.log
@@ -32,7 +32,7 @@ Waiting for aggregate transaction confirmation...
 aggregate transaction confirmed in 21 seconds
 
 --- Modifying existing metadata ---
-Fetching current metadata from /metadata?targetAddress=TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I&scopedMetadataKey=DA51DFDE6A4AD5E7&targetId=6D1314BE751B62C2&metadataType=1
+Fetching current metadata from /metadata?sourceAddress=TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I&targetAddress=TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I&scopedMetadataKey=DA51DFDE6A4AD5E7&targetId=6D1314BE751B62C2&metadataType=1
   Current value: My first mosaic
 Created embedded update transaction:
 {

--- a/mkdocs/overrides/devbook/mosaics/mosaic-metadata.mjs
+++ b/mkdocs/overrides/devbook/mosaics/mosaic-metadata.mjs
@@ -143,7 +143,8 @@ try {
 	const mosaicIdHex = mosaicId.toString(16)
 		.toUpperCase().padStart(16, '0');
 	const metadataPath = `/metadata`
-		+ `?targetAddress=${signerAddress}`
+		+ `?sourceAddress=${signerAddress}`
+		+ `&targetAddress=${signerAddress}`
 		+ `&scopedMetadataKey=${scopedKeyHex}`
 		+ `&targetId=${mosaicIdHex}`
 		+ '&metadataType=1';

--- a/mkdocs/overrides/devbook/mosaics/mosaic-metadata.py
+++ b/mkdocs/overrides/devbook/mosaics/mosaic-metadata.py
@@ -137,7 +137,8 @@ try:
 
 	# Fetch current metadata value from network
 	metadata_path = (
-		f'/metadata?targetAddress={signer_address}'
+		f'/metadata?sourceAddress={signer_address}'
+		f'&targetAddress={signer_address}'
 		f'&scopedMetadataKey={scoped_metadata_key:016X}'
 		f'&targetId={mosaic_id:016X}'
 		'&metadataType=1'

--- a/mkdocs/overrides/devbook/namespaces/namespace-metadata.log
+++ b/mkdocs/overrides/devbook/namespaces/namespace-metadata.log
@@ -33,7 +33,7 @@ Waiting for aggregate transaction confirmation...
 aggregate transaction confirmed in 20 seconds
 
 --- Modifying existing metadata ---
-Fetching current metadata from /metadata?targetAddress=TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I&scopedMetadataKey=CCE09B9D6EE43489&targetId=B53912EB77DDEF7C&metadataType=2
+Fetching current metadata from /metadata?sourceAddress=TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I&targetAddress=TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I&scopedMetadataKey=CCE09B9D6EE43489&targetId=B53912EB77DDEF7C&metadataType=2
   Current value: My first namespace
 Created embedded update transaction:
 {

--- a/mkdocs/overrides/devbook/namespaces/namespace-metadata.mjs
+++ b/mkdocs/overrides/devbook/namespaces/namespace-metadata.mjs
@@ -145,7 +145,8 @@ try {
 	const namespaceIdHex = namespaceId.toString(16)
 		.toUpperCase().padStart(16, '0');
 	const metadataPath = `/metadata`
-		+ `?targetAddress=${signerAddress}`
+		+ `?sourceAddress=${signerAddress}`
+		+ `&targetAddress=${signerAddress}`
 		+ `&scopedMetadataKey=${scopedKeyHex}`
 		+ `&targetId=${namespaceIdHex}`
 		+ '&metadataType=2';

--- a/mkdocs/overrides/devbook/namespaces/namespace-metadata.py
+++ b/mkdocs/overrides/devbook/namespaces/namespace-metadata.py
@@ -139,7 +139,8 @@ try:
 
 	# Fetch current metadata value from network
 	metadata_path = (
-		f'/metadata?targetAddress={signer_address}'
+		f'/metadata?sourceAddress={signer_address}'
+		f'&targetAddress={signer_address}'
 		f'&scopedMetadataKey={scoped_metadata_key:016X}'
 		f'&targetId={namespace_id:016X}'
 		'&metadataType=2'

--- a/mkdocs/pages/en/devbook/mosaics/mosaic-metadata.md
+++ b/mkdocs/pages/en/devbook/mosaics/mosaic-metadata.md
@@ -171,17 +171,17 @@ The aggregate transaction is signed and announced following the same process as 
 
 ### Retrieving Metadata
 
-{{ tutorial.code_snippet(['py:138:155', 'js:140:160']) }}
+{{ tutorial.code_snippet(['py:138:156', 'js:140:161']) }}
 
 To retrieve the current value of a metadata entry, the code uses the <get:/metadata> endpoint
-with filters for `targetAddress`, `scopedMetadataKey`, `targetId` (the mosaic ID), and `metadataType`
-(`1` for mosaic metadata).
+with filters for `sourceAddress`, `targetAddress`, `scopedMetadataKey`, `targetId` (the mosaic ID), and
+`metadataType` (`1` for mosaic metadata).
 
 The endpoint returns the list of entries matching the filters, which in this case contains a single item.
 
 ### Modifying Existing Metadata
 
-{{ tutorial.code_snippet(['py:157:174', 'js:162:180']) }}
+{{ tutorial.code_snippet(['py:158:175', 'js:163:181']) }}
 
 Updating an existing metadata entry requires the current value, retrieved from the network as previously shown.
 
@@ -211,7 +211,7 @@ not the length of the XOR'd bytes themselves.
 As with the [initial metadata creation](#building-the-aggregate-transaction), this metadata modification is wrapped
 in an aggregate transaction and then signed and announced.
 
-{{ tutorial.code_snippet(['py:176:198', 'js:182:210']) }}
+{{ tutorial.code_snippet(['py:177:199', 'js:183:211']) }}
 
 ## Output
 

--- a/mkdocs/pages/en/devbook/mosaics/mosaic-metadata.md
+++ b/mkdocs/pages/en/devbook/mosaics/mosaic-metadata.md
@@ -211,7 +211,7 @@ not the length of the XOR'd bytes themselves.
 As with the [initial metadata creation](#building-the-aggregate-transaction), this metadata modification is wrapped
 in an aggregate transaction and then signed and announced.
 
-{{ tutorial.code_snippet(['py:177:199', 'js:183:211']) }}
+{{ tutorial.code_snippet(['py:177:199', 'js:183:208']) }}
 
 ## Output
 

--- a/mkdocs/pages/en/devbook/namespaces/namespace-metadata.md
+++ b/mkdocs/pages/en/devbook/namespaces/namespace-metadata.md
@@ -171,17 +171,17 @@ The aggregate transaction is signed and announced following the same process as 
 
 ### Retrieving Metadata
 
-{{ tutorial.code_snippet(['py:140:157', 'js:142:162']) }}
+{{ tutorial.code_snippet(['py:140:158', 'js:142:163']) }}
 
 To retrieve the current value of a metadata entry, the code uses the <get:/metadata> endpoint
-with filters for `targetAddress`, `scopedMetadataKey`, `targetId` (the namespace ID), and `metadataType`
-(`2` for namespace metadata).
+with filters for `sourceAddress`, `targetAddress`, `scopedMetadataKey`, `targetId` (the namespace ID), and
+`metadataType` (`2` for namespace metadata).
 
 The endpoint returns the list of entries matching the filters, which in this case contains a single item.
 
 ### Modifying Existing Metadata
 
-{{ tutorial.code_snippet(['py:159:176', 'js:164:182']) }}
+{{ tutorial.code_snippet(['py:160:177', 'js:165:183']) }}
 
 Updating an existing metadata entry requires the current value, retrieved from the network as previously shown.
 
@@ -211,7 +211,7 @@ not the length of the XOR'd bytes themselves.
 As with the [initial metadata creation](#building-the-aggregate-transaction), this metadata modification is wrapped
 in an aggregate transaction and then signed and announced.
 
-{{ tutorial.code_snippet(['py:178:200', 'js:184:209']) }}
+{{ tutorial.code_snippet(['py:179:201', 'js:185:210']) }}
 
 ## Output
 


### PR DESCRIPTION
Addresses this comment https://github.com/symbol/symbol/pull/1872#issuecomment-3954220016