### PR TITLE
[linters]: relax gitlint to allow PR number

### DIFF
--- a/linters/scripts/lint_last_commit.sh
+++ b/linters/scripts/lint_last_commit.sh
@@ -7,4 +7,4 @@ GITLINT_MODULES="${GITLINT_COMMON_MODULES}|$(cat "$(git rev-parse --show-topleve
 GITLINT_CATEGORIES="feat|bug|fix|build|perf|task"
 gitlint \
 	-C "$(git rev-parse --show-toplevel)/linters/git/.gitlint" \
-	-c title-match-regex.regex="^\\[(${GITLINT_MODULES})\\]( (${GITLINT_CATEGORIES}))?: [\S ]+[a-zA-Z0-9]$"
+	-c title-match-regex.regex="^\\[(${GITLINT_MODULES})\\]( (${GITLINT_CATEGORIES}))?: [\S ]+[a-zA-Z0-9]( \(#[0-9]+\))?$"


### PR DESCRIPTION
problem: GitHub defaults to adding a PR number.
         This causes GitLint to fail in the dev branch.
solution: relax regix used by gitlint to include the PR number as an optional value