### PR TITLE
[mkdocs] fix: colors in zoomed-in image descriptions

### DIFF
--- a/mkdocs/overrides/assets/stylesheets/extra.css
+++ b/mkdocs/overrides/assets/stylesheets/extra.css
@@ -285,6 +285,19 @@ aside.md-source-file {
 	margin-right: 36px;
 }
 
+/* Colors for zoomed-in images */
+.gslide-desc a {
+	color: var(--md-typeset-a-color);
+}
+
+.gslide-desc a:hover {
+	color: var(--md-accent-fg-color);
+}
+
+.gslide-desc code {
+	background: var(--md-code-bg-color);
+}
+
 /* Links to other sections use the color of that section */
 .md-content a[href*="userbook"][href^='..'],
 .gslide-desc a[href*="userbook"][href^='..'] {


### PR DESCRIPTION
GLightbox, the plugin to show images with zoom capabilities, is not styling the text in the image captions when the image is zoomed-in.

This is most noticeable in user guides with screenshots with links in the caption.
When clicking on the screenshot, the link is still there,
but with the color of regular text.

This patch fixes the `code` and link colors, te only ones currently in use.

* [X] My pull request title is prefixed with the directory and subdirectory it affects.
* [X] My pull request contains a single change or feature.
* [X] My commits are clearly labeled with one of the following: **feat | bug | fix | build | perf | task**
* [X] My code has been linted.
* [X] My code has comments, particularly in any hard to understand areas.
* [X] My code follows the style guidelines.
* [ ] I have written and supplied test cases (either unit tests or end-to-end, where relevant).
* [ ] I have made any corresponding changes to the documentation (where relevant).