### PR TITLE
[mkdocs] fix: format main manual sections as cards

### DIFF
--- a/mkdocs/overrides/assets/stylesheets/extra.css
+++ b/mkdocs/overrides/assets/stylesheets/extra.css
@@ -153,6 +153,27 @@
 	color: var(--md-default-fg-color--light);
 }
 
+/* Force three equal-width cards per row, stacking on small screens */
+.md-typeset .grid.cards.cols-3 {
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+@media screen and (max-width: 44.9375em) {
+	.md-typeset .grid.cards.cols-3 {
+		grid-template-columns: 1fr;
+	}
+}
+
+/* Pin the "learn more" link to the bottom of each card so links align */
+.md-typeset .grid.cards > ul > li {
+	display: flex;
+	flex-direction: column;
+}
+
+.md-typeset .grid.cards > ul > li > :last-child {
+	margin-top: auto;
+}
+
 /* Top navigation tab style: centered, with icons and custom font*/
 .md-tabs .md-tabs__item:first-child {
 	display: none;

--- a/mkdocs/pages/en/devbook/intro.md
+++ b/mkdocs/pages/en/devbook/intro.md
@@ -10,27 +10,43 @@ showing how to perform common tasks with the SDK or the HTTP API.
 
 The manual is structured as follows:
 
-<div class="icon-list" markdown>
+<div class="grid cards cols-3" markdown>
 
-* :material-laptop: **Getting Started**
+* :material-rocket-launch-outline:{ .lg .middle } **Getting Started**
 
-    Set up your development machine and run a quick `Hello World` sample to check that everything is ready.
+    ---
 
-* :material-school: **Tutorials**
+    Set up your development machine and run a quick `Hello World` sample
+    to check that everything is ready.
+
+    [:octicons-arrow-right-24: Set up your environment](start/setup.md)
+
+* :material-school-outline:{ .lg .middle } **Tutorials**
+
+    ---
 
     Follow task-focused tutorials grouped by area.
-    Each tutorial links to the [textbook](../textbook/intro.md) and the relevant reference guides when background
-    information is useful.
 
-* :material-book-open-page-variant: **Reference Guides**
+    [:octicons-arrow-right-24: Create your first account](accounts/create-from-private-key.md)
 
-    Consult exhaustive information about SDK methods, HTTP and WebSockets endpoints, and binary structures.
+* :material-book-open-variant:{ .lg .middle } **Reference Guides**
+
+    ---
+
+    Consult exhaustive information about SDK methods, HTTP and WebSockets
+    endpoints, and binary structures.
+
+    [:octicons-arrow-right-24: Browse the reference](reference/py/AccountDescriptorRepository.md)
 
 </div>
+
+## Tutorials
 
 Use the navigation menu, or jump directly into one of the tutorials below.
 
 Tutorials are grouped by level, from beginner to advanced, based on the required familiarity with Symbol concepts.
+Each tutorial links to the [textbook](../textbook/intro.md) and the relevant reference guides when background
+information is useful.
 
 {% import 'tutorials_table.jinja2' as tutorials_table with context %}
 

--- a/mkdocs/pages/en/userbook/intro.md
+++ b/mkdocs/pages/en/userbook/intro.md
@@ -14,6 +14,30 @@ for background information when needed.
 
 The manual is organized into the following sections:
 
-* [The Symbol Desktop Wallet](wallet/install.md): Manage your accounts and handle transactions.
-* [Shoestring](shoestring/overview.md): Deploy and maintain Symbol nodes.
-* [Security](./security.md): Learn how to keep your funds and accounts secure.
+<div class="grid cards" markdown>
+
+- :material-monitor:{ .lg .middle } **Symbol Desktop Wallet**
+
+    ---
+
+    Manage your accounts and handle transactions from your desktop PC.
+
+    [:octicons-arrow-right-24: Install the desktop wallet](wallet/install.md)
+
+- :material-server-network:{ .lg .middle } **Shoestring Node Operation**
+
+    ---
+
+    Deploy and maintain Symbol nodes.
+
+    [:octicons-arrow-right-24: Set up a node](shoestring/overview.md)
+
+- :material-shield-lock:{ .lg .middle } **Security**
+
+    ---
+
+    Learn how to keep your funds and accounts secure.
+
+    [:octicons-arrow-right-24: Stay secure](security.md)
+
+</div>


### PR DESCRIPTION
Convert the section lists on the Developer and User manual landing pages into Material for [MkDocs grids](https://squidfunk.github.io/mkdocs-material/reference/grids/).

This is an opinionated change, but I think it makes the pages easier to scan, since the cards are displayed side by side, and feels more actionable.


<img width="1512" height="857" alt="image" src="https://github.com/user-attachments/assets/085fe1d7-f526-4edb-b592-e4f7525aae0d" />

<img width="3024" height="1714" alt="image" src="https://github.com/user-attachments/assets/6c5af372-2f6f-4cce-8d8d-efd73385140c" />

I formatted the layout as two columns in the user manual because we'll be adding more cards in #2094.

If this looks good, I'll port it to NEM.