### PR TITLE
[monorepo] fix: CodeQL fail on Java

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -31,6 +31,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
+      - uses: actions/setup-java@v6
+        with:
+          distribution: zulu
+          java-version: 21
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -42,15 +42,7 @@ jobs:
         with:
           languages: ${{ matrix.language }}
 
-      # Java: build explicitly
-      - name: Build Java
-        if: matrix.language == 'java'
-        run: |
-          ./gradlew --no-daemon clean assemble
-
-      # Keep autobuild for interpreted / non-custom cases if desired
-      - name: Autobuild (non-Java)
-        if: matrix.language != 'java'
+      - name: Autobuild
         uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -37,9 +37,15 @@ jobs:
         with:
           languages: ${{ matrix.language }}
 
-      # Autobuild attempts to build any compiled languages (C/C++, C#, Go, Java, or Swift).
-      # If this step fails, then you should remove it and run the build manually (see below)
-      - name: Autobuild
+      # Java: build explicitly
+      - name: Build Java
+        if: matrix.language == 'java'
+        run: |
+          ./gradlew --no-daemon clean assemble
+
+      # Keep autobuild for interpreted / non-custom cases if desired
+      - name: Autobuild (non-Java)
+        if: matrix.language != 'java'
         uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - uses: actions/setup-java@v6
+      - uses: actions/setup-java@v5
         with:
           distribution: zulu
           java-version: 21

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -42,11 +42,12 @@ jobs:
         with:
           languages: ${{ matrix.language }}
 
-      # Java: build explicitly
+      # Java: build explicitly (the Gradle project lives in sdk/java, not the repo root)
       - name: Build Java
         if: matrix.language == 'java'
+        working-directory: sdk/java
         run: |
-          gradle --no-daemon clean assemble
+          ./gradlew --no-daemon clean assemble
 
       # Keep autobuild for interpreted / non-custom cases if desired
       - name: Autobuild (non-Java)

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -42,7 +42,15 @@ jobs:
         with:
           languages: ${{ matrix.language }}
 
-      - name: Autobuild
+      # Java: build explicitly
+      - name: Build Java
+        if: matrix.language == 'java'
+        run: |
+          gradle --no-daemon clean assemble
+
+      # Keep autobuild for interpreted / non-custom cases if desired
+      - name: Autobuild (non-Java)
+        if: matrix.language != 'java'
         uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis


### PR DESCRIPTION
problem: CodeQL does not know how to build a Java project
solution: add a build-specific Java build command
