### PR TITLE
[linters]: fail lint_indents if rg is not installed

### DIFF
--- a/linters/scripts/lint_indents.sh
+++ b/linters/scripts/lint_indents.sh
@@ -2,6 +2,11 @@
 
 set -ex
 
+if ! [ -x "$(command -v rg)" ]; then
+	echo "Error: rg is not installed"
+	exit 1
+fi
+
 ! rg \
 		--files-with-matches \
 		--type-not=json \


### PR DESCRIPTION
 problem: linter silently succeeds when rg is not installed
solution: explicitly check and fail if not installed