### PR TITLE
[catbuffer] fix: unterminated bold text in docs

### DIFF
--- a/catbuffer/schemas/symbol/lock_hash/hash_lock.cats
+++ b/catbuffer/schemas/symbol/lock_hash/hash_lock.cats
@@ -22,7 +22,7 @@ inline struct HashLockTransactionBody
 #
 # Upon completion of the aggregate, the locked funds become available again to the account that signed the HashLockTransaction.
 #
-# If the lock expires before the aggregate is signed by all cosignatories (**48h by default),
+# If the lock expires before the aggregate is signed by all cosignatories (**48h** by default),
 # the locked funds become a reward collected by the block harvester at the height where the lock expires.
 #
 # \note It is not necessary to sign the aggregate and its HashLockTransaction with the same account.

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/HashLockTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/HashLockTransactionV1Descriptor.java
@@ -16,7 +16,7 @@ import org.symbol.sdk.symbol.models.BlockDuration;
  * it is stored in every node's partial cache while it waits to be fully signed. To avoid spam attacks a HashLockTransaction must be
  * announced and confirmed before an AggregateBondedTransaction can be announced. The HashLockTransaction locks a certain amount of funds
  * (**10** XYM by default) until the aggregate is signed. Upon completion of the aggregate, the locked funds become available again to the
- * account that signed the HashLockTransaction. If the lock expires before the aggregate is signed by all cosignatories (**48h by default),
+ * account that signed the HashLockTransaction. If the lock expires before the aggregate is signed by all cosignatories (**48h** by default),
  * the locked funds become a reward collected by the block harvester at the height where the lock expires. \note It is not necessary to sign
  * the aggregate and its HashLockTransaction with the same account. For example, if Bob wants to announce an aggregate and does not have
  * enough funds to announce a HashLockTransaction, he can ask Alice to announce the lock transaction for him by sharing the signed

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/HashLockTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/HashLockTransactionV1Descriptor.java
@@ -16,11 +16,11 @@ import org.symbol.sdk.symbol.models.BlockDuration;
  * it is stored in every node's partial cache while it waits to be fully signed. To avoid spam attacks a HashLockTransaction must be
  * announced and confirmed before an AggregateBondedTransaction can be announced. The HashLockTransaction locks a certain amount of funds
  * (**10** XYM by default) until the aggregate is signed. Upon completion of the aggregate, the locked funds become available again to the
- * account that signed the HashLockTransaction. If the lock expires before the aggregate is signed by all cosignatories (**48h** by default),
- * the locked funds become a reward collected by the block harvester at the height where the lock expires. \note It is not necessary to sign
- * the aggregate and its HashLockTransaction with the same account. For example, if Bob wants to announce an aggregate and does not have
- * enough funds to announce a HashLockTransaction, he can ask Alice to announce the lock transaction for him by sharing the signed
- * AggregateTransaction hash.
+ * account that signed the HashLockTransaction. If the lock expires before the aggregate is signed by all cosignatories (**48h** by
+ * default), the locked funds become a reward collected by the block harvester at the height where the lock expires. \note It is not
+ * necessary to sign the aggregate and its HashLockTransaction with the same account. For example, if Bob wants to announce an aggregate and
+ * does not have enough funds to announce a HashLockTransaction, he can ask Alice to announce the lock transaction for him by sharing the
+ * signed AggregateTransaction hash.
  */
 public final class HashLockTransactionV1Descriptor implements SymbolTransactionDescriptor {
 	private final Map<String, Object> rawDescriptor;

--- a/sdk/javascript/src/symbol/models_ts.js
+++ b/sdk/javascript/src/symbol/models_ts.js
@@ -482,7 +482,7 @@ export class VrfKeyLinkTransactionV1Descriptor {
  * Lock a deposit needed to announce an AggregateBondedTransaction (V1, latest).
  * An AggregateBondedTransaction consumes network resources as it is stored in every node's partial cache while it waits to be fully signed. To avoid spam attacks a HashLockTransaction must be announced and confirmed before an AggregateBondedTransaction can be announced. The HashLockTransaction locks a certain amount of funds (**10** XYM by default) until the aggregate is signed.
  * Upon completion of the aggregate, the locked funds become available again to the account that signed the HashLockTransaction.
- * If the lock expires before the aggregate is signed by all cosignatories (**48h by default), the locked funds become a reward collected by the block harvester at the height where the lock expires.
+ * If the lock expires before the aggregate is signed by all cosignatories (**48h** by default), the locked funds become a reward collected by the block harvester at the height where the lock expires.
  * \note It is not necessary to sign the aggregate and its HashLockTransaction with the same account. For example, if Bob wants to announce an aggregate and does not have enough funds to announce a HashLockTransaction, he can ask Alice to announce the lock transaction for him by sharing the signed AggregateTransaction hash.
  */
 export class HashLockTransactionV1Descriptor {


### PR DESCRIPTION
This was breaking docs rendering.
