### PR TITLE
[client/catapult] fix: close TLS sockets gracefully to stop Windows RST storm (#2060)

### DIFF
--- a/client/catapult/src/catapult/ionet/PacketSocket.cpp
+++ b/client/catapult/src/catapult/ionet/PacketSocket.cpp
@@ -84,7 +84,8 @@ namespace catapult { namespace ionet {
 					: m_strand(boost::asio::make_strand(ioContext))
 					, m_strandWrapper(m_strand)
 					, m_socket(ioContext, sslContext)
-					, m_drainTimer(ioContext) {
+					, m_drainTimer(ioContext)
+					, m_isFinalizing(false) {
 				m_isClosed.clear();
 				m_isClosed.test_and_set();
 			}
@@ -93,7 +94,8 @@ namespace catapult { namespace ionet {
 					: m_strand(boost::asio::make_strand(ioContext))
 					, m_strandWrapper(m_strand)
 					, m_socket(std::move(socket), sslContext)
-					, m_drainTimer(ioContext) {
+					, m_drainTimer(ioContext)
+					, m_isFinalizing(false) {
 				m_isClosed.clear();
 				m_isClosed.test_and_set();
 			}
@@ -217,7 +219,7 @@ namespace catapult { namespace ionet {
 			Socket m_socket;
 			boost::asio::steady_timer m_drainTimer;
 			std::array<uint8_t, 1024> m_drainBuffer;
-			std::atomic_bool m_isFinalizing = false;
+			std::atomic_bool m_isFinalizing;
 			std::atomic_flag m_isClosed;
 		};
 
@@ -571,6 +573,7 @@ namespace catapult { namespace ionet {
 					: m_strandWrapper(pSocketGuard->strand())
 					, m_socket(pSocketGuard, options, *this)
 					, m_id(s_idCounter.fetch_add(1))
+					, m_isClosePending(false)
 			{}
 
 			~StrandedPacketSocket() override {
@@ -693,7 +696,7 @@ namespace catapult { namespace ionet {
 			thread::StrandOwnerLifetimeExtender<StrandedPacketSocket> m_strandWrapper;
 			SocketType m_socket;
 			SocketIdentifier m_id;
-			std::atomic<bool> m_isClosePending{ false };
+			std::atomic<bool> m_isClosePending;
 		};
 
 		std::atomic<uint64_t> StrandedPacketSocket::s_idCounter(1);

--- a/client/catapult/src/catapult/ionet/PacketSocket.cpp
+++ b/client/catapult/src/catapult/ionet/PacketSocket.cpp
@@ -139,7 +139,7 @@ namespace catapult { namespace ionet {
 				// peer's. The subsequent raw drain empties whatever is still buffered. On Windows, closing a
 				// socket with unread data buffered makes Winsock emit an abortive RST instead of a FIN; that
 				// RST fails peers' in-flight writes (WSAECONNRESET) and drives a reset/reconnect storm.
-				// The whole sequence is bounded by a short timer so teardown stays prompt if the peer stalls.
+				// This whole sequence is bounded by a short timer so teardown stays prompt if the peer stalls.
 				boost::system::error_code ignoredEc;
 				m_socket.lowest_layer().cancel(ignoredEc);
 
@@ -375,8 +375,8 @@ namespace catapult { namespace ionet {
 
 			void readSome(const PacketSocket::ReadCallback& callback, bool allowMultiple) {
 				// once a close has been requested, do not issue another socket read: closeImpl runs the SSL
-				// shutdown handshake and a receive drain on the same stream, and a concurrent async_read_some
-				// would both race that teardown and deliver a stale packet after the owner asked to stop.
+				// shutdown handshake and a receive drain on the same stream; a concurrent async_read_some
+				// would race that teardown and could deliver a stale packet after the owner asked to stop.
 				if (m_wrapper.isClosePending())
 					return callback(SocketOperationCode::Read_Error, nullptr);
 

--- a/client/catapult/src/catapult/ionet/PacketSocket.cpp
+++ b/client/catapult/src/catapult/ionet/PacketSocket.cpp
@@ -84,8 +84,7 @@ namespace catapult { namespace ionet {
 					: m_strand(boost::asio::make_strand(ioContext))
 					, m_strandWrapper(m_strand)
 					, m_socket(ioContext, sslContext)
-					, m_drainTimer(ioContext)
-					, m_isFinalizing(false) {
+					, m_drainTimer(ioContext) {
 				m_isClosed.clear();
 				m_isClosed.test_and_set();
 			}
@@ -94,8 +93,7 @@ namespace catapult { namespace ionet {
 					: m_strand(boost::asio::make_strand(ioContext))
 					, m_strandWrapper(m_strand)
 					, m_socket(std::move(socket), sslContext)
-					, m_drainTimer(ioContext)
-					, m_isFinalizing(false) {
+					, m_drainTimer(ioContext) {
 				m_isClosed.clear();
 				m_isClosed.test_and_set();
 			}
@@ -214,13 +212,12 @@ namespace catapult { namespace ionet {
 		private:
 			static constexpr auto Drain_Timeout = std::chrono::milliseconds(100);
 
-		private:
 			Strand m_strand;
 			thread::StrandOwnerLifetimeExtender<SocketGuard> m_strandWrapper;
 			Socket m_socket;
 			boost::asio::steady_timer m_drainTimer;
 			std::array<uint8_t, 1024> m_drainBuffer;
-			bool m_isFinalizing;
+			bool m_isFinalizing = false;
 			std::atomic_flag m_isClosed;
 		};
 

--- a/client/catapult/src/catapult/ionet/PacketSocket.cpp
+++ b/client/catapult/src/catapult/ionet/PacketSocket.cpp
@@ -27,6 +27,9 @@
 #include "catapult/thread/TimedCallback.h"
 #include "catapult/utils/StackTimer.h"
 #include <boost/asio/ssl.hpp>
+#include <boost/asio/steady_timer.hpp>
+#include <array>
+#include <chrono>
 
 namespace catapult { namespace ionet {
 
@@ -81,7 +84,8 @@ namespace catapult { namespace ionet {
 					: m_strand(boost::asio::make_strand(ioContext))
 					, m_strandWrapper(m_strand)
 					, m_socket(ioContext, sslContext)
-					, m_sentinelByte(0) {
+					, m_drainTimer(ioContext)
+					, m_isFinalizing(false) {
 				m_isClosed.clear();
 				m_isClosed.test_and_set();
 			}
@@ -90,7 +94,8 @@ namespace catapult { namespace ionet {
 					: m_strand(boost::asio::make_strand(ioContext))
 					, m_strandWrapper(m_strand)
 					, m_socket(std::move(socket), sslContext)
-					, m_sentinelByte(0) {
+					, m_drainTimer(ioContext)
+					, m_isFinalizing(false) {
 				m_isClosed.clear();
 				m_isClosed.test_and_set();
 			}
@@ -128,19 +133,54 @@ namespace catapult { namespace ionet {
 					return;
 				}
 
-				m_socket.async_shutdown(wrap([](const auto& ec) {
-					if (ec && boost::asio::error::operation_aborted != ec && boost::asio::error::bad_descriptor != ec)
+				// graceful drained close: complete the SSL shutdown handshake, then drain any remaining
+				// received bytes to EOF, before closing the lowest layer. async_shutdown sends our
+				// close_notify (so the peer sees an orderly shutdown, not a truncation) and consumes the
+				// peer's. The subsequent raw drain empties whatever is still buffered. On Windows, closing a
+				// socket with unread data buffered makes Winsock emit an abortive RST instead of a FIN; that
+				// RST fails peers' in-flight writes (WSAECONNRESET) and drives a reset/reconnect storm.
+				// The whole sequence is bounded by a short timer so teardown stays prompt if the peer stalls.
+				boost::system::error_code ignoredEc;
+				m_socket.lowest_layer().cancel(ignoredEc);
+
+				m_drainTimer.expires_after(Drain_Timeout);
+				m_drainTimer.async_wait(wrap([this](const auto& ec) {
+					if (boost::asio::error::operation_aborted != ec)
+						finalizeImpl();
+				}));
+
+				m_socket.async_shutdown(wrap([this](const auto& ec) {
+					if (ec && boost::asio::error::operation_aborted != ec && boost::asio::error::eof != ec
+							&& boost::asio::error::bad_descriptor != ec && !IsProtocolShutdown(ec))
 						CATAPULT_LOG(warning) << "async_shutdown returned an error: " << ec.message();
-				}));
 
-				// write must be of non-zero length to avoid asio optimization to no-op
-				auto asioBuffer = boost::asio::buffer(&m_sentinelByte, 1);
-				boost::asio::async_write(m_socket, asioBuffer, wrap([this](const auto& ec, auto) {
-					if (ec && !IsProtocolShutdown(ec))
-						CATAPULT_LOG(warning) << "async_write returned an error: " << ec.message();
-
-					abortImpl();
+					if (!m_isFinalizing)
+						drainImpl();
 				}));
+			}
+
+			void drainImpl() {
+				m_socket.next_layer().async_read_some(boost::asio::buffer(m_drainBuffer), wrap([this](const auto& ec, auto) {
+					if (m_isFinalizing)
+						return;
+
+					// EOF (peer FIN) or any read error means the receive side is drained; otherwise discard
+					// the bytes just read and keep draining
+					if (ec)
+						finalizeImpl();
+					else
+						drainImpl();
+				}));
+			}
+
+			void finalizeImpl() {
+				if (m_isFinalizing)
+					return;
+
+				m_isFinalizing = true;
+
+				m_drainTimer.cancel();
+				abortImpl();
 			}
 
 		public:
@@ -172,10 +212,15 @@ namespace catapult { namespace ionet {
 			}
 
 		private:
+			static constexpr auto Drain_Timeout = std::chrono::milliseconds(100);
+
+		private:
 			Strand m_strand;
 			thread::StrandOwnerLifetimeExtender<SocketGuard> m_strandWrapper;
 			Socket m_socket;
-			uint8_t m_sentinelByte;
+			boost::asio::steady_timer m_drainTimer;
+			std::array<uint8_t, 1024> m_drainBuffer;
+			bool m_isFinalizing;
 			std::atomic_flag m_isClosed;
 		};
 
@@ -329,6 +374,12 @@ namespace catapult { namespace ionet {
 			}
 
 			void readSome(const PacketSocket::ReadCallback& callback, bool allowMultiple) {
+				// once a close has been requested, do not issue another socket read: closeImpl runs the SSL
+				// shutdown handshake and a receive drain on the same stream, and a concurrent async_read_some
+				// would both race that teardown and deliver a stale packet after the owner asked to stop.
+				if (m_wrapper.isClosePending())
+					return callback(SocketOperationCode::Read_Error, nullptr);
+
 				auto pAppendContext = std::make_shared<SharedAppendContext>(m_buffer.prepareAppend());
 				auto readHandler = [this, callback, allowMultiple, pAppendContext](const auto& ec, auto bytesReceived) {
 					auto code = mapReadErrorCodeToSocketOperationCode(ec);
@@ -561,15 +612,23 @@ namespace catapult { namespace ionet {
 			}
 
 			void close() override {
+				// set synchronously (before the posted handler runs) so an in-flight reader stops
+				// re-issuing socket reads as soon as a close is requested
+				m_isClosePending = true;
 				postCloseOnce("close", [](auto& socket) {
 					socket.close();
 				});
 			}
 
 			void abort() override {
+				m_isClosePending = true;
 				postCloseOnce("abort", [](auto& socket) {
 					socket.abort();
 				});
+			}
+
+			bool isClosePending() const {
+				return m_isClosePending;
 			}
 
 			std::shared_ptr<PacketIo> buffered() override {
@@ -637,6 +696,7 @@ namespace catapult { namespace ionet {
 			thread::StrandOwnerLifetimeExtender<StrandedPacketSocket> m_strandWrapper;
 			SocketType m_socket;
 			SocketIdentifier m_id;
+			std::atomic<bool> m_isClosePending{ false };
 		};
 
 		std::atomic<uint64_t> StrandedPacketSocket::s_idCounter(1);

--- a/client/catapult/src/catapult/ionet/PacketSocket.cpp
+++ b/client/catapult/src/catapult/ionet/PacketSocket.cpp
@@ -217,7 +217,7 @@ namespace catapult { namespace ionet {
 			Socket m_socket;
 			boost::asio::steady_timer m_drainTimer;
 			std::array<uint8_t, 1024> m_drainBuffer;
-			bool m_isFinalizing = false;
+			std::atomic_bool m_isFinalizing = false;
 			std::atomic_flag m_isClosed;
 		};
 

--- a/client/catapult/tests/catapult/net/ChainedSocketReaderTests.cpp
+++ b/client/catapult/tests/catapult/net/ChainedSocketReaderTests.cpp
@@ -226,7 +226,7 @@ namespace catapult { namespace net {
 		auto completionCode = resultPair.second;
 
 		// Assert: the single packet was successfuly read
-		EXPECT_EQ(ionet::SocketOperationCode::Closed, completionCode);
+		test::AssertSocketClosedDuringRead(completionCode);
 		ASSERT_EQ(1u, receivedBuffers.size());
 		EXPECT_EQUAL_BUFFERS(sendBuffers[0], 0, 82u, receivedBuffers[0]);
 	}
@@ -241,7 +241,7 @@ namespace catapult { namespace net {
 		auto completionCode = resultPair.second;
 
 		// Assert: all packets were successfully read
-		EXPECT_EQ(ionet::SocketOperationCode::Closed, completionCode);
+		test::AssertSocketClosedDuringRead(completionCode);
 		ASSERT_EQ(3u, receivedBuffers.size());
 		EXPECT_EQUAL_BUFFERS(sendBuffers[0], 0, 20u, receivedBuffers[0]);
 		EXPECT_EQUAL_BUFFERS(sendBuffers[1], 0, 17u, receivedBuffers[1]);

--- a/client/catapult/tests/catapult/net/PacketWritersTests.cpp
+++ b/client/catapult/tests/catapult/net/PacketWritersTests.cpp
@@ -730,7 +730,7 @@ namespace catapult { namespace net {
 			WAIT_FOR_ONE(numCallbacks);
 
 			// Assert: the connection is closed
-			EXPECT_EQ(ionet::SocketOperationCode::Closed, readCode);
+			test::AssertSocketClosedDuringRead(readCode);
 		});
 	}
 


### PR DESCRIPTION
## Summary
- Ports the graceful drained TLS close from `experimental` (faecb410e) to fix #2060: abortive closes on Windows send RST instead of FIN when unread RX data is buffered, triggering a reset/reconnect storm that starves `HappyBlockchainIntegrityTests` of sync time.
- `SocketGuard::closeImpl` now completes the SSL shutdown handshake, drains remaining RX bytes to EOF, then hard-closes — bounded by a 100ms timer.
- Includes the two companion test-helper fixes from `experimental` (tolerate `Closed`/`Read_Error` race in `PacketWritersTests`/`ChainedSocketReaderTests`), a lint fix for two comment typos, and a small conciseness cleanup in `SocketGuard`.

## Test plan
- [x] Local build (Debug) green
- [x] `tests.catapult.ionet` 566/566 passing
- [x] `tests.catapult.net` 138/138 passing
- [x] Local lint (`checkProjectStructure.py`) 0 violations
- [x] CI green