### PR TITLE
[linters]: add docs to the gitlint category

### DIFF
--- a/linters/scripts/lint_last_commit.sh
+++ b/linters/scripts/lint_last_commit.sh
@@ -4,7 +4,7 @@ set -ex
 
 GITLINT_COMMON_MODULES="dependency|jenkins|monorepo"
 GITLINT_MODULES="${GITLINT_COMMON_MODULES}|$(cat "$(git rev-parse --show-toplevel)"/.gitlintmodules)"
-GITLINT_CATEGORIES="feat|bug|fix|build|perf|task"
+GITLINT_CATEGORIES="bug|build|docs|feat|fix|perf|task"
 gitlint \
 	-C "$(git rev-parse --show-toplevel)/linters/git/.gitlint" \
 	-c title-match-regex.regex="^\\[(${GITLINT_MODULES})\\]( (${GITLINT_CATEGORIES}))?: [\S ]+[a-zA-Z0-9]( \(#[0-9]+\))?$"


### PR DESCRIPTION
problem: gitlint is failing due to no docs category
solution: add a docs to the gitlint category
