### PR TITLE
[client/catapult] Retry RocksDB/state-dir ops on Windows delayed handle release

### DIFF
--- a/client/catapult/src/catapult/cache_db/RocksDatabase.cpp
+++ b/client/catapult/src/catapult/cache_db/RocksDatabase.cpp
@@ -187,7 +187,6 @@ namespace catapult { namespace cache {
 #endif
 		auto status = utils::RetryWithBackoff(
 				[this, &dbOptions, &columnFamilies, &pDb]() {
-					m_handles.clear();
 					return rocksdb::DB::Open(dbOptions, m_settings.DatabaseDirectory, columnFamilies, &m_handles, &pDb);
 				},
 				IsRetryableAfterFailedOpen,

--- a/client/catapult/src/catapult/cache_db/RocksDatabase.cpp
+++ b/client/catapult/src/catapult/cache_db/RocksDatabase.cpp
@@ -195,7 +195,7 @@ namespace catapult { namespace cache {
 #endif
 		m_pDb.reset(pDb);
 		if (!status.ok())
-			CATAPULT_THROW_RUNTIME_ERROR_2("couldn't open database", m_settings.DatabaseDirectory, status.ToString());
+			CATAPULT_THROW_RUNTIME_ERROR_1(("couldn't open database: " + status.ToString()).c_str(), m_settings.DatabaseDirectory);
 	}
 
 	RocksDatabase::~RocksDatabase() {

--- a/client/catapult/src/catapult/cache_db/RocksDatabase.cpp
+++ b/client/catapult/src/catapult/cache_db/RocksDatabase.cpp
@@ -23,12 +23,12 @@
 #include "RocksInclude.h"
 #include "RocksPruningFilter.h"
 #include "catapult/config/CatapultDataDirectory.h"
-#include "catapult/exceptions.h"
 #include "catapult/utils/HexFormatter.h"
 #include "catapult/utils/Logging.h"
 #include "catapult/utils/PathUtils.h"
 #include "catapult/utils/RetryUtils.h"
 #include "catapult/utils/StackLogger.h"
+#include "catapult/exceptions.h"
 #include <chrono>
 #include <thread>
 
@@ -155,6 +155,10 @@ namespace catapult { namespace cache {
 		}
 	}
 
+	bool IsRetryableAfterFailedOpen(const rocksdb::Status& status) {
+		return !status.ok() && status.IsIOError();
+	}
+
 	RocksDatabase::RocksDatabase() = default;
 
 	RocksDatabase::RocksDatabase(const RocksDatabaseSettings& settings)
@@ -186,7 +190,7 @@ namespace catapult { namespace cache {
 					m_handles.clear();
 					return rocksdb::DB::Open(dbOptions, m_settings.DatabaseDirectory, columnFamilies, &m_handles, &pDb);
 				},
-				[](const rocksdb::Status& openStatus) { return !openStatus.ok() && openStatus.IsIOError(); },
+				IsRetryableAfterFailedOpen,
 				Num_Open_Attempts,
 				[Num_Open_Attempts](uint32_t attempt, const rocksdb::Status& openStatus) {
 					auto delayMs = 100u << attempt;

--- a/client/catapult/src/catapult/cache_db/RocksDatabase.cpp
+++ b/client/catapult/src/catapult/cache_db/RocksDatabase.cpp
@@ -200,7 +200,7 @@ namespace catapult { namespace cache {
 				});
 		m_pDb.reset(pDb);
 		if (!status.ok())
-			CATAPULT_THROW_RUNTIME_ERROR_1(("couldn't open database: " + status.ToString()).c_str(), m_settings.DatabaseDirectory);
+			CATAPULT_THROW_RUNTIME_ERROR_2("couldn't open database", m_settings.DatabaseDirectory, status.ToString());
 	}
 
 	RocksDatabase::~RocksDatabase() {

--- a/client/catapult/src/catapult/cache_db/RocksDatabase.cpp
+++ b/client/catapult/src/catapult/cache_db/RocksDatabase.cpp
@@ -27,10 +27,10 @@
 #include "catapult/utils/HexFormatter.h"
 #include "catapult/utils/Logging.h"
 #include "catapult/utils/PathUtils.h"
+#include "catapult/utils/RetryUtils.h"
 #include "catapult/utils/StackLogger.h"
-#ifdef _WIN32
+#include <chrono>
 #include <thread>
-#endif
 
 namespace catapult { namespace cache {
 
@@ -173,26 +173,28 @@ namespace catapult { namespace cache {
 
 		rocksdb::DB* pDb;
 		auto dbOptions = CreateDatabaseOptions(m_settings.DatabaseConfig);
-		rocksdb::Status status;
-#ifdef _WIN32
+
 		// On Windows, the OS may hold file handles open briefly after a prior instance closes,
 		// causing RocksDB's internal CURRENT rename to fail with ACCESS_DENIED. Retry with backoff.
-		for (auto attempt = 0u; attempt < 5u; ++attempt) {
-			m_handles.clear();
-			status = rocksdb::DB::Open(dbOptions, m_settings.DatabaseDirectory, columnFamilies, &m_handles, &pDb);
-			if (status.ok() || !status.IsIOError() || 4u == attempt)
-				break;
-			auto delayMs = 100u << attempt;
-			CATAPULT_LOG(warning)
-				<< "RocksDB open failed (attempt "
-				<< (attempt + 1) << "/5): "
-				<< status.ToString()
-				<< ", retrying in " << delayMs << "ms";
-			std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
-		}
+#ifdef _WIN32
+		constexpr uint32_t Num_Open_Attempts = 5;
 #else
-		status = rocksdb::DB::Open(dbOptions, m_settings.DatabaseDirectory, columnFamilies, &m_handles, &pDb);
+		constexpr uint32_t Num_Open_Attempts = 1;
 #endif
+		auto status = utils::RetryWithBackoff(
+				[this, &dbOptions, &columnFamilies, &pDb]() {
+					m_handles.clear();
+					return rocksdb::DB::Open(dbOptions, m_settings.DatabaseDirectory, columnFamilies, &m_handles, &pDb);
+				},
+				[](const rocksdb::Status& openStatus) { return !openStatus.ok() && openStatus.IsIOError(); },
+				Num_Open_Attempts,
+				[Num_Open_Attempts](uint32_t attempt, const rocksdb::Status& openStatus) {
+					auto delayMs = 100u << attempt;
+					CATAPULT_LOG(warning)
+							<< "RocksDB open failed (attempt " << (attempt + 1) << "/" << Num_Open_Attempts << "): "
+							<< openStatus.ToString() << ", retrying in " << delayMs << "ms";
+					std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
+				});
 		m_pDb.reset(pDb);
 		if (!status.ok())
 			CATAPULT_THROW_RUNTIME_ERROR_1(("couldn't open database: " + status.ToString()).c_str(), m_settings.DatabaseDirectory);

--- a/client/catapult/src/catapult/cache_db/RocksDatabase.cpp
+++ b/client/catapult/src/catapult/cache_db/RocksDatabase.cpp
@@ -29,8 +29,6 @@
 #include "catapult/utils/RetryUtils.h"
 #include "catapult/utils/StackLogger.h"
 #include "catapult/exceptions.h"
-#include <chrono>
-#include <thread>
 
 namespace catapult { namespace cache {
 
@@ -191,12 +189,10 @@ namespace catapult { namespace cache {
 				},
 				IsRetryableAfterFailedOpen,
 				Num_Open_Attempts,
-				[Num_Open_Attempts](uint32_t attempt, const rocksdb::Status& openStatus) {
-					auto delayMs = 100u << attempt;
+				[Num_Open_Attempts](uint32_t attempt, const rocksdb::Status& openStatus, uint32_t delayMs) {
 					CATAPULT_LOG(warning)
 							<< "RocksDB open failed (attempt " << (attempt + 1) << "/" << Num_Open_Attempts << "): "
 							<< openStatus.ToString() << ", retrying in " << delayMs << "ms";
-					std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
 				});
 		m_pDb.reset(pDb);
 		if (!status.ok())

--- a/client/catapult/src/catapult/cache_db/RocksDatabase.cpp
+++ b/client/catapult/src/catapult/cache_db/RocksDatabase.cpp
@@ -23,10 +23,14 @@
 #include "RocksInclude.h"
 #include "RocksPruningFilter.h"
 #include "catapult/config/CatapultDataDirectory.h"
+#include "catapult/exceptions.h"
 #include "catapult/utils/HexFormatter.h"
+#include "catapult/utils/Logging.h"
 #include "catapult/utils/PathUtils.h"
 #include "catapult/utils/StackLogger.h"
-#include "catapult/exceptions.h"
+#ifdef _WIN32
+#include <thread>
+#endif
 
 namespace catapult { namespace cache {
 
@@ -169,7 +173,26 @@ namespace catapult { namespace cache {
 
 		rocksdb::DB* pDb;
 		auto dbOptions = CreateDatabaseOptions(m_settings.DatabaseConfig);
-		auto status = rocksdb::DB::Open(dbOptions, m_settings.DatabaseDirectory, columnFamilies, &m_handles, &pDb);
+		rocksdb::Status status;
+#ifdef _WIN32
+		// On Windows, the OS may hold file handles open briefly after a prior instance closes,
+		// causing RocksDB's internal CURRENT rename to fail with ACCESS_DENIED. Retry with backoff.
+		for (auto attempt = 0u; attempt < 5u; ++attempt) {
+			m_handles.clear();
+			status = rocksdb::DB::Open(dbOptions, m_settings.DatabaseDirectory, columnFamilies, &m_handles, &pDb);
+			if (status.ok() || !status.IsIOError() || 4u == attempt)
+				break;
+			auto delayMs = 100u << attempt;
+			CATAPULT_LOG(warning)
+				<< "RocksDB open failed (attempt "
+				<< (attempt + 1) << "/5): "
+				<< status.ToString()
+				<< ", retrying in " << delayMs << "ms";
+			std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
+		}
+#else
+		status = rocksdb::DB::Open(dbOptions, m_settings.DatabaseDirectory, columnFamilies, &m_handles, &pDb);
+#endif
 		m_pDb.reset(pDb);
 		if (!status.ok())
 			CATAPULT_THROW_RUNTIME_ERROR_2("couldn't open database", m_settings.DatabaseDirectory, status.ToString());

--- a/client/catapult/src/catapult/cache_db/RocksDatabase.h
+++ b/client/catapult/src/catapult/cache_db/RocksDatabase.h
@@ -33,6 +33,7 @@ namespace rocksdb {
 	class DB;
 	class PinnableSlice;
 	class Slice;
+	class Status;
 	class WriteBatch;
 }
 
@@ -127,6 +128,11 @@ namespace catapult { namespace cache {
 	};
 
 	// endregion
+
+	/// Returns \c true if a database open that failed with \a status is worth retrying
+	/// (a transient I/O failure, e.g. Windows delayed file handle release after a prior close).
+	/// \note Exposed for testing; used internally to gate RocksDatabase's open-retry loop.
+	bool IsRetryableAfterFailedOpen(const rocksdb::Status& status);
 
 	// region RocksDatabase
 

--- a/client/catapult/src/catapult/extensions/LocalNodeStateFileStorage.cpp
+++ b/client/catapult/src/catapult/extensions/LocalNodeStateFileStorage.cpp
@@ -29,6 +29,7 @@
 #include "catapult/config/CatapultDataDirectory.h"
 #include "catapult/config/NodeConfiguration.h"
 #include "catapult/consumers/BlockchainSyncHandlers.h"
+#include "catapult/exceptions.h"
 #include "catapult/io/BlockStorageCache.h"
 #include "catapult/io/BufferedFileStream.h"
 #include "catapult/io/FilesystemUtils.h"
@@ -37,6 +38,7 @@
 #include "catapult/utils/Logging.h"
 #include "catapult/utils/StackLogger.h"
 #include <chrono>
+#include <system_error>
 #include <thread>
 
 namespace catapult { namespace extensions {
@@ -199,16 +201,16 @@ namespace catapult { namespace extensions {
 
 		const auto& from = m_directory.path();
 		const auto& to = destinationDirectory.path();
+		std::error_code ec;
 #ifdef _WIN32
 		// On Windows a transient open handle on the destination - delete-pending state files, antivirus,
 		// or the search indexer - can make the rename fail with ACCESS_DENIED even when it would succeed on
 		// POSIX (which frees the name on unlink). Retry with backoff before giving up; otherwise the
 		// filesystem_error escapes the block dispatcher consumer and terminates the process.
 		// (cf. RocksDatabase open-retry on Windows.)
-		std::error_code ec;
 		for (auto attempt = 0u; attempt < 5u; ++attempt) {
 			std::filesystem::rename(from, to, ec);
-			if (!ec || 4u == attempt)
+			if (!ec || std::errc::permission_denied != ec || 4u == attempt)
 				break;
 
 			auto delayMs = 100u << attempt;
@@ -217,12 +219,12 @@ namespace catapult { namespace extensions {
 					<< ec.message() << ", retrying in " << delayMs << "ms";
 			std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
 		}
+#else
+		std::filesystem::rename(from, to, ec);
+#endif
 
 		if (ec)
-			throw std::filesystem::filesystem_error("could not rename state directory", from, to, ec);
-#else
-		std::filesystem::rename(from, to);
-#endif
+			CATAPULT_THROW_RUNTIME_ERROR_2(("could not rename state directory: " + ec.message()).c_str(), from, to);
 	}
 
 	// endregion

--- a/client/catapult/src/catapult/extensions/LocalNodeStateFileStorage.cpp
+++ b/client/catapult/src/catapult/extensions/LocalNodeStateFileStorage.cpp
@@ -29,7 +29,6 @@
 #include "catapult/config/CatapultDataDirectory.h"
 #include "catapult/config/NodeConfiguration.h"
 #include "catapult/consumers/BlockchainSyncHandlers.h"
-#include "catapult/exceptions.h"
 #include "catapult/io/BlockStorageCache.h"
 #include "catapult/io/BufferedFileStream.h"
 #include "catapult/io/FilesystemUtils.h"
@@ -38,6 +37,7 @@
 #include "catapult/utils/Logging.h"
 #include "catapult/utils/RetryUtils.h"
 #include "catapult/utils/StackLogger.h"
+#include "catapult/exceptions.h"
 #include <chrono>
 #include <system_error>
 #include <thread>

--- a/client/catapult/src/catapult/extensions/LocalNodeStateFileStorage.cpp
+++ b/client/catapult/src/catapult/extensions/LocalNodeStateFileStorage.cpp
@@ -34,7 +34,10 @@
 #include "catapult/io/FilesystemUtils.h"
 #include "catapult/io/IndexFile.h"
 #include "catapult/plugins/PluginManager.h"
+#include "catapult/utils/Logging.h"
 #include "catapult/utils/StackLogger.h"
+#include <chrono>
+#include <thread>
 
 namespace catapult { namespace extensions {
 
@@ -193,7 +196,33 @@ namespace catapult { namespace extensions {
 	void LocalNodeStateSerializer::moveTo(const config::CatapultDirectory& destinationDirectory) {
 		io::PurgeDirectory(destinationDirectory.str());
 		std::filesystem::remove(destinationDirectory.path());
-		std::filesystem::rename(m_directory.path(), destinationDirectory.path());
+
+		const auto& from = m_directory.path();
+		const auto& to = destinationDirectory.path();
+#ifdef _WIN32
+		// On Windows a transient open handle on the destination - delete-pending state files, antivirus,
+		// or the search indexer - can make the rename fail with ACCESS_DENIED even when it would succeed on
+		// POSIX (which frees the name on unlink). Retry with backoff before giving up; otherwise the
+		// filesystem_error escapes the block dispatcher consumer and terminates the process.
+		// (cf. RocksDatabase open-retry on Windows.)
+		std::error_code ec;
+		for (auto attempt = 0u; attempt < 5u; ++attempt) {
+			std::filesystem::rename(from, to, ec);
+			if (!ec || 4u == attempt)
+				break;
+
+			auto delayMs = 100u << attempt;
+			CATAPULT_LOG(warning)
+					<< "renaming '" << from << "' to '" << to << "' failed (attempt " << (attempt + 1) << "/5): "
+					<< ec.message() << ", retrying in " << delayMs << "ms";
+			std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
+		}
+
+		if (ec)
+			throw std::filesystem::filesystem_error("could not rename state directory", from, to, ec);
+#else
+		std::filesystem::rename(from, to);
+#endif
 	}
 
 	// endregion

--- a/client/catapult/src/catapult/extensions/LocalNodeStateFileStorage.cpp
+++ b/client/catapult/src/catapult/extensions/LocalNodeStateFileStorage.cpp
@@ -38,9 +38,7 @@
 #include "catapult/utils/RetryUtils.h"
 #include "catapult/utils/StackLogger.h"
 #include "catapult/exceptions.h"
-#include <chrono>
 #include <system_error>
-#include <thread>
 
 namespace catapult { namespace extensions {
 
@@ -221,12 +219,10 @@ namespace catapult { namespace extensions {
 				},
 				[](const std::error_code& innerEc) { return std::errc::permission_denied == innerEc; },
 				Num_Rename_Attempts,
-				[&from, &to](uint32_t attempt, const std::error_code& innerEc) {
-					auto delayMs = 100u << attempt;
+				[&from, &to](uint32_t attempt, const std::error_code& innerEc, uint32_t delayMs) {
 					CATAPULT_LOG(warning)
 							<< "renaming '" << from << "' to '" << to << "' failed (attempt " << (attempt + 1) << "/"
 							<< Num_Rename_Attempts << "): " << innerEc.message() << ", retrying in " << delayMs << "ms";
-					std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
 				});
 
 		if (ec)

--- a/client/catapult/src/catapult/extensions/LocalNodeStateFileStorage.cpp
+++ b/client/catapult/src/catapult/extensions/LocalNodeStateFileStorage.cpp
@@ -36,6 +36,7 @@
 #include "catapult/io/IndexFile.h"
 #include "catapult/plugins/PluginManager.h"
 #include "catapult/utils/Logging.h"
+#include "catapult/utils/RetryUtils.h"
 #include "catapult/utils/StackLogger.h"
 #include <chrono>
 #include <system_error>
@@ -201,27 +202,32 @@ namespace catapult { namespace extensions {
 
 		const auto& from = m_directory.path();
 		const auto& to = destinationDirectory.path();
-		std::error_code ec;
-#ifdef _WIN32
+
 		// On Windows a transient open handle on the destination - delete-pending state files, antivirus,
 		// or the search indexer - can make the rename fail with ACCESS_DENIED even when it would succeed on
 		// POSIX (which frees the name on unlink). Retry with backoff before giving up; otherwise the
 		// filesystem_error escapes the block dispatcher consumer and terminates the process.
 		// (cf. RocksDatabase open-retry on Windows.)
-		for (auto attempt = 0u; attempt < 5u; ++attempt) {
-			std::filesystem::rename(from, to, ec);
-			if (!ec || std::errc::permission_denied != ec || 4u == attempt)
-				break;
-
-			auto delayMs = 100u << attempt;
-			CATAPULT_LOG(warning)
-					<< "renaming '" << from << "' to '" << to << "' failed (attempt " << (attempt + 1) << "/5): "
-					<< ec.message() << ", retrying in " << delayMs << "ms";
-			std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
-		}
+#ifdef _WIN32
+		constexpr uint32_t Num_Rename_Attempts = 5;
 #else
-		std::filesystem::rename(from, to, ec);
+		constexpr uint32_t Num_Rename_Attempts = 1;
 #endif
+		auto ec = utils::RetryWithBackoff(
+				[&from, &to]() {
+					std::error_code innerEc;
+					std::filesystem::rename(from, to, innerEc);
+					return innerEc;
+				},
+				[](const std::error_code& innerEc) { return std::errc::permission_denied == innerEc; },
+				Num_Rename_Attempts,
+				[&from, &to](uint32_t attempt, const std::error_code& innerEc) {
+					auto delayMs = 100u << attempt;
+					CATAPULT_LOG(warning)
+							<< "renaming '" << from << "' to '" << to << "' failed (attempt " << (attempt + 1) << "/"
+							<< Num_Rename_Attempts << "): " << innerEc.message() << ", retrying in " << delayMs << "ms";
+					std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
+				});
 
 		if (ec)
 			CATAPULT_THROW_RUNTIME_ERROR_2(("could not rename state directory: " + ec.message()).c_str(), from, to);

--- a/client/catapult/src/catapult/utils/RetryUtils.h
+++ b/client/catapult/src/catapult/utils/RetryUtils.h
@@ -20,19 +20,43 @@
 **/
 
 #pragma once
+#include <chrono>
+#include <thread>
 #include <stdint.h>
 
 namespace catapult { namespace utils {
 
+	/// Maximum delay, in milliseconds, below which RetryWithBackoff yields instead of sleeping.
+	/// \note Windows timer resolution is coarser, so it gets a higher threshold than other platforms.
+#ifdef _WIN32
+	constexpr uint32_t Retry_Yield_Threshold_Ms = 50;
+#else
+	constexpr uint32_t Retry_Yield_Threshold_Ms = 20;
+#endif
+
 	/// Runs \a operation up to \a numAttempts times, retrying only while \a shouldRetry returns \c true
-	/// for the most recent result and further attempts remain. \a onRetry is invoked with the zero-based
-	/// attempt index and the result before every retry; it is expected to apply backoff.
+	/// for the most recent result and further attempts remain. Waits between attempts with exponential
+	/// backoff starting at \a baseDelayMs (doubling each attempt): a zero delay does not wait at all,
+	/// a delay up to \c Retry_Yield_Threshold_Ms yields the thread, otherwise it sleeps for that long.
+	/// \a onRetry is invoked with the zero-based attempt index, the result and the upcoming delay before
+	/// every retry, for logging purposes only.
 	/// \note \a shouldRetry must return \c false for a result that indicates success.
 	template<typename TOperation, typename TShouldRetry, typename TOnRetry>
-	auto RetryWithBackoff(TOperation operation, TShouldRetry shouldRetry, uint32_t numAttempts, TOnRetry onRetry) {
+	auto RetryWithBackoff(
+			TOperation operation,
+			TShouldRetry shouldRetry,
+			uint32_t numAttempts,
+			TOnRetry onRetry,
+			uint32_t baseDelayMs = 100) {
 		auto result = operation();
 		for (auto attempt = 0u; shouldRetry(result) && attempt + 1 < numAttempts; ++attempt) {
-			onRetry(attempt, result);
+			auto delayMs = baseDelayMs << attempt;
+			onRetry(attempt, result, delayMs);
+			if (delayMs > Retry_Yield_Threshold_Ms)
+				std::this_thread::sleep_for(std::chrono::milliseconds(delayMs));
+			else if (delayMs > 0)
+				std::this_thread::yield();
+
 			result = operation();
 		}
 

--- a/client/catapult/src/catapult/utils/RetryUtils.h
+++ b/client/catapult/src/catapult/utils/RetryUtils.h
@@ -24,18 +24,18 @@
 
 namespace catapult { namespace utils {
 
-	/// Runs \a operation up to \a numAttempts times, retrying only while \a isRetryable returns \c true
-	/// for the most recent error and further attempts remain. \a onRetry is invoked with the zero-based
-	/// attempt index and the error before every retry; it is expected to apply backoff.
-	/// \note \a operation must return a default-constructed (falsy) error to signal success.
-	template<typename TOperation, typename TIsRetryable, typename TOnRetry>
-	auto RetryWithBackoff(TOperation operation, TIsRetryable isRetryable, uint32_t numAttempts, TOnRetry onRetry) {
-		auto error = operation();
-		for (auto attempt = 0u; error && isRetryable(error) && attempt + 1 < numAttempts; ++attempt) {
-			onRetry(attempt, error);
-			error = operation();
+	/// Runs \a operation up to \a numAttempts times, retrying only while \a shouldRetry returns \c true
+	/// for the most recent result and further attempts remain. \a onRetry is invoked with the zero-based
+	/// attempt index and the result before every retry; it is expected to apply backoff.
+	/// \note \a shouldRetry must return \c false for a result that indicates success.
+	template<typename TOperation, typename TShouldRetry, typename TOnRetry>
+	auto RetryWithBackoff(TOperation operation, TShouldRetry shouldRetry, uint32_t numAttempts, TOnRetry onRetry) {
+		auto result = operation();
+		for (auto attempt = 0u; shouldRetry(result) && attempt + 1 < numAttempts; ++attempt) {
+			onRetry(attempt, result);
+			result = operation();
 		}
 
-		return error;
+		return result;
 	}
 }}

--- a/client/catapult/src/catapult/utils/RetryUtils.h
+++ b/client/catapult/src/catapult/utils/RetryUtils.h
@@ -1,0 +1,41 @@
+/**
+*** Copyright (c) 2016-2019, Jaguar0625, gimre, BloodyRookie, Tech Bureau, Corp.
+*** Copyright (c) 2020-present, Jaguar0625, gimre, BloodyRookie.
+*** All rights reserved.
+***
+*** This file is part of Catapult.
+***
+*** Catapult is free software: you can redistribute it and/or modify
+*** it under the terms of the GNU Lesser General Public License as published by
+*** the Free Software Foundation, either version 3 of the License, or
+*** (at your option) any later version.
+***
+*** Catapult is distributed in the hope that it will be useful,
+*** but WITHOUT ANY WARRANTY; without even the implied warranty of
+*** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*** GNU Lesser General Public License for more details.
+***
+*** You should have received a copy of the GNU Lesser General Public License
+*** along with Catapult. If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#pragma once
+#include <stdint.h>
+
+namespace catapult { namespace utils {
+
+	/// Runs \a operation up to \a numAttempts times, retrying only while \a isRetryable returns \c true
+	/// for the most recent error and further attempts remain. \a onRetry is invoked with the zero-based
+	/// attempt index and the error before every retry; it is expected to apply backoff.
+	/// \note \a operation must return a default-constructed (falsy) error to signal success.
+	template<typename TOperation, typename TIsRetryable, typename TOnRetry>
+	auto RetryWithBackoff(TOperation operation, TIsRetryable isRetryable, uint32_t numAttempts, TOnRetry onRetry) {
+		auto error = operation();
+		for (auto attempt = 0u; error && isRetryable(error) && attempt + 1 < numAttempts; ++attempt) {
+			onRetry(attempt, error);
+			error = operation();
+		}
+
+		return error;
+	}
+}}

--- a/client/catapult/tests/catapult/cache_db/RocksDatabaseTests.cpp
+++ b/client/catapult/tests/catapult/cache_db/RocksDatabaseTests.cpp
@@ -20,6 +20,7 @@
 **/
 
 #include "catapult/cache_db/RocksDatabase.h"
+#include "catapult/cache_db/RocksInclude.h"
 #include "catapult/io/FileLock.h"
 #include "catapult/io/RawFile.h"
 #include "tests/catapult/cache_db/test/RdbTestUtils.h"
@@ -58,6 +59,20 @@ namespace catapult { namespace cache {
 			return CreateSettings({ "default", "beta", "gamma" });
 		}
 	}
+
+	// region IsRetryableAfterFailedOpen
+
+	TEST(TEST_CLASS, IsRetryableAfterFailedOpen_ReturnsTrueOnlyForIoError) {
+		EXPECT_TRUE(IsRetryableAfterFailedOpen(rocksdb::Status::IOError()));
+
+		EXPECT_FALSE(IsRetryableAfterFailedOpen(rocksdb::Status::OK()));
+		EXPECT_FALSE(IsRetryableAfterFailedOpen(rocksdb::Status::InvalidArgument()));
+		EXPECT_FALSE(IsRetryableAfterFailedOpen(rocksdb::Status::NotFound()));
+		EXPECT_FALSE(IsRetryableAfterFailedOpen(rocksdb::Status::Corruption()));
+		EXPECT_FALSE(IsRetryableAfterFailedOpen(rocksdb::Status::NotSupported()));
+	}
+
+	// endregion
 
 	// region constructor
 

--- a/client/catapult/tests/catapult/utils/RetryUtilsTests.cpp
+++ b/client/catapult/tests/catapult/utils/RetryUtilsTests.cpp
@@ -1,0 +1,151 @@
+/**
+*** Copyright (c) 2016-2019, Jaguar0625, gimre, BloodyRookie, Tech Bureau, Corp.
+*** Copyright (c) 2020-present, Jaguar0625, gimre, BloodyRookie.
+*** All rights reserved.
+***
+*** This file is part of Catapult.
+***
+*** Catapult is free software: you can redistribute it and/or modify
+*** it under the terms of the GNU Lesser General Public License as published by
+*** the Free Software Foundation, either version 3 of the License, or
+*** (at your option) any later version.
+***
+*** Catapult is distributed in the hope that it will be useful,
+*** but WITHOUT ANY WARRANTY; without even the implied warranty of
+*** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+*** GNU Lesser General Public License for more details.
+***
+*** You should have received a copy of the GNU Lesser General Public License
+*** along with Catapult. If not, see <http://www.gnu.org/licenses/>.
+**/
+
+#include "catapult/utils/RetryUtils.h"
+#include "tests/TestHarness.h"
+#include <system_error>
+#include <vector>
+
+namespace catapult { namespace utils {
+
+#define TEST_CLASS RetryUtilsTests
+
+	namespace {
+		auto Success() {
+			return std::error_code();
+		}
+
+		auto RetryableError() {
+			return std::make_error_code(std::errc::permission_denied);
+		}
+
+		auto NonRetryableError() {
+			return std::make_error_code(std::errc::no_such_file_or_directory);
+		}
+
+		auto IsRetryable(const std::error_code& ec) {
+			return std::errc::permission_denied == ec;
+		}
+
+		// Tracks operation invocations and onRetry (attempt, error) callbacks for assertions.
+		struct RetryContext {
+		public:
+			size_t NumOperationCalls = 0;
+			std::vector<std::pair<uint32_t, std::error_code>> RetryCalls;
+
+		public:
+			auto onRetry() {
+				return [this](auto attempt, const auto& ec) {
+					RetryCalls.emplace_back(attempt, ec);
+				};
+			}
+		};
+	}
+
+	TEST(TEST_CLASS, SucceedsOnFirstAttempt_WithoutRetrying) {
+		// Arrange:
+		RetryContext context;
+		auto operation = [&context]() {
+			++context.NumOperationCalls;
+			return Success();
+		};
+
+		// Act:
+		auto result = RetryWithBackoff(operation, IsRetryable, 5u, context.onRetry());
+
+		// Assert:
+		EXPECT_FALSE(result);
+		EXPECT_EQ(1u, context.NumOperationCalls);
+		EXPECT_TRUE(context.RetryCalls.empty());
+	}
+
+	TEST(TEST_CLASS, StopsImmediately_WhenErrorIsNotRetryable) {
+		// Arrange:
+		RetryContext context;
+		auto operation = [&context]() {
+			++context.NumOperationCalls;
+			return NonRetryableError();
+		};
+
+		// Act:
+		auto result = RetryWithBackoff(operation, IsRetryable, 5u, context.onRetry());
+
+		// Assert:
+		EXPECT_EQ(NonRetryableError(), result);
+		EXPECT_EQ(1u, context.NumOperationCalls);
+		EXPECT_TRUE(context.RetryCalls.empty());
+	}
+
+	TEST(TEST_CLASS, RetriesUntilSuccess_WhenErrorIsRetryable) {
+		// Arrange: fail twice, then succeed
+		RetryContext context;
+		auto operation = [&context]() {
+			++context.NumOperationCalls;
+			return 3 == context.NumOperationCalls ? Success() : RetryableError();
+		};
+
+		// Act:
+		auto result = RetryWithBackoff(operation, IsRetryable, 5u, context.onRetry());
+
+		// Assert:
+		EXPECT_FALSE(result);
+		EXPECT_EQ(3u, context.NumOperationCalls);
+		ASSERT_EQ(2u, context.RetryCalls.size());
+		EXPECT_EQ(0u, context.RetryCalls[0].first);
+		EXPECT_EQ(1u, context.RetryCalls[1].first);
+		EXPECT_EQ(RetryableError(), context.RetryCalls[0].second);
+		EXPECT_EQ(RetryableError(), context.RetryCalls[1].second);
+	}
+
+	TEST(TEST_CLASS, GivesUpAfterExhaustingAttempts_WhenErrorPersists) {
+		// Arrange:
+		RetryContext context;
+		auto operation = [&context]() {
+			++context.NumOperationCalls;
+			return RetryableError();
+		};
+
+		// Act:
+		auto result = RetryWithBackoff(operation, IsRetryable, 3u, context.onRetry());
+
+		// Assert: three attempts total, two retries in between
+		EXPECT_EQ(RetryableError(), result);
+		EXPECT_EQ(3u, context.NumOperationCalls);
+		EXPECT_EQ(2u, context.RetryCalls.size());
+	}
+
+	TEST(TEST_CLASS, NeverRetries_WhenNumAttemptsIsOne) {
+		// Arrange:
+		RetryContext context;
+		auto operation = [&context]() {
+			++context.NumOperationCalls;
+			return RetryableError();
+		};
+
+		// Act:
+		auto result = RetryWithBackoff(operation, IsRetryable, 1u, context.onRetry());
+
+		// Assert:
+		EXPECT_EQ(RetryableError(), result);
+		EXPECT_EQ(1u, context.NumOperationCalls);
+		EXPECT_TRUE(context.RetryCalls.empty());
+	}
+}}

--- a/client/catapult/tests/catapult/utils/RetryUtilsTests.cpp
+++ b/client/catapult/tests/catapult/utils/RetryUtilsTests.cpp
@@ -65,15 +65,20 @@ namespace catapult { namespace utils {
 				};
 			}
 		};
+
+		// Creates an operation that increments \a context's call counter and always returns \a result.
+		auto MakeOperation(RetryContext& context, std::error_code result) {
+			return [&context, result]() {
+				++context.NumOperationCalls;
+				return result;
+			};
+		}
 	}
 
 	TEST(TEST_CLASS, SucceedsOnFirstAttempt_WithoutRetrying) {
 		// Arrange:
 		RetryContext context;
-		auto operation = [&context]() {
-			++context.NumOperationCalls;
-			return Success();
-		};
+		auto operation = MakeOperation(context, Success());
 
 		// Act:
 		auto result = RetryWithBackoff(operation, IsRetryable, 5u, context.onRetry(), 0);
@@ -87,10 +92,7 @@ namespace catapult { namespace utils {
 	TEST(TEST_CLASS, StopsImmediately_WhenErrorIsNotRetryable) {
 		// Arrange:
 		RetryContext context;
-		auto operation = [&context]() {
-			++context.NumOperationCalls;
-			return NonRetryableError();
-		};
+		auto operation = MakeOperation(context, NonRetryableError());
 
 		// Act:
 		auto result = RetryWithBackoff(operation, IsRetryable, 5u, context.onRetry(), 0);
@@ -125,10 +127,7 @@ namespace catapult { namespace utils {
 	TEST(TEST_CLASS, GivesUpAfterExhaustingAttempts_WhenErrorPersists) {
 		// Arrange:
 		RetryContext context;
-		auto operation = [&context]() {
-			++context.NumOperationCalls;
-			return RetryableError();
-		};
+		auto operation = MakeOperation(context, RetryableError());
 
 		// Act:
 		auto result = RetryWithBackoff(operation, IsRetryable, 3u, context.onRetry(), 0);
@@ -142,10 +141,7 @@ namespace catapult { namespace utils {
 	TEST(TEST_CLASS, NeverRetries_WhenNumAttemptsIsOne) {
 		// Arrange:
 		RetryContext context;
-		auto operation = [&context]() {
-			++context.NumOperationCalls;
-			return RetryableError();
-		};
+		auto operation = MakeOperation(context, RetryableError());
 
 		// Act:
 		auto result = RetryWithBackoff(operation, IsRetryable, 1u, context.onRetry(), 0);
@@ -159,10 +155,7 @@ namespace catapult { namespace utils {
 	TEST(TEST_CLASS, DelayDoublesEachAttempt_WhenBaseDelayIsNonzero) {
 		// Arrange:
 		RetryContext context;
-		auto operation = [&context]() {
-			++context.NumOperationCalls;
-			return RetryableError();
-		};
+		auto operation = MakeOperation(context, RetryableError());
 
 		// Act: use a tiny base delay so the (real) sleeps stay negligible
 		auto result = RetryWithBackoff(operation, IsRetryable, 4u, context.onRetry(), 1);
@@ -178,10 +171,7 @@ namespace catapult { namespace utils {
 	TEST(TEST_CLASS, ZeroBaseDelaySkipsWait) {
 		// Arrange:
 		RetryContext context;
-		auto operation = [&context]() {
-			++context.NumOperationCalls;
-			return RetryableError();
-		};
+		auto operation = MakeOperation(context, RetryableError());
 
 		// Act:
 		RetryWithBackoff(operation, IsRetryable, 3u, context.onRetry(), 0);

--- a/client/catapult/tests/catapult/utils/RetryUtilsTests.cpp
+++ b/client/catapult/tests/catapult/utils/RetryUtilsTests.cpp
@@ -45,16 +45,23 @@ namespace catapult { namespace utils {
 			return std::errc::permission_denied == ec;
 		}
 
-		// Tracks operation invocations and onRetry (attempt, error) callbacks for assertions.
+		struct RetryCall {
+		public:
+			uint32_t Attempt;
+			std::error_code Error;
+			uint32_t DelayMs;
+		};
+
+		// Tracks operation invocations and onRetry (attempt, error, delay) callbacks for assertions.
 		struct RetryContext {
 		public:
 			size_t NumOperationCalls = 0;
-			std::vector<std::pair<uint32_t, std::error_code>> RetryCalls;
+			std::vector<RetryCall> RetryCalls;
 
 		public:
 			auto onRetry() {
-				return [this](auto attempt, const auto& ec) {
-					RetryCalls.emplace_back(attempt, ec);
+				return [this](auto attempt, const auto& ec, auto delayMs) {
+					RetryCalls.push_back({ attempt, ec, delayMs });
 				};
 			}
 		};
@@ -69,10 +76,10 @@ namespace catapult { namespace utils {
 		};
 
 		// Act:
-		auto result = RetryWithBackoff(operation, IsRetryable, 5u, context.onRetry());
+		auto result = RetryWithBackoff(operation, IsRetryable, 5u, context.onRetry(), 0);
 
 		// Assert:
-		EXPECT_FALSE(result);
+		EXPECT_EQ(std::error_code(), result);
 		EXPECT_EQ(1u, context.NumOperationCalls);
 		EXPECT_TRUE(context.RetryCalls.empty());
 	}
@@ -86,7 +93,7 @@ namespace catapult { namespace utils {
 		};
 
 		// Act:
-		auto result = RetryWithBackoff(operation, IsRetryable, 5u, context.onRetry());
+		auto result = RetryWithBackoff(operation, IsRetryable, 5u, context.onRetry(), 0);
 
 		// Assert:
 		EXPECT_EQ(NonRetryableError(), result);
@@ -103,16 +110,16 @@ namespace catapult { namespace utils {
 		};
 
 		// Act:
-		auto result = RetryWithBackoff(operation, IsRetryable, 5u, context.onRetry());
+		auto result = RetryWithBackoff(operation, IsRetryable, 5u, context.onRetry(), 0);
 
 		// Assert:
-		EXPECT_FALSE(result);
+		EXPECT_EQ(std::error_code(), result);
 		EXPECT_EQ(3u, context.NumOperationCalls);
 		ASSERT_EQ(2u, context.RetryCalls.size());
-		EXPECT_EQ(0u, context.RetryCalls[0].first);
-		EXPECT_EQ(1u, context.RetryCalls[1].first);
-		EXPECT_EQ(RetryableError(), context.RetryCalls[0].second);
-		EXPECT_EQ(RetryableError(), context.RetryCalls[1].second);
+		EXPECT_EQ(0u, context.RetryCalls[0].Attempt);
+		EXPECT_EQ(1u, context.RetryCalls[1].Attempt);
+		EXPECT_EQ(RetryableError(), context.RetryCalls[0].Error);
+		EXPECT_EQ(RetryableError(), context.RetryCalls[1].Error);
 	}
 
 	TEST(TEST_CLASS, GivesUpAfterExhaustingAttempts_WhenErrorPersists) {
@@ -124,7 +131,7 @@ namespace catapult { namespace utils {
 		};
 
 		// Act:
-		auto result = RetryWithBackoff(operation, IsRetryable, 3u, context.onRetry());
+		auto result = RetryWithBackoff(operation, IsRetryable, 3u, context.onRetry(), 0);
 
 		// Assert: three attempts total, two retries in between
 		EXPECT_EQ(RetryableError(), result);
@@ -141,11 +148,47 @@ namespace catapult { namespace utils {
 		};
 
 		// Act:
-		auto result = RetryWithBackoff(operation, IsRetryable, 1u, context.onRetry());
+		auto result = RetryWithBackoff(operation, IsRetryable, 1u, context.onRetry(), 0);
 
 		// Assert:
 		EXPECT_EQ(RetryableError(), result);
 		EXPECT_EQ(1u, context.NumOperationCalls);
 		EXPECT_TRUE(context.RetryCalls.empty());
+	}
+
+	TEST(TEST_CLASS, DelayDoublesEachAttempt_WhenBaseDelayIsNonzero) {
+		// Arrange:
+		RetryContext context;
+		auto operation = [&context]() {
+			++context.NumOperationCalls;
+			return RetryableError();
+		};
+
+		// Act: use a tiny base delay so the (real) sleeps stay negligible
+		auto result = RetryWithBackoff(operation, IsRetryable, 4u, context.onRetry(), 1);
+
+		// Assert:
+		EXPECT_EQ(RetryableError(), result);
+		ASSERT_EQ(3u, context.RetryCalls.size());
+		EXPECT_EQ(1u, context.RetryCalls[0].DelayMs);
+		EXPECT_EQ(2u, context.RetryCalls[1].DelayMs);
+		EXPECT_EQ(4u, context.RetryCalls[2].DelayMs);
+	}
+
+	TEST(TEST_CLASS, ZeroBaseDelaySkipsWait) {
+		// Arrange:
+		RetryContext context;
+		auto operation = [&context]() {
+			++context.NumOperationCalls;
+			return RetryableError();
+		};
+
+		// Act:
+		RetryWithBackoff(operation, IsRetryable, 3u, context.onRetry(), 0);
+
+		// Assert: delay is reported as zero to onRetry (and, per contract, no sleep is performed)
+		ASSERT_EQ(2u, context.RetryCalls.size());
+		EXPECT_EQ(0u, context.RetryCalls[0].DelayMs);
+		EXPECT_EQ(0u, context.RetryCalls[1].DelayMs);
 	}
 }}


### PR DESCRIPTION
## Summary
Fixes #2045 — Windows delays releasing file handles after close, causing RocksDB reopen (and the paired state-directory rename in `LocalNodeStateSerializer::moveTo`) to fail with ACCESS_DENIED during rapid boot/shutdown/reboot cycles.

- Retry with exponential backoff on Windows only, gated to the specific transient error (`IOError` for RocksDB open, `permission_denied` for the rename) — not a blanket retry-on-any-failure.
- POSIX path unchanged in behavior (single attempt, no backoff) — the underlying OS quirk doesn't exist there.
- Retry loop extracted into a generic, injectable `utils::RetryWithBackoff` helper so the gating logic is unit-testable without needing real permission-denied filesystem/DB state.

## Test plan
- [x] New `RetryUtilsTests` cover the generic helper: success-first-try, non-retryable error stops immediately, retries-until-success, exhausts-attempts, `numAttempts=1` never retries.
- [x] New `RocksDatabaseTests.IsRetryableAfterFailedOpen_ReturnsTrueOnlyForIoError` covers the RocksDB-specific gate against `IOError`/`OK`/`InvalidArgument`/`NotFound`/`Corruption`/`NotSupported`.
- [x] Existing `RocksDatabaseTests` (35/35) and `LocalNodeStateFileStorageTests` (15/15) pass unchanged.
- [x] Local structure/style lint clean (0 violations).