### PR TITLE
[sdk/python]: add helper functions for calculating NEM and Symbol fees

### DIFF
--- a/sdk/javascript/src/RuleBasedTransactionFactory.js
+++ b/sdk/javascript/src/RuleBasedTransactionFactory.js
@@ -56,8 +56,11 @@ const typeConverterFactory = (module, customTypeConverter, value) => {
 const autoEncodeStrings = entity => {
 	Object.getOwnPropertyNames(entity).forEach(key => {
 		const value = entity[key];
-		if ('string' === typeof (value))
+		if ('string' === typeof value)
 			entity[key] = new TextEncoder().encode(value);
+
+		if ('object' === typeof value && null !== value)
+			autoEncodeStrings(value);
 	});
 };
 

--- a/sdk/javascript/src/nem/FeeCalculator.js
+++ b/sdk/javascript/src/nem/FeeCalculator.js
@@ -1,0 +1,101 @@
+import * as nc from './models.js';
+
+/**
+ * Calculates the minimum required mosaic rental fee.
+ * @returns {bigint} Rental fee.
+ */
+const calculateMosaicRentalFee = () => 10n * 1_000_000n;
+
+/**
+ * Calculates the minimum required namespace rental fee.
+ * @param {boolean} isRoot \c true if the fee should be calculated for a root namespace.
+ * @returns {bigint} Rental fee.
+ */
+const calculateNamespaceRentalFee = isRoot => ((isRoot ? 100n : 10n) * 1_000_000n);
+
+const decodeMosaicId = mosaicId => {
+	const decoder = new TextDecoder();
+	return { namespaceId: { name: decoder.decode(mosaicId.namespaceId.name) }, name: decoder.decode(mosaicId.name) };
+};
+
+const calculateUnweightedTransferFee = (transaction, mosaicInformationLookup) => {
+	const XEM_SUPPLY = 8_999_999_999n;
+	const MAX_MOSAIC_UNITS = 9_000_000_000_000_000n;
+
+	// Math.min and Math.max don't work with bigint
+	const min = (lhs, rhs) => (lhs < rhs ? lhs : rhs);
+	const max = (lhs, rhs) => (lhs > rhs ? lhs : rhs);
+
+	const calculateXemTransferFee = amount => min(25n, max(1n, amount / 10000n));
+
+	const calculateMosaicTotalQuantity = mosaicInformation => mosaicInformation.supply * (10n ** BigInt(mosaicInformation.divisibility));
+
+	const calculateXemEquivalent = (amount, /** @type {bigint} */ mosaicAmount, mosaicInformation) => {
+		if (0n === mosaicInformation.supply)
+			return 0n;
+
+		// amount          XEM whole units
+		// mosaicAmount    mosaic atomic units
+		// XEM_SUPPLY / calculateMosaicTotalQuantity(mosaicInformation)    convert mosaicAmount from mosaic units to XEM equivalent units
+		return amount * mosaicAmount * XEM_SUPPLY / calculateMosaicTotalQuantity(mosaicInformation);
+	};
+
+	const calculateMosaicTransferFee = (amount, mosaic, mosaicInformation) => {
+		if (0 === mosaicInformation.divisibility && 10_000n >= mosaicInformation.supply)
+			return 1n;
+
+		const xemEquivalent = calculateXemEquivalent(amount, mosaic.mosaic.amount.value, mosaicInformation);
+		const xemFee = calculateXemTransferFee(xemEquivalent);
+		const mosaicTotalQuantity = calculateMosaicTotalQuantity(mosaicInformation);
+		const supplyRelatedAdjustment = 0 < mosaicTotalQuantity
+			? BigInt(Math.trunc(0.8 * Math.log(Number(MAX_MOSAIC_UNITS / mosaicTotalQuantity))))
+			: 0n;
+		return max(1n, xemFee - supplyRelatedAdjustment);
+	};
+
+	const messageFee = BigInt(!transaction.message ? 0 : Math.trunc(transaction.message.message.length / 32) + 1);
+	const amount = transaction.amount.value / 1_000_000n; // convert to XEM whole units
+	if (0 === transaction.mosaics.length) {
+		const transferFee = calculateXemTransferFee(amount);
+		return messageFee + transferFee;
+	}
+
+	const transferFee = transaction.mosaics.reduce((totalFee, mosaic) => {
+		const mosaicId = decodeMosaicId(mosaic.mosaic.mosaicId);
+		const mosaicInformation = mosaicInformationLookup(mosaicId);
+		if (!mosaicInformation)
+			throw Error(`unable to find fee information for ${mosaicId.namespaceId.name}:${mosaicId.name}`);
+
+		return totalFee + calculateMosaicTransferFee(amount, mosaic, mosaicInformation);
+	}, 0n);
+
+	return messageFee + transferFee;
+};
+
+/**
+ * Calculates the minimum required transaction fee for a transaction.
+ * @param {nc.Transaction} transaction Transaction.
+ * @param {Function|{[key: string]: object}|undefined} mosaicInformationLookup
+ * Looks up mosaic information ({supply, divisibility}) given mosaic identifier.
+ * When a function, mosaic identifier will be passed as parameter.
+ * When an object map, fully qualified mosaic identifier will be used as an index.
+ * When undefined, this function will be unable to calculate fees for custom mosaic transfers.
+ * @returns {bigint} Transaction fee.
+ */
+const calculateTransactionFee = (transaction, mosaicInformationLookup = undefined) => {
+	const weightWithFeeUnit = amount => amount * 50_000n;
+
+	if (nc.TransactionType.TRANSFER !== transaction.type)
+		return weightWithFeeUnit(nc.TransactionType.MULTISIG_ACCOUNT_MODIFICATION === transaction.type ? 10n : 3n);
+
+	const makeLookupFunction = lookup => ('function' === typeof lookup
+		? lookup
+		: mosaicId => lookup[`${mosaicId.namespaceId.name}:${mosaicId.name}`]);
+	return weightWithFeeUnit(calculateUnweightedTransferFee(transaction, makeLookupFunction(mosaicInformationLookup)));
+};
+
+export {
+	calculateMosaicRentalFee,
+	calculateNamespaceRentalFee,
+	calculateTransactionFee
+};

--- a/sdk/javascript/src/nem/TransactionFactory.js
+++ b/sdk/javascript/src/nem/TransactionFactory.js
@@ -77,10 +77,6 @@ export default class TransactionFactory {
 		if (autosort)
 			transaction.sort();
 
-		// hack: explicitly translate transfer message
-		if (nc.TransactionType.TRANSFER === transaction.type && transaction.message && 'string' === typeof (transaction.message.message))
-			transaction.message.message = new TextEncoder().encode(transaction.message.message);
-
 		return transaction;
 	}
 

--- a/sdk/javascript/src/nem/index.js
+++ b/sdk/javascript/src/nem/index.js
@@ -1,3 +1,4 @@
+import { calculateMosaicRentalFee, calculateNamespaceRentalFee, calculateTransactionFee } from './FeeCalculator.js';
 import { KeyPair, Verifier } from './KeyPair.js';
 import MessageEncoder from './MessageEncoder.js';
 import { Address, Network, NetworkTimestamp } from './Network.js';
@@ -74,6 +75,10 @@ export {
 	Verifier,
 
 	// region NEM extensions
+
+	calculateMosaicRentalFee,
+	calculateNamespaceRentalFee,
+	calculateTransactionFee,
 
 	/**
 	 * Raw models generated from catbuffer schemas.

--- a/sdk/javascript/src/symbol/FeeCalculator.js
+++ b/sdk/javascript/src/symbol/FeeCalculator.js
@@ -1,0 +1,13 @@
+import * as sc from './models.js';
+
+/**
+ * Calculates the minimum required transaction fee for a transaction.
+ * @param {sc.Transaction} transaction Transaction.
+ * @param {number} feeMultiplier Fee multiplier to use.
+ * @param {number} cosignatureCount Number of expected cosignatures to be attached.
+ * @returns {bigint} Transaction fee.
+ */
+const calculateTransactionFee = (transaction, feeMultiplier, cosignatureCount = 0) =>
+	(BigInt(transaction.size) * BigInt(feeMultiplier)) + (BigInt(new sc.Cosignature().size) * BigInt(cosignatureCount));
+
+export { calculateTransactionFee }; // eslint-disable-line import/prefer-default-export

--- a/sdk/javascript/src/symbol/index.js
+++ b/sdk/javascript/src/symbol/index.js
@@ -1,3 +1,4 @@
+import { calculateTransactionFee } from './FeeCalculator.js';
 import { KeyPair, Verifier } from './KeyPair.js';
 import MessageEncoder from './MessageEncoder.js';
 import { Address, Network, NetworkTimestamp } from './Network.js';
@@ -92,6 +93,8 @@ export {
 	// endregion
 
 	// region Symbol extensions
+
+	calculateTransactionFee,
 
 	generateMosaicId,
 	generateNamespaceId,

--- a/sdk/javascript/test/RuleBasedTransactionFactory_spec.js
+++ b/sdk/javascript/test/RuleBasedTransactionFactory_spec.js
@@ -83,6 +83,26 @@ describe('RuleBasedTransactionFactory', () => {
 			}
 		};
 
+		static StructWrapped = class StructWrapped {
+			static TYPE_HINTS = {
+				inner: 'struct:StructPlain'
+			};
+
+			constructor() {
+				this.inner = new Module.StructPlain();
+			}
+		};
+
+		static StructAggregate = class StructAggregate {
+			TYPE_HINTS = {
+				components: 'array[StructPlain]'
+			};
+
+			constructor() {
+				this.components = [];
+			}
+		};
+
 		static StructArrayMember = class StructArrayParse {
 			static TYPE_HINTS = {
 				mosaicIds: 'array[UnresolvedMosaicId]'
@@ -593,6 +613,64 @@ describe('RuleBasedTransactionFactory', () => {
 				0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x5F, 0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46
 			]));
 			expect(parsed.amount).to.deep.equal(new Uint8Array([
+				0x31, 0x32, 0x33, 0x5F, 0x34, 0x35, 0x36, 0x5F, 0x37, 0x38, 0x39, 0x5F,
+				0x31, 0x32, 0x33, 0x5F, 0x34, 0x35, 0x36, 0x5F, 0x37, 0x38, 0x39
+			]));
+			expect(parsed.type).to.equal(undefined);
+		});
+
+		it('can create struct and auto encode nested strings', () => {
+			// Arrange: use a wrapped struct but set string values in the inner struct
+			const factory = new RuleBasedTransactionFactory(Module);
+			factory.addStructParser('StructPlain');
+			factory.addStructParser('StructWrapped');
+			const entityFactory = entityType => (123 !== entityType ? undefined : new Module.StructWrapped());
+
+			// Act:
+			const parsed = factory.createFromFactory(entityFactory, {
+				type: 123,
+				inner: {
+					mosaicId: '01234567_89ABCDEF',
+					amount: '123_456_789_123_456_789'
+				}
+			});
+
+			// Assert: string values were encoded into utf8
+			expect(parsed.inner.mosaicId).to.deep.equal(new Uint8Array([
+				0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x5F, 0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46
+			]));
+			expect(parsed.inner.amount).to.deep.equal(new Uint8Array([
+				0x31, 0x32, 0x33, 0x5F, 0x34, 0x35, 0x36, 0x5F, 0x37, 0x38, 0x39, 0x5F,
+				0x31, 0x32, 0x33, 0x5F, 0x34, 0x35, 0x36, 0x5F, 0x37, 0x38, 0x39
+			]));
+			expect(parsed.type).to.equal(undefined);
+		});
+
+		it('can create struct and auto encode nested strings in array', () => {
+			// Arrange: use an aggregate struct but set string values in the inner struct
+			const factory = new RuleBasedTransactionFactory(Module);
+			factory.addStructParser('StructPlain');
+			factory.addArrayParser('struct:StructPlain');
+			factory.addStructParser('StructAggregate');
+			const entityFactory = entityType => (123 !== entityType ? undefined : new Module.StructAggregate());
+
+			// Act:
+			const parsed = factory.createFromFactory(entityFactory, {
+				type: 123,
+				components: [
+					{
+						mosaicId: '01234567_89ABCDEF',
+						amount: '123_456_789_123_456_789'
+					}
+				]
+			});
+
+			// Assert: string values were encoded into utf8
+			expect(parsed.components.length).to.equal(1);
+			expect(parsed.components[0].mosaicId).to.deep.equal(new Uint8Array([
+				0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x5F, 0x38, 0x39, 0x41, 0x42, 0x43, 0x44, 0x45, 0x46
+			]));
+			expect(parsed.components[0].amount).to.deep.equal(new Uint8Array([
 				0x31, 0x32, 0x33, 0x5F, 0x34, 0x35, 0x36, 0x5F, 0x37, 0x38, 0x39, 0x5F,
 				0x31, 0x32, 0x33, 0x5F, 0x34, 0x35, 0x36, 0x5F, 0x37, 0x38, 0x39
 			]));

--- a/sdk/javascript/test/nem/FeeCalculator_spec.js
+++ b/sdk/javascript/test/nem/FeeCalculator_spec.js
@@ -1,0 +1,390 @@
+import { calculateMosaicRentalFee, calculateNamespaceRentalFee, calculateTransactionFee } from '../../src/nem/FeeCalculator.js';
+import { Network } from '../../src/nem/Network.js';
+import TransactionFactory from '../../src/nem/TransactionFactory.js';
+import * as nc from '../../src/nem/models.js';
+import { expect } from 'chai';
+
+describe('FeeCalculator', () => {
+	describe('calculateMosaicRentalFee', () => {
+		it('calculates correct fee', () => {
+			expect(calculateMosaicRentalFee()).to.equal(10_000_000n);
+		});
+	});
+
+	describe('calculateNamespaceRentalFee', () => {
+		it('calculates correct root fee', () => {
+			expect(calculateNamespaceRentalFee(true)).to.equal(100_000_000n);
+		});
+
+		it('calculates correct child fee', () => {
+			expect(calculateNamespaceRentalFee(false)).to.equal(10_000_000n);
+		});
+	});
+
+	describe('calculateTransactionFee', () => {
+		const createTransactionWithType = type => {
+			const transaction = new nc.Transaction();
+			transaction.type = type;
+			return transaction;
+		};
+
+		it('calculates correct fee for multisig account modification', () => {
+			// Act:
+			const fee = calculateTransactionFee(createTransactionWithType(nc.TransactionType.MULTISIG_ACCOUNT_MODIFICATION));
+
+			// Assert:
+			expect(fee).to.equal(500_000n);
+		});
+
+		it('calculates correct fee for other transactions', () => {
+			// Arrange:
+			const specialTransactionTypeNames = ['TRANSFER', 'MULTISIG_ACCOUNT_MODIFICATION'];
+			const otherTransactionTypeNames = Object.getOwnPropertyNames(nc.TransactionType).filter(propertyName =>
+				nc.TransactionType[propertyName].value && !specialTransactionTypeNames.includes(propertyName));
+
+			// Sanity:
+			expect(otherTransactionTypeNames.length).to.equal(6);
+
+			// Act:
+			otherTransactionTypeNames.forEach(transactionTypeName => {
+				const fee = calculateTransactionFee(createTransactionWithType(nc.TransactionType[transactionTypeName]));
+
+				// Assert:
+				expect(fee, transactionTypeName).to.equal(150_000n);
+			});
+		});
+
+		describe('calculates correct fee for transfers', () => {
+			const weightWithFeeUnit = amount => amount * 50_000n;
+			const createMosaicId = (namespaceName, name) => {
+				const encoder = new TextEncoder();
+				return { namespaceId: { name: encoder.encode(namespaceName) }, name: encoder.encode(name) };
+			};
+
+			describe('simple', () => {
+				const assertXemFee = (amount, messageSize, expectedFee) => {
+					// Arrange:
+					const factory = new TransactionFactory(Network.TESTNET);
+
+					const descriptor = {
+						type: 'transfer_transaction_v2',
+						amount: amount * 1_000_000
+					};
+					if (messageSize) {
+						descriptor.message = {
+							messageType: 1,
+							message: 'a'.repeat(messageSize)
+						};
+					}
+
+					const transaction = factory.create(descriptor);
+
+					// Act:
+					const fee = calculateTransactionFee(transaction);
+
+					// Assert:
+					expect(fee, `amount ${amount}, messageSize ${messageSize}`).to.equal(expectedFee);
+				};
+
+				it('when empty', () => {
+					assertXemFee(0, 0, weightWithFeeUnit(1n));
+				});
+
+				it('near step increases', () => {
+					// Arrange: fee is initially 1 and increased every 10k XEM until is reaches a max fee of 25 XEM
+					const step = 10_000;
+					for (let i = 0; 26 > i; ++i) {
+						const amount = i * step;
+						const fee = BigInt(Math.max(1, Math.min(25, amount / step)));
+
+						// Act + Assert:
+						assertXemFee(amount, 0, weightWithFeeUnit(fee));
+						assertXemFee(amount + 1, 0, weightWithFeeUnit(fee));
+						assertXemFee(amount + 100, 0, weightWithFeeUnit(fee));
+						assertXemFee(amount + step - 1, 0, weightWithFeeUnit(fee));
+					}
+				});
+
+				it('caps fee at 25 XEM', () => {
+					const amounts = [250_000, 250_001, 500_000, 1_000_000, 10_000_000, 100_000_000, 1_000_000_000];
+					amounts.forEach(amount => {
+						assertXemFee(amount, 0, weightWithFeeUnit(25n));
+					});
+				});
+
+				it('with message', () => {
+					assertXemFee(10_000, 96, weightWithFeeUnit(1n + 4n));
+					assertXemFee(100_000, 128, weightWithFeeUnit(10n + 5n));
+					assertXemFee(1_000_000, 96, weightWithFeeUnit(25n + 4n));
+					assertXemFee(2_000_000, 128, weightWithFeeUnit(25n + 5n));
+				});
+
+				it('with smallest message', () => {
+					assertXemFee(1200, 1, weightWithFeeUnit(1n + 1n));
+				});
+
+				it('near message step increases', () => {
+					assertXemFee(1200, 31, weightWithFeeUnit(1n + 1n));
+					assertXemFee(1200, 32, weightWithFeeUnit(1n + 2n));
+					assertXemFee(1200, 33, weightWithFeeUnit(1n + 2n));
+
+					assertXemFee(1200, 63, weightWithFeeUnit(1n + 2n));
+					assertXemFee(1200, 64, weightWithFeeUnit(1n + 3n));
+					assertXemFee(1200, 65, weightWithFeeUnit(1n + 3n));
+				});
+
+				it('with large message', () => {
+					assertXemFee(1200, 96, weightWithFeeUnit(1n + 4n));
+					assertXemFee(1200, 128, weightWithFeeUnit(1n + 5n));
+					assertXemFee(1200, 256, weightWithFeeUnit(1n + 9n));
+					assertXemFee(1200, 320, weightWithFeeUnit(1n + 11n));
+				});
+			});
+
+			describe('small business mosaics', () => {
+				// A so-called small business mosaic has divisibility of 0 and a max supply of 10000
+				// It is always charged 1 XEM fee no matter how many mosaics are transferred
+				// Mosaic 'small business x' has divisibility 0 and supply x * 1000 for x > 0
+				// Mosaic 'small business 0' has divisibility 1 and supply 1000 (so it is NOT a small business mosaic)
+
+				const mosaicInformationLookup = mosaicId => {
+					const smallBusinessPrefix = 'small business';
+					if (`${smallBusinessPrefix} 0` === mosaicId.name)
+						return { supply: 1000n, divisibility: 1 };
+
+					if (mosaicId.name.startsWith(smallBusinessPrefix)) {
+						const supply = BigInt(parseInt(mosaicId.name.substring(smallBusinessPrefix.length + 1), 10) * 1000);
+						return { supply, divisibility: 0 };
+					}
+
+					return undefined;
+				};
+
+				const assertSmallBusinessMosaicFee = (smallBusinessId, amount, expectedFee) => {
+					// Arrange:
+					const factory = new TransactionFactory(Network.TESTNET);
+					const transaction = factory.create({
+						type: 'transfer_transaction_v2',
+						amount: 1_000_000,
+						mosaics: [
+							{
+								mosaic: {
+									mosaicId: createMosaicId('foo', `small business ${smallBusinessId}`),
+									amount
+								}
+							}
+						]
+					});
+
+					// Act:
+					const fee = calculateTransactionFee(transaction, mosaicInformationLookup);
+
+					// Assert:
+					expect(fee, `smallBusinessId ${smallBusinessId}`).to.equal(expectedFee);
+				};
+
+				it('uses minimum fee for mosaics with divisibility zero and low supply', () => {
+					for (let i = 1; 10 >= i; ++i)
+						assertSmallBusinessMosaicFee(i, i * 1000, weightWithFeeUnit(1n));
+				});
+
+				it('does not use minimum fee for mosaics with divisibility zero and supply above threshold', () => {
+					// Assert: supply of 11000 means it is not a small business mosaic
+					assertSmallBusinessMosaicFee(11, 1000, weightWithFeeUnit(4n));
+				});
+
+				it('does not use minimum fee for mosaics with divisibility greater than zero', () => {
+					// Arrange: nonzero divisibility means it is not a small business mosaic
+					assertSmallBusinessMosaicFee(0, 1000, weightWithFeeUnit(3n));
+				});
+			});
+
+			describe('other mosaic', () => {
+				// mosaic definition data used for the following tests: supply = 100_000_000, divisibility = 3
+				// supply ratio: 8_999_999_999 / 100_000_000 ≈ 90
+				// divisibility ratio = 1_000_000 / 1_000 = 1000
+				// 1000 / 90 = 11.11..., so transferring a quantity of 12 is roughly like transferring 1 XEM
+				// Adjustment for the fee is 9 XEM due to the lower supply and divisibility
+
+				const mosaicInformationLookup = mosaicId => {
+					const multiplier = parseInt(mosaicId.name, 10);
+					const divisibilityChange = multiplier - 1;
+					return { supply: 100_000_000n * BigInt(multiplier), divisibility: 3 + divisibilityChange };
+				};
+
+				const assertSingleMosaicFee = (amount, messageSize, quantity, expectedFee) => {
+					// Arrange:
+					const factory = new TransactionFactory(Network.TESTNET);
+
+					const descriptor = {
+						type: 'transfer_transaction_v2',
+						amount: amount * 1_000_000,
+						mosaics: [
+							{
+								mosaic: {
+									mosaicId: createMosaicId('foo', '1'),
+									amount: quantity
+								}
+							}
+						]
+					};
+					if (messageSize) {
+						descriptor.message = {
+							messageType: 1,
+							message: 'a'.repeat(messageSize)
+						};
+					}
+
+					const transaction = factory.create(descriptor);
+
+					// Act:
+					const fee = calculateTransactionFee(transaction, mosaicInformationLookup);
+
+					// Assert:
+					expect(fee, `amount ${amount}, messageSize ${messageSize}, quantity ${quantity}`).to.equal(expectedFee);
+				};
+
+				it('near mosaic transfer step increases', () => {
+					// Assert: minimum fee for low amounts
+					assertSingleMosaicFee(1, 0, 12, weightWithFeeUnit(1n)); // ~ 1 XEM
+					assertSingleMosaicFee(1, 0, 111_000, weightWithFeeUnit(1n)); // ~9_999 XEM
+
+					// - 1 -> 2 roughly at 1222.222 units
+					assertSingleMosaicFee(1, 0, 1_222_000n, weightWithFeeUnit(1n));
+					assertSingleMosaicFee(1, 0, 1_223_000n, weightWithFeeUnit(2n)); // ~ 110_000 XEM
+					assertSingleMosaicFee(1, 0, 1_224_000n, weightWithFeeUnit(2n));
+
+					// - 2 -> 3 roughly at 1333.333 units
+					assertSingleMosaicFee(1, 0, 1_333_000n, weightWithFeeUnit(2n));
+					assertSingleMosaicFee(1, 0, 1_334_000n, weightWithFeeUnit(3n)); // ~ 120_000 XEM
+					assertSingleMosaicFee(1, 0, 1_335_000n, weightWithFeeUnit(3n));
+
+					// - 3 -> 4 roughly at 1444.444 units
+					assertSingleMosaicFee(1, 0, 1_444_000n, weightWithFeeUnit(3n));
+					assertSingleMosaicFee(1, 0, 1_445_000n, weightWithFeeUnit(4n)); // ~ 130_000 XEM
+					assertSingleMosaicFee(1, 0, 1_446_000n, weightWithFeeUnit(4n));
+				});
+
+				it('large mosaic transfers', () => {
+					assertSingleMosaicFee(1, 0, 2_112_000n, weightWithFeeUnit(10n)); // ~ 190_000 XEM
+					assertSingleMosaicFee(1, 0, 2_445_000n, weightWithFeeUnit(13n)); // ~ 220_000 XEM
+					assertSingleMosaicFee(1, 0, 2_778_000n, weightWithFeeUnit(16n)); // ~ 250_000 XEM
+					assertSingleMosaicFee(1, 0, 3_000_000n, weightWithFeeUnit(16n));
+					assertSingleMosaicFee(1, 0, 10_000_000n, weightWithFeeUnit(16n));
+					assertSingleMosaicFee(1, 0, 100_000_000n, weightWithFeeUnit(16n));
+				});
+
+				it('with amounts greater than one', () => {
+					// Assert: notice that amount * quantity is constant
+					assertSingleMosaicFee(1, 0, 2_112_000n, weightWithFeeUnit(10n));
+					assertSingleMosaicFee(2, 0, 1_056_000n, weightWithFeeUnit(10n));
+					assertSingleMosaicFee(5, 0, 422_400n, weightWithFeeUnit(10n));
+					assertSingleMosaicFee(10, 0, 211_200n, weightWithFeeUnit(10n));
+					assertSingleMosaicFee(100, 0, 21_120n, weightWithFeeUnit(10n));
+					assertSingleMosaicFee(1_000, 0, 2_112n, weightWithFeeUnit(10n));
+					assertSingleMosaicFee(21_120, 0, 100n, weightWithFeeUnit(10n));
+					assertSingleMosaicFee(2_112_000, 0, 1n, weightWithFeeUnit(10n));
+				});
+
+				it('with message', () => {
+					assertSingleMosaicFee(1, 15, 2_112_000n, weightWithFeeUnit(10n + 1n));
+					assertSingleMosaicFee(1, 32, 2_112_000n, weightWithFeeUnit(10n + 2n));
+					assertSingleMosaicFee(1, 96, 2_112_000n, weightWithFeeUnit(10n + 4n));
+					assertSingleMosaicFee(1, 160, 2_112_000n, weightWithFeeUnit(10n + 6n));
+				});
+
+				it('sums fees when transferring several mosaics (function based lookup)', () => {
+					// Arrange: mosaic definitions are (100M, 3), (200M, 4), (300M, 5)
+					const factory = new TransactionFactory(Network.TESTNET);
+					const transaction = factory.create({
+						type: 'transfer_transaction_v2',
+						amount: 1_000_000,
+						mosaics: [2_000_000n, 50_000_000n, 800_000_000n].map((amount, i) => ({
+							mosaic: {
+								mosaicId: createMosaicId('foo', (i + 1).toString()),
+								amount
+							}
+						}))
+					});
+
+					// Act:
+					const fee = calculateTransactionFee(transaction, mosaicInformationLookup);
+
+					// Assert:
+					expect(fee).to.equal(weightWithFeeUnit(8n + 16n + 19n));
+				});
+
+				it('sums fees when transferring several mosaics (object based lookup)', () => {
+					// Arrange: mosaic definitions are (100M, 3), (200M, 4), (300M, 5)
+					const factory = new TransactionFactory(Network.TESTNET);
+					const transaction = factory.create({
+						type: 'transfer_transaction_v2',
+						amount: 1_000_000,
+						mosaics: [2_000_000n, 50_000_000n, 800_000_000n].map((amount, i) => ({
+							mosaic: {
+								mosaicId: createMosaicId('foo', (i + 1).toString()),
+								amount
+							}
+						}))
+					});
+
+					// Act:
+					const fee = calculateTransactionFee(transaction, {
+						'foo:1': { supply: 100_000_000n, divisibility: 3 },
+						'foo:2': { supply: 200_000_000n, divisibility: 4 },
+						'foo:3': { supply: 300_000_000n, divisibility: 5 }
+					});
+
+					// Assert:
+					expect(fee).to.equal(weightWithFeeUnit(8n + 16n + 19n));
+				});
+			});
+
+			describe('edge case', () => {
+				it('uses minimum fee when mosaic supply is zero', () => {
+					// Arrange:
+					const factory = new TransactionFactory(Network.TESTNET);
+					const transaction = factory.create({
+						type: 'transfer_transaction_v2',
+						amount: 1_000_000,
+						mosaics: [
+							{
+								mosaic: {
+									mosaicId: createMosaicId('foo', 'zero supply'),
+									amount: 5000000
+								}
+							}
+						]
+					});
+
+					// Act:
+					const fee = calculateTransactionFee(transaction, () => ({ supply: 0n, divisibility: 3 }));
+
+					// Assert:
+					expect(fee).to.equal(weightWithFeeUnit(1n));
+				});
+
+				it('fails for unknown mosaic', () => {
+					// Arrange:
+					const factory = new TransactionFactory(Network.TESTNET);
+					const transaction = factory.create({
+						type: 'transfer_transaction_v2',
+						amount: 1_000_000,
+						mosaics: [
+							{
+								mosaic: {
+									mosaicId: createMosaicId('foo', 'bar'),
+									amount: 5000000
+								}
+							}
+						]
+					});
+
+					// Act + Assert:
+					expect(() => calculateTransactionFee(transaction, () => undefined))
+						.to.throw('unable to find fee information for foo:bar');
+				});
+			});
+		});
+	});
+});

--- a/sdk/javascript/test/nem/TransactionFactory_spec.js
+++ b/sdk/javascript/test/nem/TransactionFactory_spec.js
@@ -188,7 +188,7 @@ describe('transaction factory (NEM)', () => {
 
 	// endregion
 
-	// region message encoding
+	// region string handling
 
 	it('can create transfer with string message', () => {
 		// Arrange:
@@ -206,6 +206,30 @@ describe('transaction factory (NEM)', () => {
 
 		// Assert:
 		expect(transaction.message.message).to.deep.equal(new TextEncoder().encode('You miss 100%% of the shots you don\'t take'));
+	});
+
+	it('can create transfer with string mosaic id', () => {
+		// Arrange:
+		const factory = testDescriptor.createFactory();
+
+		// Act:
+		const transaction = testDescriptor.createTransaction(factory)({
+			type: 'transfer_transaction_v2',
+			signerPublicKey: TEST_SIGNER_PUBLIC_KEY,
+			mosaics: [
+				{
+					mosaic: {
+						mosaicId: { namespaceId: { name: 'foo' }, name: 'bar' },
+						amount: 1
+					}
+				}
+			]
+		});
+
+		// Assert:
+		expect(transaction.mosaics.length).to.equal(1);
+		expect(transaction.mosaics[0].mosaic.mosaicId.namespaceId.name).to.deep.equal(new TextEncoder().encode('foo'));
+		expect(transaction.mosaics[0].mosaic.mosaicId.name).to.deep.equal(new TextEncoder().encode('bar'));
 	});
 
 	// endregion

--- a/sdk/javascript/test/symbol/FeeCalculator_spec.js
+++ b/sdk/javascript/test/symbol/FeeCalculator_spec.js
@@ -1,0 +1,34 @@
+import { calculateTransactionFee } from '../../src/symbol/FeeCalculator.js';
+import { Network } from '../../src/symbol/Network.js';
+import TransactionFactory from '../../src/symbol/TransactionFactory.js';
+import { expect } from 'chai';
+
+describe('FeeCalculator', () => {
+	describe('calculateTransactionFee', () => {
+		it('can calculate fee for transaction without cosignatures', () => {
+			// Arrange:
+			const factory = new TransactionFactory(Network.TESTNET);
+			const transaction = factory.create({
+				type: 'transfer_transaction_v1'
+			});
+
+			// Act + Assert: transfer size is 160
+			expect(calculateTransactionFee(transaction, 100)).to.equal(16000n);
+			expect(calculateTransactionFee(transaction, 150)).to.equal(24000n);
+			expect(calculateTransactionFee(transaction, 200)).to.equal(32000n);
+		});
+
+		it('can calculate fee for transaction with cosignatures', () => {
+			// Arrange:
+			const factory = new TransactionFactory(Network.TESTNET);
+			const transaction = factory.create({
+				type: 'transfer_transaction_v1'
+			});
+
+			// Act + Assert: transfer size is 160, cosignature size is 104
+			expect(calculateTransactionFee(transaction, 100, 3)).to.equal(16000n + 312n);
+			expect(calculateTransactionFee(transaction, 150, 4)).to.equal(24000n + 416n);
+			expect(calculateTransactionFee(transaction, 200, 5)).to.equal(32000n + 520n);
+		});
+	});
+});

--- a/sdk/python/symbolchain/RuleBasedTransactionFactory.py
+++ b/sdk/python/symbolchain/RuleBasedTransactionFactory.py
@@ -161,6 +161,17 @@ class RuleBasedTransactionFactory:
 
 	@staticmethod
 	def _auto_encode_strings(entity):
+		if not hasattr(entity, '__dict__'):  # skip non-objects
+			return
+
 		for key, value in vars(entity).items():
+			if '_' == key[0] and '_' == key[-1]:  # skip system properties
+				continue
+
 			if isinstance(value, str):
-				setattr(entity, key, value.encode('utf8'))
+				setattr(entity, key, value.encode('utf8'))  # convert string literals to byte array
+			elif hasattr(value, '__len__'):  # process list items
+				for item in value:
+					RuleBasedTransactionFactory._auto_encode_strings(item)
+			else:
+				RuleBasedTransactionFactory._auto_encode_strings(value)  # process nested objects

--- a/sdk/python/symbolchain/nem/FeeCalculator.py
+++ b/sdk/python/symbolchain/nem/FeeCalculator.py
@@ -1,0 +1,94 @@
+import math
+
+from symbolchain.nc import TransactionType
+
+
+def calculate_mosaic_rental_fee():
+	"""Calculates the minimum required mosaic rental fee."""
+
+	return 10 * 1_000_000
+
+
+def calculate_namespace_rental_fee(is_root):
+	"""
+	Calculates the minimum required namespace rental fee.
+	When is_root is True, calculates the root namespace fee.
+	Otherwise, calculates the child namespace fee.
+	"""
+
+	return (100 if is_root else 10) * 1_000_000
+
+
+def _decode_mosaic_id(mosaic_id):
+	return {'namespace_id': {'name': mosaic_id.namespace_id.name.decode('utf8')}, 'name': mosaic_id.name.decode('utf8')}
+
+
+def _calculate_unweighted_transfer_fee(transaction, mosaic_information_lookup):
+	xem_supply = 8_999_999_999
+	max_mosaic_units = 9_000_000_000_000_000
+
+	def _calculate_xem_transfer_fee(amount):
+		return int(min(25, max(1, amount // 10000)))
+
+	def _calculate_mosaic_total_quantity(mosaic_information):
+		return mosaic_information['supply'] * (10 ** mosaic_information['divisibility'])
+
+	def _calculate_xem_equivalent(amount, mosaic_amount, mosaic_information):
+		if 0 == mosaic_information['supply']:
+			return 0
+
+		# amount          XEM whole units
+		# mosaic_amount   mosaic atomic units
+		# xem_supply / _calculate_mosaic_total_quantity(mosaic_information)  convert mosaic_amount from mosaic units to XEM equivalent units
+		return amount * mosaic_amount * xem_supply / _calculate_mosaic_total_quantity(mosaic_information)
+
+	def _calculate_mosaic_transfer_fee(amount, mosaic, mosaic_information):
+		if 0 == mosaic_information['divisibility'] and 10_000 >= mosaic_information['supply']:
+			return 1
+
+		xem_equivalent = _calculate_xem_equivalent(amount, mosaic.mosaic.amount.value, mosaic_information)
+		xem_fee = _calculate_xem_transfer_fee(xem_equivalent)
+		mosaic_total_quantity = _calculate_mosaic_total_quantity(mosaic_information)
+		supply_related_adjustment = 0 if 0 == mosaic_total_quantity else int(0.8 * math.log(max_mosaic_units / mosaic_total_quantity))
+		return max(1, xem_fee - supply_related_adjustment)
+
+	message_fee = 0 if not transaction.message else len(transaction.message.message) // 32 + 1
+	amount = transaction.amount.value // 1_000_000  # convert to XEM whole units
+	if not transaction.mosaics:
+		transfer_fee = _calculate_xem_transfer_fee(amount)
+		return message_fee + transfer_fee
+
+	def _lookup_and_calculate_mosaic_transfer_fee(mosaic):
+		mosaic_id = _decode_mosaic_id(mosaic.mosaic.mosaic_id)
+		mosaic_information = mosaic_information_lookup(mosaic_id)
+		if not mosaic_information:
+			raise ValueError(f'unable to find fee information for {mosaic_id["namespace_id"]["name"]}:{mosaic_id["name"]}')
+
+		return _calculate_mosaic_transfer_fee(amount, mosaic, mosaic_information)
+
+	transfer_fee = sum(_lookup_and_calculate_mosaic_transfer_fee(mosaic) for mosaic in transaction.mosaics)
+	return message_fee + transfer_fee
+
+
+def calculate_transaction_fee(transaction, mosaic_information_lookup=None):
+	"""
+	Calculates the minimum required transaction fee for a transaction.
+	mosaic_information_lookup looks up mosaic information ({supply, divisibility}) given mosaic identifier.
+	When a function, mosaic identifier will be passed as parameter.
+	When an object map, fully qualified mosaic identifier will be used as an index.
+	When None, this function will be unable to calculate fees for custom mosaic transfers.
+	"""
+
+	def _weight_with_fee_unit(amount):
+		return amount * 50_000
+
+	if TransactionType.TRANSFER != transaction.type_:
+		return _weight_with_fee_unit(10 if TransactionType.MULTISIG_ACCOUNT_MODIFICATION == transaction.type_ else 3)
+
+	def _make_lookup_function(lookup):
+		if callable(lookup):
+			return lookup
+
+		return lambda mosaic_id: lookup[f'{mosaic_id["namespace_id"]["name"]}:{mosaic_id["name"]}']
+
+	return _weight_with_fee_unit(_calculate_unweighted_transfer_fee(transaction, _make_lookup_function(mosaic_information_lookup)))

--- a/sdk/python/symbolchain/nem/TransactionFactory.py
+++ b/sdk/python/symbolchain/nem/TransactionFactory.py
@@ -33,10 +33,6 @@ class TransactionFactory:
 		if autosort:
 			transaction.sort()
 
-		# hack: explicitly translate transfer message
-		if nc.TransactionType.TRANSFER == transaction.type_ and transaction.message and isinstance(transaction.message.message, str):
-			transaction.message.message = transaction.message.message.encode('utf8')
-
 		return transaction
 
 	@staticmethod

--- a/sdk/python/symbolchain/symbol/FeeCalculator.py
+++ b/sdk/python/symbolchain/symbol/FeeCalculator.py
@@ -1,0 +1,7 @@
+from symbolchain.sc import Cosignature
+
+
+def calculate_transaction_fee(transaction, fee_multiplier, cosignature_count=0):
+	"""Calculates the minimum required transaction fee for a transaction."""
+
+	return transaction.size * fee_multiplier + Cosignature().size * cosignature_count

--- a/sdk/python/tests/nem/test_FeeCalculator.py
+++ b/sdk/python/tests/nem/test_FeeCalculator.py
@@ -1,0 +1,379 @@
+import unittest
+
+from symbolchain.nc import Transaction, TransactionType
+from symbolchain.nem.FeeCalculator import calculate_mosaic_rental_fee, calculate_namespace_rental_fee, calculate_transaction_fee
+from symbolchain.nem.Network import Network
+from symbolchain.nem.TransactionFactory import TransactionFactory
+
+
+class CalculateMosaicRentalFeeTest(unittest.TestCase):
+	def test_calculates_correct_fee(self):
+		self.assertEqual(10_000_000, calculate_mosaic_rental_fee())
+
+
+class CalculateNamespaceRentalFeeTest(unittest.TestCase):
+	def test_calculates_correct_root_fee(self):
+		self.assertEqual(100_000_000, calculate_namespace_rental_fee(True))
+
+	def test_calculates_correct_child_fee(self):
+		self.assertEqual(10_000_000, calculate_namespace_rental_fee(False))
+
+
+class CalculateTransactionFeeTest(unittest.TestCase):
+	@staticmethod
+	def _create_transaction_with_type(transaction_type):
+		transaction = Transaction()
+		transaction.type_ = transaction_type
+		return transaction
+
+	def test_calculates_correct_fee_for_multisig_account_modification(self):
+		# Act:
+		fee = calculate_transaction_fee(self._create_transaction_with_type(TransactionType.MULTISIG_ACCOUNT_MODIFICATION))
+
+		# Assert:
+		self.assertIsInstance(fee, int)
+		self.assertEqual(500_000, fee)
+
+	def test_calculates_correct_fee_for_other_transactions(self):
+		# Arrange:
+		special_transaction_type_names = ['TRANSFER', 'MULTISIG_ACCOUNT_MODIFICATION']
+
+		def _is_other_transaction_type(property_name):
+			return property_name not in special_transaction_type_names and not property_name.startswith('_')
+
+		other_transaction_type_names = list(filter(_is_other_transaction_type, dir(TransactionType)))
+
+		# Sanity:
+		self.assertEqual(6, len(other_transaction_type_names))
+
+		# Act:
+		for transaction_type_name in other_transaction_type_names:
+			fee = calculate_transaction_fee(self._create_transaction_with_type(TransactionType[transaction_type_name]))
+
+			# Assert:
+			self.assertIsInstance(fee, int)
+			self.assertEqual(150_000, fee)
+
+	@staticmethod
+	def _weight_with_fee_unit(amount):
+		return amount * 50_000
+
+	@staticmethod
+	def _create_mosaic_id(namespace_name, name):
+		return {'namespace_id': {'name': namespace_name.encode('utf8')}, 'name': name.encode('utf8')}
+
+	# region transfers - simple
+
+	def _assert_xem_fee(self, amount, message_size, expected_fee):
+		# Arrange:
+		factory = TransactionFactory(Network.TESTNET)
+
+		descriptor = {
+			'type': 'transfer_transaction_v2',
+			'amount': amount * 1_000_000
+		}
+		if message_size:
+			descriptor['message'] = {
+				'message_type': 1,
+				'message': 'a' * message_size
+			}
+
+		transaction = factory.create(descriptor)
+
+		# Act:
+		fee = calculate_transaction_fee(transaction)
+
+		# Assert:
+		self.assertIsInstance(fee, int)
+		self.assertEqual(expected_fee, fee, f'amount ${amount}, message_size ${message_size}')
+
+	def test_calculates_correct_fee_for_transfers_simple_when_empty(self):
+		self._assert_xem_fee(0, 0, self._weight_with_fee_unit(1))
+
+	def test_calculates_correct_fee_for_transfers_simple_near_step_increases(self):
+		# Arrange: fee is initially 1 and increased every 10k XEM until is reaches a max fee of 25 XEM
+		step = 10_000
+		for i in range(26):
+			amount = i * step
+			fee = max(1, min(25, amount / step))
+
+			# Act + Assert:
+			self._assert_xem_fee(amount, 0, self._weight_with_fee_unit(fee))
+			self._assert_xem_fee(amount + 1, 0, self._weight_with_fee_unit(fee))
+			self._assert_xem_fee(amount + 100, 0, self._weight_with_fee_unit(fee))
+			self._assert_xem_fee(amount + step - 1, 0, self._weight_with_fee_unit(fee))
+
+	def test_calculates_correct_fee_for_transfers_simple_caps_fee(self):
+		amounts = [250_000, 250_001, 500_000, 1_000_000, 10_000_000, 100_000_000, 1_000_000_000]
+		for amount in amounts:
+			self._assert_xem_fee(amount, 0, self._weight_with_fee_unit(25))
+
+	def test_calculates_correct_fee_for_transfers_simple_with_message(self):
+		self._assert_xem_fee(10_000, 96, self._weight_with_fee_unit(1 + 4))
+		self._assert_xem_fee(100_000, 128, self._weight_with_fee_unit(10 + 5))
+		self._assert_xem_fee(1_000_000, 96, self._weight_with_fee_unit(25 + 4))
+		self._assert_xem_fee(2_000_000, 128, self._weight_with_fee_unit(25 + 5))
+
+	def test_calculates_correct_fee_for_transfers_simple_with_smallest_message(self):
+		self._assert_xem_fee(1200, 1, self._weight_with_fee_unit(1 + 1))
+
+	def test_calculates_correct_fee_for_transfers_simple_near_message_step_increases(self):
+		self._assert_xem_fee(1200, 31, self._weight_with_fee_unit(1 + 1))
+		self._assert_xem_fee(1200, 32, self._weight_with_fee_unit(1 + 2))
+		self._assert_xem_fee(1200, 33, self._weight_with_fee_unit(1 + 2))
+
+		self._assert_xem_fee(1200, 63, self._weight_with_fee_unit(1 + 2))
+		self._assert_xem_fee(1200, 64, self._weight_with_fee_unit(1 + 3))
+		self._assert_xem_fee(1200, 65, self._weight_with_fee_unit(1 + 3))
+
+	def test_calculates_correct_fee_for_transfers_simple_with_large_message(self):
+		self._assert_xem_fee(1200, 96, self._weight_with_fee_unit(1 + 4))
+		self._assert_xem_fee(1200, 128, self._weight_with_fee_unit(1 + 5))
+		self._assert_xem_fee(1200, 256, self._weight_with_fee_unit(1 + 9))
+		self._assert_xem_fee(1200, 320, self._weight_with_fee_unit(1 + 11))
+
+	# endregion
+
+	# region transfers - small business mosaics
+
+	# A so-called small business mosaic has divisibility of 0 and a max supply of 10000
+	# It is always charged 1 XEM fee no matter how many mosaics are transferred
+	# Mosaic 'small business x' has divisibility 0 and supply x * 1000 for x > 0
+	# Mosaic 'small business 0' has divisibility 1 and supply 1000 (so it is NOT a small business mosaic)
+
+	def _assert_small_business_mosaic_fee(self, small_business_id, amount, expected_fee):
+		def _mosaic_information_lookup(mosaic_id):
+			small_business_prefix = 'small business'
+			if f'{small_business_prefix} 0' == mosaic_id['name']:
+				return {'supply': 1000, 'divisibility': 1}
+
+			if mosaic_id['name'].startswith(small_business_prefix):
+				supply = int(mosaic_id['name'][len(small_business_prefix) + 1:]) * 1000
+				return {'supply': supply, 'divisibility': 0}
+
+			return None
+
+		# Arrange:
+		factory = TransactionFactory(Network.TESTNET)
+		transaction = factory.create({
+			'type': 'transfer_transaction_v2',
+			'amount': 1_000_000,
+			'mosaics': [
+				{
+					'mosaic': {
+						'mosaic_id': self._create_mosaic_id('foo', f'small business {small_business_id}'),
+						'amount': amount
+					}
+				}
+			]
+		})
+
+		# Act:
+		fee = calculate_transaction_fee(transaction, _mosaic_information_lookup)
+
+		# Assert:
+		self.assertIsInstance(fee, int)
+		self.assertEqual(expected_fee, fee, f'small_business_id {small_business_id}')
+
+	def test_calculates_correct_fee_for_transfers_uses_minimum_fee_for_mosaics_with_divisibility_zero_and_low_supply(self):
+		for i in range(11):
+			self._assert_small_business_mosaic_fee(i, i * 1000, self._weight_with_fee_unit(1))
+
+	def test_calculates_correct_fee_for_transfers_does_not_use_minimum_fee_for_mosaics_with_divisibility_zero_and_supply_above_threshold(self):
+		# Assert: supply of 11000 means it is not a small business mosaic
+		self._assert_small_business_mosaic_fee(11, 1000, self._weight_with_fee_unit(4))
+
+	def test_calculates_correct_fee_for_transfers_does_not_use_minimum_fee_for_mosaics_with_divisibility_greater_than_zero(self):
+		# Arrange: nonzero divisibility means it is not a small business mosaic
+		self._assert_small_business_mosaic_fee(0, 1000, self._weight_with_fee_unit(3))
+
+	# endregion
+
+	# region transfers - other mosaic
+
+	# mosaic definition data used for the following tests: supply = 100_000_000, divisibility = 3
+	# supply ratio: 8_999_999_999 / 100_000_000 ≈ 90
+	# divisibility ratio = 1_000_000 / 1_000 = 1000
+	# 1000 / 90 = 11.11..., so transferring a quantity of 12 is roughly like transferring 1 XEM
+	# Adjustment for the fee is 9 XEM due to the lower supply and divisibility
+
+	@staticmethod
+	def _mosaic_information_lookup_other_mosaic(mosaic_id):
+		multiplier = int(mosaic_id['name'])
+		divisibility_change = multiplier - 1
+		return {'supply': 100_000_000 * multiplier, 'divisibility': 3 + divisibility_change}
+
+	def _assert_single_mosaic_fee(self, amount, message_size, quantity, expected_fee):
+		# Arrange:
+		factory = TransactionFactory(Network.TESTNET)
+
+		descriptor = {
+			'type': 'transfer_transaction_v2',
+			'amount': amount * 1_000_000,
+			'mosaics': [
+				{
+					'mosaic': {
+						'mosaic_id': self._create_mosaic_id('foo', '1'),
+						'amount': quantity
+					}
+				}
+			]
+		}
+		if message_size:
+			descriptor['message'] = {
+				'message_type': 1,
+				'message': 'a' * message_size
+			}
+
+		transaction = factory.create(descriptor)
+
+		# Act:
+		fee = calculate_transaction_fee(transaction, self._mosaic_information_lookup_other_mosaic)
+
+		# Assert:
+		self.assertIsInstance(fee, int)
+		self.assertEqual(expected_fee, fee, f'amount ${amount}, messageSize ${message_size}, quantity ${quantity}')
+
+	def test_calculates_correct_fee_for_transfers_other_mosaic_near_mosaic_transfer_step_increases(self):
+		# Assert: minimum fee for low amounts
+		self._assert_single_mosaic_fee(1, 0, 12, self._weight_with_fee_unit(1))  # ~ 1 XEM
+		self._assert_single_mosaic_fee(1, 0, 111_000, self._weight_with_fee_unit(1))  # ~9_999 XEM
+
+		# - 1 -> 2 roughly at 1222.222 units
+		self._assert_single_mosaic_fee(1, 0, 1_222_000, self._weight_with_fee_unit(1))
+		self._assert_single_mosaic_fee(1, 0, 1_223_000, self._weight_with_fee_unit(2))  # ~ 110_000 XEM
+		self._assert_single_mosaic_fee(1, 0, 1_224_000, self._weight_with_fee_unit(2))
+
+		# - 2 -> 3 roughly at 1333.333 units
+		self._assert_single_mosaic_fee(1, 0, 1_333_000, self._weight_with_fee_unit(2))
+		self._assert_single_mosaic_fee(1, 0, 1_334_000, self._weight_with_fee_unit(3))  # ~ 120_000 XEM
+		self._assert_single_mosaic_fee(1, 0, 1_335_000, self._weight_with_fee_unit(3))
+
+		# - 3 -> 4 roughly at 1444.444 units
+		self._assert_single_mosaic_fee(1, 0, 1_444_000, self._weight_with_fee_unit(3))
+		self._assert_single_mosaic_fee(1, 0, 1_445_000, self._weight_with_fee_unit(4))  # ~ 130_000 XEM
+		self._assert_single_mosaic_fee(1, 0, 1_446_000, self._weight_with_fee_unit(4))
+
+	def test_calculates_correct_fee_for_transfers_other_mosaic_large_mosaic_transfers(self):
+		self._assert_single_mosaic_fee(1, 0, 2_112_000, self._weight_with_fee_unit(10))  # ~ 190_000 XEM
+		self._assert_single_mosaic_fee(1, 0, 2_445_000, self._weight_with_fee_unit(13))  # ~ 220_000 XEM
+		self._assert_single_mosaic_fee(1, 0, 2_778_000, self._weight_with_fee_unit(16))  # ~ 250_000 XEM
+		self._assert_single_mosaic_fee(1, 0, 3_000_000, self._weight_with_fee_unit(16))
+		self._assert_single_mosaic_fee(1, 0, 10_000_000, self._weight_with_fee_unit(16))
+		self._assert_single_mosaic_fee(1, 0, 100_000_000, self._weight_with_fee_unit(16))
+
+	def test_calculates_correct_fee_for_transfers_other_mosaic_with_amounts_greater_than_one(self):
+		# Assert: notice that amount * quantity is constant
+		self._assert_single_mosaic_fee(1, 0, 2_112_000, self._weight_with_fee_unit(10))
+		self._assert_single_mosaic_fee(2, 0, 1_056_000, self._weight_with_fee_unit(10))
+		self._assert_single_mosaic_fee(5, 0, 422_400, self._weight_with_fee_unit(10))
+		self._assert_single_mosaic_fee(10, 0, 211_200, self._weight_with_fee_unit(10))
+		self._assert_single_mosaic_fee(100, 0, 21_120, self._weight_with_fee_unit(10))
+		self._assert_single_mosaic_fee(1_000, 0, 2_112, self._weight_with_fee_unit(10))
+		self._assert_single_mosaic_fee(21_120, 0, 100, self._weight_with_fee_unit(10))
+		self._assert_single_mosaic_fee(2_112_000, 0, 1, self._weight_with_fee_unit(10))
+
+	def test_calculates_correct_fee_for_transfers_other_mosaic_with_message(self):
+		self._assert_single_mosaic_fee(1, 15, 2_112_000, self._weight_with_fee_unit(10 + 1))
+		self._assert_single_mosaic_fee(1, 32, 2_112_000, self._weight_with_fee_unit(10 + 2))
+		self._assert_single_mosaic_fee(1, 96, 2_112_000, self._weight_with_fee_unit(10 + 4))
+		self._assert_single_mosaic_fee(1, 160, 2_112_000, self._weight_with_fee_unit(10 + 6))
+
+	def test_calculates_correct_fee_for_transfers_other_mosaic_sums_fees_when_transferring_several_mosaics_function_based_lookup(self):
+		# Arrange: mosaic definitions are (100M, 3), (200M, 4), (300M, 5)
+		factory = TransactionFactory(Network.TESTNET)
+		transaction = factory.create({
+			'type': 'transfer_transaction_v2',
+			'amount': 1_000_000,
+			'mosaics': [
+				{
+					'mosaic': {
+						'mosaic_id': self._create_mosaic_id('foo', str(i + 1)),
+						'amount': amount
+					}
+				} for (i, amount) in enumerate([2_000_000, 50_000_000, 800_000_000])
+			]
+		})
+
+		# Act:
+		fee = calculate_transaction_fee(transaction, self._mosaic_information_lookup_other_mosaic)
+
+		# Assert:
+		self.assertIsInstance(fee, int)
+		self.assertEqual(self._weight_with_fee_unit(8 + 16 + 19), fee)
+
+	def test_calculates_correct_fee_for_transfers_other_mosaic_sums_fees_when_transferring_several_mosaics_object_based_lookup(self):
+		# Arrange: mosaic definitions are (100M, 3), (200M, 4), (300M, 5)
+		factory = TransactionFactory(Network.TESTNET)
+		transaction = factory.create({
+			'type': 'transfer_transaction_v2',
+			'amount': 1_000_000,
+			'mosaics': [
+				{
+					'mosaic': {
+						'mosaic_id': self._create_mosaic_id('foo', str(i + 1)),
+						'amount': amount
+					}
+				} for (i, amount) in enumerate([2_000_000, 50_000_000, 800_000_000])
+			]
+		})
+
+		# Act:
+		fee = calculate_transaction_fee(transaction, {
+			'foo:1': {'supply': 100_000_000, 'divisibility': 3},
+			'foo:2': {'supply': 200_000_000, 'divisibility': 4},
+			'foo:3': {'supply': 300_000_000, 'divisibility': 5}
+		})
+
+		# Assert:
+		self.assertIsInstance(fee, int)
+		self.assertEqual(self._weight_with_fee_unit(8 + 16 + 19), fee)
+
+	# endregion
+
+	# region transfers - edge case
+
+	def test_calculates_correct_fee_for_transfers_uses_minimum_fee_when_mosaic_supply_is_zero(self):
+		# Arrange:
+		factory = TransactionFactory(Network.TESTNET)
+		transaction = factory.create({
+			'type': 'transfer_transaction_v2',
+			'amount': 1_000_000,
+			'mosaics': [
+				{
+					'mosaic': {
+						'mosaic_id': self._create_mosaic_id('foo', 'zero supply'),
+						'amount': 5000000
+					}
+				}
+			]
+		})
+
+		# Act:
+		fee = calculate_transaction_fee(transaction, lambda _: {'supply': 0, 'divisibility': 3})
+
+		# Assert:
+		self.assertIsInstance(fee, int)
+		self.assertEqual(self._weight_with_fee_unit(1), fee)
+
+	def test_fails_calculating_fee_for_transfers_with_unknown_mosaic(self):
+		# Arrange:
+		factory = TransactionFactory(Network.TESTNET)
+		transaction = factory.create({
+			'type': 'transfer_transaction_v2',
+			'amount': 1_000_000,
+			'mosaics': [
+				{
+					'mosaic': {
+						'mosaic_id': self._create_mosaic_id('foo', 'bar'),
+						'amount': 5000000
+					}
+				}
+			]
+		})
+
+		# Act + Assert:
+		with self.assertRaisesRegex(ValueError, 'unable to find fee information for foo:bar'):
+			calculate_transaction_fee(transaction, lambda _: None)
+
+	# endregion

--- a/sdk/python/tests/nem/test_TransactionFactory.py
+++ b/sdk/python/tests/nem/test_TransactionFactory.py
@@ -182,7 +182,7 @@ class TransactionFactoryTest(BasicTransactionFactoryTest, unittest.TestCase):
 
 	# endregion
 
-	# region message encoding
+	# region string handling
 
 	def test_can_create_transfer_with_string_message(self):
 		# Arrange:
@@ -200,6 +200,29 @@ class TransactionFactoryTest(BasicTransactionFactoryTest, unittest.TestCase):
 
 		# Assert:
 		self.assertEqual(b'You miss 100%% of the shots you don\'t take', transaction.message.message)
+
+	def test_can_create_transfer_with_string_mosaic_id(self):
+		# Arrange:
+		factory = self.create_factory()
+
+		# Act:
+		transaction = self.create_transaction(factory)({
+			'type': 'transfer_transaction_v2',
+			'signer_public_key': TEST_SIGNER_PUBLIC_KEY,
+			'mosaics': [
+				{
+					'mosaic': {
+						'mosaic_id': {'namespace_id': {'name': 'foo'}, 'name': 'bar'},
+						'amount': 1
+					}
+				}
+			]
+		})
+
+		# Assert:
+		self.assertEqual(1, len(transaction.mosaics))
+		self.assertEqual(b'foo', transaction.mosaics[0].mosaic.mosaic_id.namespace_id.name)
+		self.assertEqual(b'bar', transaction.mosaics[0].mosaic.mosaic_id.name)
 
 	# endregion
 

--- a/sdk/python/tests/symbol/test_FeeCalculator.py
+++ b/sdk/python/tests/symbol/test_FeeCalculator.py
@@ -1,0 +1,31 @@
+import unittest
+
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
+from symbolchain.symbol.Network import Network
+from symbolchain.symbol.TransactionFactory import TransactionFactory
+
+
+class CalculateTransactionFeeTest(unittest.TestCase):
+	def test_can_calculate_fee_for_transaction_without_cosignatures(self):
+		# Arrange:
+		factory = TransactionFactory(Network.TESTNET)
+		transaction = factory.create({
+			'type': 'transfer_transaction_v1'
+		})
+
+		# Act + Assert: transfer size is 160
+		self.assertEqual(16000, calculate_transaction_fee(transaction, 100))
+		self.assertEqual(24000, calculate_transaction_fee(transaction, 150))
+		self.assertEqual(32000, calculate_transaction_fee(transaction, 200))
+
+	def test_can_calculate_fee_for_transaction_with_cosignatures(self):
+		# Arrange:
+		factory = TransactionFactory(Network.TESTNET)
+		transaction = factory.create({
+			'type': 'transfer_transaction_v1'
+		})
+
+		# Act + Assert: transfer size is 160, cosignature size is 104
+		self.assertEqual(16000 + 312, calculate_transaction_fee(transaction, 100, 3))
+		self.assertEqual(24000 + 416, calculate_transaction_fee(transaction, 150, 4))
+		self.assertEqual(32000 + 520, calculate_transaction_fee(transaction, 200, 5))

--- a/sdk/python/tests/test_RuleBasedTransactionFactory.py
+++ b/sdk/python/tests/test_RuleBasedTransactionFactory.py
@@ -56,6 +56,22 @@ class Module:
 			self.mosaic_id = 0
 			self.amount = 0
 
+	class StructWrapped:
+		TYPE_HINTS = {
+			'inner': 'struct:StructPlain'
+		}
+
+		def __init__(self):
+			self.inner = Module.StructPlain()
+
+	class StructAggregate:
+		TYPE_HINTS = {
+			'components': 'array[StructPlain]'
+		}
+
+		def __init__(self):
+			self.components = []
+
 	class StructArrayMember:
 		TYPE_HINTS = {
 			'mosaic_ids': 'array[UnresolvedMosaicId]'
@@ -475,6 +491,56 @@ class RuleBasedTransactionFactoryTest(unittest.TestCase):
 		# Assert: string values were encoded into utf8
 		self.assertEqual(b'01234567_89ABCDEF', parsed.mosaic_id)
 		self.assertEqual(b'123_456_789_123_456_789', parsed.amount)
+		self.assertFalse(hasattr(parsed, 'type'))
+
+	def test_can_create_struct_from_factory_and_auto_encode_nested_strings(self):
+		# Arrange: use a wrapped struct but set string values in the inner struct
+		factory = RuleBasedTransactionFactory(Module)
+		factory.add_struct_parser('StructPlain')
+		factory.add_struct_parser('StructWrapped')
+
+		def entity_factory(entity_type):
+			return None if 123 != entity_type else Module.StructWrapped()
+
+		# Act:
+		parsed = factory.create_from_factory(entity_factory, {
+			'type': 123,
+			'inner': {
+				'mosaic_id': '01234567_89ABCDEF',
+				'amount': '123_456_789_123_456_789'
+			}
+		})
+
+		# Assert: string values were encoded into utf8
+		self.assertEqual(b'01234567_89ABCDEF', parsed.inner.mosaic_id)
+		self.assertEqual(b'123_456_789_123_456_789', parsed.inner.amount)
+		self.assertFalse(hasattr(parsed, 'type'))
+
+	def test_can_create_struct_from_factory_and_auto_encode_nested_strings_in_array(self):
+		# Arrange: use an aggregate struct but set string values in the inner struct
+		factory = RuleBasedTransactionFactory(Module)
+		factory.add_struct_parser('StructPlain')
+		factory.add_array_parser('struct:StructPlain')
+		factory.add_struct_parser('StructAggregate')
+
+		def entity_factory(entity_type):
+			return None if 123 != entity_type else Module.StructAggregate()
+
+		# Act:
+		parsed = factory.create_from_factory(entity_factory, {
+			'type': 123,
+			'components': [
+				{
+					'mosaic_id': '01234567_89ABCDEF',
+					'amount': '123_456_789_123_456_789'
+				}
+			]
+		})
+
+		# Assert: string values were encoded into utf8
+		self.assertEqual(1, len(parsed.components))
+		self.assertEqual(b'01234567_89ABCDEF', parsed.components[0].mosaic_id)
+		self.assertEqual(b'123_456_789_123_456_789', parsed.components[0].amount)
 		self.assertFalse(hasattr(parsed, 'type'))
 
 	def test_cannot_create_struct_from_factory_when_descriptor_does_not_have_type(self):


### PR DESCRIPTION
problem: NEM fee calculation rules are complicated
solution: add helper functions to the sdk

---

Notes
1. this complements javascript changes https://github.com/symbol/symbol/pull/2025
2. auto string conversion is a bit more complicated in python, so i will make a followup PR for that