### PR TITLE
[mkdocs] refactor: use SDK Address methods for hex-to-address conversion

### DIFF
--- a/mkdocs/overrides/devbook/namespaces/link-namespace-to-address.mjs
+++ b/mkdocs/overrides/devbook/namespaces/link-namespace-to-address.mjs
@@ -2,6 +2,7 @@ import { PrivateKey } from 'symbol-sdk';
 import {
 	SymbolFacade,
 	NetworkTimestamp,
+	Address,
 	models,
 	generateNamespacePath,
 	generateMosaicAliasId
@@ -139,9 +140,8 @@ try {
 	console.log('Alias information:');
 	console.log('  Alias type:', namespaceInfo.alias.type);
 	if (namespaceInfo.alias.type === 2) { // ADDRESS type
-		const aliasedAddress = new models.Address(
-			Uint8Array.from(Buffer.from(
-				namespaceInfo.alias.address, 'hex')));
+		const aliasedAddress = Address.fromDecodedAddressHexString(
+			namespaceInfo.alias.address);
 		console.log('  Linked address:', aliasedAddress.toString());
 	}
 

--- a/mkdocs/overrides/devbook/namespaces/link-namespace-to-address.py
+++ b/mkdocs/overrides/devbook/namespaces/link-namespace-to-address.py
@@ -121,8 +121,8 @@ try:
 		alias_type = namespace_info['alias']['type']
 		print(f'  Alias type: {alias_type}')
 		if alias_type == 2:  # ADDRESS type
-			aliased_address_hex = namespace_info['alias']['address']
-			aliased_address = Address(bytes.fromhex(aliased_address_hex))
+			aliased_address = Address.from_decoded_address_hex_string(
+				namespace_info['alias']['address'])
 			print(f'  Linked address: {aliased_address}')
 
 	# Send a transfer using the alias instead of a raw address

--- a/mkdocs/overrides/devbook/namespaces/register-root-namespace.mjs
+++ b/mkdocs/overrides/devbook/namespaces/register-root-namespace.mjs
@@ -2,6 +2,7 @@ import { PrivateKey } from 'symbol-sdk';
 import {
 	SymbolFacade,
 	NetworkTimestamp,
+	Address,
 	models,
 	generateNamespaceId
 } from 'symbol-sdk/symbol';
@@ -131,8 +132,8 @@ try {
 	console.log('Namespace information:');
 	console.log(
 		'  Registration type:', namespaceInfo.registrationType);
-	const ownerAddress = new models.Address(
-		Uint8Array.from(Buffer.from(namespaceInfo.ownerAddress, 'hex')));
+	const ownerAddress = Address.fromDecodedAddressHexString(
+		namespaceInfo.ownerAddress);
 	console.log('  Owner address:', ownerAddress.toString());
 	console.log('  Start height:', namespaceInfo.startHeight);
 	console.log('  End height:', namespaceInfo.endHeight);

--- a/mkdocs/overrides/devbook/namespaces/register-root-namespace.py
+++ b/mkdocs/overrides/devbook/namespaces/register-root-namespace.py
@@ -113,8 +113,8 @@ try:
 		print('Namespace information:')
 		reg_type = namespace_info["registrationType"]
 		print(f'  Registration type: {reg_type}')
-		owner_address_hex = bytes.fromhex(namespace_info["ownerAddress"])
-		owner_address = Address(owner_address_hex)
+		owner_address = Address.from_decoded_address_hex_string(
+			namespace_info["ownerAddress"])
 		print(f'  Owner address: {owner_address}')
 		print(f'  Start height: {namespace_info["startHeight"]}')
 		print(f'  End height: {namespace_info["endHeight"]}')

--- a/mkdocs/overrides/devbook/namespaces/register-subnamespace.mjs
+++ b/mkdocs/overrides/devbook/namespaces/register-subnamespace.mjs
@@ -2,6 +2,7 @@ import { PrivateKey } from 'symbol-sdk';
 import {
 	SymbolFacade,
 	NetworkTimestamp,
+	Address,
 	models,
 	generateNamespaceId
 } from 'symbol-sdk/symbol';
@@ -140,8 +141,8 @@ try {
 	console.log('Namespace information:');
 	console.log(
 		'  Registration type:', namespaceInfo.registrationType);
-	const ownerAddress = new models.Address(
-		Uint8Array.from(Buffer.from(namespaceInfo.ownerAddress, 'hex')));
+	const ownerAddress = Address.fromDecodedAddressHexString(
+		namespaceInfo.ownerAddress);
 	console.log('  Owner address:', ownerAddress.toString());
 	console.log('  Parent ID:', namespaceInfo.parentId);
 	console.log('  Depth:', namespaceInfo.depth);

--- a/mkdocs/overrides/devbook/namespaces/register-subnamespace.py
+++ b/mkdocs/overrides/devbook/namespaces/register-subnamespace.py
@@ -121,8 +121,8 @@ try:
 		print('Namespace information:')
 		reg_type = namespace_info["registrationType"]
 		print(f'  Registration type: {reg_type}')
-		owner_address_hex = bytes.fromhex(namespace_info["ownerAddress"])
-		owner_address = Address(owner_address_hex)
+		owner_address = Address.from_decoded_address_hex_string(
+			namespace_info["ownerAddress"])
 		print(f'  Owner address: {owner_address}')
 		print(f'  Parent ID: {namespace_info["parentId"]}')
 		print(f'  Depth: {namespace_info["depth"]}')

--- a/mkdocs/overrides/devbook/namespaces/resolve-namespace-from-receipt.mjs
+++ b/mkdocs/overrides/devbook/namespaces/resolve-namespace-from-receipt.mjs
@@ -1,4 +1,4 @@
-import { SymbolFacade } from 'symbol-sdk/symbol';
+import { Address } from 'symbol-sdk/symbol';
 
 const NODE_URL = process.env.NODE_URL ||
 	'https://reference.symboltest.net:3001';
@@ -67,9 +67,8 @@ try {
 					resolved = entry.resolved;
 			}
 			if (resolved) {
-				const bytes = Uint8Array.from(
-					Buffer.from(resolved, 'hex'));
-				const address = new SymbolFacade.Address(bytes);
+				const address =
+					Address.fromDecodedAddressHexString(resolved);
 				console.log('\nAddress resolution:');
 				console.log('  Unresolved:', statement.unresolved);
 				console.log(`  Resolved:   ${address}`);

--- a/mkdocs/overrides/devbook/namespaces/resolve-namespace-from-receipt.py
+++ b/mkdocs/overrides/devbook/namespaces/resolve-namespace-from-receipt.py
@@ -67,7 +67,7 @@ try:
 				if source['primaryId'] <= tx_primary:
 					resolved = entry['resolved']
 			if resolved:
-				address = Address(bytes.fromhex(resolved))
+				address = Address.from_decoded_address_hex_string(resolved)
 				print('\nAddress resolution:')
 				print(f'  Unresolved:  {statement["unresolved"]}')
 				print(f'  Resolved:   {address}')

--- a/mkdocs/pages/en/devbook/namespaces/link-namespace-to-address.md
+++ b/mkdocs/pages/en/devbook/namespaces/link-namespace-to-address.md
@@ -38,7 +38,7 @@ transactions are announced and confirmed.
 
 ### Setting Up the Account
 
-{{ tutorial.code_snippet(['py:18:26', 'js:14:22']) }}
+{{ tutorial.code_snippet(['py:18:26', 'js:15:23']) }}
 
 The snippet reads the signer's private key from the `SIGNER_PRIVATE_KEY` environment variable, which defaults to a
 test key if not set.
@@ -47,7 +47,7 @@ This account must own the namespace being linked.
 
 ### Defining the Namespace and Target Address
 
-{{ tutorial.code_snippet(['py:28:38', 'js:24:37']) }}
+{{ tutorial.code_snippet(['py:28:38', 'js:25:38']) }}
 
 The code defines:
 
@@ -72,14 +72,14 @@ The code defines:
 
 ### Fetching Network Time and Fees
 
-{{ tutorial.code_snippet(['py:41:59', 'js:40:59']) }}
+{{ tutorial.code_snippet(['py:41:59', 'js:41:60']) }}
 
 Network time and recommended fees are fetched from <get:/node/time> and <get:/network/fees/transaction> respectively,
 following the process described in the [Transfer Transaction](../transactions/transfer.md) tutorial.
 
 ### Building the Transaction
 
-{{ tutorial.code_snippet(['py:61:70', 'js:61:70']) }}
+{{ tutorial.code_snippet(['py:61:70', 'js:62:71']) }}
 
 The address alias transaction specifies:
 
@@ -103,19 +103,19 @@ The address alias transaction specifies:
 
 ### Submitting the Transaction
 
-{{ tutorial.code_snippet(['py:72:91', 'js:72:92']) }}
+{{ tutorial.code_snippet(['py:72:91', 'js:73:93']) }}
 
 The transaction is signed and announced following the same process as in
 [Creating a Transfer Transaction](../transactions/transfer.md#announcing-the-transaction).
 
-{{ tutorial.code_snippet(['py:93:111', 'js:94:128']) }}
+{{ tutorial.code_snippet(['py:93:111', 'js:95:129']) }}
 
 The code then waits for the transaction to be confirmed by polling the
 <get:/transactionStatus/{hash}> endpoint until the status changes to `confirmed`.
 
 ### Verifying the Alias
 
-{{ tutorial.code_snippet(['py:113:126', 'js:130:146']) }}
+{{ tutorial.code_snippet(['py:113:125', 'js:131:146']) }}
 
 To verify the alias was created, the code retrieves the namespace information from the network
 using the <get:/namespaces/{namespaceId}> endpoint.

--- a/mkdocs/pages/en/devbook/namespaces/register-root-namespace.md
+++ b/mkdocs/pages/en/devbook/namespaces/register-root-namespace.md
@@ -38,7 +38,7 @@ transactions are announced and confirmed.
 
 ### Setting Up the Account
 
-{{ tutorial.code_snippet(['py:17:25', 'js:13:21']) }}
+{{ tutorial.code_snippet(['py:17:25', 'js:14:22']) }}
 
 The snippet reads the signer's private key from the `SIGNER_PRIVATE_KEY` environment variable, which defaults to a
 test key if not set.
@@ -47,14 +47,14 @@ This account will own the registered namespace.
 
 ### Fetching Network Time and Fees
 
-{{ tutorial.code_snippet(['py:28:46', 'js:24:43']) }}
+{{ tutorial.code_snippet(['py:28:46', 'js:25:44']) }}
 
 Network time and recommended fees are fetched from <get:/node/time> and <get:/network/fees/transaction> respectively,
 following the process described in the [Transfer Transaction](../transactions/transfer.md) tutorial.
 
 ### Building the Transaction
 
-{{ tutorial.code_snippet(['py:48:60', 'js:45:57']) }}
+{{ tutorial.code_snippet(['py:48:60', 'js:46:58']) }}
 
 The namespace registration transaction specifies:
 
@@ -88,19 +88,19 @@ The namespace registration transaction specifies:
 
 ### Submitting the Transaction
 
-{{ tutorial.code_snippet(['py:62:81', 'js:59:79']) }}
+{{ tutorial.code_snippet(['py:62:81', 'js:60:80']) }}
 
 The transaction is signed and announced following the same process as in
 [Creating a Transfer Transaction](../transactions/transfer.md#announcing-the-transaction).
 
-{{ tutorial.code_snippet(['py:83:101', 'js:81:115']) }}
+{{ tutorial.code_snippet(['py:83:101', 'js:82:116']) }}
 
 The code then waits for the transaction to be confirmed by polling the
 <get:/transactionStatus/{hash}> endpoint until the status changes to `confirmed`.
 
 ### Retrieving the Namespace
 
-{{ tutorial.code_snippet(['py:103:120', 'js:117:138']) }}
+{{ tutorial.code_snippet(['py:103:119', 'js:118:139']) }}
 
 To verify the namespace was registered, the code retrieves it from the network
 using the <get:/namespaces/{namespaceId}> endpoint and displays its properties.

--- a/mkdocs/pages/en/devbook/namespaces/register-subnamespace.md
+++ b/mkdocs/pages/en/devbook/namespaces/register-subnamespace.md
@@ -46,7 +46,7 @@ see [Registering a Root Namespace](./register-root-namespace.md).
 
 ### Building the Transaction
 
-{{ tutorial.code_snippet(['py:48:67', 'js:45:65']) }}
+{{ tutorial.code_snippet(['py:48:67', 'js:46:66']) }}
 
 The main difference when registering a subnamespace is in the transaction descriptor:
 
@@ -88,7 +88,7 @@ The transaction is then signed, announced, and confirmed following the same proc
 
 ### Retrieving the Subnamespace
 
-{{ tutorial.code_snippet(['py:110:136', 'js:125:157']) }}
+{{ tutorial.code_snippet(['py:110:135', 'js:126:158']) }}
 
 To verify the subnamespace was registered, the code retrieves it from the network
 using the <get:/namespaces/{namespaceId}> endpoint and displays its properties.

--- a/mkdocs/pages/en/devbook/namespaces/resolve-namespace-from-receipt.md
+++ b/mkdocs/pages/en/devbook/namespaces/resolve-namespace-from-receipt.md
@@ -89,7 +89,7 @@ Each resolution statement contains:
 * **Unresolved:** The namespace alias (encoded as an address) that was used in the transaction.
 * **Resolution entries:** An array mapping the alias to the actual address at the time of confirmation.
 
-{{ tutorial.code_snippet(['py:60:73', 'js:59:78']) }}
+{{ tutorial.code_snippet(['py:60:73', 'js:59:77']) }}
 
 The endpoint returns all address resolution statements for the block.
 The code skips any statement whose `unresolved` field does not match the transaction's `recipientAddress`,
@@ -113,7 +113,7 @@ even if the alias was defined multiple times in the same block.
 
 ### Querying Mosaic Resolution Statements
 
-{{ tutorial.code_snippet(['py:76:99', 'js:81:110']) }}
+{{ tutorial.code_snippet(['py:76:99', 'js:80:109']) }}
 
 The same transaction also used `symbol.xym` as a mosaic alias instead of a raw mosaic ID.
 The code queries the <get:/statements/resolutions/mosaic> endpoint with the same block height to retrieve


### PR DESCRIPTION
Spotted this improvement while working in our of the latest tutorials.

Replaces manual `bytes.fromhex/Buffer.from` patterns with the SDK built-in methods across namespace tutorials.