### PR TITLE
[jenkins] fix: install the exact package version for 'npm install'

### DIFF
--- a/jenkins/shared-library/vars/configureArtifactRepository.groovy
+++ b/jenkins/shared-library/vars/configureArtifactRepository.groovy
@@ -56,6 +56,7 @@ void configureNpm(Map info) {
 		npmrcContent += "\n//${hostNamePath}:_auth=${userNamePasswordEncoding}"
 	}
 
+	npmrcContent += '\n"config": {\n    "save-exact": true\n}'
 	writeFile(file: '.npmrc', text: npmrcContent)
 }
 

--- a/jenkins/shared-library/vars/configureArtifactRepository.groovy
+++ b/jenkins/shared-library/vars/configureArtifactRepository.groovy
@@ -10,6 +10,9 @@ void call(String environments, Boolean isPublicGitHubRepo) {
 			if ('javascript' == environment && fileExists('package-lock.json')) {
 				// remove package-lock.json file since the hashes will not match private repository
 				sh('rm -f package-lock.json')
+
+				// remove ^ and ~ from package.json to prevent npm from installing latest versions which can cause issues
+				sh('sed -i \'s/"[\\^~]/"/g\' package.json')
 			}
 		}
 	}
@@ -56,7 +59,6 @@ void configureNpm(Map info) {
 		npmrcContent += "\n//${hostNamePath}:_auth=${userNamePasswordEncoding}"
 	}
 
-	npmrcContent += '\n"config": {\n    "save-exact": true\n}'
 	writeFile(file: '.npmrc', text: npmrcContent)
 }
 


### PR DESCRIPTION
problem: for builds that use the internal Nexus repo, Jenkins will delete the package-lock.json.
         npm install will then install the latest version of dependencies.
         In certain cases, the newer updates can break or have bugs that cause failures in CI.
solution: add the save-exact flag to npm to not upgrade the packages

Just for reference, this was causing the REST build to fail due to an update to Sinon package(https://github.com/sinonjs/sinon/issues/2678)