### PR TITLE
[openapi] fix: document /node/storage database fields

### DIFF
--- a/openapi/.redocly.yaml
+++ b/openapi/.redocly.yaml
@@ -2,8 +2,8 @@ extends:
   - recommended
 
 rules:
-  no-ambiguous-paths: off
-  operation-4xx-response: off
+  no-ambiguous-paths: "off"
+  operation-4xx-response: "off"
 
 apis:
   main:

--- a/openapi/CHANGELOG.md
+++ b/openapi/CHANGELOG.md
@@ -27,6 +27,7 @@ Milestone: Symbol Mainnet
 - feat: Migrated to OpenAPI 3.1.0
 - fix: Replaced ``format: hex`` usage with explicit regex patterns in schemas.
 - fix: Clarified query/filter semantics in endpoint documentation.
+- fix: Updated ``/node/storage`` schema to document database stats.
 
 ## [1.0.4] - 25-Nov-2025
 

--- a/openapi/spec/core/node/routes/getNodeStorage.yml
+++ b/openapi/spec/core/node/routes/getNodeStorage.yml
@@ -1,7 +1,9 @@
 tags:
   - Node routes
 summary: Get the storage information of the node
-description: Returns storage information about the node.
+description: |
+  Returns estimated counts of blocks, transactions, and accounts in the REST
+  server's MongoDB database, along with database size statistics (`db.stats()`).
 operationId: getNodeStorage
 responses:
   '200':
@@ -14,6 +16,18 @@ responses:
           nodeStorage:
             summary: Example node storage statistics
             value:
-              numBlocks: 245053
-              numTransactions: 58590
-              numAccounts: 177
+              numBlocks: 5379090
+              numTransactions: 12529188
+              numAccounts: 690320
+              database:
+                numIndexes:
+                  low: 73
+                  high: 0
+                  unsigned: false
+                numObjects:
+                  low: 25006115
+                  high: 0
+                  unsigned: false
+                dataSize: 23504074239
+                indexSize: 2029621248
+                storageSize: 13225127936

--- a/openapi/spec/core/node/schemas/StorageInfoDTO.yml
+++ b/openapi/spec/core/node/schemas/StorageInfoDTO.yml
@@ -1,31 +1,39 @@
 type: object
 description: |
-  Storage statistics: number of blocks, transactions, and accounts stored by the node.
+  Storage statistics for the node: estimated document counts in the REST server's
+  MongoDB collections (blocks, transactions, accounts) plus database allocation
+  stats from `db.stats()`. Counts use estimated collection sizes and may differ
+  slightly from exact figures under load.
 required:
   - numBlocks
   - numTransactions
   - numAccounts
+  - database
 properties:
   numBlocks:
     type: integer
+    format: int64
     description: |
-      Number of blocks stored. Under normal operation, this equals the chain height
-      (see chain info). When the node is synchronizing with the network, both values
-      are lower than the network chain height.
+      Estimated number of block documents in the `blocks` collection. Under normal
+      operation this tracks chain height; when synchronizing, it lags the network.
     examples:
       - 245053
   numTransactions:
     type: integer
+    format: int64
     description: |
-      Number of confirmed transactions stored, i.e. transactions included in blocks.
-      Excludes unconfirmed transactions in the mempool. For aggregate transactions
-      (e.g. multisig), each inner transaction counts as a separate document.
+      Estimated number of confirmed transaction documents in the `transactions`
+      collection. Excludes unconfirmed transactions. For aggregate transactions,
+      each inner transaction is stored as a separate document.
     examples:
       - 58590
   numAccounts:
     type: integer
+    format: int64
     description: |
-      Number of accounts with on-chain state, i.e. addresses that have participated
-      in at least one confirmed transaction (e.g. as sender, recipient, or cosigner).
+      Estimated number of account documents in the `accounts` collection (addresses
+      with persisted on-chain state).
     examples:
       - 177
+  database:
+    $ref: ./StorageInfoDatabaseDTO.yml

--- a/openapi/spec/core/node/schemas/StorageInfoDatabaseDTO.yml
+++ b/openapi/spec/core/node/schemas/StorageInfoDatabaseDTO.yml
@@ -1,0 +1,48 @@
+type: object
+description: |
+  MongoDB database statistics for the node's data store, as returned by
+  [`db.stats()`](https://www.mongodb.com/docs/manual/reference/command/dbStats/).
+required:
+  - numIndexes
+  - numObjects
+  - dataSize
+  - indexSize
+  - storageSize
+properties:
+  numIndexes:
+    description: |
+      Total number of indexes across all collections in the database.
+      Represented as BSON Long with `low` / `high` / `unsigned` fields.
+    $ref: ../../../schemas/BsonLongDTO.yml
+  numObjects:
+    description: |
+      Approximate number of documents (objects) stored in the database.
+      Represented as BSON Long with `low` / `high` / `unsigned` fields.
+    $ref: ../../../schemas/BsonLongDTO.yml
+  dataSize:
+    type: integer
+    format: int64
+    description: |
+      Total logical size of collection data (uncompressed), in bytes.
+      This reflects document payload size and excludes index allocation.
+      Useful as an estimate of raw data footprint, not on-disk usage.
+    examples:
+      - 1073741824
+  indexSize:
+    type: integer
+    format: int64
+    description: |
+      Total logical size of all indexes, in bytes.
+      This includes index structures across collections and grows with
+      both document count and the number of distinct indexed values.
+    examples:
+      - 134217728
+  storageSize:
+    type: integer
+    format: int64
+    description: |
+      Total physical storage allocated by the database engine for collection
+      data, in bytes. This is an allocation metric and can differ from
+      `dataSize` because it includes engine overhead and internal padding.
+    examples:
+      - 1207959552

--- a/openapi/spec/schemas/BsonLongDTO.yml
+++ b/openapi/spec/schemas/BsonLongDTO.yml
@@ -1,0 +1,23 @@
+type: object
+description: |
+  64-bit integer in the BSON Long shape produced by the MongoDB Node.js driver when serialized to JSON.
+required:
+  - low
+  - high
+  - unsigned
+properties:
+  low:
+    type: integer
+    description: Low 32 bits (signed 32-bit integer in the BSON representation).
+    examples:
+      - 73
+  high:
+    type: integer
+    description: High 32 bits (signed 32-bit integer in the BSON representation).
+    examples:
+      - 0
+  unsigned:
+    type: boolean
+    description: Whether the Long is treated as unsigned in the driver.
+    examples:
+      - false


### PR DESCRIPTION
# Summary
- update `/node/storage` OpenAPI docs to match observed API response shape
- introduce `BsonLongDTO` and use it for `database.numIndexes` and `database.numObjects` in `StorageInfoDatabaseDTO`
- expand descriptions for `dataSize`, `indexSize`, and `storageSize` to clarify logical vs allocated size semantics
- add changelog entry for the `/node/storage` documentation update
- (fix linting) quote Redocly "off" rule values for yamllint compatibility