### PR TITLE
[client/catapult] fix: add reentrancy guards to LocalNode boot and shutdown

### DIFF
--- a/client/catapult/src/catapult/local/ProcessHost.h
+++ b/client/catapult/src/catapult/local/ProcessHost.h
@@ -31,6 +31,7 @@ namespace catapult { namespace local {
 
 	public:
 		/// Shuts down the process host.
+		/// \note No-op if the host was never booted or has already been shut down. Safe to call from destructors.
 		virtual void shutdown() = 0;
 	};
 }}

--- a/client/catapult/src/catapult/local/server/LocalNode.cpp
+++ b/client/catapult/src/catapult/local/server/LocalNode.cpp
@@ -221,7 +221,8 @@ namespace catapult { namespace local {
 							m_dataDirectory))
 					, m_pTransactionStatusSubscriber(m_pBootstrapper->subscriptionManager().createTransactionStatusSubscriber())
 					, m_pluginManager(m_pBootstrapper->pluginManager())
-					, m_isBooted(false) {
+					, m_isBooted(false)
+					, m_isShutdown(false) {
 				ValidateNodes(m_pBootstrapper->staticNodes());
 				AddLocalNode(m_nodes, m_pBootstrapper->config());
 			}
@@ -232,6 +233,9 @@ namespace catapult { namespace local {
 
 		public:
 			void boot() {
+				if(m_isBooted)
+					CATAPULT_THROW_RUNTIME_ERROR("local node is already booted");
+
 				CATAPULT_LOG(info) << "registering system plugins";
 				m_pluginModules = LoadAllPlugins(*m_pBootstrapper);
 
@@ -336,6 +340,10 @@ namespace catapult { namespace local {
 
 		public:
 			void shutdown() override {
+				if (!m_isBooted || m_isShutdown)
+					return;
+
+				m_isShutdown = true;
 				utils::StackLogger stackLogger("shutting down local node", utils::LogLevel::info);
 
 				m_pBootstrapper->pool().shutdown();
@@ -344,9 +352,6 @@ namespace catapult { namespace local {
 
 		private:
 			void saveStateToDisk() {
-				// only save to storage if boot succeeded
-				if (!m_isBooted)
-					return;
 
 				constexpr auto SaveStateToDirectoryWithCheckpointing = extensions::SaveStateToDirectoryWithCheckpointing;
 				SaveStateToDirectoryWithCheckpointing(m_dataDirectory, m_config.Node, m_catapultCache, m_score.get());
@@ -404,6 +409,7 @@ namespace catapult { namespace local {
 			std::vector<utils::DiagnosticCounter> m_counters;
 			extensions::BannedNodeIdentitySink m_bannedNodeIdentitySink;
 			bool m_isBooted;
+			bool m_isShutdown;
 		};
 	}
 

--- a/client/catapult/src/catapult/local/server/LocalNode.cpp
+++ b/client/catapult/src/catapult/local/server/LocalNode.cpp
@@ -233,7 +233,7 @@ namespace catapult { namespace local {
 
 		public:
 			void boot() override {
-				if(m_isBooted)
+				if (m_isBooted)
 					CATAPULT_THROW_RUNTIME_ERROR("local node is already booted");
 
 				CATAPULT_LOG(info) << "registering system plugins";

--- a/client/catapult/src/catapult/local/server/LocalNode.cpp
+++ b/client/catapult/src/catapult/local/server/LocalNode.cpp
@@ -232,7 +232,7 @@ namespace catapult { namespace local {
 			}
 
 		public:
-			void boot() {
+			void boot() override {
 				if(m_isBooted)
 					CATAPULT_THROW_RUNTIME_ERROR("local node is already booted");
 

--- a/client/catapult/src/catapult/local/server/LocalNode.h
+++ b/client/catapult/src/catapult/local/server/LocalNode.h
@@ -73,6 +73,10 @@ namespace catapult { namespace local {
 	/// Represents a local node.
 	class LocalNode : public ProcessHost {
 	public:
+		/// Boots the local node.
+		/// \throws catapult_runtime_error if the node has already been booted. Calling boot() twice is always a programming error.
+		virtual void boot() = 0;
+
 		/// Gets the current cache.
 		virtual const cache::CatapultCache& cache() const = 0;
 

--- a/client/catapult/tests/int/node/basic/LocalNodeBasicTests.cpp
+++ b/client/catapult/tests/int/node/basic/LocalNodeBasicTests.cpp
@@ -157,4 +157,29 @@ namespace catapult { namespace local {
 	}
 
 	// endregion
+
+	// region reentrancy guard tests
+
+	TEST(TEST_CLASS, BootThrowsWhenNodeIsAlreadyBooted) {
+		// Arrange: create and boot a local node
+		TestContext context(NodeFlag::Regular);
+
+		// Act & Assert: calling boot again on an already booted node throws
+		EXPECT_THROW(context.localNode().boot(), catapult_runtime_error);
+	}
+
+	TEST(TEST_CLASS, ShutdownIsIdempotentAndCanBeCalledMultipleTimes) {
+		// Arrange: create and boot a local node
+		TestContext context(NodeFlag::Regular);
+
+		// Act & Assert: calling shutdown multiple times should not throw
+		context.localNode().shutdown();
+		context.localNode().shutdown();
+		context.localNode().shutdown();
+
+		// Assert: the node shutdown properly
+		context.assertShutdown();
+	}
+
+	// endregion
 }}


### PR DESCRIPTION
## Problem

`LocalNode::Impl` lacked guards against double-boot and double-shutdown, leaving the node in an undefined state if either method was called more than once.

Specific issues:
- `boot()` could be called twice, re-registering plugins and re-initializing subsystems on an already-running node.
- `shutdown()` could be called on an unbooted node or called multiple times, causing redundant teardown and potential use-after-free in pool shutdown.
- `saveStateToDisk()` guarded on `m_isBooted` internally, creating implicit coupling instead of an explicit contract at the call site.

## Changes

- `boot()`: throws `CATAPULT_THROW_RUNTIME_ERROR` if called when already booted.
- `shutdown()`: early-returns if node was never booted or has already been shut down.
- Adds `m_isShutdown` boolean member (initialized to `false`), set to `true` on first shutdown entry.
- Removes the redundant `m_isBooted` guard from `saveStateToDisk()` — `shutdown()` now owns that invariant.

Fixes #2044