### PR TITLE
[sdk]: fix bug in symbol fee calculation

### DIFF
--- a/sdk/javascript/src/symbol/FeeCalculator.js
+++ b/sdk/javascript/src/symbol/FeeCalculator.js
@@ -8,6 +8,6 @@ import * as sc from './models.js';
  * @returns {bigint} Transaction fee.
  */
 const calculateTransactionFee = (transaction, feeMultiplier, cosignatureCount = 0) =>
-	(BigInt(transaction.size) * BigInt(feeMultiplier)) + (BigInt(new sc.Cosignature().size) * BigInt(cosignatureCount));
+	(BigInt(transaction.size) + (BigInt(new sc.Cosignature().size) * BigInt(cosignatureCount))) * BigInt(feeMultiplier);
 
 export { calculateTransactionFee }; // eslint-disable-line import/prefer-default-export

--- a/sdk/javascript/test/symbol/FeeCalculator_spec.js
+++ b/sdk/javascript/test/symbol/FeeCalculator_spec.js
@@ -26,9 +26,9 @@ describe('FeeCalculator', () => {
 			});
 
 			// Act + Assert: transfer size is 160, cosignature size is 104
-			expect(calculateTransactionFee(transaction, 100, 3)).to.equal(16000n + 312n);
-			expect(calculateTransactionFee(transaction, 150, 4)).to.equal(24000n + 416n);
-			expect(calculateTransactionFee(transaction, 200, 5)).to.equal(32000n + 520n);
+			expect(calculateTransactionFee(transaction, 100, 3)).to.equal((160n + 312n) * 100n);
+			expect(calculateTransactionFee(transaction, 150, 4)).to.equal((160n + 416n) * 150n);
+			expect(calculateTransactionFee(transaction, 200, 5)).to.equal((160n + 520n) * 200n);
 		});
 	});
 });

--- a/sdk/python/symbolchain/symbol/FeeCalculator.py
+++ b/sdk/python/symbolchain/symbol/FeeCalculator.py
@@ -4,4 +4,4 @@ from symbolchain.sc import Cosignature
 def calculate_transaction_fee(transaction, fee_multiplier, cosignature_count=0):
 	"""Calculates the minimum required transaction fee for a transaction."""
 
-	return transaction.size * fee_multiplier + Cosignature().size * cosignature_count
+	return (transaction.size + Cosignature().size * cosignature_count) * fee_multiplier

--- a/sdk/python/tests/symbol/test_FeeCalculator.py
+++ b/sdk/python/tests/symbol/test_FeeCalculator.py
@@ -26,6 +26,6 @@ class CalculateTransactionFeeTest(unittest.TestCase):
 		})
 
 		# Act + Assert: transfer size is 160, cosignature size is 104
-		self.assertEqual(16000 + 312, calculate_transaction_fee(transaction, 100, 3))
-		self.assertEqual(24000 + 416, calculate_transaction_fee(transaction, 150, 4))
-		self.assertEqual(32000 + 520, calculate_transaction_fee(transaction, 200, 5))
+		self.assertEqual((160 + 312) * 100, calculate_transaction_fee(transaction, 100, 3))
+		self.assertEqual((160 + 416) * 150, calculate_transaction_fee(transaction, 150, 4))
+		self.assertEqual((160 + 520) * 200, calculate_transaction_fee(transaction, 200, 5))


### PR DESCRIPTION
 problem: cosignature size is not being multipled by fee multiplier
solution: multiply it
