### PR TITLE
[client/catapult] fix: null dereference in BlockchainSyncConsumer.cpp

### DIFF
--- a/client/catapult/src/catapult/consumers/BlockchainSyncConsumer.cpp
+++ b/client/catapult/src/catapult/consumers/BlockchainSyncConsumer.cpp
@@ -336,10 +336,13 @@ namespace catapult { namespace consumers {
 
 		private:
 			static bool Contains(const io::BlockStorageView& storageView, const model::HeightHashPair& heightHashPair) {
-				if (storageView.chainHeight() < heightHashPair.Height)
+				if (Height(0) == heightHashPair.Height || storageView.chainHeight() < heightHashPair.Height)
 					return false;
 
 				auto storageHashRange = storageView.loadHashesFrom(heightHashPair.Height, 1);
+				if (storageHashRange.empty())
+					return false;
+
 				return heightHashPair.Hash == *storageHashRange.cbegin();
 			}
 

--- a/client/catapult/src/catapult/consumers/BlockchainSyncConsumer.cpp
+++ b/client/catapult/src/catapult/consumers/BlockchainSyncConsumer.cpp
@@ -336,9 +336,8 @@ namespace catapult { namespace consumers {
 
 		private:
 			static bool Contains(const io::BlockStorageView& storageView, const model::HeightHashPair& heightHashPair) {
-				if (Height(0) == heightHashPair.Height || storageView.chainHeight() < heightHashPair.Height)
-					return false;
-
+				// loadHashesFrom returns an empty range when the height is unavailable (Height(0) or above the
+				// chain height), so an empty result is the single, authoritative signal that the block is absent
 				auto storageHashRange = storageView.loadHashesFrom(heightHashPair.Height, 1);
 				if (storageHashRange.empty())
 					return false;

--- a/client/catapult/src/catapult/consumers/BlockchainSyncConsumer.cpp
+++ b/client/catapult/src/catapult/consumers/BlockchainSyncConsumer.cpp
@@ -339,10 +339,7 @@ namespace catapult { namespace consumers {
 				// loadHashesFrom returns an empty range when the height is unavailable (Height(0) or above the
 				// chain height), so an empty result is the single, authoritative signal that the block is absent
 				auto storageHashRange = storageView.loadHashesFrom(heightHashPair.Height, 1);
-				if (storageHashRange.empty())
-					return false;
-
-				return heightHashPair.Hash == *storageHashRange.cbegin();
+				return !storageHashRange.empty() && heightHashPair.Hash == *storageHashRange.cbegin();
 			}
 
 			static bool Contains(const BlockElements& elements, const model::HeightHashPair& heightHashPair) {


### PR DESCRIPTION
Fixes #2015

At node startup network finalized height is Height(0), so the height guard was false and code called loadHashesFrom(Height(0), 1), returning empty HashRange. Dereferencing its value-initialized iterator tripped MSVC debug assertion, UB in release.

## Summary
- Guard empty hash range before dereferencing (990a49d3c)
- Remove now-redundant height check (f862bd5c8)
- Collapse empty-check into single return expression (dd32aa5cb)