### PR TITLE
[catapult/sdk] Amend out-of-bounds vector access on MemoryStream

### DIFF
--- a/client/catapult/sdk/src/extensions/MemoryStream.cpp
+++ b/client/catapult/sdk/src/extensions/MemoryStream.cpp
@@ -32,6 +32,8 @@ namespace catapult { namespace extensions {
 	{}
 
 	void MemoryStream::write(const RawBuffer& buffer) {
+		if(0u == buffer.Size)
+			return;
 		m_buffer.resize(std::max<size_t>(m_buffer.size(), m_position + buffer.Size));
 		utils::memcpy_cond(&m_buffer[m_position], buffer.pData, buffer.Size);
 		m_position += buffer.Size;

--- a/client/catapult/sdk/src/extensions/MemoryStream.cpp
+++ b/client/catapult/sdk/src/extensions/MemoryStream.cpp
@@ -32,11 +32,7 @@ namespace catapult { namespace extensions {
 	{}
 
 	void MemoryStream::write(const RawBuffer& buffer) {
-		if(0u == buffer.Size)
-			return;
-
-		m_buffer.resize(std::max<size_t>(m_buffer.size(), m_position + buffer.Size));
-		std::memcpy(&m_buffer[m_position], buffer.pData, buffer.Size);
+		m_buffer.insert(m_buffer.end(), buffer.pData, buffer.pData + buffer.Size);
 		m_position += buffer.Size;
 	}
 

--- a/client/catapult/sdk/src/extensions/MemoryStream.cpp
+++ b/client/catapult/sdk/src/extensions/MemoryStream.cpp
@@ -32,7 +32,11 @@ namespace catapult { namespace extensions {
 	{}
 
 	void MemoryStream::write(const RawBuffer& buffer) {
-		m_buffer.insert(m_buffer.end(), buffer.pData, buffer.pData + buffer.Size);
+		if(0u == buffer.Size)
+			return;
+
+		m_buffer.resize(std::max<size_t>(m_buffer.size(), m_position + buffer.Size));
+		std::memcpy(&m_buffer[m_position], buffer.pData, buffer.Size);
 		m_position += buffer.Size;
 	}
 

--- a/client/catapult/sdk/src/extensions/MemoryStream.cpp
+++ b/client/catapult/sdk/src/extensions/MemoryStream.cpp
@@ -35,7 +35,7 @@ namespace catapult { namespace extensions {
 		if(0u == buffer.Size)
 			return;
 		m_buffer.resize(std::max<size_t>(m_buffer.size(), m_position + buffer.Size));
-		utils::memcpy_cond(&m_buffer[m_position], buffer.pData, buffer.Size);
+		std::memcpy(&m_buffer[m_position], buffer.pData, buffer.Size);
 		m_position += buffer.Size;
 	}
 

--- a/client/catapult/sdk/src/extensions/MemoryStream.cpp
+++ b/client/catapult/sdk/src/extensions/MemoryStream.cpp
@@ -34,6 +34,7 @@ namespace catapult { namespace extensions {
 	void MemoryStream::write(const RawBuffer& buffer) {
 		if(0u == buffer.Size)
 			return;
+
 		m_buffer.resize(std::max<size_t>(m_buffer.size(), m_position + buffer.Size));
 		std::memcpy(&m_buffer[m_position], buffer.pData, buffer.Size);
 		m_position += buffer.Size;

--- a/client/catapult/sdk/src/extensions/MemoryStream.cpp
+++ b/client/catapult/sdk/src/extensions/MemoryStream.cpp
@@ -35,9 +35,12 @@ namespace catapult { namespace extensions {
 		if(0u == buffer.Size)
 			return;
 
-		m_buffer.resize(std::max<size_t>(m_buffer.size(), m_position + buffer.Size));
+		const auto end = m_position + buffer.Size;
+		if(end > m_buffer.size())
+			m_buffer.resize(end);
+
 		std::memcpy(&m_buffer[m_position], buffer.pData, buffer.Size);
-		m_position += buffer.Size;
+		m_position = end;
 	}
 
 	void MemoryStream::flush()


### PR DESCRIPTION
When m_buffer is pristine and input buffer is empty then m_buffer[0] is out-of-bounds.
Early exit also saves void calls to resize and memcpy.
