### PR TITLE
[jenkins] fix: switch the default to public

### DIFF
--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -16,7 +16,7 @@ void call(Closure body) {
 				choices: jenkinsfileParams.operatingSystem ?: ['ubuntu'],
 				description: 'Operating System'
 			choice name: 'BUILD_CONFIGURATION',
-				choices: ['release-private', 'release-public'],
+				choices: ['release-public', 'release-private'],
 				description: 'build configuration'
 			choice name: 'ARCHITECTURE',
 				choices: ['arm64', 'amd64'],

--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -16,7 +16,7 @@ void call(Closure body) {
 				choices: jenkinsfileParams.operatingSystem ?: ['ubuntu'],
 				description: 'Operating System'
 			choice name: 'BUILD_CONFIGURATION',
-				choices: ['release-public', 'release-private'],
+				choices: ['release-private', 'release-public'],
 				description: 'build configuration'
 			choice name: 'ARCHITECTURE',
 				choices: ['arm64', 'amd64'],

--- a/jenkins/shared-library/vars/monorepoControllerPipeline.groovy
+++ b/jenkins/shared-library/vars/monorepoControllerPipeline.groovy
@@ -12,6 +12,9 @@ void call(Closure body) {
 			choice name: 'OPERATING_SYSTEM',
 				choices: jenkinsfileParams.operatingSystem ?: ['ubuntu'],
 				description: 'Run on specific OS'
+			choice name: 'BUILD_CONFIGURATION',
+				choices: ['release-public', 'release-private'],
+				description: 'build configuration'
 			choice name: 'ARCHITECTURE',
 				choices: ['arm64', 'amd64'],
 				description: 'Computer architecture'
@@ -149,7 +152,7 @@ void triggerJobs(String branchName) {
 				build job: "${fullJobName}", parameters: [
 					gitParameter(name: 'MANUAL_GIT_BRANCH', value: branchName),
 					string(name: 'OPERATING_SYSTEM', value: osValue ?: 'ubuntu'),
-					string(name: 'BUILD_CONFIGURATION', value: 'release-private'),
+					string(name: 'BUILD_CONFIGURATION', value: params.BUILD_CONFIGURATION),
 					string(name: 'TEST_MODE', value: 'code-coverage'),
 					string(name: 'ARCHITECTURE', value: params.ARCHITECTURE),
 					booleanParam(name: 'SHOULD_PUBLISH_IMAGE', value: false),


### PR DESCRIPTION
problem: There have been a lot of dependency-related failures for JavaScript.
                  This is due to Jenkins removing the package-lock.json for private builds,
                  and some projects fail with the newer deps.
solution: Set the default build to public, which will not delete the package-lock file.