### PR TITLE
[client/rest]: get transaction endpoint returns 500 when hash/id is malformed

### DIFF
--- a/client/rest/src/routes/transactionRoutes.js
+++ b/client/rest/src/routes/transactionRoutes.js
@@ -92,7 +92,7 @@ export default {
 			let paramType = constants.sizes.objectId === params.transactionId.length ? 'id' : undefined;
 			paramType = constants.sizes.hash === params.transactionId.length ? 'hash' : paramType;
 			if (!paramType)
-				throw Error(`invalid length of transaction id '${params.transactionId}'`);
+				throw errors.createInvalidArgumentError(`invalid length of transaction id '${params.transactionId}'`);
 
 			const transactionId = routeUtils.parseArgument(params, 'transactionId', 'id' === paramType ? 'objectId' : 'hash256');
 

--- a/client/rest/test/routes/transactionRoutes_spec.js
+++ b/client/rest/test/routes/transactionRoutes_spec.js
@@ -25,6 +25,7 @@ import routeResultTypes from '../../src/routes/routeResultTypes.js';
 import routeUtils from '../../src/routes/routeUtils.js';
 import transactionRoutes from '../../src/routes/transactionRoutes.js';
 import { expect } from 'chai';
+import restifyErrors from 'restify-errors';
 import sinon from 'sinon';
 import { utils } from 'symbol-sdk';
 import { Address } from 'symbol-sdk/symbol';
@@ -84,7 +85,8 @@ describe('transaction routes', () => {
 					const req = { params: { group: TransactionGroups.confirmed, transactionId: '12345' } };
 
 					// Act + Assert:
-					expect(() => mockServer.callRoute(route, req)).to.throw('invalid length of transaction id \'12345\'');
+					expect(() => mockServer.callRoute(route, req))
+						.to.throw(restifyErrors.InvalidArgumentError, 'invalid length of transaction id \'12345\'');
 				});
 
 				it('calls parseArgument with correct parser for id', () => runParseArgumentParamTest(validObjectId, 'objectId'));
@@ -490,7 +492,8 @@ describe('transaction routes', () => {
 				const req = { params: { group: TransactionGroups.confirmed } };
 
 				// Act + Assert:
-				expect(() => mockServer.callRoute(route, req)).to.throw('either ids or hashes must be provided');
+				expect(() => mockServer.callRoute(route, req))
+					.to.throw(restifyErrors.InvalidArgumentError, 'either ids or hashes must be provided');
 			});
 
 			it('throws if both ids and hashes are provided', () => {
@@ -498,7 +501,8 @@ describe('transaction routes', () => {
 				const req = { params: { group: TransactionGroups.confirmed, transactionIds: [], hashes: [] } };
 
 				// Act + Assert:
-				expect(() => mockServer.callRoute(route, req)).to.throw('either ids or hashes must be provided');
+				expect(() => mockServer.callRoute(route, req))
+					.to.throw(restifyErrors.InvalidArgumentError, 'either ids or hashes must be provided');
 			});
 
 			describe('checks correct group is provided', () => {


### PR DESCRIPTION
 problem: 500 is returned indicating server error
solution: return 409 instead

   issue: #1985