### PR TITLE
[sdk/java] fix: symbol fee calculation with cosigners

### DIFF
--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/FeeCalculator.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/FeeCalculator.java
@@ -32,6 +32,6 @@ public final class FeeCalculator {
 	 * @return Transaction fee.
 	 */
 	public static long calculateTransactionFee(final Transaction transaction, final long feeMultiplier, final int cosignatureCount) {
-		return (long) transaction.size() * feeMultiplier + COSIGNATURE_SIZE * cosignatureCount;
+		return (transaction.size() + COSIGNATURE_SIZE * cosignatureCount) * feeMultiplier;
 	}
 }

--- a/sdk/java/src/test/java/org/symbol/sdk/symbol/FeeCalculatorTest.java
+++ b/sdk/java/src/test/java/org/symbol/sdk/symbol/FeeCalculatorTest.java
@@ -52,8 +52,8 @@ final class FeeCalculatorTest {
 		final long fee200 = FeeCalculator.calculateTransactionFee(transaction, 200, 5);
 
 		// Assert: transfer size is 160, cosignature size is 104
-		assertThat(fee100, equalTo(16000L + 312L));
-		assertThat(fee150, equalTo(24000L + 416L));
-		assertThat(fee200, equalTo(32000L + 520L));
+		assertThat(fee100, equalTo((160L + 312L) * 100L));
+		assertThat(fee150, equalTo((160L + 416L) * 150L));
+		assertThat(fee200, equalTo((160L + 520L) * 200L));
 	}
 }


### PR DESCRIPTION
problem: cosignature size was not multiplied by fee multiplier
solution: add transaction and cosignature size, then multiply by the fee multiplier
