### PR TITLE
[mkdocs] docs: improve query block rewards tutorial

### DIFF
--- a/mkdocs/pages/en/devbook/network-currency/query-block-rewards.md
+++ b/mkdocs/pages/en/devbook/network-currency/query-block-rewards.md
@@ -25,6 +25,12 @@ This tutorial only reads data from the network. No <account:> or <XYM:> balance 
 
 {{ tutorial.code_full_tagged('devbook/network-currency/query_block_rewards', ['py', 'js']) }}
 
+The snippet uses the `NODE_URL` environment variable to set the Symbol API node.
+If no value is provided, a default <testnet:> node is used.
+
+The `BLOCK_HEIGHT` environment variable selects which block to query.
+If not set, it defaults to `3222290`, a block harvested on testnet.
+
 ## Code Explanation
 
 The code retrieves the block's signer key, beneficiary and network sink addresses, along with the inflation amount.
@@ -35,10 +41,6 @@ Finally, it derives the transaction fees by subtracting inflation from the total
 ### Fetching Block Information
 
 {{ tutorial.code_snippet_tagged('step-1') }}
-
-The snippet retrieves the block header using the `NODE_URL` and `BLOCK_HEIGHT` environment variables to select the API
-node and the target block.
-If not set, they default to the reference testnet node and block `3222290`.
 
 The <get:/blocks/{height}> endpoint returns the block header, which includes the `signerPublicKey` and the
 `beneficiaryAddress` designated by the node operator.

--- a/mkdocs/pages/ja/devbook/network-currency/query-block-rewards.md
+++ b/mkdocs/pages/ja/devbook/network-currency/query-block-rewards.md
@@ -22,6 +22,12 @@ Symbol上の各[ブロック](default:ブロック)は、[インフレーショ�
 
 {{ tutorial.code_full_tagged('devbook/network-currency/query_block_rewards', ['py', 'js']) }}
 
+このスニペットでは、 `NODE_URL` 環境変数を使用して Symbol API ノードを設定します。
+値が指定されない場合は、デフォルトの[テストネット](default:テストネット)ノードが使用されます。
+
+`BLOCK_HEIGHT` 環境変数は、照会するブロックを指定します。
+設定されていない場合は、デフォルトでテストネットでハーベストされたブロック `3222290` が使用されます。
+
 ## コード解説 {: #code-explanation }
 
 コードは、ブロックの署名者キー、受益者およびネットワークのシンクアドレスを、インフレーション額とともに取得します。
@@ -31,9 +37,6 @@ Symbol上の各[ブロック](default:ブロック)は、[インフレーショ�
 ### ブロック情報の取得 {: #fetching-block-information }
 
 {{ tutorial.code_snippet_tagged('step-1') }}
-
-このスニペットは、 `NODE_URL` および `BLOCK_HEIGHT` 環境変数を使用して、APIノードと対象ブロックを選択し、ブロックヘッダーを取得します。
-設定されていない場合は、デフォルトで参照用のテストネットノードとブロック `3222290` が使用されます。
 
 <get:/blocks/{height}> エンドポイントは、ブロックヘッダーを返します。これには、ノードオペレーターによって指定された `signerPublicKey` および `beneficiaryAddress` が含まれます。
 受益者アドレスは、後で受益者のレシートを特定するために必要になります。


### PR DESCRIPTION
Brings improvement from https://github.com/NemProject/nem/pull/898 to Symbol.

Defines global env variables earlier to match other tutorials style and splits node url from block height explanation.