### PR TITLE
Revert "[mkdocs] fix: stop patching ezglossary"

### DIFF
--- a/mkdocs/scripts/ci/ezglossary.patch
+++ b/mkdocs/scripts/ci/ezglossary.patch
@@ -1,0 +1,12 @@
+--- a/src/mkdocs_ezglossary_plugin/plugin.py
++++ b/src/mkdocs_ezglossary_plugin/plugin.py
+@@ -239,6 +239,9 @@
+				 sec = f"{td.section}:" if td.section != "_" else ""
+				 return f'<a href="{sec}{term}">{text}</a>'
+ 
++            entry.definition = re.sub(r'<([^:<]*):>', r'\1', entry.definition)
++            entry.definition = re.sub(r'<[^:<]*:\|([^>]*)>', r'\1', entry.definition)
++
+			# Preserve visible text from nested glossary links/anchors before html2text
+			entry.definition = _preserve_visible_text_for_tooltip(entry.definition)
+			entry.definition = _html2text(entry.definition)

--- a/mkdocs/scripts/ci/setup_build.sh
+++ b/mkdocs/scripts/ci/setup_build.sh
@@ -16,3 +16,8 @@ pushd ../openapi
 npm install
 npm run build:openapi-yaml
 popd
+
+# Patch the ezglossary plugin, ignoring errors if it was already patched
+ez_root="$(pip show mkdocs-ezglossary-plugin | sed -n 's/Location: \(.*\)/\1/p')"
+ez_plugin="${ez_root}/mkdocs_ezglossary_plugin/plugin.py"
+patch "${ez_plugin}" scripts/ci/ezglossary.patch --force --ignore-whitespace --fuzz 0 || true


### PR DESCRIPTION
This reverts commit 4fd0bf72a86c3b3acb59d3200877d7ac5f531401.

There was a problem with the ezglossary plugin when the definition of a term included other terms.
We had a patch to fix it while waiting for an upstream fix.
The fix arrived so I removed the patch.
But it turns out the fix is incomplete, we still have issues when terms contain spaces.
I opened [a new issue](https://github.com/realtimeprojects/mkdocs-ezglossary/issues/35) upstream,
but while we wait, I am bringing back our patch.

