### PR TITLE
[client/catapult] Dev usability on Win and *nix

### DIFF
--- a/client/catapult/.gitattributes
+++ b/client/catapult/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/linters/cpp/HeaderParser.py
+++ b/linters/cpp/HeaderParser.py
@@ -179,7 +179,7 @@ class HeaderParser:
 
 		for raw_line in input_stream:
 			line = raw_line.decode('utf8')
-			line = line.strip('\n')
+			line = line.strip('\r\n')
 
 			pprev = prev
 			prev = temp


### PR DESCRIPTION
This allows linters to be used locally on Windows too