### PR TITLE
[sdk]: fix string autodetection for NEM MosaicDefinition properties

### DIFF
--- a/sdk/javascript/test/nem/TransactionFactory_spec.js
+++ b/sdk/javascript/test/nem/TransactionFactory_spec.js
@@ -232,6 +232,28 @@ describe('transaction factory (NEM)', () => {
 		expect(transaction.mosaics[0].mosaic.mosaicId.name).to.deep.equal(new TextEncoder().encode('bar'));
 	});
 
+	it('can create mosaic definition with string properties', () => {
+		// Arrange:
+		const factory = testDescriptor.createFactory();
+
+		// Act:
+		const transaction = testDescriptor.createTransaction(factory)({
+			type: 'mosaic_definition_transaction_v1',
+			signerPublicKey: TEST_SIGNER_PUBLIC_KEY,
+			mosaicDefinition: {
+				properties: [
+					{property: { name: 'divisibility', value: '2'}}
+				]
+			}
+		});
+
+		// Assert:
+		const { properties } = transaction.mosaicDefinition;
+		expect(properties.length).to.equal(1);
+		expect(properties[0].property.name).to.deep.equal(new TextEncoder().encode('divisibility'));
+		expect(properties[0].property.value).to.deep.equal(new TextEncoder().encode('2'));
+	});
+
 	// endregion
 
 	// region non verifiable

--- a/sdk/python/symbolchain/RuleBasedTransactionFactory.py
+++ b/sdk/python/symbolchain/RuleBasedTransactionFactory.py
@@ -165,7 +165,7 @@ class RuleBasedTransactionFactory:
 			return
 
 		for key, value in vars(entity).items():
-			if '_' == key[0] and '_' == key[-1]:  # skip system properties
+			if '_' == key[0] and '_' == key[-1] and key[1:-1] not in ('property'):  # skip system properties
 				continue
 
 			if isinstance(value, str):

--- a/sdk/python/tests/nem/test_TransactionFactory.py
+++ b/sdk/python/tests/nem/test_TransactionFactory.py
@@ -224,6 +224,27 @@ class TransactionFactoryTest(BasicTransactionFactoryTest, unittest.TestCase):
 		self.assertEqual(b'foo', transaction.mosaics[0].mosaic.mosaic_id.namespace_id.name)
 		self.assertEqual(b'bar', transaction.mosaics[0].mosaic.mosaic_id.name)
 
+	def test_can_create_mosaic_definition_with_string_properties(self):
+		# Arrange:
+		factory = self.create_factory()
+
+		# Act:
+		transaction = self.create_transaction(factory)({
+			'type': 'mosaic_definition_transaction_v1',
+			'signer_public_key': TEST_SIGNER_PUBLIC_KEY,
+			'mosaic_definition': {
+				'properties': [
+					{'property_': {'name': 'divisibility', 'value': '2'}},
+				]
+			}
+		})
+
+		# Assert:
+		properties = transaction.mosaic_definition.properties
+		self.assertEqual(1, len(properties))
+		self.assertEqual(b'divisibility', properties[0].property_.name)
+		self.assertEqual(b'2', properties[0].property_.value)
+
 	# endregion
 
 	# region non verifiable

--- a/sdk/python/tests/test_RuleBasedTransactionFactory.py
+++ b/sdk/python/tests/test_RuleBasedTransactionFactory.py
@@ -56,6 +56,12 @@ class Module:
 			self.mosaic_id = 0
 			self.amount = 0
 
+	class StructWithKeywords:
+		TYPE_HINTS = {}
+
+		def __init__(self):
+			self._property_ = ''
+
 	class StructWrapped:
 		TYPE_HINTS = {
 			'inner': 'struct:StructPlain'
@@ -491,6 +497,24 @@ class RuleBasedTransactionFactoryTest(unittest.TestCase):
 		# Assert: string values were encoded into utf8
 		self.assertEqual(b'01234567_89ABCDEF', parsed.mosaic_id)
 		self.assertEqual(b'123_456_789_123_456_789', parsed.amount)
+		self.assertFalse(hasattr(parsed, 'type'))
+
+	def test_can_create_struct_from_factory_and_auto_encode_strings_reserved_keywords(self):
+		# Arrange: use a struct but set string values
+		factory = RuleBasedTransactionFactory(Module)
+		factory.add_struct_parser('StructWithKeywords')
+
+		def entity_factory(entity_type):
+			return None if 123 != entity_type else Module.StructWithKeywords()
+
+		# Act:
+		parsed = factory.create_from_factory(entity_factory, {
+			'type': 123,
+			'_property_': 'alpha'
+		})
+
+		# Assert: string values were encoded into utf8
+		self.assertEqual(b'alpha', parsed._property_)  # pylint: disable=protected-access
 		self.assertFalse(hasattr(parsed, 'type'))
 
 	def test_can_create_struct_from_factory_and_auto_encode_nested_strings(self):


### PR DESCRIPTION
 problem: property is reserved keyword in python, so property maps to _property_ field, which is misidentified as system property and skipped
solution: add special handling for this field and tests in both PY and JS sdks for consistency
