### PR TITLE
[mkdocs] fix: source code links

### DIFF
--- a/mkdocs/config/mkdocs.base.yml
+++ b/mkdocs/config/mkdocs.base.yml
@@ -122,7 +122,7 @@ extra:
       link: /ja/
       lang: ja
   symbol:
-    branch: new-docs
+    branch: dev
     java-sdk:
       include-prefixes: [classorg, interfaceorg]
     ts-sdk:

--- a/mkdocs/config/mkdocs.en.yml
+++ b/mkdocs/config/mkdocs.en.yml
@@ -4,7 +4,7 @@ site_name: Symbol Docs WIP 🚧
 site_url: https://docs.symboltest.net/en
 docs_dir: ../pages/en
 site_dir: ../../docs/en
-edit_uri: blob/new-docs/mkdocs/pages/en
+edit_uri: blob/dev/mkdocs/pages/en
 plugins:
   search:
     lang: en

--- a/mkdocs/config/mkdocs.ja.yml
+++ b/mkdocs/config/mkdocs.ja.yml
@@ -4,7 +4,7 @@ site_name: Symbolドキュメント WIP ⚠
 site_url: https://docs.symboltest.net/ja
 docs_dir: ../pages/ja
 site_dir: ../../docs/ja
-edit_uri: blob/new-docs/mkdocs/pages/ja
+edit_uri: blob/dev/mkdocs/pages/ja
 plugins:
   search:
     lang: ja

--- a/mkdocs/pages/en/devbook/transactions/typed-descriptors.md
+++ b/mkdocs/pages/en/devbook/transactions/typed-descriptors.md
@@ -26,7 +26,7 @@ The rest of the process, including signing and announcing the transaction, remai
     --8<-- "devbook/transactions/transfer.typed.mjs:41:55"
     ```
 
-    [Download the full tutorial code.]({{ config.repo_url }}/raw/refs/heads/{{config.extra.symbol.branch}}/mkdocs/overrides/devbook/transactions/transfer.typed.mjs){ .source-link }
+    [Download the full tutorial code.]({{ config.repo_url }}/raw/refs/heads/{{config.extra.symbol.branch}}/mkdocs/snippets/devbook/transactions/transfer.typed.mjs){ .source-link }
 
 ## Creation Process
 

--- a/mkdocs/pages/ja/devbook/transactions/typed-descriptors.md
+++ b/mkdocs/pages/ja/devbook/transactions/typed-descriptors.md
@@ -23,7 +23,7 @@ tutorial_level: beginner
     --8<-- "devbook/transactions/transfer.typed.mjs:41:55"
     ```
 
-    [完全なチュートリアルコードをダウンロードする]({{ config.repo_url }}/raw/refs/heads/{{config.extra.symbol.branch}}/mkdocs/overrides/devbook/transactions/transfer.typed.mjs){ .source-link }
+    [完全なチュートリアルコードをダウンロードする]({{ config.repo_url }}/raw/refs/heads/{{config.extra.symbol.branch}}/mkdocs/snippets/devbook/transactions/transfer.typed.mjs){ .source-link }
 
 ## 作成プロセス {: #creation-process }
 

--- a/mkdocs/scripts/deploy-gh-pages.sh
+++ b/mkdocs/scripts/deploy-gh-pages.sh
@@ -13,5 +13,5 @@ mv docs-staging docs
 git add -f docs
 git commit -m "[docs] Update"
 git push
-git checkout new-docs
+git checkout dev
 cd mkdocs

--- a/mkdocs/templates/macros/tutorial.jinja2
+++ b/mkdocs/templates/macros/tutorial.jinja2
@@ -46,7 +46,7 @@
     {% endfor %}
     ```
 
-    [Download source]({{ config.repo_url }}/raw/refs/heads/{{config.extra.symbol.branch}}/mkdocs/overrides/{{filename}}.{{lang_ext[l]}}){ .source-link }
+    [Download source]({{ config.repo_url }}/raw/refs/heads/{{config.extra.symbol.branch}}/mkdocs/snippets/{{filename}}.{{lang_ext[l]}}){ .source-link }
 
 {% endfor %}
 {%- endif -%}


### PR DESCRIPTION
Docs have been living in the `new-docs` branch for a long time.
Now that they have been merged into `dev`, links to view and edit the page source need to be updated.

Additionally, example source code was moved a while ago from the `overrides` folder to `snippets`,
and the links to download them needed to be updated too.

## What is the current behavior?

Buttons in page headers to View and Edit the page's source markdown file are broken.
Link below tutorial source code to download the source file is broken.

## What's the issue?

Docs have moved from the `new-docs` branch to `dev`.
Source code has moved from the `overrides` folder to `snippets`.
Links were not updated.

## How have you changed the behavior?

Updated the links in the relevant config files and templates.
No code or documentation changes needed.

## How was this change tested?

Deployed locally and tested that links point to the proper place now.
Run a global search for `new-docs` and `overrides` and found no more required changes.

## Requirements

* [X] My pull request title is prefixed with the directory and subdirectory it affects.
* [X] My pull request contains a single change or feature.
* [X] My commits are clearly labeled with one of the following: **feat | bug | fix | build | perf | task**
* [X] My code has been linted.
* [ ] My code has comments, particularly in any hard to understand areas.
* [ ] My code follows the style guidelines.
* [ ] I have written and supplied test cases (either unit tests or end-to-end, where relevant).
* [ ] I have made any corresponding changes to the documentation (where relevant).