### PR TITLE
[jenkins] fix: default to public build if build configuration is not set

### DIFF
--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -16,7 +16,7 @@ void call(Closure body) {
 				choices: jenkinsfileParams.operatingSystem ?: ['ubuntu'],
 				description: 'Operating System'
 			choice name: 'BUILD_CONFIGURATION',
-				choices: ['release-private', 'release-public'],
+				choices: ['release-public', 'release-private'],
 				description: 'build configuration'
 			choice name: 'ARCHITECTURE',
 				choices: ['arm64', 'amd64'],

--- a/jenkins/shared-library/vars/helper.groovy
+++ b/jenkins/shared-library/vars/helper.groovy
@@ -10,7 +10,7 @@ String resolveBranchName(String manualBranch) {
 }
 
 Boolean isPublicBuild(String buildConfiguration) {
-	return buildConfiguration == 'release-public'
+	return null == buildConfiguration || '' == buildConfiguration || 'release-public' == buildConfiguration
 }
 
 String resolveRepoName() {


### PR DESCRIPTION
problem: The default CI build configuration is not set when triggered
solution: default to public build if configuration is not set 