### PR TITLE
[jenkins] fix: update node and OS versions used in CI

### DIFF
--- a/jenkins/docker/fedora/javascript.Dockerfile
+++ b/jenkins/docker/fedora/javascript.Dockerfile
@@ -1,4 +1,4 @@
-ARG FROM_IMAGE='fedora:40'
+ARG FROM_IMAGE='fedora:44'
 
 FROM ${FROM_IMAGE}
 

--- a/jenkins/docker/fedora/python.Dockerfile
+++ b/jenkins/docker/fedora/python.Dockerfile
@@ -1,4 +1,4 @@
-ARG FROM_IMAGE='fedora:40'
+ARG FROM_IMAGE='fedora:44'
 
 FROM ${FROM_IMAGE}
 

--- a/jenkins/docker/ubuntu/javascript.Dockerfile
+++ b/jenkins/docker/ubuntu/javascript.Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get install -y wget gnupg \
 
 # nodejs
 ENV NODE_OPTIONS="--dns-result-order=ipv4first"
-ARG NODEJS_VERSION=20
+ARG NODEJS_VERSION=22
 RUN apt-get install -y ca-certificates curl gnupg \
 	&& mkdir -p /etc/apt/keyrings \
 	&& curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \
@@ -64,7 +64,7 @@ RUN mkdir -p /data/db \
 
 # install rust and wasm-pack
 ENV PATH=$PATH:/home/ubuntu/.cargo/bin
-ENV CARGO_HOME=/home/ubuntu/.cargo 
+ENV CARGO_HOME=/home/ubuntu/.cargo
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y \
 	&& curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | bash -s -- \
 	&& chown -R ubuntu:ubuntu /home/ubuntu/.cargo \

--- a/jenkins/docker/ubuntu/linter.Dockerfile
+++ b/jenkins/docker/ubuntu/linter.Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update >/dev/null \
 
 # install npm-groovy-lint which requires java 17
 ENV NODE_OPTIONS="--dns-result-order=ipv4first"
-ARG NODE_MAJOR=18
+ARG NODE_MAJOR=22
 RUN apt-get install -y openjdk-17-jre ca-certificates curl gnupg \
 	&& mkdir -p /etc/apt/keyrings \
 	&& curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg \

--- a/jenkins/shared-library/resources/buildEnvironment/baseImages.yaml
+++ b/jenkins/shared-library/resources/buildEnvironment/baseImages.yaml
@@ -1,16 +1,16 @@
 fedora-lts:
-  image: fedora:43
+  image: fedora:44
 ubuntu-lts:
   image: ubuntu:24.04
   python: 3.12
-  nodejs: 20
+  nodejs: 24
 ubuntu-base:
   image: ubuntu:22.04
   python: '3.10'
-  nodejs: 20
+  nodejs: 22
 ubuntu-latest:
-  image: ubuntu:24.04
+  image: ubuntu:26.04
   python: 3.14
-  nodejs: 24
+  nodejs: 26
 windows-lts:
   image: symbolplatform/symbol-server-compiler:windows-msvc-17


### PR DESCRIPTION
problem: CI is currently using an outdated NodeJS version
solution: update NodeJS version plus some OS