### PR TITLE
[client/catapult] fix: compile missing mongo plugin test/src files (#1992)

### DIFF
--- a/client/catapult/extensions/mongo/plugins/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/CMakeLists.txt
@@ -2,55 +2,42 @@ cmake_minimum_required(VERSION 3.23)
 
 set(PLUGIN_CATAPULT_LIBS catapult.mongo)
 
-function(catapult_mongo_plugin_src_no_deps PLUGIN_BASE_NAME)
-	catapult_shared_library_target(${PLUGIN_BASE_NAME} "${ARGN}")
-	catapult_add_mongo_dependencies(${PLUGIN_BASE_NAME})
-	target_link_libraries(${PLUGIN_BASE_NAME} ${PLUGIN_CATAPULT_LIBS})
+# a plugin needs a deps lib when it has a cache storage (living under a "storages" subdir);
+# the cache storage needs access to the plugin's core cache, hence the extra .deps link target
+function(catapult_mongo_plugin_src PLUGIN_BASE_NAME)
+	if(IS_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/storages")
+		# create a deps lib
+		catapult_library_target(${PLUGIN_BASE_NAME}.deps "${ARGN}")
+		catapult_add_mongo_dependencies(${PLUGIN_BASE_NAME}.deps)
+		target_link_libraries(${PLUGIN_BASE_NAME}.deps ${PLUGIN_CATAPULT_LIBS})
+
+		# create a plugin dll
+		catapult_shared_library_target(${PLUGIN_BASE_NAME})
+		target_link_libraries(${PLUGIN_BASE_NAME} ${PLUGIN_BASE_NAME}.deps)
+	else()
+		catapult_shared_library_target(${PLUGIN_BASE_NAME} "${ARGN}")
+		catapult_add_mongo_dependencies(${PLUGIN_BASE_NAME})
+		target_link_libraries(${PLUGIN_BASE_NAME} ${PLUGIN_CATAPULT_LIBS})
+	endif()
 
 	add_dependencies(mongo ${PLUGIN_BASE_NAME})
 endfunction()
 
-function(catapult_mongo_plugin_src_with_deps PLUGIN_BASE_NAME)
-	# create a deps lib
-	catapult_library_target(${PLUGIN_BASE_NAME}.deps "${ARGN}")
-	catapult_add_mongo_dependencies(${PLUGIN_BASE_NAME}.deps)
-	target_link_libraries(${PLUGIN_BASE_NAME}.deps ${PLUGIN_CATAPULT_LIBS})
-
-	# create a plugin dll
-	catapult_shared_library_target(${PLUGIN_BASE_NAME})
-	target_link_libraries(${PLUGIN_BASE_NAME} ${PLUGIN_BASE_NAME}.deps)
-
-	add_dependencies(mongo ${PLUGIN_BASE_NAME})
-endfunction()
-
-function(catapult_mongo_plugin_tests_no_deps TARGET_NAME)
-	catapult_test_executable_target(${TARGET_NAME} mongo)
-	catapult_add_mongo_dependencies(${TARGET_NAME})
-
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" PARENT_SCOPE)
-endfunction()
-
-function(catapult_mongo_plugin_tests_with_header_only_deps TARGET_NAME)
+function(catapult_mongo_plugin_tests TARGET_NAME)
 	string(REGEX MATCH "\.[a-z_]+$" PLUGIN_NAME ${TARGET_NAME})
 	string(SUBSTRING ${PLUGIN_NAME} 1 -1 PLUGIN_NAME)
 
 	catapult_test_executable_target(${TARGET_NAME} mongo "${ARGN}")
 	catapult_add_mongo_dependencies(${TARGET_NAME})
-	target_link_libraries(${TARGET_NAME} catapult.mongo.plugins.${PLUGIN_NAME}.deps)
 
-	if(TARGET "tests.catapult.test.plugins.${PLUGIN_NAME}")
-		target_link_libraries(${TARGET_NAME} tests.catapult.test.plugins.${PLUGIN_NAME})
+	if(TARGET catapult.mongo.plugins.${PLUGIN_NAME}.deps)
+		target_link_libraries(${TARGET_NAME} catapult.mongo.plugins.${PLUGIN_NAME}.deps)
+		target_link_libraries(${TARGET_NAME} tests.catapult.test.mongo.plugins.${PLUGIN_NAME})
+
+		if(TARGET "tests.catapult.test.plugins.${PLUGIN_NAME}")
+			target_link_libraries(${TARGET_NAME} tests.catapult.test.plugins.${PLUGIN_NAME})
+		endif()
 	endif()
-
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" PARENT_SCOPE)
-endfunction()
-
-function(catapult_mongo_plugin_tests_with_deps TARGET_NAME)
-	string(REGEX MATCH "\.[a-z]+$" PLUGIN_NAME ${TARGET_NAME})
-	string(SUBSTRING ${PLUGIN_NAME} 1 -1 PLUGIN_NAME)
-
-	catapult_mongo_plugin_tests_with_header_only_deps(${TARGET_NAME} "${ARGN}")
-	target_link_libraries(${TARGET_NAME} tests.catapult.test.mongo.plugins.${PLUGIN_NAME})
 
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" PARENT_SCOPE)
 endfunction()

--- a/client/catapult/extensions/mongo/plugins/account_link/src/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/account_link/src/CMakeLists.txt
@@ -2,4 +2,4 @@ cmake_minimum_required(VERSION 3.23)
 
 set(PLUGIN_BASE_NAME catapult.mongo.plugins.accountlink)
 
-catapult_mongo_plugin_src_no_deps(${PLUGIN_BASE_NAME})
+catapult_mongo_plugin_src(${PLUGIN_BASE_NAME})

--- a/client/catapult/extensions/mongo/plugins/account_link/tests/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/account_link/tests/CMakeLists.txt
@@ -2,4 +2,4 @@ cmake_minimum_required(VERSION 3.23)
 
 set(TARGET_NAME tests.catapult.mongo.plugins.accountlink)
 
-catapult_mongo_plugin_tests_no_deps(${TARGET_NAME})
+catapult_mongo_plugin_tests(${TARGET_NAME})

--- a/client/catapult/extensions/mongo/plugins/aggregate/src/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/aggregate/src/CMakeLists.txt
@@ -2,5 +2,5 @@ cmake_minimum_required(VERSION 3.23)
 
 set(PLUGIN_BASE_NAME catapult.mongo.plugins.aggregate)
 
-catapult_mongo_plugin_src_no_deps(${PLUGIN_BASE_NAME})
+catapult_mongo_plugin_src(${PLUGIN_BASE_NAME})
 target_link_libraries(${PLUGIN_BASE_NAME} catapult.plugins.aggregate)

--- a/client/catapult/extensions/mongo/plugins/aggregate/tests/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/aggregate/tests/CMakeLists.txt
@@ -2,4 +2,4 @@ cmake_minimum_required(VERSION 3.23)
 
 set(TARGET_NAME tests.catapult.mongo.plugins.aggregate)
 
-catapult_mongo_plugin_tests_no_deps(${TARGET_NAME})
+catapult_mongo_plugin_tests(${TARGET_NAME})

--- a/client/catapult/extensions/mongo/plugins/lock_hash/src/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/lock_hash/src/CMakeLists.txt
@@ -3,4 +3,4 @@ cmake_minimum_required(VERSION 3.23)
 set(PLUGIN_BASE_NAME catapult.mongo.plugins.lockhash)
 
 include_directories(${PROJECT_SOURCE_DIR}/plugins/txes/lock_hash)
-catapult_mongo_plugin_src_with_deps(${PLUGIN_BASE_NAME} mappers storages)
+catapult_mongo_plugin_src(${PLUGIN_BASE_NAME} mappers storages)

--- a/client/catapult/extensions/mongo/plugins/lock_hash/tests/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/lock_hash/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.23)
 set(TARGET_NAME tests.catapult.mongo.plugins.lockhash)
 
 include_directories(${PROJECT_SOURCE_DIR}/plugins/txes/lock_hash)
-catapult_mongo_plugin_tests_no_deps(${TARGET_NAME} mappers)
+catapult_mongo_plugin_tests(${TARGET_NAME} mappers)
 
 add_subdirectory(int)
 add_subdirectory(test)

--- a/client/catapult/extensions/mongo/plugins/lock_secret/src/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/lock_secret/src/CMakeLists.txt
@@ -3,4 +3,4 @@ cmake_minimum_required(VERSION 3.23)
 set(PLUGIN_BASE_NAME catapult.mongo.plugins.locksecret)
 
 include_directories(${PROJECT_SOURCE_DIR}/plugins/txes/lock_secret)
-catapult_mongo_plugin_src_with_deps(${PLUGIN_BASE_NAME} mappers storages)
+catapult_mongo_plugin_src(${PLUGIN_BASE_NAME} mappers storages)

--- a/client/catapult/extensions/mongo/plugins/lock_secret/tests/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/lock_secret/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.23)
 set(TARGET_NAME tests.catapult.mongo.plugins.locksecret)
 
 include_directories(${PROJECT_SOURCE_DIR}/plugins/txes/lock_secret)
-catapult_mongo_plugin_tests_no_deps(${TARGET_NAME} mappers)
+catapult_mongo_plugin_tests(${TARGET_NAME} mappers)
 
 add_subdirectory(int)
 add_subdirectory(test)

--- a/client/catapult/extensions/mongo/plugins/metadata/src/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/metadata/src/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.23)
 set(PLUGIN_BASE_NAME catapult.mongo.plugins.metadata)
 
 include_directories(${PROJECT_SOURCE_DIR}/plugins/txes/metadata)
-catapult_mongo_plugin_src_with_deps(${PLUGIN_BASE_NAME} mappers storages)
+catapult_mongo_plugin_src(${PLUGIN_BASE_NAME} mappers storages)
 
 # metadata.deps is needed because the mongo metadata cache storage needs the metadata cache
 target_link_libraries(${PLUGIN_BASE_NAME}.deps catapult.plugins.metadata.deps)

--- a/client/catapult/extensions/mongo/plugins/metadata/tests/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/metadata/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.23)
 set(TARGET_NAME tests.catapult.mongo.plugins.metadata)
 
 include_directories(${PROJECT_SOURCE_DIR}/plugins/txes/metadata)
-catapult_mongo_plugin_tests_with_deps(${TARGET_NAME} mappers)
+catapult_mongo_plugin_tests(${TARGET_NAME} mappers)
 
 add_subdirectory(int)
 add_subdirectory(test)

--- a/client/catapult/extensions/mongo/plugins/mosaic/src/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/mosaic/src/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.23)
 set(PLUGIN_BASE_NAME catapult.mongo.plugins.mosaic)
 
 include_directories(${PROJECT_SOURCE_DIR}/plugins/txes/mosaic)
-catapult_mongo_plugin_src_with_deps(${PLUGIN_BASE_NAME} mappers storages)
+catapult_mongo_plugin_src(${PLUGIN_BASE_NAME} mappers storages)
 
 # mosaic.deps is needed because the mongo mosaic cache storage needs the mosaic cache
 target_link_libraries(${PLUGIN_BASE_NAME}.deps catapult.plugins.mosaic.deps)

--- a/client/catapult/extensions/mongo/plugins/mosaic/tests/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/mosaic/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.23)
 set(TARGET_NAME tests.catapult.mongo.plugins.mosaic)
 
 include_directories(${PROJECT_SOURCE_DIR}/plugins/txes/mosaic)
-catapult_mongo_plugin_tests_with_deps(${TARGET_NAME} mappers storages)
+catapult_mongo_plugin_tests(${TARGET_NAME} mappers storages)
 
 add_subdirectory(int)
 add_subdirectory(test)

--- a/client/catapult/extensions/mongo/plugins/multisig/src/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/multisig/src/CMakeLists.txt
@@ -3,4 +3,4 @@ cmake_minimum_required(VERSION 3.23)
 set(PLUGIN_BASE_NAME catapult.mongo.plugins.multisig)
 
 include_directories(${PROJECT_SOURCE_DIR}/plugins/txes/multisig)
-catapult_mongo_plugin_src_with_deps(${PLUGIN_BASE_NAME} mappers storages)
+catapult_mongo_plugin_src(${PLUGIN_BASE_NAME} mappers storages)

--- a/client/catapult/extensions/mongo/plugins/multisig/tests/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/multisig/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.23)
 set(TARGET_NAME tests.catapult.mongo.plugins.multisig)
 
 include_directories(${PROJECT_SOURCE_DIR}/plugins/txes/multisig)
-catapult_mongo_plugin_tests_with_deps(${TARGET_NAME} mappers)
+catapult_mongo_plugin_tests(${TARGET_NAME} mappers)
 
 add_subdirectory(int)
 add_subdirectory(test)

--- a/client/catapult/extensions/mongo/plugins/namespace/src/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/namespace/src/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.23)
 set(PLUGIN_BASE_NAME catapult.mongo.plugins.namespace)
 
 include_directories(${PROJECT_SOURCE_DIR}/plugins/txes/namespace)
-catapult_mongo_plugin_src_with_deps(${PLUGIN_BASE_NAME} mappers storages)
+catapult_mongo_plugin_src(${PLUGIN_BASE_NAME} mappers storages)
 
 # namespace.deps is needed because the mongo namespace cache storage needs the namespace cache
 target_link_libraries(${PLUGIN_BASE_NAME}.deps catapult.plugins.namespace.deps)

--- a/client/catapult/extensions/mongo/plugins/namespace/tests/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/namespace/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.23)
 set(TARGET_NAME tests.catapult.mongo.plugins.namespace)
 
 include_directories(${PROJECT_SOURCE_DIR}/plugins/txes/namespace)
-catapult_mongo_plugin_tests_with_deps(${TARGET_NAME} mappers storages)
+catapult_mongo_plugin_tests(${TARGET_NAME} mappers storages)
 
 add_subdirectory(int)
 add_subdirectory(test)

--- a/client/catapult/extensions/mongo/plugins/restriction_account/src/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/restriction_account/src/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.23)
 set(PLUGIN_BASE_NAME catapult.mongo.plugins.restrictionaccount)
 
 include_directories(${PROJECT_SOURCE_DIR}/plugins/txes/restriction_account)
-catapult_mongo_plugin_src_with_deps(${PLUGIN_BASE_NAME} mappers storages)
+catapult_mongo_plugin_src(${PLUGIN_BASE_NAME} mappers storages)
 
 # restrictionaccount.deps is needed because the mongo account restriction cache storage needs the account restriction cache
 target_link_libraries(${PLUGIN_BASE_NAME}.deps catapult.plugins.restrictionaccount.deps)

--- a/client/catapult/extensions/mongo/plugins/restriction_account/tests/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/restriction_account/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.23)
 set(TARGET_NAME tests.catapult.mongo.plugins.restrictionaccount)
 
 include_directories(${PROJECT_SOURCE_DIR}/plugins/txes/restriction_account)
-catapult_mongo_plugin_tests_with_deps(${TARGET_NAME} mappers)
+catapult_mongo_plugin_tests(${TARGET_NAME} mappers)
 
 add_subdirectory(int)
 add_subdirectory(test)

--- a/client/catapult/extensions/mongo/plugins/restriction_mosaic/src/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/restriction_mosaic/src/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.23)
 set(PLUGIN_BASE_NAME catapult.mongo.plugins.restrictionmosaic)
 
 include_directories(${PROJECT_SOURCE_DIR}/plugins/txes/restriction_mosaic)
-catapult_mongo_plugin_src_with_deps(${PLUGIN_BASE_NAME} mappers storages)
+catapult_mongo_plugin_src(${PLUGIN_BASE_NAME} mappers storages)
 
 # restrictionmosaic.deps is needed because the mongo mosaic restriction cache storage needs the mosaic restriction cache
 target_link_libraries(${PLUGIN_BASE_NAME}.deps catapult.plugins.restrictionmosaic.deps)

--- a/client/catapult/extensions/mongo/plugins/restriction_mosaic/tests/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/restriction_mosaic/tests/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.23)
 set(TARGET_NAME tests.catapult.mongo.plugins.restrictionmosaic)
 
 include_directories(${PROJECT_SOURCE_DIR}/plugins/txes/restriction_mosaic)
-catapult_mongo_plugin_tests_with_deps(${TARGET_NAME} mappers)
+catapult_mongo_plugin_tests(${TARGET_NAME} mappers)
 
 add_subdirectory(int)
 add_subdirectory(test)

--- a/client/catapult/extensions/mongo/plugins/transfer/src/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/transfer/src/CMakeLists.txt
@@ -2,4 +2,4 @@ cmake_minimum_required(VERSION 3.23)
 
 set(PLUGIN_BASE_NAME catapult.mongo.plugins.transfer)
 
-catapult_mongo_plugin_src_no_deps(${PLUGIN_BASE_NAME})
+catapult_mongo_plugin_src(${PLUGIN_BASE_NAME})

--- a/client/catapult/extensions/mongo/plugins/transfer/tests/CMakeLists.txt
+++ b/client/catapult/extensions/mongo/plugins/transfer/tests/CMakeLists.txt
@@ -2,4 +2,4 @@ cmake_minimum_required(VERSION 3.23)
 
 set(TARGET_NAME tests.catapult.mongo.plugins.transfer)
 
-catapult_mongo_plugin_tests_no_deps(${TARGET_NAME})
+catapult_mongo_plugin_tests(${TARGET_NAME})


### PR DESCRIPTION
Fixes #1992

catapult_mongo_plugin_tests_no_deps dropped extra source dir args, so lock_secret and lock_hash mappers cpp files were never compiled.

Merged the no deps / with deps helper pairs, both for tests and for src, into one helper each:

Tests: catapult_mongo_plugin_tests now decides deps linkage by checking if TARGET catapult.mongo.plugins.<name>.deps exists, and always forwards extra source dir args to the underlying glob.

Src: catapult_mongo_plugin_src now decides deps linkage by checking if a storages subdir exists (that is where CacheStorage code lives, and it is the reason the deps lib is needed).

## Test plan

Full local build passes. Full local test suite passes, 87/87 (mongod active for int tests).