### PR TITLE
[mkdocs] docs: add chain and finalization height tutorial

### DIFF
--- a/mkdocs/config/mkdocs.en.yml
+++ b/mkdocs/config/mkdocs.en.yml
@@ -100,6 +100,8 @@ nav:
               - devbook/mosaics/change-mosaic-supply.md
               - devbook/mosaics/modify-mosaic-definition.md
               - devbook/mosaics/mosaic-metadata.md
+          - Chain State:
+              - devbook/chain/chain-heights.md
       - Reference Guides:
           - Python SDK: devbook/reference/py/
           - TypeScript SDK: devbook/reference/ts/

--- a/mkdocs/overrides/devbook/chain/chain-heights.log
+++ b/mkdocs/overrides/devbook/chain/chain-heights.log
@@ -1,0 +1,8 @@
+Using node https://reference.symboltest.net:3001
+Height:  3,159,411  (changed -)  |  Finalized:  3,159,388  (changed -)
+Height:  3,159,411  (changed -)  |  Finalized:  3,159,388  (changed -)
+Height:  3,159,411  (changed -)  |  Finalized:  3,159,388  (changed -)
+Height:  3,159,412  (changed 0s ago)  |  Finalized:  3,159,388  (changed -)
+Height:  3,159,412  (changed 1s ago)  |  Finalized:  3,159,388  (changed -)
+Height:  3,159,412  (changed 2s ago)  |  Finalized:  3,159,411  (changed 0s ago)
+Height:  3,159,412  (changed 3s ago)  |  Finalized:  3,159,411  (changed 1s ago)

--- a/mkdocs/overrides/devbook/chain/chain-heights.mjs
+++ b/mkdocs/overrides/devbook/chain/chain-heights.mjs
@@ -1,0 +1,53 @@
+const NODE_URL = process.env.NODE_URL ||
+	'https://reference.symboltest.net:3001';
+console.log(`Using node ${NODE_URL}`);
+
+let prevHeight = null;
+let prevFinalizedHeight = null;
+let heightChangedAt = null;
+let finalizedChangedAt = null;
+
+try {
+	while (true) {
+		const response = await fetch(`${NODE_URL}/chain/info`);
+		if (!response.ok) {
+			throw new Error(`HTTP error! status: ${response.status}`);
+		}
+		const chainInfo = await response.json();
+
+		const height = parseInt(chainInfo.height, 10);
+		const finalized = chainInfo.latestFinalizedBlock;
+		const finalizedHeight = parseInt(finalized.height, 10);
+
+		const now = Date.now();
+
+		if (prevHeight !== null && height !== prevHeight) {
+			heightChangedAt = now;
+		}
+		if (prevFinalizedHeight !== null
+			&& finalizedHeight !== prevFinalizedHeight) {
+			finalizedChangedAt = now;
+		}
+
+		const hAgo = heightChangedAt !== null
+			? `${Math.floor((now - heightChangedAt) / 1000)}s ago`
+			: '-';
+		const fAgo = finalizedChangedAt !== null
+			? `${Math.floor((now - finalizedChangedAt) / 1000)}s ago`
+			: '-';
+
+		const h = height.toLocaleString().padStart(10);
+		const fh = finalizedHeight.toLocaleString().padStart(10);
+		console.log(
+			`Height: ${h}  (changed ${hAgo})`
+			+ `  |  Finalized: ${fh}`
+			+ `  (changed ${fAgo})`
+		);
+
+		prevHeight = height;
+		prevFinalizedHeight = finalizedHeight;
+		await new Promise((resolve) => setTimeout(resolve, 1000));
+	}
+} catch (error) {
+	throw error;
+}

--- a/mkdocs/overrides/devbook/chain/chain-heights.py
+++ b/mkdocs/overrides/devbook/chain/chain-heights.py
@@ -1,0 +1,55 @@
+import json
+import os
+import time
+import urllib.request
+
+NODE_URL = os.getenv(
+	'NODE_URL', 'https://reference.symboltest.net:3001')
+print(f'Using node {NODE_URL}')
+
+prev_height = None
+prev_finalized_height = None
+height_changed_at = None
+finalized_changed_at = None
+
+try:
+	while True:
+		with urllib.request.urlopen(f'{NODE_URL}/chain/info') as response:
+			chain_info = json.loads(response.read().decode())
+
+		height = int(chain_info['height'])
+		finalized = chain_info['latestFinalizedBlock']
+		finalized_height = int(finalized['height'])
+
+		now = time.time()
+
+		if prev_height is not None and height != prev_height:
+			height_changed_at = now
+		if (
+			prev_finalized_height is not None
+			and finalized_height != prev_finalized_height
+		):
+			finalized_changed_at = now
+
+		if height_changed_at is not None:
+			h_ago = f"{int(now - height_changed_at)}s ago"
+		else:
+			h_ago = "-"
+		if finalized_changed_at is not None:
+			f_ago = f"{int(now - finalized_changed_at)}s ago"
+		else:
+			f_ago = "-"
+
+		print(
+			f"Height: {height:>10,}"
+			f"  (changed {h_ago})"
+			f"  |  Finalized: {finalized_height:>10,}"
+			f"  (changed {f_ago})"
+		)
+
+		prev_height = height
+		prev_finalized_height = finalized_height
+		time.sleep(1)
+
+except Exception as error:
+	print(error)

--- a/mkdocs/pages/en/devbook/chain/chain-heights.md
+++ b/mkdocs/pages/en/devbook/chain/chain-heights.md
@@ -1,0 +1,100 @@
+---
+title: Chain and Finalization Height
+---
+
+# Querying Chain and Finalization Height
+
+The <get:/chain/info> endpoint returns the current chain height and the latest <finalization:> height.
+Comparing both values shows how far behind the finalized state is from the chain tip, which is useful for
+applications that need to confirm transactions are irreversible.
+
+This tutorial shows how to poll chain state in a loop and display how long ago each height last changed.
+
+## Prerequisites
+
+This tutorial uses the [Symbol REST API](../reference/rest/symbol.md) without requiring an SDK.
+You only need a way to make HTTP requests.
+
+## Full Code
+
+{% import 'tutorial.jinja2' as tutorial with context %}
+
+{{ tutorial.code_full('devbook/chain/chain-heights', ['py', 'js']) }}
+
+The snippet uses the `NODE_URL` environment variable to set the Symbol API node.
+If no value is provided, a default one is used.
+
+The program runs in an infinite loop, printing a status line every second.
+A keyboard interrupt (`Ctrl+C`) stops the loop.
+
+## Code Explanation
+
+### Fetching Chain Information
+
+{{ tutorial.code_snippet(['py:17:22', 'js:12:20']) }}
+
+On each iteration, the code sends a `GET` request to the <get:/chain/info> endpoint.
+The response contains:
+
+* **height:** The current chain height (the latest <block:> known to the node).
+* **latestFinalizedBlock:** An object with details about the most recently finalized block, including:
+    * **height:** The finalized block height.
+    * **finalizationEpoch:** The finalization epoch number.
+    * **finalizationPoint:** The finalization point within the epoch.
+    * **hash:** The hash of the finalized block.
+
+The chain height increases each time a new block produced (approximately every 30 seconds).
+
+The finalized height lags behind the chain tip because a block is typically finalized 10 to 20 minutes after it is
+produced.
+When a finalization round completes, the finalized height jumps forward by many blocks at once rather than
+advancing one block at a time.
+See the [Consensus](../../textbook/consensus.md#finalization) textbook section for details on how
+<voting nodes:> drive this process.
+
+### Tracking Height Changes
+
+{{ tutorial.code_snippet(['py:26:41', 'js:24:37']) }}
+
+To show how long ago each height last changed, the code stores the previous values and their timestamps.
+When a height differs from the previous value, the timestamp is updated to the current time.
+
+Until a change is observed, the timestamp remains unset and the output displays `-` instead of a number.
+Once a change occurs, the counter starts from `0s ago` and increments each second until the next change.
+
+### Polling Loop
+
+{{ tutorial.code_snippet(['py:43:52', 'js:39:49']) }}
+
+Each iteration prints a single status line showing:
+
+* The current chain height and how many seconds since it last changed.
+* The finalized height and how many seconds since it last changed.
+
+The loop sleeps for one second between iterations.
+
+## Output
+
+The following output shows a typical run monitoring the chain and finalization heights:
+
+```text
+--8<-- 'devbook/chain/chain-heights.log'
+```
+
+The output shows:
+
+1. Both heights initially show `-` because no change has been observed yet.
+2. The chain height advances from `3,159,411` to `3,159,412`, and the counter starts at `0s ago`.
+3. The finalized height catches up from `3,159,388` to `3,159,411`, resetting its counter to `0s ago`.
+
+The gap between the chain height and the finalized height is normal.
+A transaction included in a block at the chain tip is confirmed but not yet irreversible.
+Once the finalized height reaches or exceeds that block, the transaction is guaranteed to remain in the chain.
+
+## Conclusion
+
+This tutorial showed how to:
+
+| Step                                                   | Related documentation                                      |
+| ------------------------------------------------------ | ---------------------------------------------------------- |
+| [Fetch chain information](#fetching-chain-information) | <get:/chain/info>                                          |

--- a/mkdocs/pages/en/devbook/chain/chain-heights.md
+++ b/mkdocs/pages/en/devbook/chain/chain-heights.md
@@ -43,7 +43,7 @@ The response contains:
     * **finalizationPoint:** The finalization point within the epoch.
     * **hash:** The hash of the finalized block.
 
-The chain height increases each time a new block produced (approximately every 30 seconds).
+The chain height increases each time a new block is produced (approximately every 30 seconds).
 
 The finalized height lags behind the chain tip because a block is typically finalized 10 to 20 minutes after it is
 produced.
@@ -68,10 +68,10 @@ Once a change occurs, the counter starts from `0s ago` and increments each secon
 
 Each iteration prints a single status line showing:
 
-* The current chain height and how many seconds since it last changed.
-* The finalized height and how many seconds since it last changed.
+* The current chain height and how many seconds have elapsed since it last changed.
+* The finalized height and how many seconds have elapsed since it last changed.
 
-The loop sleeps for one second between iterations.
+The loop then sleeps for one second between iterations.
 
 ## Output
 
@@ -83,9 +83,11 @@ The following output shows a typical run monitoring the chain and finalization h
 
 The output shows:
 
-1. Both heights initially show `-` because no change has been observed yet.
-2. The chain height advances from `3,159,411` to `3,159,412`, and the counter starts at `0s ago`.
-3. The finalized height catches up from `3,159,388` to `3,159,411`, resetting its counter to `0s ago`.
+1. The chain height advances 1 block, from `3,159,411` to `3,159,412`.
+    At that point, the change counter starts from `0s`.
+2. Later, the finalized height catches up and advances 23 blocks, from `3,159,388` to `3,159,411`.
+    Its change counter starts from `0s` too.
+3. Both heights initially show `-` because no change has been observed yet.
 
 The gap between the chain height and the finalized height is normal.
 A transaction included in a block at the chain tip is confirmed but not yet irreversible.

--- a/mkdocs/pages/en/devbook/transactions/monitoring-status.md
+++ b/mkdocs/pages/en/devbook/transactions/monitoring-status.md
@@ -173,7 +173,8 @@ This tutorial showed how to:
 
 For production applications, consider these improvements:
 
-* **Wait for finalization:** Verify that the block containing the transaction has been finalized.
+* **Wait for finalization:** Verify that the block containing the transaction has been finalized
+    to ensure it is truly irreversible.
     See [Querying Chain and Finalization Height](../chain/chain-heights.md).
 * **Query multiple nodes:** Check status and finalization across several <nodes:> for greater reliability and
     protection against single-node issues.

--- a/mkdocs/pages/en/devbook/transactions/monitoring-status.md
+++ b/mkdocs/pages/en/devbook/transactions/monitoring-status.md
@@ -173,8 +173,8 @@ This tutorial showed how to:
 
 For production applications, consider these improvements:
 
-* **Wait for finalization:** Verify that the block containing the transaction has been finalized
-    using <get:/finalization/proof/height/{height}> to ensure it is truly irreversible.
+* **Wait for finalization:** Verify that the block containing the transaction has been finalized.
+    See [Querying Chain and Finalization Height](../chain/chain-heights.md).
 * **Query multiple nodes:** Check status and finalization across several <nodes:> for greater reliability and
     protection against single-node issues.
 * **Use WebSockets:** Replace polling with WebSocket subscriptions for real-time updates without repeated API calls.


### PR DESCRIPTION
Adds chain and finalization height  tutorial based on https://github.com/symbol/symbol/blob/main/docs/index.md#tutorial-querying-finalization-height and https://github.com/symbol/symbol/blob/main/docs/index.md#tutorial-querying-current-height.