### PR TITLE
[client/catapult] fix: remove unneeded lambda capture in RocksDatabase

### DIFF
--- a/client/catapult/src/catapult/cache_db/RocksDatabase.cpp
+++ b/client/catapult/src/catapult/cache_db/RocksDatabase.cpp
@@ -189,7 +189,7 @@ namespace catapult { namespace cache {
 				},
 				IsRetryableAfterFailedOpen,
 				Num_Open_Attempts,
-				[Num_Open_Attempts](uint32_t attempt, const rocksdb::Status& openStatus, uint32_t delayMs) {
+				[](uint32_t attempt, const rocksdb::Status& openStatus, uint32_t delayMs) {
 					CATAPULT_LOG(warning)
 							<< "RocksDB open failed (attempt " << (attempt + 1) << "/" << Num_Open_Attempts << "): "
 							<< openStatus.ToString() << ", retrying in " << delayMs << "ms";


### PR DESCRIPTION
## Summary
* `Num_Open_Attempts` is `constexpr`; capturing it in the retry lambda triggers clang's `-Wunused-lambda-capture` (`-Werror`), breaking clang builds.
* Removed the capture; the constant is still usable inside the lambda body without odr-use.

## Test plan
- [x] `cmake --build --preset conan-relwithdebinfo` no longer errors on this file