### PR TITLE
[mkdocs] fix: update tutorial snippets to use calculate_transaction_fee

### DIFF
--- a/mkdocs/config/mkdocs.base.yml
+++ b/mkdocs/config/mkdocs.base.yml
@@ -153,6 +153,7 @@ extra:
       - IdGenerator
       - Restriction
       - ripemd160
+      - FeeCalculator
     redirections:
       - from: guides/account/scams-and-security.html
         to: /en/userbook/security/

--- a/mkdocs/package-lock.json
+++ b/mkdocs/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "symbol-docs",
       "dependencies": {
-        "symbol-sdk": "^3.3.1",
+        "symbol-sdk": "^3.3.2",
         "typedoc": "^0.28.0",
         "typedoc-plugin-markdown": "^4.5.0"
       },
@@ -550,9 +550,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -567,9 +564,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -584,9 +578,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -601,9 +592,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -618,9 +606,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -635,9 +620,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -652,9 +634,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -669,9 +648,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -686,9 +662,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -703,9 +676,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/mkdocs/package.json
+++ b/mkdocs/package.json
@@ -5,7 +5,7 @@
     "lint": "eslint \"snippets/**/*.mjs\""
   },
   "dependencies": {
-    "symbol-sdk": "^3.3.1",
+    "symbol-sdk": "^3.3.2",
     "typedoc": "^0.28.0",
     "typedoc-plugin-markdown": "^4.5.0"
   },

--- a/mkdocs/pages/en/devbook/accounts/configure-multisig.md
+++ b/mkdocs/pages/en/devbook/accounts/configure-multisig.md
@@ -169,6 +169,8 @@ See the tutorials on [complete](../transactions/complete-aggregate.md) and
 [bonded](../transactions/bonded-aggregate.md) aggregate transactions for more details.
 
 Care is taken when calculating the transaction fee to account for the space required by all cosignatures.
+The {{ tutorial.var('calculate_transaction_fee') }} helper reserves this space through its cosignature-count
+argument, set to the number of cosignatories.
 
 Finally, signatures are attached to the aggregate transaction:
 

--- a/mkdocs/pages/en/devbook/accounts/configure-multisig.md
+++ b/mkdocs/pages/en/devbook/accounts/configure-multisig.md
@@ -169,7 +169,7 @@ See the tutorials on [complete](../transactions/complete-aggregate.md) and
 [bonded](../transactions/bonded-aggregate.md) aggregate transactions for more details.
 
 Care is taken when calculating the transaction fee to account for the space required by all cosignatures.
-The {{ tutorial.var('calculate_transaction_fee') }} helper reserves this space through its cosignature-count
+The <dy:FeeCalculator.calculateTransactionFee> helper reserves this space through its cosignature-count
 argument, set to the number of cosignatories.
 
 Finally, signatures are attached to the aggregate transaction:

--- a/mkdocs/pages/en/devbook/transactions/bonded-aggregate.md
+++ b/mkdocs/pages/en/devbook/transactions/bonded-aggregate.md
@@ -171,7 +171,7 @@ Once the embedded transactions are prepared, create the bonded aggregate transac
 
 The fee is calculated based on the aggregate's total size, which includes all embedded transactions plus space reserved
 for one cosignature.
-The {{ tutorial.var('calculate_transaction_fee') }} helper reserves this space through its cosignature-count
+The <dy:FeeCalculator.calculateTransactionFee> helper reserves this space through its cosignature-count
 argument, set to `1` here.
 
 ### Signing the Bonded Transaction

--- a/mkdocs/pages/en/devbook/transactions/bonded-aggregate.md
+++ b/mkdocs/pages/en/devbook/transactions/bonded-aggregate.md
@@ -171,6 +171,8 @@ Once the embedded transactions are prepared, create the bonded aggregate transac
 
 The fee is calculated based on the aggregate's total size, which includes all embedded transactions plus space reserved
 for one cosignature.
+The {{ tutorial.var('calculate_transaction_fee') }} helper reserves this space through its cosignature-count
+argument, set to `1` here.
 
 ### Signing the Bonded Transaction
 

--- a/mkdocs/pages/en/devbook/transactions/complete-aggregate.md
+++ b/mkdocs/pages/en/devbook/transactions/complete-aggregate.md
@@ -178,6 +178,8 @@ Once the embedded transactions are prepared, create the complete aggregate trans
 
 The fee is calculated based on the aggregate's total size, which includes all embedded transactions plus
 space reserved for one cosignature.
+The {{ tutorial.var('calculate_transaction_fee') }} helper reserves this space through its cosignature-count
+argument, set to `1` here.
 
 ### Signing the Transaction
 

--- a/mkdocs/pages/en/devbook/transactions/complete-aggregate.md
+++ b/mkdocs/pages/en/devbook/transactions/complete-aggregate.md
@@ -178,7 +178,7 @@ Once the embedded transactions are prepared, create the complete aggregate trans
 
 The fee is calculated based on the aggregate's total size, which includes all embedded transactions plus
 space reserved for one cosignature.
-The {{ tutorial.var('calculate_transaction_fee') }} helper reserves this space through its cosignature-count
+The <dy:FeeCalculator.calculateTransactionFee> helper reserves this space through its cosignature-count
 argument, set to `1` here.
 
 ### Signing the Transaction

--- a/mkdocs/pages/en/devbook/transactions/transfer.md
+++ b/mkdocs/pages/en/devbook/transactions/transfer.md
@@ -112,8 +112,10 @@ The snippet includes the following fields:
     For XYM, the divisibility is 6, so 1 XYM must be expressed as `1_000_000`.
 
 Note that the `fee` field is not set in the descriptor.
-Instead, the fee is calculated after the transaction is built, using the previously obtained multiplier and the
-transaction's size in bytes, which is only known once the descriptor has been constructed.
+Instead, the fee is calculated after the transaction is built, once its size in bytes is known.
+
+The SDK's {{ tutorial.var('calculate_transaction_fee') }} helper computes the fee by multiplying the transaction size by
+the fee multiplier.
 
 !!! info "Including a message in the transaction"
 

--- a/mkdocs/pages/en/devbook/transactions/transfer.md
+++ b/mkdocs/pages/en/devbook/transactions/transfer.md
@@ -114,7 +114,7 @@ The snippet includes the following fields:
 Note that the `fee` field is not set in the descriptor.
 Instead, the fee is calculated after the transaction is built, once its size in bytes is known.
 
-The SDK's {{ tutorial.var('calculate_transaction_fee') }} helper computes the fee by multiplying the transaction size by
+The SDK's <dy:FeeCalculator.calculateTransactionFee> helper computes the fee by multiplying the transaction size by
 the fee multiplier.
 
 !!! info "Including a message in the transaction"

--- a/mkdocs/snippets/devbook/accounts/account_metadata.mjs
+++ b/mkdocs/snippets/devbook/accounts/account_metadata.mjs
@@ -2,6 +2,7 @@ import { PrivateKey } from 'symbol-sdk';
 import {
 	NetworkTimestamp,
 	SymbolFacade,
+	calculateTransactionFee,
 	metadataGenerateKey,
 	metadataUpdateValue,
 	models
@@ -111,7 +112,8 @@ try {
 			embeddedTransactions),
 		transactions: embeddedTransactions
 	});
-	transaction.fee = new models.Amount(feeMultiplier * transaction.size);
+	transaction.fee = new models.Amount(
+		calculateTransactionFee(transaction, feeMultiplier));
 	// [<step-5]
 	// Sign and generate final payload [>step-6]
 	const signature = facade.signTransaction(signerKeyPair, transaction);
@@ -176,7 +178,7 @@ try {
 		transactions: updateEmbedded
 	});
 	updateTransaction.fee = new models.Amount(
-		feeMultiplier * updateTransaction.size);
+		calculateTransactionFee(updateTransaction, feeMultiplier));
 
 	// Sign and announce the update
 	const updateSignature = facade.signTransaction(

--- a/mkdocs/snippets/devbook/accounts/account_metadata.py
+++ b/mkdocs/snippets/devbook/accounts/account_metadata.py
@@ -139,7 +139,7 @@ try:
 	)
 	print(f'Fetching current metadata from {metadata_path}')
 	with urllib.request.urlopen(
-			f'{NODE_URL}{metadata_path}') as response:
+		f'{NODE_URL}{metadata_path}') as response:
 		response_json = json.loads(response.read().decode())
 
 	# Get the metadata entry

--- a/mkdocs/snippets/devbook/accounts/account_metadata.py
+++ b/mkdocs/snippets/devbook/accounts/account_metadata.py
@@ -6,6 +6,7 @@ import urllib.request
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
 from symbolchain.sc import Amount
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.Metadata import (
 	metadata_generate_key,
 	metadata_update_value
@@ -43,7 +44,8 @@ def wait_for_confirmation(tx_hash, label):
 					print(f'{label} confirmed in {attempt} seconds')
 					return
 				if status['group'] == 'failed':
-					raise RuntimeError(f'{label} failed: {status["code"]}')
+					raise RuntimeError(
+						f'{label} failed: {status["code"]}')
 		except urllib.error.HTTPError:
 			print('  Transaction status: unknown')
 	raise TimeoutError(f'{label} not confirmed after 60 seconds')
@@ -111,7 +113,8 @@ try:
 			embedded_transactions),
 		'transactions': embedded_transactions
 	})
-	transaction.fee = Amount(fee_multiplier * transaction.size)
+	transaction.fee = Amount(
+		calculate_transaction_fee(transaction, fee_multiplier))
 	# [<step-5]
 	# Sign and generate final payload [>step-6]
 	signature = facade.sign_transaction(signer_key_pair, transaction)
@@ -135,7 +138,8 @@ try:
 		'&metadataType=0'
 	)
 	print(f'Fetching current metadata from {metadata_path}')
-	with urllib.request.urlopen(f'{NODE_URL}{metadata_path}') as response:
+	with urllib.request.urlopen(
+			f'{NODE_URL}{metadata_path}') as response:
 		response_json = json.loads(response.read().decode())
 
 	# Get the metadata entry
@@ -172,7 +176,7 @@ try:
 		'transactions': embedded_transactions
 	})
 	update_transaction.fee = Amount(
-		fee_multiplier * update_transaction.size)
+		calculate_transaction_fee(update_transaction, fee_multiplier))
 
 	# Sign and announce the update
 	signature = facade.sign_transaction(

--- a/mkdocs/snippets/devbook/accounts/account_restrictions.mjs
+++ b/mkdocs/snippets/devbook/accounts/account_restrictions.mjs
@@ -5,6 +5,7 @@ import {
 	NetworkTimestamp,
 	SymbolFacade,
 	SymbolTransactionFactory,
+	calculateTransactionFee,
 	models
 } from 'symbol-sdk/symbol';
 
@@ -90,7 +91,8 @@ function restrictionEnableTransaction(timestamp, feeMultiplier) { // [>step-5]
 		// This is the only authorized outgoing address
 		restrictionAdditions: [authAddress]
 	});
-	transaction.fee = new models.Amount(feeMultiplier * transaction.size);
+	transaction.fee = new models.Amount(
+		calculateTransactionFee(transaction, feeMultiplier));
 	console.log('Enabling the restriction with transaction:');
 	console.dir(transaction.toJson(), { colors: true, depth: null });
 
@@ -113,7 +115,8 @@ function restrictionDisableTransaction(timestamp, feeMultiplier, // [>step-6]
 		restrictionDeletions: restriction.values.map(hex =>
 			Address.fromDecodedAddressHexString(hex))
 	});
-	transaction.fee = new models.Amount(feeMultiplier * transaction.size);
+	transaction.fee = new models.Amount(
+		calculateTransactionFee(transaction, feeMultiplier));
 	console.log('Disabling the restriction with transaction:');
 	console.dir(transaction.toJson(), { colors: true, depth: null });
 
@@ -173,7 +176,8 @@ try {
 		deadline: timestamp.addHours(2).timestamp,
 		recipientAddress: 'TBBHGE77IHHOIYA46B3XSORRNR2L5MLW54YO75Y'
 	});
-	transaction.fee = new models.Amount(feeMultiplier * transaction.size);
+	transaction.fee = new models.Amount(
+		calculateTransactionFee(transaction, feeMultiplier));
 	payload = SymbolTransactionFactory.attachSignature(
 		transaction,
 		facade.signTransaction(signerKeyPair, transaction));

--- a/mkdocs/snippets/devbook/accounts/account_restrictions.py
+++ b/mkdocs/snippets/devbook/accounts/account_restrictions.py
@@ -6,6 +6,7 @@ import urllib.request
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.facade.SymbolFacade import Address, SymbolFacade
 from symbolchain.sc import AccountRestrictionFlags, Amount
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.Network import NetworkTimestamp
 
 NODE_URL = os.getenv('NODE_URL', 'https://reference.symboltest.net:3001')
@@ -51,7 +52,8 @@ def wait_for_confirmation(tx_hash, label):
 					print(f'{label} confirmed in {attempt} seconds')
 					return
 				if status['group'] == 'failed':
-					raise RuntimeError(f'{label} failed: {status["code"]}')
+					raise RuntimeError(
+						f'{label} failed: {status["code"]}')
 		except urllib.error.HTTPError:
 			print('  Transaction status: unknown')
 	raise TimeoutError(f'{label} not confirmed after 60 seconds')
@@ -89,7 +91,7 @@ def restriction_enable_transaction():  # [>step-5]
 		'restriction_additions': [auth_address]
 	})
 	enable_transaction.fee = Amount(
-		fee_multiplier * enable_transaction.size)
+		calculate_transaction_fee(enable_transaction, fee_multiplier))
 	print('Enabling the restriction with transaction:')
 	print(json.dumps(enable_transaction.to_json(), indent=2))
 
@@ -114,7 +116,7 @@ def restriction_disable_transaction(restriction):  # [>step-6]
 		]
 	})
 	disable_transaction.fee = Amount(
-		fee_multiplier * disable_transaction.size)
+		calculate_transaction_fee(disable_transaction, fee_multiplier))
 	print('Disabling the restriction with transaction:')
 	print(json.dumps(disable_transaction.to_json(), indent=2))
 
@@ -152,7 +154,8 @@ try:
 	else:
 		# Disable the restriction
 		print('\n--- Disabling restriction ---')
-		agg_transaction = restriction_disable_transaction(restrictions[0])
+		agg_transaction = restriction_disable_transaction(
+			restrictions[0])
 	# [<step-4]
 	# Sign, announce and wait for confirmation [>step-7]
 	json_payload = facade.transaction_factory.attach_signature(
@@ -169,7 +172,8 @@ try:
 		'deadline': timestamp.add_hours(2).timestamp,
 		'recipient_address': 'TBBHGE77IHHOIYA46B3XSORRNR2L5MLW54YO75Y'
 	})
-	transaction.fee = Amount(fee_multiplier * transaction.size)
+	transaction.fee = Amount(
+		calculate_transaction_fee(transaction, fee_multiplier))
 	json_payload = facade.transaction_factory.attach_signature(
 		transaction,
 		facade.sign_transaction(signer_key_pair, transaction))

--- a/mkdocs/snippets/devbook/accounts/configure_multisig.mjs
+++ b/mkdocs/snippets/devbook/accounts/configure_multisig.mjs
@@ -4,6 +4,7 @@ import {
 	NetworkTimestamp,
 	SymbolFacade,
 	SymbolTransactionFactory,
+	calculateTransactionFee,
 	models
 } from 'symbol-sdk/symbol';
 
@@ -18,7 +19,8 @@ const KEY_PREFIX = '0'.repeat(63);
 // Setup the keys for the multisig account and its two cosignatories
 const MULTISIG_PRIVATE_KEY = process.env.MULTISIG_PRIVATE_KEY || (
 	`${KEY_PREFIX}1`);
-const multisigKeyPair = new KeyPair(new PrivateKey(MULTISIG_PRIVATE_KEY));
+const multisigKeyPair = new KeyPair(
+	new PrivateKey(MULTISIG_PRIVATE_KEY));
 const multisigAddress = facade.network.publicKeyToAddress(
 	multisigKeyPair.publicKey);
 console.log(`Multisig address: ${multisigAddress}`,
@@ -119,9 +121,8 @@ function multisigEnableTransaction(timestamp, feeMultiplier) {
 	});
 	// Reserve space for two cosignatures
 	// and calculate fee for the final transaction size
-	const cosignatureSize = new models.Cosignature().size;
-	transaction.fee = new models.Amount(feeMultiplier * (transaction.size +
-		(cosignatureSize * cosignatoryKeyPairs.length)));
+	transaction.fee = new models.Amount(calculateTransactionFee(
+		transaction, feeMultiplier, cosignatoryKeyPairs.length));
 	console.log('Enabling the multisig with the aggregate transaction:');
 	console.log(JSON.stringify(transaction.toJson(), null, 2));
 	// [<step-6]
@@ -177,11 +178,13 @@ function multisigDisableTransaction(timestamp, feeMultiplier) {
 	});
 	// Calculate fee for the final transaction size
 	// (No need to reserve space for cosignatures, as there are none)
-	transaction.fee = new models.Amount(feeMultiplier * transaction.size);
-	console.log('Disabling the multisig with the aggregate transaction:');
+	transaction.fee = new models.Amount(
+		calculateTransactionFee(transaction, feeMultiplier));
+	console.log(
+		'Disabling the multisig with the aggregate transaction:');
 	console.log(JSON.stringify(transaction.toJson(), null, 2));
 
-	// Sign the aggregate transaction using the first cosigner's signature
+	// Sign the aggregate with the first cosigner's signature
 	SymbolTransactionFactory.attachSignature(transaction,
 		facade.signTransaction(cosignatoryKeyPairs[0], transaction));
 	// [<step-9]
@@ -211,19 +214,23 @@ try {
 	// [<step-2]
 	// Get current state of the multisig account and decide which [>step-4]
 	// operation to perform
-	const cosignatories = await getMultisigCosignatories(multisigAddress);
+	const cosignatories =
+		await getMultisigCosignatories(multisigAddress);
 	let transaction;
 	if (0 === cosignatories.length) {
 		// Enable the multisig
-		transaction = multisigEnableTransaction(timestamp, feeMultiplier);
+		transaction =
+			multisigEnableTransaction(timestamp, feeMultiplier);
 	} else {
 		// Disable the multisig
-		transaction = multisigDisableTransaction(timestamp, feeMultiplier);
+		transaction =
+			multisigDisableTransaction(timestamp, feeMultiplier);
 	}
 	const payload = SymbolTransactionFactory.toJson(transaction);
 	// [<step-4]
 	// Announce and wait for confirmation [>step-10]
-	const transactionHash = facade.hashTransaction(transaction).toString();
+	const transactionHash =
+		facade.hashTransaction(transaction).toString();
 	console.log(
 		'Built aggregate transaction with hash:', transactionHash);
 	await announceTransaction(payload, 'aggregate transaction');

--- a/mkdocs/snippets/devbook/accounts/configure_multisig.py
+++ b/mkdocs/snippets/devbook/accounts/configure_multisig.py
@@ -5,7 +5,8 @@ import urllib.request
 
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
-from symbolchain.sc import Amount, Cosignature
+from symbolchain.sc import Amount
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.Network import NetworkTimestamp
 
 NODE_URL = os.getenv('NODE_URL', 'https://reference.symboltest.net:3001')
@@ -18,7 +19,8 @@ KEY_TEMPLATE = '0' * 63 + '{}'
 # Setup the keys for the multisig account and its two cosignatories
 MULTISIG_PRIVATE_KEY = os.getenv(
 	'MULTISIG_PRIVATE_KEY', KEY_TEMPLATE.format(1))
-multisig_key_pair = SymbolFacade.KeyPair(PrivateKey(MULTISIG_PRIVATE_KEY))
+multisig_key_pair = SymbolFacade.KeyPair(
+	PrivateKey(MULTISIG_PRIVATE_KEY))
 multisig_address = facade.network.public_key_to_address(
 	multisig_key_pair.public_key)
 print(f'Multisig address: {multisig_address} '
@@ -64,7 +66,8 @@ def wait_for_confirmation(tx_hash, label):
 					print(f'{label} confirmed in {attempt} seconds')
 					return
 				if status['group'] == 'failed':
-					raise RuntimeError(f'{label} failed: {status["code"]}')
+					raise RuntimeError(
+						f'{label} failed: {status["code"]}')
 		except urllib.error.HTTPError:
 			print('  Transaction status: unknown')
 	raise TimeoutError(f'{label} not confirmed after 60 seconds')
@@ -79,7 +82,8 @@ def get_multisig_cosignatories(address):
 		url = f'{NODE_URL}{multisig_path}'
 		with urllib.request.urlopen(url) as multisig_response:
 			status = json.loads(multisig_response.read().decode())
-			found_cosignatories = status['multisig']['cosignatoryAddresses']
+			found_cosignatories = (
+				status['multisig']['cosignatoryAddresses'])
 			print(f'  Response: {found_cosignatories}')
 			return found_cosignatories
 	except urllib.error.HTTPError:
@@ -116,9 +120,8 @@ def multisig_enable_transaction():
 	})
 	# Reserve space for two cosignatures
 	# and calculate fee for the final transaction size
-	cosignature_size = Cosignature().size
-	transaction.fee = Amount(fee_multiplier *
-		(transaction.size + cosignature_size * len(cosignatory_key_pairs)))
+	transaction.fee = Amount(calculate_transaction_fee(
+		transaction, fee_multiplier, len(cosignatory_key_pairs)))
 	print('Enabling the multisig with the aggregate transaction:')
 	print(json.dumps(transaction.to_json(), indent=2))
 	# [<step-6]
@@ -172,7 +175,8 @@ def multisig_disable_transaction():
 	})
 	# Calculate fee for the final transaction size
 	# (No need to reserve space for cosignatures, as there are none)
-	transaction.fee = Amount(fee_multiplier * transaction.size)
+	transaction.fee = Amount(
+		calculate_transaction_fee(transaction, fee_multiplier))
 	print('Disabling the multisig with the aggregate transaction:')
 	print(json.dumps(transaction.to_json(), indent=2))
 
@@ -217,7 +221,8 @@ try:
 	# [<step-4]
 	# Announce and wait for confirmation [>step-10]
 	agg_transaction_hash = facade.hash_transaction(agg_transaction)
-	print(f'Built aggregate transaction with hash: {agg_transaction_hash}')
+	print(
+		f'Built aggregate transaction with hash: {agg_transaction_hash}')
 	announce_transaction(json_payload, 'aggregate transaction')
 	wait_for_confirmation(agg_transaction_hash, 'aggregate transaction')
 	# [<step-10]

--- a/mkdocs/snippets/devbook/accounts/query_balance.mjs
+++ b/mkdocs/snippets/devbook/accounts/query_balance.mjs
@@ -126,13 +126,14 @@ try {
 
 			// Format and display the balance
 			const formattedBalance = formatAmount(balance, divisibility);
-			const mosaicIdHex =
-				`0x${mosaicId.toString(16).toUpperCase().padStart(16, '0')}`;
+			const mosaicIdHex = `0x${mosaicId.toString(16)
+				.toUpperCase().padStart(16, '0')}`;
 
 			// Display mosaic ID and names (if available)
 			const names = mosaicNames.get(mosaicId) || [];
 			if (0 < names.length)
-				console.log(`- Mosaic ${mosaicIdHex} (${names.join(', ')})`);
+				console.log(
+					`- Mosaic ${mosaicIdHex} (${names.join(', ')})`);
 			else
 				console.log(`- Mosaic ${mosaicIdHex}`);
 

--- a/mkdocs/snippets/devbook/accounts/query_balance.mjs
+++ b/mkdocs/snippets/devbook/accounts/query_balance.mjs
@@ -131,11 +131,12 @@ try {
 
 			// Display mosaic ID and names (if available)
 			const names = mosaicNames.get(mosaicId) || [];
-			if (0 < names.length)
+			if (0 < names.length) {
 				console.log(
 					`- Mosaic ${mosaicIdHex} (${names.join(', ')})`);
-			else
+			} else {
 				console.log(`- Mosaic ${mosaicIdHex}`);
+			}
 
 			console.log(`  Balance: ${formattedBalance}`);
 			console.log(`  Balance (atomic): ${balance.toString()}`);

--- a/mkdocs/snippets/devbook/accounts/query_balance.py
+++ b/mkdocs/snippets/devbook/accounts/query_balance.py
@@ -134,7 +134,8 @@ try:
 			mosaic_divisibility = info['divisibility']
 
 			# Format and display the balance
-			formatted_balance = format_amount(balance, mosaic_divisibility)
+			formatted_balance = format_amount(
+				balance, mosaic_divisibility)
 			mosaic_id_hex = f'0x{mosaic_id:016X}'
 
 			# Display mosaic ID and names (if available)

--- a/mkdocs/snippets/devbook/chain/chain_heights.py
+++ b/mkdocs/snippets/devbook/chain/chain_heights.py
@@ -14,7 +14,7 @@ finalized_changed_at = None
 try:
 	while True:
 		with urllib.request.urlopen(  # [>step-1]
-				f'{NODE_URL}/chain/info') as response:
+			f'{NODE_URL}/chain/info') as response:
 			chain_info = json.loads(response.read().decode())
 
 		height = int(chain_info['height'])

--- a/mkdocs/snippets/devbook/chain/chain_heights.py
+++ b/mkdocs/snippets/devbook/chain/chain_heights.py
@@ -13,7 +13,8 @@ finalized_changed_at = None
 
 try:
 	while True:
-		with urllib.request.urlopen(f'{NODE_URL}/chain/info') as response:  # [>step-1]
+		with urllib.request.urlopen(  # [>step-1]
+				f'{NODE_URL}/chain/info') as response:
 			chain_info = json.loads(response.read().decode())
 
 		height = int(chain_info['height'])

--- a/mkdocs/snippets/devbook/chain/network_time.mjs
+++ b/mkdocs/snippets/devbook/chain/network_time.mjs
@@ -6,7 +6,8 @@ try {
 	// Fetch Nemesis timestamp
 	const propertiesPath = '/network/properties'; // [>step-1]
 	console.log(`Fetching network properties from ${propertiesPath}`);
-	const propertiesResponse = await fetch(`${NODE_URL}${propertiesPath}`);
+	const propertiesResponse =
+		await fetch(`${NODE_URL}${propertiesPath}`);
 	const propertiesJson = await propertiesResponse.json();
 	const nemesisStr = propertiesJson.network.epochAdjustment;
 	const nemesisSeconds = parseInt(nemesisStr.replace('s', ''), 10);
@@ -23,7 +24,8 @@ try {
 	const networkDatetime = new Date(
 		nemesisDatetime.getTime() + networkMs);
 
-	console.log(`\nNemesis time (UTC): ${nemesisDatetime.toISOString()}`);
+	console.log(
+		`\nNemesis time (UTC): ${nemesisDatetime.toISOString()}`);
 	console.log(`Network time (ms since Nemesis): ${networkMs}`);
 	console.log(`Network time (UTC): ${networkDatetime.toISOString()}`); // [<step-3]
 } catch (error) {

--- a/mkdocs/snippets/devbook/chain/network_time.py
+++ b/mkdocs/snippets/devbook/chain/network_time.py
@@ -10,7 +10,8 @@ try:
 	# Fetch Nemesis timestamp
 	properties_path = '/network/properties'  # [>step-1]
 	print(f'Fetching network properties from {properties_path}')
-	with urllib.request.urlopen(f'{NODE_URL}{properties_path}') as response:
+	with urllib.request.urlopen(
+			f'{NODE_URL}{properties_path}') as response:
 		response_json = json.loads(response.read().decode())
 		nemesis_datetime = datetime.datetime.fromtimestamp(
 			int(response_json['network']['epochAdjustment'].rstrip('s')),

--- a/mkdocs/snippets/devbook/chain/network_time.py
+++ b/mkdocs/snippets/devbook/chain/network_time.py
@@ -11,7 +11,7 @@ try:
 	properties_path = '/network/properties'  # [>step-1]
 	print(f'Fetching network properties from {properties_path}')
 	with urllib.request.urlopen(
-			f'{NODE_URL}{properties_path}') as response:
+		f'{NODE_URL}{properties_path}') as response:
 		response_json = json.loads(response.read().decode())
 		nemesis_datetime = datetime.datetime.fromtimestamp(
 			int(response_json['network']['epochAdjustment'].rstrip('s')),

--- a/mkdocs/snippets/devbook/chain/prove_mosaic_definition.py
+++ b/mkdocs/snippets/devbook/chain/prove_mosaic_definition.py
@@ -102,7 +102,8 @@ try:
 		encoded_key, hashed_value, merkle_path, state_hash, roots)
 
 	if result.name == 'VALID_POSITIVE':
-		print(f'Mosaic {mosaic_id_hex} state verified at height {height}')
+		print(
+			f'Mosaic {mosaic_id_hex} state verified at height {height}')
 	else:
 		raise RuntimeError(
 			f'Mosaic {mosaic_id_hex} proof failed: {result.name}')

--- a/mkdocs/snippets/devbook/mosaics/create_mosaic.mjs
+++ b/mkdocs/snippets/devbook/mosaics/create_mosaic.mjs
@@ -2,6 +2,7 @@ import { PrivateKey } from 'symbol-sdk';
 import {
 	NetworkTimestamp,
 	SymbolFacade,
+	calculateTransactionFee,
 	generateMosaicId,
 	models
 } from 'symbol-sdk/symbol';
@@ -94,7 +95,7 @@ try {
 		flags: 'transferable restrictable'
 	});
 	definitionTx.fee = new models.Amount(
-		feeMultiplier * definitionTx.size);
+		calculateTransactionFee(definitionTx, feeMultiplier));
 
 	const mosaicId = generateMosaicId(signerAddress, nonce);
 	console.log(`Mosaic ID: ${mosaicId} (0x${mosaicId.toString(16)})`);
@@ -108,7 +109,8 @@ try {
 	console.dir(definitionTx.toJson(), { colors: true });
 
 	// Announce and wait for confirmation
-	const definitionHash = facade.hashTransaction(definitionTx).toString();
+	const definitionHash =
+		facade.hashTransaction(definitionTx).toString();
 	console.log('Transaction hash:', definitionHash);
 	await announceTransaction(defPayload, 'mosaic definition');
 	await waitForConfirmation(definitionHash, 'mosaic definition');
@@ -124,7 +126,8 @@ try {
 		action: 'increase',
 		delta: 100_00n
 	});
-	supplyTx.fee = new models.Amount(feeMultiplier * supplyTx.size);
+	supplyTx.fee = new models.Amount(
+		calculateTransactionFee(supplyTx, feeMultiplier));
 	// [<step-6]
 	// Sign and generate final payload [>step-7]
 	const supSignature = facade.signTransaction(

--- a/mkdocs/snippets/devbook/mosaics/create_mosaic.py
+++ b/mkdocs/snippets/devbook/mosaics/create_mosaic.py
@@ -6,6 +6,7 @@ import urllib.request
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
 from symbolchain.sc import Amount
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.IdGenerator import generate_mosaic_id
 from symbolchain.symbol.Network import NetworkTimestamp
 
@@ -40,7 +41,8 @@ def wait_for_confirmation(tx_hash, label):
 					print(f'{label} confirmed in {attempt} seconds')
 					return
 				if status['group'] == 'failed':
-					raise RuntimeError(f'{label} failed: {status["code"]}')
+					raise RuntimeError(
+						f'{label} failed: {status["code"]}')
 		except urllib.error.HTTPError:
 			print('  Transaction status: unknown')
 	raise TimeoutError(f'{label} not confirmed after 60 seconds')
@@ -93,7 +95,8 @@ try:
 		'nonce': nonce,
 		'flags': 'transferable restrictable'
 	})
-	definition_tx.fee = Amount(fee_multiplier * definition_tx.size)
+	definition_tx.fee = Amount(
+		calculate_transaction_fee(definition_tx, fee_multiplier))
 
 	mosaic_id = generate_mosaic_id(signer_address, nonce)
 	print(f'Mosaic ID: {mosaic_id} ({hex(mosaic_id)})')
@@ -122,7 +125,8 @@ try:
 		'action': 'increase',
 		'delta': 100_00
 	})
-	supply_tx.fee = Amount(fee_multiplier * supply_tx.size)
+	supply_tx.fee = Amount(
+		calculate_transaction_fee(supply_tx, fee_multiplier))
 	# [<step-6]
 	# Sign and generate final payload [>step-7]
 	signature = facade.sign_transaction(signer_key_pair, supply_tx)

--- a/mkdocs/snippets/devbook/mosaics/modify_mosaic_definition.mjs
+++ b/mkdocs/snippets/devbook/mosaics/modify_mosaic_definition.mjs
@@ -2,6 +2,7 @@ import { PrivateKey } from 'symbol-sdk';
 import {
 	NetworkTimestamp,
 	SymbolFacade,
+	calculateTransactionFee,
 	generateMosaicId,
 	models
 } from 'symbol-sdk/symbol';
@@ -58,7 +59,8 @@ try {
 		nonce: MOSAIC_NONCE,
 		flags: 'revokable'
 	});
-	modifyTx.fee = new models.Amount(feeMultiplier * modifyTx.size);
+	modifyTx.fee = new models.Amount(
+		calculateTransactionFee(modifyTx, feeMultiplier));
 	// [<step-3]
 	// Sign and generate final payload [>step-4]
 	const signature = facade.signTransaction(

--- a/mkdocs/snippets/devbook/mosaics/modify_mosaic_definition.py
+++ b/mkdocs/snippets/devbook/mosaics/modify_mosaic_definition.py
@@ -6,6 +6,7 @@ import urllib.request
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
 from symbolchain.sc import Amount
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.IdGenerator import generate_mosaic_id
 from symbolchain.symbol.Network import NetworkTimestamp
 
@@ -59,7 +60,8 @@ try:
 		'nonce': MOSAIC_NONCE,
 		'flags': 'revokable'
 	})
-	modify_tx.fee = Amount(fee_multiplier * modify_tx.size)
+	modify_tx.fee = Amount(
+		calculate_transaction_fee(modify_tx, fee_multiplier))
 	# [<step-3]
 	# Sign and generate final payload [>step-4]
 	signature = facade.sign_transaction(signer_key_pair, modify_tx)

--- a/mkdocs/snippets/devbook/mosaics/mosaic_metadata.mjs
+++ b/mkdocs/snippets/devbook/mosaics/mosaic_metadata.mjs
@@ -2,6 +2,7 @@ import { PrivateKey } from 'symbol-sdk';
 import {
 	NetworkTimestamp,
 	SymbolFacade,
+	calculateTransactionFee,
 	metadataGenerateKey,
 	metadataUpdateValue,
 	models
@@ -118,7 +119,8 @@ try {
 			embeddedTransactions),
 		transactions: embeddedTransactions
 	});
-	transaction.fee = new models.Amount(feeMultiplier * transaction.size);
+	transaction.fee = new models.Amount(
+		calculateTransactionFee(transaction, feeMultiplier));
 	// [<step-5]
 	// Sign and generate final payload [>step-6]
 	const signature = facade.signTransaction(signerKeyPair, transaction);
@@ -126,7 +128,8 @@ try {
 		transaction, signature);
 
 	// Announce and wait for confirmation
-	const transactionHash = facade.hashTransaction(transaction).toString();
+	const transactionHash =
+		facade.hashTransaction(transaction).toString();
 	console.log(
 		'Built aggregate transaction with hash:', transactionHash);
 	await announceTransaction(jsonPayload, 'aggregate transaction');
@@ -189,7 +192,7 @@ try {
 		transactions: updateEmbedded
 	});
 	updateTransaction.fee = new models.Amount(
-		feeMultiplier * updateTransaction.size);
+		calculateTransactionFee(updateTransaction, feeMultiplier));
 
 	// Sign and announce the update
 	const updateSignature = facade.signTransaction(

--- a/mkdocs/snippets/devbook/mosaics/mosaic_metadata.py
+++ b/mkdocs/snippets/devbook/mosaics/mosaic_metadata.py
@@ -146,7 +146,7 @@ try:
 	)
 	print(f'Fetching current metadata from {metadata_path}')
 	with urllib.request.urlopen(
-			f'{NODE_URL}{metadata_path}') as response:
+		f'{NODE_URL}{metadata_path}') as response:
 		response_json = json.loads(response.read().decode())
 
 	# Get the metadata entry

--- a/mkdocs/snippets/devbook/mosaics/mosaic_metadata.py
+++ b/mkdocs/snippets/devbook/mosaics/mosaic_metadata.py
@@ -6,6 +6,7 @@ import urllib.request
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
 from symbolchain.sc import Amount
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.Metadata import (
 	metadata_generate_key,
 	metadata_update_value
@@ -43,7 +44,8 @@ def wait_for_confirmation(tx_hash, label):
 					print(f'{label} confirmed in {attempt} seconds')
 					return
 				if status['group'] == 'failed':
-					raise RuntimeError(f'{label} failed: {status["code"]}')
+					raise RuntimeError(
+						f'{label} failed: {status["code"]}')
 		except urllib.error.HTTPError:
 			print('  Transaction status: unknown')
 	raise TimeoutError(f'{label} not confirmed after 60 seconds')
@@ -117,7 +119,8 @@ try:
 			embedded_transactions),
 		'transactions': embedded_transactions
 	})
-	transaction.fee = Amount(fee_multiplier * transaction.size)
+	transaction.fee = Amount(
+		calculate_transaction_fee(transaction, fee_multiplier))
 	# [<step-5]
 	# Sign and generate final payload [>step-6]
 	signature = facade.sign_transaction(signer_key_pair, transaction)
@@ -142,7 +145,8 @@ try:
 		'&metadataType=1'
 	)
 	print(f'Fetching current metadata from {metadata_path}')
-	with urllib.request.urlopen(f'{NODE_URL}{metadata_path}') as response:
+	with urllib.request.urlopen(
+			f'{NODE_URL}{metadata_path}') as response:
 		response_json = json.loads(response.read().decode())
 
 	# Get the metadata entry
@@ -182,7 +186,7 @@ try:
 		'transactions': embedded_transactions
 	})
 	update_transaction.fee = Amount(
-		fee_multiplier * update_transaction.size)
+		calculate_transaction_fee(update_transaction, fee_multiplier))
 
 	# Sign and announce the update
 	signature = facade.sign_transaction(

--- a/mkdocs/snippets/devbook/mosaics/mosaic_restrictions.mjs
+++ b/mkdocs/snippets/devbook/mosaics/mosaic_restrictions.mjs
@@ -4,6 +4,7 @@ import {
 	NetworkTimestamp,
 	SymbolFacade,
 	SymbolTransactionFactory,
+	calculateTransactionFee,
 	models,
 	mosaicRestrictionGenerateKey
 } from 'symbol-sdk/symbol';
@@ -71,7 +72,7 @@ async function waitForConfirmation(transactionHash, label) {
 	throw new Error(`${label} not confirmed after 60 seconds`);
 }
 
-// Returns a filtered list of restrictions currently applied to the mosaic
+// Returns restrictions currently applied to the mosaic
 // matching the given restriction key
 async function getMosaicRestrictions(query, key) { // [>step-4]
 	const restrictionsPath = `/restrictions/mosaic?${query}`;
@@ -203,7 +204,8 @@ try {
 			transactions),
 		transactions
 	});
-	aggregate.fee = new models.Amount(feeMultiplier * aggregate.size);
+	aggregate.fee = new models.Amount(
+		calculateTransactionFee(aggregate, feeMultiplier));
 	// [<step-7]
 	// Sign, announce and wait for confirmation
 	let payload = SymbolTransactionFactory.attachSignature( // [>step-8]
@@ -224,7 +226,8 @@ try {
 			amount: 1n
 		}]
 	});
-	transfer.fee = new models.Amount(feeMultiplier * transfer.size);
+	transfer.fee = new models.Amount(
+		calculateTransactionFee(transfer, feeMultiplier));
 
 	payload = SymbolTransactionFactory.attachSignature(
 		transfer,

--- a/mkdocs/snippets/devbook/mosaics/mosaic_restrictions.py
+++ b/mkdocs/snippets/devbook/mosaics/mosaic_restrictions.py
@@ -8,8 +8,7 @@ from symbolchain.facade.SymbolFacade import SymbolFacade
 from symbolchain.sc import Amount
 from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.Network import NetworkTimestamp
-from symbolchain.symbol.Restriction import (
-	mosaic_restriction_generate_key)
+from symbolchain.symbol.Restriction import mosaic_restriction_generate_key
 
 NODE_URL = os.getenv('NODE_URL', 'https://reference.symboltest.net:3001')
 print(f'Using node {NODE_URL}')

--- a/mkdocs/snippets/devbook/mosaics/mosaic_restrictions.py
+++ b/mkdocs/snippets/devbook/mosaics/mosaic_restrictions.py
@@ -6,8 +6,10 @@ import urllib.request
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
 from symbolchain.sc import Amount
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.Network import NetworkTimestamp
-from symbolchain.symbol.Restriction import mosaic_restriction_generate_key
+from symbolchain.symbol.Restriction import (
+	mosaic_restriction_generate_key)
 
 NODE_URL = os.getenv('NODE_URL', 'https://reference.symboltest.net:3001')
 print(f'Using node {NODE_URL}')
@@ -61,7 +63,8 @@ def wait_for_confirmation(tx_hash, label):
 					print(f'{label} confirmed in {attempt} seconds')
 					return
 				if status['group'] == 'failed':
-					raise RuntimeError(f"{label} failed: {status['code']}")
+					raise RuntimeError(
+						f"{label} failed: {status['code']}")
 		except urllib.error.HTTPError:
 			print('  Transaction status: unknown')
 	raise TimeoutError(f'{label} not confirmed after 60 seconds')
@@ -187,7 +190,8 @@ try:
 			prev_value, 0, target_address))
 	# [<step-6]
 	# Build an aggregate transaction
-	print('Bundling', len(transactions), 'transaction(s) in an aggregate')  # [>step-7]
+	print(  # [>step-7]
+		'Bundling', len(transactions), 'transaction(s) in an aggregate')
 	transaction = facade.transaction_factory.create({
 		'type': 'aggregate_complete_transaction_v3',
 		'signer_public_key': owner_key_pair.public_key,
@@ -196,7 +200,8 @@ try:
 			transactions),
 		'transactions': transactions
 	})
-	transaction.fee = Amount(fee_multiplier * transaction.size)
+	transaction.fee = Amount(
+		calculate_transaction_fee(transaction, fee_multiplier))
 	# [<step-7]
 	# Sign, announce and wait for confirmation
 	payload = facade.transaction_factory.attach_signature(  # [>step-8]
@@ -217,7 +222,8 @@ try:
 			'amount': 1
 		}]
 	})
-	transaction.fee = Amount(fee_multiplier * transaction.size)
+	transaction.fee = Amount(
+		calculate_transaction_fee(transaction, fee_multiplier))
 	payload = facade.transaction_factory.attach_signature(
 		transaction,
 		facade.sign_transaction(owner_key_pair, transaction))

--- a/mkdocs/snippets/devbook/mosaics/revoke_mosaic.mjs
+++ b/mkdocs/snippets/devbook/mosaics/revoke_mosaic.mjs
@@ -2,6 +2,7 @@ import { PrivateKey } from 'symbol-sdk';
 import {
 	NetworkTimestamp,
 	SymbolFacade,
+	calculateTransactionFee,
 	models
 } from 'symbol-sdk/symbol';
 
@@ -82,7 +83,8 @@ try {
 			amount: 7_00n
 		}
 	});
-	revokeTx.fee = new models.Amount(feeMultiplier * revokeTx.size);
+	revokeTx.fee = new models.Amount(
+		calculateTransactionFee(revokeTx, feeMultiplier));
 	// [<step-4]
 	// Sign and generate final payload [>step-5]
 	const signature = facade.signTransaction(signerKeyPair, revokeTx);

--- a/mkdocs/snippets/devbook/mosaics/revoke_mosaic.py
+++ b/mkdocs/snippets/devbook/mosaics/revoke_mosaic.py
@@ -6,6 +6,7 @@ import urllib.request
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
 from symbolchain.sc import Amount
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.Network import NetworkTimestamp
 
 NODE_URL = os.getenv('NODE_URL', 'https://reference.symboltest.net:3001')
@@ -80,7 +81,8 @@ try:
 			'amount': 7_00
 		}
 	})
-	revoke_tx.fee = Amount(fee_multiplier * revoke_tx.size)
+	revoke_tx.fee = Amount(
+		calculate_transaction_fee(revoke_tx, fee_multiplier))
 	# [<step-4]
 	# Sign and generate final payload [>step-5]
 	signature = facade.sign_transaction(

--- a/mkdocs/snippets/devbook/namespaces/get_namespace_info.mjs
+++ b/mkdocs/snippets/devbook/namespaces/get_namespace_info.mjs
@@ -18,9 +18,10 @@ try {
 	const namespacePath = `/namespaces/${namespaceIdHex}`;
 	console.log('Fetching namespace information from', namespacePath);
 	const namespaceResponse = await fetch(`${NODE_URL}${namespacePath}`);
-	if (!namespaceResponse.ok)
+	if (!namespaceResponse.ok) {
 		throw new Error(
 			`HTTP error! status: ${namespaceResponse.status}`);
+	}
 
 	const namespaceJSON = await namespaceResponse.json();
 	const ns = namespaceJSON.namespace;

--- a/mkdocs/snippets/devbook/namespaces/get_namespace_info.mjs
+++ b/mkdocs/snippets/devbook/namespaces/get_namespace_info.mjs
@@ -19,7 +19,8 @@ try {
 	console.log('Fetching namespace information from', namespacePath);
 	const namespaceResponse = await fetch(`${NODE_URL}${namespacePath}`);
 	if (!namespaceResponse.ok)
-		throw new Error(`HTTP error! status: ${namespaceResponse.status}`);
+		throw new Error(
+			`HTTP error! status: ${namespaceResponse.status}`);
 
 	const namespaceJSON = await namespaceResponse.json();
 	const ns = namespaceJSON.namespace;

--- a/mkdocs/snippets/devbook/namespaces/get_namespace_info.py
+++ b/mkdocs/snippets/devbook/namespaces/get_namespace_info.py
@@ -21,7 +21,8 @@ try:
 	# Fetch namespace information [>step-2]
 	namespace_path = f'/namespaces/{namespace_id_hex}'
 	print(f'Fetching namespace information from {namespace_path}')
-	with urllib.request.urlopen(f'{NODE_URL}{namespace_path}') as response:
+	with urllib.request.urlopen(
+			f'{NODE_URL}{namespace_path}') as response:
 		response_json = json.loads(response.read().decode())
 		ns = response_json['namespace']
 		print('Namespace information:')

--- a/mkdocs/snippets/devbook/namespaces/get_namespace_info.py
+++ b/mkdocs/snippets/devbook/namespaces/get_namespace_info.py
@@ -22,7 +22,7 @@ try:
 	namespace_path = f'/namespaces/{namespace_id_hex}'
 	print(f'Fetching namespace information from {namespace_path}')
 	with urllib.request.urlopen(
-			f'{NODE_URL}{namespace_path}') as response:
+		f'{NODE_URL}{namespace_path}') as response:
 		response_json = json.loads(response.read().decode())
 		ns = response_json['namespace']
 		print('Namespace information:')

--- a/mkdocs/snippets/devbook/namespaces/link_namespace_to_address.mjs
+++ b/mkdocs/snippets/devbook/namespaces/link_namespace_to_address.mjs
@@ -3,6 +3,7 @@ import {
 	Address,
 	NetworkTimestamp,
 	SymbolFacade,
+	calculateTransactionFee,
 	generateMosaicAliasId,
 	generateNamespacePath,
 	models
@@ -105,7 +106,8 @@ try {
 		address: targetAddress,
 		aliasAction: 'link'
 	});
-	transaction.fee = new models.Amount(feeMultiplier * transaction.size);
+	transaction.fee = new models.Amount(
+		calculateTransactionFee(transaction, feeMultiplier));
 	// [<step-4]
 	// Sign transaction and generate final payload [>step-5]
 	const jsonPayload = facade.transactionFactory.static.attachSignature(
@@ -114,12 +116,14 @@ try {
 	console.log('Built transaction:');
 	console.dir(transaction.toJson(), { colors: true });
 
-	const transactionHash = facade.hashTransaction(transaction).toString();
+	const transactionHash =
+		facade.hashTransaction(transaction).toString();
 	console.log('Transaction hash:', transactionHash);
 
 	// Announce and confirm transaction
 	await announceTransaction(jsonPayload, 'address alias transaction');
-	await waitForConfirmation(transactionHash, 'address alias transaction');
+	await waitForConfirmation(
+		transactionHash, 'address alias transaction');
 	// [<step-5]
 	// Retrieve the namespace to verify the alias [>step-6]
 	const namespacePath = `/namespaces/${namespaceId.toString(16)}`;
@@ -157,7 +161,7 @@ try {
 		}]
 	});
 	test_transaction.fee = new models.Amount(
-		feeMultiplier * test_transaction.size);
+		calculateTransactionFee(test_transaction, feeMultiplier));
 	const testJsonPayload =
 		facade.transactionFactory.static.attachSignature(
 			test_transaction,

--- a/mkdocs/snippets/devbook/namespaces/link_namespace_to_address.py
+++ b/mkdocs/snippets/devbook/namespaces/link_namespace_to_address.py
@@ -6,6 +6,7 @@ import urllib.request
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
 from symbolchain.sc import Amount, NamespaceId
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.IdGenerator import (
 	generate_mosaic_alias_id,
 	generate_namespace_path
@@ -43,7 +44,8 @@ def wait_for_confirmation(tx_hash, label):
 					print(f'{label} confirmed in {attempt} seconds')
 					return
 				if status['group'] == 'failed':
-					raise RuntimeError(f"{label} failed: {status['code']}")
+					raise RuntimeError(
+						f"{label} failed: {status['code']}")
 		except urllib.error.HTTPError:
 			print('  Transaction status: unknown')
 	raise TimeoutError(f'{label} not confirmed after 60 seconds')
@@ -101,7 +103,8 @@ try:
 		'address': target_address,
 		'alias_action': 'link'
 	})
-	transaction.fee = Amount(fee_multiplier * transaction.size)
+	transaction.fee = Amount(
+		calculate_transaction_fee(transaction, fee_multiplier))
 	# [<step-4]
 	# Sign transaction and generate final payload [>step-5]
 	json_payload = facade.transaction_factory.attach_signature(
@@ -120,7 +123,8 @@ try:
 	# Retrieve the namespace to verify the alias [>step-6]
 	namespace_path = f'/namespaces/{namespace_id:x}'
 	print(f'Fetching namespace information from {namespace_path}')
-	with urllib.request.urlopen(f'{NODE_URL}{namespace_path}') as response:
+	with urllib.request.urlopen(
+			f'{NODE_URL}{namespace_path}') as response:
 		response_json = json.loads(response.read().decode())
 		namespace_info = response_json['namespace']
 		print('Alias information:')
@@ -150,7 +154,8 @@ try:
 			'amount': 1_000_000  # 1 XYM
 		}]
 	})
-	test_transaction.fee = Amount(fee_multiplier * test_transaction.size)
+	test_transaction.fee = Amount(
+		calculate_transaction_fee(test_transaction, fee_multiplier))
 	test_json_payload = facade.transaction_factory.attach_signature(
 		test_transaction,
 		facade.sign_transaction(signer_key_pair, test_transaction))

--- a/mkdocs/snippets/devbook/namespaces/link_namespace_to_address.py
+++ b/mkdocs/snippets/devbook/namespaces/link_namespace_to_address.py
@@ -124,7 +124,7 @@ try:
 	namespace_path = f'/namespaces/{namespace_id:x}'
 	print(f'Fetching namespace information from {namespace_path}')
 	with urllib.request.urlopen(
-			f'{NODE_URL}{namespace_path}') as response:
+		f'{NODE_URL}{namespace_path}') as response:
 		response_json = json.loads(response.read().decode())
 		namespace_info = response_json['namespace']
 		print('Alias information:')

--- a/mkdocs/snippets/devbook/namespaces/link_namespace_to_mosaic.mjs
+++ b/mkdocs/snippets/devbook/namespaces/link_namespace_to_mosaic.mjs
@@ -2,6 +2,7 @@ import { PrivateKey } from 'symbol-sdk';
 import {
 	NetworkTimestamp,
 	SymbolFacade,
+	calculateTransactionFee,
 	generateMosaicAliasId,
 	generateNamespacePath,
 	models
@@ -102,7 +103,8 @@ try {
 		mosaicId,
 		aliasAction: 'link'
 	});
-	transaction.fee = new models.Amount(feeMultiplier * transaction.size);
+	transaction.fee = new models.Amount(
+		calculateTransactionFee(transaction, feeMultiplier));
 	// [<step-4]
 	// Sign transaction and generate final payload [>step-5]
 	const jsonPayload = facade.transactionFactory.static.attachSignature(
@@ -111,12 +113,14 @@ try {
 	console.log('Built transaction:');
 	console.dir(transaction.toJson(), { colors: true });
 
-	const transactionHash = facade.hashTransaction(transaction).toString();
+	const transactionHash =
+		facade.hashTransaction(transaction).toString();
 	console.log('Transaction hash:', transactionHash);
 
 	// Announce and confirm transaction
 	await announceTransaction(jsonPayload, 'mosaic alias transaction');
-	await waitForConfirmation(transactionHash, 'mosaic alias transaction');
+	await waitForConfirmation(
+		transactionHash, 'mosaic alias transaction');
 	// [<step-5]
 	// Retrieve the namespace to verify the alias [>step-6]
 	const namespacePath = `/namespaces/${namespaceId.toString(16)}`;
@@ -150,7 +154,7 @@ try {
 		}]
 	});
 	test_transaction.fee = new models.Amount(
-		feeMultiplier * test_transaction.size);
+		calculateTransactionFee(test_transaction, feeMultiplier));
 	const testJsonPayload =
 		facade.transactionFactory.static.attachSignature(
 			test_transaction,

--- a/mkdocs/snippets/devbook/namespaces/link_namespace_to_mosaic.py
+++ b/mkdocs/snippets/devbook/namespaces/link_namespace_to_mosaic.py
@@ -122,7 +122,7 @@ try:
 	namespace_path = f'/namespaces/{namespace_id:x}'
 	print(f'Fetching namespace information from {namespace_path}')
 	with urllib.request.urlopen(
-			f'{NODE_URL}{namespace_path}') as response:
+		f'{NODE_URL}{namespace_path}') as response:
 		response_json = json.loads(response.read().decode())
 		namespace_info = response_json['namespace']
 		print('Alias information:')

--- a/mkdocs/snippets/devbook/namespaces/link_namespace_to_mosaic.py
+++ b/mkdocs/snippets/devbook/namespaces/link_namespace_to_mosaic.py
@@ -6,6 +6,7 @@ import urllib.request
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
 from symbolchain.sc import Amount
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.IdGenerator import (
 	generate_mosaic_alias_id,
 	generate_namespace_path
@@ -43,7 +44,8 @@ def wait_for_confirmation(tx_hash, label):
 					print(f'{label} confirmed in {attempt} seconds')
 					return
 				if status['group'] == 'failed':
-					raise RuntimeError(f"{label} failed: {status['code']}")
+					raise RuntimeError(
+						f"{label} failed: {status['code']}")
 		except urllib.error.HTTPError:
 			print('  Transaction status: unknown')
 	raise TimeoutError(f'{label} not confirmed after 60 seconds')
@@ -99,7 +101,8 @@ try:
 		'mosaic_id': mosaic_id,
 		'alias_action': 'link'
 	})
-	transaction.fee = Amount(fee_multiplier * transaction.size)
+	transaction.fee = Amount(
+		calculate_transaction_fee(transaction, fee_multiplier))
 	# [<step-4]
 	# Sign transaction and generate final payload [>step-5]
 	json_payload = facade.transaction_factory.attach_signature(
@@ -118,7 +121,8 @@ try:
 	# Retrieve the namespace to verify the alias [>step-6]
 	namespace_path = f'/namespaces/{namespace_id:x}'
 	print(f'Fetching namespace information from {namespace_path}')
-	with urllib.request.urlopen(f'{NODE_URL}{namespace_path}') as response:
+	with urllib.request.urlopen(
+			f'{NODE_URL}{namespace_path}') as response:
 		response_json = json.loads(response.read().decode())
 		namespace_info = response_json['namespace']
 		print('Alias information:')
@@ -148,7 +152,8 @@ try:
 			'amount': 1
 		}]
 	})
-	test_transaction.fee = Amount(fee_multiplier * test_transaction.size)
+	test_transaction.fee = Amount(
+		calculate_transaction_fee(test_transaction, fee_multiplier))
 	test_json_payload = facade.transaction_factory.attach_signature(
 		test_transaction,
 		facade.sign_transaction(signer_key_pair, test_transaction))

--- a/mkdocs/snippets/devbook/namespaces/namespace_metadata.mjs
+++ b/mkdocs/snippets/devbook/namespaces/namespace_metadata.mjs
@@ -2,6 +2,7 @@ import { PrivateKey } from 'symbol-sdk';
 import {
 	NetworkTimestamp,
 	SymbolFacade,
+	calculateTransactionFee,
 	generateNamespaceId,
 	metadataGenerateKey,
 	metadataUpdateValue,
@@ -120,7 +121,8 @@ try {
 			embeddedTransactions),
 		transactions: embeddedTransactions
 	});
-	transaction.fee = new models.Amount(feeMultiplier * transaction.size);
+	transaction.fee = new models.Amount(
+		calculateTransactionFee(transaction, feeMultiplier));
 	// [<step-5]
 	// Sign and generate final payload [>step-6]
 	const signature = facade.signTransaction(signerKeyPair, transaction);
@@ -128,7 +130,8 @@ try {
 		transaction, signature);
 
 	// Announce and wait for confirmation
-	const transactionHash = facade.hashTransaction(transaction).toString();
+	const transactionHash =
+		facade.hashTransaction(transaction).toString();
 	console.log(
 		'Built aggregate transaction with hash:', transactionHash);
 	await announceTransaction(jsonPayload, 'aggregate transaction');
@@ -190,7 +193,7 @@ try {
 		transactions: updateEmbedded
 	});
 	updateTransaction.fee = new models.Amount(
-		feeMultiplier * updateTransaction.size);
+		calculateTransactionFee(updateTransaction, feeMultiplier));
 
 	// Sign and announce the update
 	const updateSignature = facade.signTransaction(

--- a/mkdocs/snippets/devbook/namespaces/namespace_metadata.py
+++ b/mkdocs/snippets/devbook/namespaces/namespace_metadata.py
@@ -6,6 +6,7 @@ import urllib.request
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
 from symbolchain.sc import Amount
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.IdGenerator import generate_namespace_id
 from symbolchain.symbol.Metadata import (
 	metadata_generate_key,
@@ -44,7 +45,8 @@ def wait_for_confirmation(tx_hash, label):
 					print(f'{label} confirmed in {attempt} seconds')
 					return
 				if status['group'] == 'failed':
-					raise RuntimeError(f'{label} failed: {status["code"]}')
+					raise RuntimeError(
+						f'{label} failed: {status["code"]}')
 		except urllib.error.HTTPError:
 			print('  Transaction status: unknown')
 	raise TimeoutError(f'{label} not confirmed after 60 seconds')
@@ -119,7 +121,8 @@ try:
 			embedded_transactions),
 		'transactions': embedded_transactions
 	})
-	transaction.fee = Amount(fee_multiplier * transaction.size)
+	transaction.fee = Amount(
+		calculate_transaction_fee(transaction, fee_multiplier))
 	# [<step-5]
 	# Sign and generate final payload [>step-6]
 	signature = facade.sign_transaction(signer_key_pair, transaction)
@@ -144,7 +147,8 @@ try:
 		'&metadataType=2'
 	)
 	print(f'Fetching current metadata from {metadata_path}')
-	with urllib.request.urlopen(f'{NODE_URL}{metadata_path}') as response:
+	with urllib.request.urlopen(
+			f'{NODE_URL}{metadata_path}') as response:
 		response_json = json.loads(response.read().decode())
 
 	# Get the metadata entry
@@ -184,7 +188,7 @@ try:
 		'transactions': embedded_transactions
 	})
 	update_transaction.fee = Amount(
-		fee_multiplier * update_transaction.size)
+		calculate_transaction_fee(update_transaction, fee_multiplier))
 
 	# Sign and announce the update
 	signature = facade.sign_transaction(

--- a/mkdocs/snippets/devbook/namespaces/namespace_metadata.py
+++ b/mkdocs/snippets/devbook/namespaces/namespace_metadata.py
@@ -148,7 +148,7 @@ try:
 	)
 	print(f'Fetching current metadata from {metadata_path}')
 	with urllib.request.urlopen(
-			f'{NODE_URL}{metadata_path}') as response:
+		f'{NODE_URL}{metadata_path}') as response:
 		response_json = json.loads(response.read().decode())
 
 	# Get the metadata entry

--- a/mkdocs/snippets/devbook/namespaces/register_root_namespace.mjs
+++ b/mkdocs/snippets/devbook/namespaces/register_root_namespace.mjs
@@ -3,6 +3,7 @@ import {
 	Address,
 	NetworkTimestamp,
 	SymbolFacade,
+	calculateTransactionFee,
 	generateNamespaceId,
 	models
 } from 'symbol-sdk/symbol';
@@ -58,7 +59,7 @@ try {
 		name: namespaceName
 	});
 	transaction.fee = new models.Amount(
-		feeMultiplier * transaction.size);
+		calculateTransactionFee(transaction, feeMultiplier));
 	// [<step-4]
 	// Sign transaction and generate final payload [>step-5]
 	const signature = facade.signTransaction(

--- a/mkdocs/snippets/devbook/namespaces/register_root_namespace.py
+++ b/mkdocs/snippets/devbook/namespaces/register_root_namespace.py
@@ -6,6 +6,7 @@ import urllib.request
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
 from symbolchain.sc import Amount
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.IdGenerator import generate_namespace_id
 from symbolchain.symbol.Network import Address, NetworkTimestamp
 
@@ -57,7 +58,8 @@ try:
 		'duration': 86400,  # approximately 30 days
 		'name': namespace_name
 	})
-	transaction.fee = Amount(fee_multiplier * transaction.size)
+	transaction.fee = Amount(
+		calculate_transaction_fee(transaction, fee_multiplier))
 	# [<step-4]
 	# Sign transaction and generate final payload [>step-5]
 	signature = facade.sign_transaction(signer_key_pair, transaction)

--- a/mkdocs/snippets/devbook/namespaces/register_subnamespace.mjs
+++ b/mkdocs/snippets/devbook/namespaces/register_subnamespace.mjs
@@ -3,6 +3,7 @@ import {
 	Address,
 	NetworkTimestamp,
 	SymbolFacade,
+	calculateTransactionFee,
 	generateNamespaceId,
 	models
 } from 'symbol-sdk/symbol';
@@ -65,7 +66,8 @@ try {
 		parentId,
 		name: subnamespaceName
 	});
-	transaction.fee = new models.Amount(feeMultiplier * transaction.size);
+	transaction.fee = new models.Amount(
+		calculateTransactionFee(transaction, feeMultiplier));
 	// [<step-2]
 	// Sign transaction and generate final payload
 	const signature = facade.signTransaction(

--- a/mkdocs/snippets/devbook/namespaces/register_subnamespace.py
+++ b/mkdocs/snippets/devbook/namespaces/register_subnamespace.py
@@ -6,6 +6,7 @@ import urllib.request
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
 from symbolchain.sc import Amount
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.IdGenerator import generate_namespace_id
 from symbolchain.symbol.Network import Address, NetworkTimestamp
 
@@ -64,7 +65,8 @@ try:
 		'parent_id': parent_id,
 		'name': subnamespace_name
 	})
-	transaction.fee = Amount(fee_multiplier * transaction.size)
+	transaction.fee = Amount(
+		calculate_transaction_fee(transaction, fee_multiplier))
 	# [<step-2]
 	# Sign transaction and generate final payload
 	signature = facade.sign_transaction(signer_key_pair, transaction)

--- a/mkdocs/snippets/devbook/namespaces/resolve_namespace_from_receipt.py
+++ b/mkdocs/snippets/devbook/namespaces/resolve_namespace_from_receipt.py
@@ -68,7 +68,8 @@ try:
 					break
 				resolved = entry['resolved']
 			if resolved:
-				address = Address.from_decoded_address_hex_string(resolved)
+				address = Address.from_decoded_address_hex_string(
+					resolved)
 				print('\nAddress resolution:')
 				print(f'  Unresolved:  {statement["unresolved"]}')
 				print(f'  Resolved:   {address}')
@@ -83,7 +84,8 @@ try:
 			mosaic_data = json.loads(response.read().decode())
 
 		mosaic_statements = mosaic_data['data']
-		print(f'  Found {len(mosaic_statements)} resolution statement(s)')
+		print(
+			f'  Found {len(mosaic_statements)} resolution statement(s)')
 
 		for item in mosaic_statements:
 			statement = item['statement']

--- a/mkdocs/snippets/devbook/network-currency/query_currency_supply.mjs
+++ b/mkdocs/snippets/devbook/network-currency/query_currency_supply.mjs
@@ -9,7 +9,8 @@ try {
 		v.toLocaleString('en-US', { minimumFractionDigits: 6 });
 
 	const maximumResponse = await fetch(`${NODE_URL}${SUPPLY_PATH}/max`);
-	const maximumSupply = parseFloat((await maximumResponse.text()).trim());
+	const maximumSupply =
+		parseFloat((await maximumResponse.text()).trim());
 	console.log(`Maximum supply: ${fmt(maximumSupply)} XYM`);
 
 	const totalResponse = await fetch(`${NODE_URL}${SUPPLY_PATH}/total`);
@@ -23,7 +24,8 @@ try {
 	console.log(`Circulating supply: ${fmt(circulatingSupply)} XYM`); // [<step-1]
 	// [>step-2]
 	const nonCirculatingSupply = totalSupply - circulatingSupply;
-	console.log(`Non-circulating supply: ${fmt(nonCirculatingSupply)} XYM`);
+	console.log(
+		`Non-circulating supply: ${fmt(nonCirculatingSupply)} XYM`);
 
 	const unmintedSupply = maximumSupply - totalSupply;
 	console.log(`Unminted supply: ${fmt(unmintedSupply)} XYM`); // [<step-2]

--- a/mkdocs/snippets/devbook/start/hello_world.mjs
+++ b/mkdocs/snippets/devbook/start/hello_world.mjs
@@ -21,7 +21,8 @@ try {
 		throw new Error(`HTTP error! status: ${response.status}`);
 	const responseJson = await response.json();
 	const height = parseInt(responseJson.height, 10);
-	console.log(`  Blockchain height: ${height.toLocaleString()} blocks`);
+	console.log(
+		`  Blockchain height: ${height.toLocaleString()} blocks`);
 } catch (e) {
 	console.error(e.message, '| Cause:', e.cause?.code ?? 'unknown');
 } // [<step-2]

--- a/mkdocs/snippets/devbook/transactions/bonded_aggregate.mjs
+++ b/mkdocs/snippets/devbook/transactions/bonded_aggregate.mjs
@@ -2,6 +2,7 @@ import { Hash256, PrivateKey } from 'symbol-sdk';
 import {
 	NetworkTimestamp,
 	SymbolFacade,
+	calculateTransactionFee,
 	generateMosaicAliasId,
 	models
 } from 'symbol-sdk/symbol';
@@ -148,10 +149,8 @@ try {
 	});
 	// Reserve space for one cosignature
 	// and calculate fee for the final transaction size
-	const cosignatureSize = new models.Cosignature().size;
 	bondedTransaction.fee = new models.Amount(
-		feeMultiplier * (bondedTransaction.size + cosignatureSize)
-	);
+		calculateTransactionFee(bondedTransaction, feeMultiplier, 1));
 	console.log('Built aggregate without signatures:');
 	console.log(JSON.stringify(bondedTransaction.toJson(), null, 2));
 	// [<step-4]
@@ -179,7 +178,8 @@ try {
 		duration: 100n, // Lock duration in blocks
 		hash: bondedHash
 	});
-	hashLock.fee = new models.Amount(feeMultiplier * hashLock.size);
+	hashLock.fee = new models.Amount(
+		calculateTransactionFee(hashLock, feeMultiplier));
 
 	// Sign hash lock
 	console.log('[Account A] Signing the hash lock...');
@@ -208,7 +208,8 @@ try {
 	// [<step-7]
 	// --- ACCOUNT B (Cosigner) --- [>step-8]
 	// Retrieves partial transactions waiting for signature
-	const partialPath =		`/transactions/partial?address=${accountBAddress}`;
+	const partialPath =
+		`/transactions/partial?address=${accountBAddress}`;
 	console.log(
 		'[Account B] Checking for partial transactions from ' +
 		'/transactions/partial'
@@ -218,7 +219,8 @@ try {
 	if (!partialTxs.data || 0 === partialTxs.data.length)
 		throw new Error('No partial transactions found');
 
-	console.log(`Found ${partialTxs.data.length} partial transaction(s)`);
+	console.log(
+		`Found ${partialTxs.data.length} partial transaction(s)`);
 
 	// Find the transaction matching the expected hash
 	const found = partialTxs.data.some(

--- a/mkdocs/snippets/devbook/transactions/bonded_aggregate.py
+++ b/mkdocs/snippets/devbook/transactions/bonded_aggregate.py
@@ -5,7 +5,8 @@ import urllib.request
 
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
-from symbolchain.sc import Amount, Cosignature
+from symbolchain.sc import Amount
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.IdGenerator import generate_mosaic_alias_id
 from symbolchain.symbol.Network import NetworkTimestamp
 
@@ -41,7 +42,8 @@ def wait_for_status(hash_value, expected_status, label):
 				print(f'  Transaction status: {status["group"]}')
 
 				if status['group'] == 'failed':
-					raise RuntimeError(f'{label} failed: {status["code"]}')
+					raise RuntimeError(
+						f'{label} failed: {status["code"]}')
 
 				if status['group'] == expected_status:
 					print(f'{label} {expected_status} ' +
@@ -138,9 +140,8 @@ try:
 	})
 	# Reserve space for one cosignature
 	# and calculate fee for the final transaction size
-	cosignature_size = Cosignature().size
 	bonded_transaction.fee = Amount(
-		fee_multiplier * (bonded_transaction.size + cosignature_size))
+		calculate_transaction_fee(bonded_transaction, fee_multiplier, 1))
 	print('Built aggregate without signatures:')
 	print(json.dumps(bonded_transaction.to_json(), indent=2))
 	# [<step-4]
@@ -167,7 +168,8 @@ try:
 		'duration': 100,  # Lock duration in blocks
 		'hash': bonded_hash
 	})
-	hash_lock.fee = Amount(fee_multiplier * hash_lock.size)
+	hash_lock.fee = Amount(
+		calculate_transaction_fee(hash_lock, fee_multiplier))
 
 	# Sign hash lock
 	print('[Account A] Signing the hash lock...')

--- a/mkdocs/snippets/devbook/transactions/complete_aggregate.mjs
+++ b/mkdocs/snippets/devbook/transactions/complete_aggregate.mjs
@@ -2,6 +2,7 @@ import { PrivateKey } from 'symbol-sdk';
 import {
 	NetworkTimestamp,
 	SymbolFacade,
+	calculateTransactionFee,
 	generateMosaicAliasId,
 	models
 } from 'symbol-sdk/symbol';
@@ -89,10 +90,8 @@ try {
 	});
 	// Reserve space for one cosignature
 	// and calculate fee for the final transaction size
-	const cosignatureSize = new models.Cosignature().size;
 	transaction.fee = new models.Amount(
-		feeMultiplier * (transaction.size + cosignatureSize)
-	);
+		calculateTransactionFee(transaction, feeMultiplier, 1));
 	console.log('Built aggregate transaction without signatures:');
 	console.log(JSON.stringify(transaction.toJson(), null, 2));
 	// [<step-4]
@@ -150,7 +149,8 @@ try {
 	console.log('  Response:', await announceResponse.text());
 
 	// Compute hash of final transaction (with cosignatures)
-	const transactionHash = facade.hashTransaction(transaction).toString();
+	const transactionHash =
+		facade.hashTransaction(transaction).toString();
 	// [<step-8]
 	// Wait for confirmation [>step-9]
 	const statusPath = `/transactionStatus/${transactionHash}`;

--- a/mkdocs/snippets/devbook/transactions/complete_aggregate.py
+++ b/mkdocs/snippets/devbook/transactions/complete_aggregate.py
@@ -5,7 +5,7 @@ import urllib.request
 
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
-from symbolchain.sc import Amount, Cosignature
+from symbolchain.sc import Amount
 from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.IdGenerator import generate_mosaic_alias_id
 from symbolchain.symbol.Network import NetworkTimestamp

--- a/mkdocs/snippets/devbook/transactions/complete_aggregate.py
+++ b/mkdocs/snippets/devbook/transactions/complete_aggregate.py
@@ -6,6 +6,7 @@ import urllib.request
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
 from symbolchain.sc import Amount, Cosignature
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.IdGenerator import generate_mosaic_alias_id
 from symbolchain.symbol.Network import NetworkTimestamp
 
@@ -91,15 +92,15 @@ try:
 	})
 	# Reserve space for one cosignature
 	# and calculate fee for the final transaction size
-	cosignature_size = Cosignature().size
 	transaction.fee = Amount(
-		fee_multiplier * (transaction.size + cosignature_size))
+		calculate_transaction_fee(transaction, fee_multiplier, 1))
 	print('Built aggregate transaction without signatures:')
 	print(json.dumps(transaction.to_json(), indent=2))
 	# [<step-4]
 	# --- ACCOUNT A (Initiator) --- [>step-5]
 	print('[Account A] Signing the aggregate...')
-	signature_a = facade.sign_transaction(account_a_key_pair, transaction)
+	signature_a = facade.sign_transaction(
+		account_a_key_pair, transaction)
 	transaction_payload = facade.transaction_factory.attach_signature(
 		transaction, signature_a)
 	payload_formatted = json.dumps(
@@ -124,7 +125,8 @@ try:
 	# --- OFF-CHAIN COORDINATION ---
 	# Account B sends the cosignature back to Account A
 	shared_cosignature = cosignature_b
-	print('[Account B] <== Cosignature sent back to Account A (offchain)')
+	print(
+		'[Account B] <== Cosignature sent back to Account A (offchain)')
 	# [<step-6]
 	# --- ACCOUNT A (Initiator) --- [>step-7]
 	# Add cosignature to the transaction and rebuild payload

--- a/mkdocs/snippets/devbook/transactions/cross_chain_swap.mjs
+++ b/mkdocs/snippets/devbook/transactions/cross_chain_swap.mjs
@@ -4,6 +4,7 @@ import { PrivateKey } from 'symbol-sdk';
 import {
 	NetworkTimestamp,
 	SymbolFacade,
+	calculateTransactionFee,
 	generateMosaicAliasId,
 	models
 } from 'symbol-sdk/symbol';
@@ -246,7 +247,8 @@ try {
 		hashAlgorithm: 'hash_256'
 	});
 	secretLockTransaction.fee = new models.Amount(
-		(await getFeeMultiplier()) * secretLockTransaction.size);
+		calculateTransactionFee(
+			secretLockTransaction, (await getFeeMultiplier())));
 
 	// Sign and announce
 	const lockSignature = facade.signTransaction(
@@ -278,13 +280,15 @@ try {
 		proof
 	});
 	secretProofTransaction.fee = new models.Amount(
-		(await getFeeMultiplier()) * secretProofTransaction.size);
+		calculateTransactionFee(
+			secretProofTransaction, (await getFeeMultiplier())));
 
 	// Sign and announce
 	const proofSignature = facade.signTransaction(
 		aliceXymKeyPair, secretProofTransaction);
-	const proofPayload = facade.transactionFactory.static.attachSignature(
-		secretProofTransaction, proofSignature);
+	const proofPayload =
+		facade.transactionFactory.static.attachSignature(
+			secretProofTransaction, proofSignature);
 
 	console.log('Built secret proof transaction:');
 	console.dir(secretProofTransaction.toJson(), { colors: true });

--- a/mkdocs/snippets/devbook/transactions/cross_chain_swap.py
+++ b/mkdocs/snippets/devbook/transactions/cross_chain_swap.py
@@ -8,6 +8,7 @@ import urllib.request
 from symbolchain.CryptoTypes import Hash256, PrivateKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
 from symbolchain.sc import Amount
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.IdGenerator import generate_mosaic_alias_id
 from symbolchain.symbol.Network import NetworkTimestamp
 from web3 import Web3
@@ -135,7 +136,8 @@ def wait_for_status(hash_value, expected_status, label):
 				print(f'  Transaction status: {status["group"]}')
 
 				if status['group'] == 'failed':
-					raise RuntimeError(f'{label} failed: {status["code"]}')
+					raise RuntimeError(
+						f'{label} failed: {status["code"]}')
 
 				if status['group'] == expected_status:
 					print(f'{label} {expected_status}'
@@ -273,7 +275,8 @@ try:
 		'hash_algorithm': 'hash_256'
 	})
 	secret_lock_transaction.fee = Amount(
-		get_fee_multiplier() * secret_lock_transaction.size)
+		calculate_transaction_fee(
+			secret_lock_transaction, get_fee_multiplier()))
 
 	# Sign and announce
 	lock_signature = facade.sign_transaction(
@@ -302,7 +305,8 @@ try:
 		'proof': proof
 	})
 	secret_proof_transaction.fee = Amount(
-		get_fee_multiplier() * secret_proof_transaction.size)
+		calculate_transaction_fee(
+			secret_proof_transaction, get_fee_multiplier()))
 
 	# Sign and announce
 	proof_signature = facade.sign_transaction(

--- a/mkdocs/snippets/devbook/transactions/fee_sponsorship.mjs
+++ b/mkdocs/snippets/devbook/transactions/fee_sponsorship.mjs
@@ -2,6 +2,7 @@ import { PrivateKey } from 'symbol-sdk';
 import {
 	NetworkTimestamp,
 	SymbolFacade,
+	calculateTransactionFee,
 	generateMosaicAliasId,
 	models
 } from 'symbol-sdk/symbol';
@@ -62,10 +63,8 @@ function buildPrefundedMessageTransaction(recipientAddress, message) {
 		transactions: [messageTransaction, prefundTransaction]
 	});
 	// Calculate total fee, reserving space for a cosignature
-	const cosignatureSize = new models.Cosignature().size;
 	transaction.fee = new models.Amount(
-		feeMultiplier * (transaction.size + cosignatureSize)
-	);
+		calculateTransactionFee(transaction, feeMultiplier, 1));
 	// Update the prefund amount to match the total fee
 	prefundTransaction.mosaics[0].amount = transaction.fee;
 	// Update the embedded transaction hashes
@@ -125,10 +124,8 @@ function buildSponsoredMessageTransaction(recipientAddress, message) {
 		transactions: [messageTransaction, fillerTransaction]
 	});
 	// Calculate total fee, reserving space for a cosignature
-	const cosignatureSize = new models.Cosignature().size;
 	transaction.fee = new models.Amount(
-		feeMultiplier * (transaction.size + cosignatureSize)
-	);
+		calculateTransactionFee(transaction, feeMultiplier, 1));
 	// [<step-9]
 	// Sign the aggregate transaction using the app's signature [>step-10]
 	facade.transactionFactory.static.attachSignature(
@@ -206,7 +203,8 @@ try {
 			const status = await response.json();
 			console.log(`  Transaction status: ${status.group}`);
 			if ('confirmed' === status.group) {
-				console.log(`Transaction confirmed in ${attempt} seconds`);
+				console.log(
+					`Transaction confirmed in ${attempt} seconds`);
 				break;
 			}
 			if ('failed' === status.group) {

--- a/mkdocs/snippets/devbook/transactions/fee_sponsorship.py
+++ b/mkdocs/snippets/devbook/transactions/fee_sponsorship.py
@@ -3,9 +3,10 @@ import os
 import time
 import urllib.request
 
-from symbolchain import sc
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
+from symbolchain.sc import Amount, Hash256
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.IdGenerator import generate_mosaic_alias_id
 from symbolchain.symbol.Network import NetworkTimestamp
 
@@ -61,13 +62,12 @@ def build_prefunded_message_transaction(recipient_address, message):
 		'transactions': [message_transaction, prefund_transaction]
 	})
 	# Calculate total fee, reserving space for a cosignature
-	cosignature_size = sc.Cosignature().size
-	transaction.fee = sc.Amount(
-		fee_multiplier * (transaction.size + cosignature_size))
+	transaction.fee = Amount(
+		calculate_transaction_fee(transaction, fee_multiplier, 1))
 	# Update the prefund amount to match the total fee
 	prefund_transaction.mosaics[0].amount = transaction.fee
 	# Update the embedded transaction hashes
-	transaction.transactions_hash = sc.Hash256(
+	transaction.transactions_hash = Hash256(
 		facade.hash_embedded_transactions(
 			[message_transaction, prefund_transaction]).bytes)
 	# [<step-4]
@@ -118,9 +118,8 @@ def build_sponsored_message_transaction(recipient_address, message):
 		'transactions': [message_transaction, filler_transaction]
 	})
 	# Calculate total fee, reserving space for a cosignature
-	cosignature_size = sc.Cosignature().size
-	transaction.fee = sc.Amount(
-		fee_multiplier * (transaction.size + cosignature_size))
+	transaction.fee = Amount(
+		calculate_transaction_fee(transaction, fee_multiplier, 1))
 	# [<step-9]
 	# Sign the aggregate transaction using the app's signature [>step-10]
 	facade.transaction_factory.attach_signature(
@@ -141,8 +140,9 @@ try:
 	print(f'Fetching current network time from {time_path}')
 	with urllib.request.urlopen(f'{NODE_URL}{time_path}') as response:
 		response_json = json.loads(response.read().decode())
-		timestamp = NetworkTimestamp(int(
-			response_json['communicationTimestamps']['receiveTimestamp']))
+		receive_timestamp = (
+			response_json['communicationTimestamps']['receiveTimestamp'])
+		timestamp = NetworkTimestamp(int(receive_timestamp))
 		print(f'  Network time: {timestamp.timestamp} ms since nemesis')
 
 	# Fetch recommended fees

--- a/mkdocs/snippets/devbook/transactions/messages.mjs
+++ b/mkdocs/snippets/devbook/transactions/messages.mjs
@@ -3,6 +3,7 @@ import {
 	MessageEncoder,
 	NetworkTimestamp,
 	SymbolFacade,
+	calculateTransactionFee,
 	models
 } from 'symbol-sdk/symbol';
 
@@ -94,7 +95,7 @@ const plainTransaction = facade.transactionFactory.create({
 	message: plainMessage
 }); // [<step-2]
 plainTransaction.fee = new models.Amount(
-	feeMultiplier * plainTransaction.size);
+	calculateTransactionFee(plainTransaction, feeMultiplier));
 
 // Sign and announce the transaction
 const plainSignature = facade.signTransaction(
@@ -137,7 +138,8 @@ const secretMessage = new TextEncoder().encode(
 const encryptedPayload = senderMessageEncoder.encode(
 	recipientKeyPair.publicKey, secretMessage
 );
-console.log('Original message:', new TextDecoder().decode(secretMessage));
+console.log(
+	'Original message:', new TextDecoder().decode(secretMessage));
 console.log('Encrypted payload:',
 	Buffer.from(encryptedPayload).toString('hex'));
 
@@ -151,7 +153,7 @@ const encryptedTransaction = facade.transactionFactory.create({
 	message: encryptedPayload
 }); // [<step-4]
 encryptedTransaction.fee = new models.Amount(
-	feeMultiplier * encryptedTransaction.size);
+	calculateTransactionFee(encryptedTransaction, feeMultiplier));
 
 // Sign and announce the transaction
 const encryptedSignature = facade.signTransaction(

--- a/mkdocs/snippets/devbook/transactions/messages.py
+++ b/mkdocs/snippets/devbook/transactions/messages.py
@@ -8,6 +8,7 @@ from binascii import hexlify
 from symbolchain.CryptoTypes import PrivateKey, PublicKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
 from symbolchain.sc import Amount
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.MessageEncoder import MessageEncoder
 from symbolchain.symbol.Network import NetworkTimestamp
 
@@ -105,7 +106,8 @@ plain_transaction = facade.transaction_factory.create(
 		"message": plain_message,
 	}
 )  # [<step-2]
-plain_transaction.fee = Amount(fee_multiplier * plain_transaction.size)
+plain_transaction.fee = Amount(
+	calculate_transaction_fee(plain_transaction, fee_multiplier))
 
 # Sign and announce the transaction
 plain_signature = facade.sign_transaction(
@@ -170,7 +172,7 @@ encrypted_transaction = facade.transaction_factory.create(
 	}
 )  # [<step-4]
 encrypted_transaction.fee = Amount(
-	fee_multiplier * encrypted_transaction.size)
+	calculate_transaction_fee(encrypted_transaction, fee_multiplier))
 
 # Sign and announce the transaction
 encrypted_signature = facade.sign_transaction(

--- a/mkdocs/snippets/devbook/transactions/monitoring_status.mjs
+++ b/mkdocs/snippets/devbook/transactions/monitoring_status.mjs
@@ -10,7 +10,7 @@ const transactionHash = process.env.TRANSACTION_HASH || // [>step-1]
 console.log(`Monitoring transaction: ${transactionHash}`);
 // [>step-2]
 /**
- * Poll the transaction status endpoint until the transaction is confirmed.
+ * Poll the transaction status endpoint until it is confirmed.
  * @param {string} txHash - The hash of the transaction to monitor
  * @param {number} maxAttempts - Maximum number of polling attempts
  *   for confirmation
@@ -29,7 +29,8 @@ async function waitForTransactionConfirmation(
 	for (let attempt = 1; attempt <= maxAttempts; attempt++) {
 		try {
 			// Query the transaction status endpoint
-			const statusResponse = await fetch(`${NODE_URL}${statusPath}`);
+			const statusResponse =
+				await fetch(`${NODE_URL}${statusPath}`);
 
 			if (!statusResponse.ok) {
 				const status = statusResponse.status;

--- a/mkdocs/snippets/devbook/transactions/sign_multisig.mjs
+++ b/mkdocs/snippets/devbook/transactions/sign_multisig.mjs
@@ -2,6 +2,7 @@ import { PrivateKey } from 'symbol-sdk';
 import {
 	NetworkTimestamp,
 	SymbolFacade,
+	calculateTransactionFee,
 	generateMosaicAliasId,
 	models
 } from 'symbol-sdk/symbol';
@@ -14,8 +15,8 @@ const MULTISIG_PRIVATE_KEY = process.env.MULTISIG_PRIVATE_KEY || (
 const multisigKeyPair = new SymbolFacade.KeyPair(
 	new PrivateKey(MULTISIG_PRIVATE_KEY));
 console.log(`Multisig public key: ${multisigKeyPair.publicKey}`);
-const COSIGNATORY0_PRIVATE_KEY = process.env.COSIGNATORY0_PRIVATE_KEY || (
-	'0000000000000000000000000000000000000000000000000000000000000002');
+const COSIGNATORY0_PRIVATE_KEY = process.env.COSIGNATORY0_PRIVATE_KEY ||
+	'0000000000000000000000000000000000000000000000000000000000000002';
 const cosignatoryKeyPair = new SymbolFacade.KeyPair(
 	new PrivateKey(COSIGNATORY0_PRIVATE_KEY));
 console.log(`Cosignatory public key: ${cosignatoryKeyPair.publicKey}`);
@@ -44,16 +45,17 @@ try {
 	console.log('  Fee multiplier:', feeMultiplier);
 	// [<step-2]
 	// Build the embedded transfer transaction [>step-3]
-	const transferTransaction = facade.transactionFactory.createEmbedded({
-		type: 'transfer_transaction_v1',
-		signerPublicKey: multisigKeyPair.publicKey.toString(),
-		recipientAddress: facade.network.publicKeyToAddress(
-			multisigKeyPair.publicKey).toString(),
-		mosaics: [{
-			mosaicId: generateMosaicAliasId('symbol.xym'),
-			amount: 1_000_000n // 1 XYM
-		}]
-	});
+	const transferTransaction =
+		facade.transactionFactory.createEmbedded({
+			type: 'transfer_transaction_v1',
+			signerPublicKey: multisigKeyPair.publicKey.toString(),
+			recipientAddress: facade.network.publicKeyToAddress(
+				multisigKeyPair.publicKey).toString(),
+			mosaics: [{
+				mosaicId: generateMosaicAliasId('symbol.xym'),
+				amount: 1_000_000n // 1 XYM
+			}]
+		});
 	// [<step-3]
 	// Build the wrapper aggregate transaction [>step-4]
 	const transaction = facade.transactionFactory.create({
@@ -65,7 +67,8 @@ try {
 			[transferTransaction]),
 		transactions: [transferTransaction]
 	});
-	transaction.fee = new models.Amount(feeMultiplier * transaction.size);
+	transaction.fee = new models.Amount(
+		calculateTransactionFee(transaction, feeMultiplier));
 	// [<step-4]
 	// Sign the aggregate transaction using the cosignatory's signature [>step-5]
 	const jsonPayload = facade.transactionFactory.static.attachSignature(
@@ -85,7 +88,8 @@ try {
 	console.log('  Response:', await announceResponse.text());
 
 	// Wait for confirmation
-	const transactionHash = facade.hashTransaction(transaction).toString();
+	const transactionHash =
+		facade.hashTransaction(transaction).toString();
 	const statusPath = `/transactionStatus/${transactionHash}`;
 	console.log('Waiting for confirmation from', statusPath);
 

--- a/mkdocs/snippets/devbook/transactions/sign_multisig.py
+++ b/mkdocs/snippets/devbook/transactions/sign_multisig.py
@@ -6,6 +6,7 @@ import urllib.request
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
 from symbolchain.sc import Amount
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.IdGenerator import generate_mosaic_alias_id
 from symbolchain.symbol.Network import NetworkTimestamp
 
@@ -34,8 +35,9 @@ try:
 	print(f'Fetching current network time from {time_path}')
 	with urllib.request.urlopen(f'{NODE_URL}{time_path}') as response:
 		response_json = json.loads(response.read().decode())
-		timestamp = NetworkTimestamp(int(
-			response_json['communicationTimestamps']['receiveTimestamp']))
+		receive_timestamp = (
+			response_json['communicationTimestamps']['receiveTimestamp'])
+		timestamp = NetworkTimestamp(int(receive_timestamp))
 		print(f'  Network time: {timestamp.timestamp} ms since nemesis')
 
 	# Fetch recommended fees
@@ -71,7 +73,8 @@ try:
 			[transfer_transaction]),
 		'transactions': [transfer_transaction]
 	})
-	transaction.fee = Amount(fee_multiplier * transaction.size)
+	transaction.fee = Amount(
+		calculate_transaction_fee(transaction, fee_multiplier))
 	# [<step-4]
 	# Sign the aggregate transaction using the cosignatory's signature [>step-5]
 	json_payload = facade.transaction_factory.attach_signature(

--- a/mkdocs/snippets/devbook/transactions/transaction_batching.mjs
+++ b/mkdocs/snippets/devbook/transactions/transaction_batching.mjs
@@ -3,6 +3,7 @@ import {
 	Address,
 	NetworkTimestamp,
 	SymbolFacade,
+	calculateTransactionFee,
 	generateMosaicAliasId,
 	models
 } from 'symbol-sdk/symbol';
@@ -88,7 +89,7 @@ try {
 		transactions: embeddedTransactions
 	});
 	transaction.fee = new models.Amount(
-		feeMultiplier * transaction.size);
+		calculateTransactionFee(transaction, feeMultiplier));
 	console.log('Built aggregate transaction:');
 	console.log(JSON.stringify(transaction.toJson(), null, 2));
 	// [<step-4]
@@ -110,7 +111,8 @@ try {
 	console.log('  Response:', await announceResponse.text());
 	// [<step-5]
 	// Wait for confirmation [>step-6]
-	const transactionHash = facade.hashTransaction(transaction).toString();
+	const transactionHash =
+		facade.hashTransaction(transaction).toString();
 	const statusPath = `/transactionStatus/${transactionHash}`;
 	console.log('Waiting for confirmation from', statusPath);
 

--- a/mkdocs/snippets/devbook/transactions/transaction_batching.py
+++ b/mkdocs/snippets/devbook/transactions/transaction_batching.py
@@ -6,6 +6,7 @@ import urllib.request
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
 from symbolchain.sc import Amount
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.IdGenerator import generate_mosaic_alias_id
 from symbolchain.symbol.Network import Address, NetworkTimestamp
 
@@ -87,7 +88,8 @@ try:
 			facade.hash_embedded_transactions(embedded_transactions),
 		'transactions': embedded_transactions
 	})
-	transaction.fee = Amount(fee_multiplier * transaction.size)
+	transaction.fee = Amount(
+		calculate_transaction_fee(transaction, fee_multiplier))
 	print('Built aggregate transaction:')
 	print(json.dumps(transaction.to_json(), indent=2))
 	# [<step-4]

--- a/mkdocs/snippets/devbook/transactions/transfer.mjs
+++ b/mkdocs/snippets/devbook/transactions/transfer.mjs
@@ -2,6 +2,7 @@ import { PrivateKey } from 'symbol-sdk';
 import {
 	NetworkTimestamp,
 	SymbolFacade,
+	calculateTransactionFee,
 	generateMosaicAliasId,
 	models
 } from 'symbol-sdk/symbol';
@@ -50,7 +51,8 @@ try {
 			amount: 1_000_000n // 1 XYM
 		}]
 	});
-	transaction.fee = new models.Amount(feeMultiplier * transaction.size);
+	transaction.fee = new models.Amount(
+		calculateTransactionFee(transaction, feeMultiplier));
 	// [<step-4]
 	// Sign transaction and generate final payload [>step-5]
 	const signature = facade.signTransaction(signerKeyPair, transaction);
@@ -70,7 +72,8 @@ try {
 	console.log('  Response:', await announceResponse.text());
 	// [<step-6]
 	// Wait for confirmation [>step-7]
-	const transactionHash = facade.hashTransaction(transaction).toString();
+	const transactionHash =
+		facade.hashTransaction(transaction).toString();
 	const statusPath = `/transactionStatus/${transactionHash}`;
 	console.log('Waiting for confirmation from', statusPath);
 

--- a/mkdocs/snippets/devbook/transactions/transfer.py
+++ b/mkdocs/snippets/devbook/transactions/transfer.py
@@ -6,6 +6,7 @@ import urllib.request
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
 from symbolchain.sc import Amount
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.IdGenerator import generate_mosaic_alias_id
 from symbolchain.symbol.Network import NetworkTimestamp
 
@@ -25,8 +26,9 @@ try:
 	print(f'Fetching current network time from {time_path}')
 	with urllib.request.urlopen(f'{NODE_URL}{time_path}') as response:
 		response_json = json.loads(response.read().decode())
-		timestamp = NetworkTimestamp(int(
-			response_json['communicationTimestamps']['receiveTimestamp']))
+		receive_timestamp = (
+			response_json['communicationTimestamps']['receiveTimestamp'])
+		timestamp = NetworkTimestamp(int(receive_timestamp))
 		print(f'  Network time: {timestamp.timestamp} ms since nemesis')
 	# [<step-2]
 	# Fetch recommended fees [>step-3]
@@ -52,7 +54,8 @@ try:
 			'amount': 1_000_000  # 1 XYM
 		}]
 	})
-	transaction.fee = Amount(fee_multiplier * transaction.size)
+	transaction.fee = Amount(
+		calculate_transaction_fee(transaction, fee_multiplier))
 	# [<step-4]
 	# Sign transaction and generate final payload [>step-5]
 	signature = facade.sign_transaction(signer_key_pair, transaction)

--- a/mkdocs/snippets/devbook/transactions/transfer.typed.mjs
+++ b/mkdocs/snippets/devbook/transactions/transfer.typed.mjs
@@ -2,6 +2,7 @@ import { PrivateKey } from 'symbol-sdk';
 import {
 	NetworkTimestamp,
 	SymbolFacade,
+	calculateTransactionFee,
 	descriptors,
 	generateMosaicAliasId,
 	models
@@ -52,7 +53,8 @@ try {
 		);
 	const transaction = facade.createTransactionFromTypedDescriptor(
 		typedDescriptor, signerKeyPair.publicKey, 0, 2 * 60 * 60);
-	transaction.fee = new models.Amount(feeMultiplier * transaction.size);
+	transaction.fee = new models.Amount(
+		calculateTransactionFee(transaction, feeMultiplier));
 
 	// Sign transaction and generate final payload
 	const signature = facade.signTransaction(signerKeyPair, transaction);

--- a/mkdocs/snippets/devbook/websockets/listen_bonded_transaction_flow.mjs
+++ b/mkdocs/snippets/devbook/websockets/listen_bonded_transaction_flow.mjs
@@ -2,6 +2,7 @@ import { Hash256, PrivateKey } from 'symbol-sdk';
 import {
 	NetworkTimestamp,
 	SymbolFacade,
+	calculateTransactionFee,
 	generateMosaicAliasId,
 	models
 } from 'symbol-sdk/symbol';
@@ -71,9 +72,8 @@ try {
 			facade.static.hashEmbeddedTransactions(embeddedTxs),
 		transactions: embeddedTxs
 	});
-	const cosignatureSize = new models.Cosignature().size;
 	bondedTx.fee = new models.Amount(
-		feeMultiplier * (bondedTx.size + cosignatureSize));
+		calculateTransactionFee(bondedTx, feeMultiplier, 1));
 
 	// Sign the bonded aggregate
 	const bondedSignature = facade.signTransaction(
@@ -97,7 +97,8 @@ try {
 		duration: 100n,
 		hash: bondedHash
 	});
-	hashLock.fee = new models.Amount(feeMultiplier * hashLock.size);
+	hashLock.fee = new models.Amount(
+		calculateTransactionFee(hashLock, feeMultiplier));
 	const hashLockSignature = facade.signTransaction(
 		accountAKeyPair, hashLock);
 	const hashLockPayload = facade.transactionFactory
@@ -146,7 +147,8 @@ try {
 				resolve();
 			}
 
-			if ('status' === name && message.data.hash === hashLockHash) {
+			if ('status' === name &&
+				message.data.hash === hashLockHash) {
 				reject(new Error(
 					`Hash lock failed: ${message.data.code}`));
 			}

--- a/mkdocs/snippets/devbook/websockets/listen_bonded_transaction_flow.py
+++ b/mkdocs/snippets/devbook/websockets/listen_bonded_transaction_flow.py
@@ -5,7 +5,8 @@ import urllib.request
 
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
-from symbolchain.sc import Amount, Cosignature
+from symbolchain.sc import Amount
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.IdGenerator import generate_mosaic_alias_id
 from symbolchain.symbol.Network import NetworkTimestamp
 from websockets import connect
@@ -86,9 +87,8 @@ async def main():
 			embedded_txs),
 		'transactions': embedded_txs
 	})
-	cosignature_size = Cosignature().size
 	bonded_tx.fee = Amount(
-		fee_multiplier * (bonded_tx.size + cosignature_size))
+		calculate_transaction_fee(bonded_tx, fee_multiplier, 1))
 
 	# Sign the bonded aggregate
 	bonded_signature = facade.sign_transaction(
@@ -112,7 +112,8 @@ async def main():
 		'duration': 100,
 		'hash': bonded_hash
 	})
-	hash_lock.fee = Amount(fee_multiplier * hash_lock.size)
+	hash_lock.fee = Amount(
+		calculate_transaction_fee(hash_lock, fee_multiplier))
 	hash_lock_signature = facade.sign_transaction(
 		account_a_key_pair, hash_lock)
 	hash_lock_payload = facade.transaction_factory.attach_signature(

--- a/mkdocs/snippets/devbook/websockets/listen_new_blocks.mjs
+++ b/mkdocs/snippets/devbook/websockets/listen_new_blocks.mjs
@@ -33,7 +33,8 @@ try {
 			const blockMeta = message.data.meta;
 			console.log(
 				'New block:' +
-				` height=${parseInt(block.height, 10).toLocaleString()}` +
+				' height=' +
+				`${parseInt(block.height, 10).toLocaleString()}` +
 				` hash=${blockMeta.hash.substring(0, 16)}...`
 			);
 		}

--- a/mkdocs/snippets/devbook/websockets/listen_transaction_error.mjs
+++ b/mkdocs/snippets/devbook/websockets/listen_transaction_error.mjs
@@ -2,6 +2,7 @@ import { PrivateKey } from 'symbol-sdk';
 import {
 	NetworkTimestamp,
 	SymbolFacade,
+	calculateTransactionFee,
 	generateMosaicAliasId,
 	models
 } from 'symbol-sdk/symbol';
@@ -59,12 +60,14 @@ try {
 			amount: 1n
 		}]
 	});
-	transaction.fee = new models.Amount(feeMultiplier * transaction.size);
+	transaction.fee = new models.Amount(
+		calculateTransactionFee(transaction, feeMultiplier));
 
 	const signature = facade.signTransaction(signerKeyPair, transaction);
 	const jsonPayload = facade.transactionFactory.static.attachSignature(
 		transaction, signature);
-	const transactionHash = facade.hashTransaction(transaction).toString(); // [<step-4]
+	const transactionHash =
+		facade.hashTransaction(transaction).toString(); // [<step-4]
 	// [>step-5]
 	const rejected = new Promise(resolve => {
 		websocket.addEventListener('message', event => {

--- a/mkdocs/snippets/devbook/websockets/listen_transaction_error.py
+++ b/mkdocs/snippets/devbook/websockets/listen_transaction_error.py
@@ -6,6 +6,7 @@ import urllib.request
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
 from symbolchain.sc import Amount
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.IdGenerator import generate_mosaic_alias_id
 from symbolchain.symbol.Network import NetworkTimestamp
 from websockets import connect
@@ -41,8 +42,9 @@ async def main():
 		# Build a transfer transaction with a non-existent mosaic [>step-4]
 		with urllib.request.urlopen(f'{NODE_URL}/node/time') as resp:
 			time_json = json.loads(resp.read().decode())
-			timestamp = NetworkTimestamp(int(
-				time_json['communicationTimestamps']['receiveTimestamp']))
+			receive_timestamp = (
+				time_json['communicationTimestamps']['receiveTimestamp'])
+			timestamp = NetworkTimestamp(int(receive_timestamp))
 
 		with urllib.request.urlopen(
 			f'{NODE_URL}/network/fees/transaction'
@@ -62,7 +64,8 @@ async def main():
 				'amount': 1
 			}],
 		})
-		transaction.fee = Amount(fee_multiplier * transaction.size)
+		transaction.fee = Amount(
+			calculate_transaction_fee(transaction, fee_multiplier))
 
 		signature = facade.sign_transaction(signer_key_pair, transaction)
 		json_payload = facade.transaction_factory.attach_signature(

--- a/mkdocs/snippets/devbook/websockets/listen_transaction_flow.mjs
+++ b/mkdocs/snippets/devbook/websockets/listen_transaction_flow.mjs
@@ -1,5 +1,10 @@
 import { PrivateKey } from 'symbol-sdk';
-import { NetworkTimestamp, SymbolFacade, models } from 'symbol-sdk/symbol';
+import {
+	NetworkTimestamp,
+	SymbolFacade,
+	calculateTransactionFee,
+	models
+} from 'symbol-sdk/symbol';
 
 const NODE_URL = process.env.NODE_URL ||
 	'https://reference.symboltest.net:3001';
@@ -57,12 +62,14 @@ try {
 		deadline: timestamp.addHours(2).timestamp,
 		recipientAddress: MONITOR_ADDRESS
 	});
-	transaction.fee = new models.Amount(feeMultiplier * transaction.size);
+	transaction.fee = new models.Amount(
+		calculateTransactionFee(transaction, feeMultiplier));
 
 	const signature = facade.signTransaction(signerKeyPair, transaction);
 	const jsonPayload = facade.transactionFactory.static.attachSignature(
 		transaction, signature);
-	const transactionHash = facade.hashTransaction(transaction).toString(); // [<step-4]
+	const transactionHash =
+		facade.hashTransaction(transaction).toString(); // [<step-4]
 	// [>step-5]
 	const confirmed = new Promise(resolve => {
 		websocket.addEventListener('message', event => {

--- a/mkdocs/snippets/devbook/websockets/listen_transaction_flow.py
+++ b/mkdocs/snippets/devbook/websockets/listen_transaction_flow.py
@@ -6,6 +6,7 @@ import urllib.request
 from symbolchain.CryptoTypes import PrivateKey
 from symbolchain.facade.SymbolFacade import SymbolFacade
 from symbolchain.sc import Amount
+from symbolchain.symbol.FeeCalculator import calculate_transaction_fee
 from symbolchain.symbol.Network import NetworkTimestamp
 from websockets import connect
 
@@ -50,8 +51,9 @@ async def main():
 		# Build and announce a transfer transaction [>step-4]
 		with urllib.request.urlopen(f'{NODE_URL}/node/time') as resp:
 			time_json = json.loads(resp.read().decode())
-			timestamp = NetworkTimestamp(int(
-				time_json['communicationTimestamps']['receiveTimestamp']))
+			receive_timestamp = (
+				time_json['communicationTimestamps']['receiveTimestamp'])
+			timestamp = NetworkTimestamp(int(receive_timestamp))
 
 		with urllib.request.urlopen(
 			f'{NODE_URL}/network/fees/transaction'
@@ -67,7 +69,8 @@ async def main():
 			'deadline': timestamp.add_hours(2).timestamp,
 			'recipient_address': MONITOR_ADDRESS,
 		})
-		transaction.fee = Amount(fee_multiplier * transaction.size)
+		transaction.fee = Amount(
+			calculate_transaction_fee(transaction, fee_multiplier))
 
 		signature = facade.sign_transaction(signer_key_pair, transaction)
 		json_payload = facade.transaction_factory.attach_signature(
@@ -94,7 +97,8 @@ async def main():
 
 			if (name == 'confirmedAdded' and
 					message_hash == transaction_hash):
-				print(f'Transaction {transaction_hash[:16]}... confirmed')
+				print(
+					f'Transaction {transaction_hash[:16]}... confirmed')
 				break
 		# [<step-5]
 		# Unsubscribe before closing [>step-6]


### PR DESCRIPTION
Replaces the manual fee calculation in every devbook tutorial snippet with the SDK's `calculate_transaction_fee' helper.

It also wraps any snippet line over 74 characters so the rendered code blocks no longer show a horizontal scrollbar.