### PR TITLE
[catapult/rest]: cannot fetch Merkle state information for an account by public key

### DIFF
--- a/client/rest/src/routes/accountRoutes.js
+++ b/client/rest/src/routes/accountRoutes.js
@@ -25,6 +25,8 @@ import routeUtils from './routeUtils.js';
 import catapult from '../catapult-sdk/index.js';
 import AccountType from '../plugins/AccountType.js';
 import errors from '../server/errors.js';
+import { NetworkLocator, PublicKey } from 'symbol-sdk';
+import { Network } from 'symbol-sdk/symbol';
 
 const { PacketType } = catapult.packet;
 
@@ -72,7 +74,9 @@ export default {
 		// this endpoint is here because it is expected to support requests by block other than <current block>
 		server.get('/accounts/:accountId/merkle', (req, res, next) => {
 			const [type, accountId] = routeUtils.parseArgument(req.params, 'accountId', 'accountId');
-			const encodedAddress = 'publicKey' === type ? catapult.model.address.publicKeyToAddress(accountId, db.networkId) : accountId;
+			const encodedAddress = 'publicKey' === type
+				? NetworkLocator.findByIdentifier(Network.NETWORKS, db.networkId).publicKeyToAddress(new PublicKey(accountId)).bytes
+				: accountId;
 			const state = PacketType.accountStatePath;
 			return merkleUtils.requestTree(services, state, encodedAddress).then(response => {
 				res.send(response);

--- a/client/rest/test/routes/accountRoutes_spec.js
+++ b/client/rest/test/routes/accountRoutes_spec.js
@@ -29,7 +29,7 @@ import routeUtils from '../../src/routes/routeUtils.js';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { utils } from 'symbol-sdk';
-import { Address } from 'symbol-sdk/symbol';
+import { Address, Network } from 'symbol-sdk/symbol';
 
 const { PacketType } = catapult.packet;
 
@@ -425,24 +425,27 @@ describe('account routes', () => {
 			const merkleTree = new MerkleTree();
 			const tree = merkleTree.parseMerkleTreeFromRaw(stateTreeBytes);
 
-			// Act:
-			it(`for ${packetType} state`, () =>
-				test.route.prepareExecuteRoute(
-					accountRoutes.register,
-					'/accounts/:accountId/merkle',
-					'get',
-					{ accountId: testAddress },
-					{}, services, routeContext => routeContext.routeInvoker().then(() => {
-						// Assert:
-						expect(routeContext.numNextCalls).to.equal(1);
-						expect(routeContext.responses.length).to.equal(1);
-						expect(routeContext.redirects.length).to.equal(0);
-						expect(routeContext.responses[0]).to.deep.equal({
-							raw: stateTree,
-							tree
-						});
-					})
-				));
+			const assertCanAccessStateTree = accountId => test.route.prepareExecuteRoute(
+				accountRoutes.register,
+				'/accounts/:accountId/merkle',
+				'get',
+				{ accountId },
+				{ networkId: Network.TESTNET.identifier },
+				services,
+				routeContext => routeContext.routeInvoker().then(() => {
+					// Assert:
+					expect(routeContext.numNextCalls).to.equal(1);
+					expect(routeContext.responses.length).to.equal(1);
+					expect(routeContext.redirects.length).to.equal(0);
+					expect(routeContext.responses[0]).to.deep.equal({
+						raw: stateTree,
+						tree
+					});
+				})
+			);
+
+			it(`for ${packetType} state (address)`, () => assertCanAccessStateTree(testAddress));
+			it(`for ${packetType} state (publicKey)`, () => assertCanAccessStateTree(testPublicKey));
 		});
 
 		it('returns error for invalid address', () =>


### PR DESCRIPTION
 problem: lookup only works for address
solution: allow public key to be used for lookup

  issue: #1915