### PR TITLE
[sdk/java] fix: create a single ctor for descriptors

### DIFF
--- a/sdk/java/README.md
+++ b/sdk/java/README.md
@@ -136,12 +136,15 @@ The SDK exposes two descriptor surfaces:
 ## Usage
 
 ```java
+import java.util.List;
+
 import org.symbol.sdk.CryptoTypes;
 import org.symbol.sdk.facade.SymbolFacade;
 import org.symbol.sdk.symbol.Address;
 import org.symbol.sdk.symbol.descriptors.TransferTransactionV1Descriptor;
 import org.symbol.sdk.symbol.descriptors.UnresolvedMosaicDescriptor;
 import org.symbol.sdk.symbol.models.Amount;
+import org.symbol.sdk.symbol.models.EmbeddedTransaction;
 import org.symbol.sdk.symbol.models.Signature;
 import org.symbol.sdk.symbol.models.Transaction;
 import org.symbol.sdk.symbol.models.UnresolvedMosaicId;
@@ -150,32 +153,19 @@ SymbolFacade facade = new SymbolFacade("testnet");
 SymbolFacade.SymbolAccount account = facade.createAccount(
         new CryptoTypes.PrivateKey("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
 
-// Each descriptor takes its required fields as constructor arguments and exposes a fluent
-// setter for every optional field. Both the constructor and the setters come in a typed and a
-// string-parsing flavour (nested descriptors included), and array setters accept a List or varargs.
-
-// 1. typed form — pass the SDK types directly
+// Each descriptor takes every field as a constructor argument — required fields first, then
+// optional fields, which may be null (a null optional is omitted from the descriptor). For
+// string-driven construction, use the JSON path below.
 TransferTransactionV1Descriptor descriptor = new TransferTransactionV1Descriptor(
-        new Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"))
-        .mosaics(new UnresolvedMosaicDescriptor(
+        new Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"),
+        List.of(new UnresolvedMosaicDescriptor(
                 new UnresolvedMosaicId(0x7CDF3B117A3C40CCL),
-                new Amount(1_000_000L)))
-        .message("hello symbol".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+                new Amount(1_000_000L))),
+        "hello symbol".getBytes(java.nio.charset.StandardCharsets.UTF_8));
 
-// 2. string form — every field accepts its canonical string form, nested descriptors included.
-//    Integer ids accept 0x-prefixed hex (or decimal); amounts are usually given in decimal.
-TransferTransactionV1Descriptor stringDescriptor = new TransferTransactionV1Descriptor(
-        "TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I")
-        .mosaics(new UnresolvedMosaicDescriptor("0x7CDF3B117A3C40CC", "1000000"))
-        .message("hello symbol");
-
-// 3. array input — pass multiple elements as varargs (or a List) to the array setter
-TransferTransactionV1Descriptor multiMosaicDescriptor = new TransferTransactionV1Descriptor(
-        "TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I")
-        .mosaics(
-                new UnresolvedMosaicDescriptor("0x7CDF3B117A3C40CC", "1000000"),
-                new UnresolvedMosaicDescriptor("0x1F031D8D3905B931", "5"))
-        .message("hello symbol");
+// optional fields may be null — a transfer with no mosaics and no message
+TransferTransactionV1Descriptor minimalDescriptor = new TransferTransactionV1Descriptor(
+        new Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"), /* mosaics */ null, /* message */ null);
 
 Transaction transaction = facade.createTransactionFromTypedDescriptor(
         descriptor, account.publicKey(), /* feeMultiplier */ 100L, /* deadlineSeconds */ 60L);
@@ -201,6 +191,10 @@ String json = """
         }""";
 Transaction jsonTransaction = facade.createTransactionFromJson(
         json, account.publicKey(), /* feeMultiplier */ 100L, /* deadlineSeconds */ 60L);
+
+// the same document also creates an embedded transaction (for use inside an aggregate);
+// embedded transactions carry no fee or deadline, so only the signer is needed
+EmbeddedTransaction jsonEmbedded = facade.createEmbeddedTransactionFromJson(json, account.publicKey());
 ```
 
 A raw `Map<String, Object>` descriptor works through `facade.transactionFactory.create(map)` — identical
@@ -210,21 +204,24 @@ for the typed / JSON / map paths side by side.
 ### NEM
 
 NEM works the same way via `NemFacade`, except the fee is an absolute `long` rather than a
-fee multiplier. Descriptors and their setters share the same typed/string flavours:
+fee multiplier:
 
 ```java
 import org.symbol.sdk.facade.NemFacade;
+import org.symbol.sdk.nem.Address;
 import org.symbol.sdk.nem.descriptors.MessageDescriptor;
 import org.symbol.sdk.nem.descriptors.TransferTransactionV1Descriptor; // note: nem.descriptors
+import org.symbol.sdk.nem.models.Amount;
+import org.symbol.sdk.nem.models.MessageType;
 
 NemFacade nemFacade = new NemFacade("testnet");
 NemFacade.NemAccount nemAccount = nemFacade.createAccount(
         new CryptoTypes.PrivateKey("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
 
-// string form: base32 address, decimal amount, nested message descriptor
+// base32 address, amount, nested message descriptor (optional — may be null)
 TransferTransactionV1Descriptor nemTransfer = new TransferTransactionV1Descriptor(
-        "TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C", "5000000")
-        .message(new MessageDescriptor("plain").message("hello nem"));
+        new Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C"), new Amount(5_000_000L),
+        new MessageDescriptor(MessageType.PLAIN, "hello nem".getBytes(java.nio.charset.StandardCharsets.UTF_8)));
 
 Transaction nemTransaction = nemFacade.createTransactionFromTypedDescriptor(
         nemTransfer, nemAccount.publicKey(),

--- a/sdk/java/examples/src/main/java/org/symbol/examples/TransactionAggregate.java
+++ b/sdk/java/examples/src/main/java/org/symbol/examples/TransactionAggregate.java
@@ -13,6 +13,8 @@ import org.symbol.sdk.symbol.KeyPair;
 import org.symbol.sdk.symbol.SymbolTransactionFactory;
 import org.symbol.sdk.symbol.descriptors.AggregateCompleteTransactionV3Descriptor;
 import org.symbol.sdk.symbol.descriptors.TransferTransactionV1Descriptor;
+import org.symbol.sdk.symbol.descriptors.UnresolvedMosaicDescriptor;
+import org.symbol.sdk.symbol.models.Cosignature;
 import org.symbol.sdk.symbol.models.EmbeddedTransaction;
 import org.symbol.sdk.symbol.models.EmbeddedTransferTransactionV1;
 import org.symbol.sdk.symbol.models.Transaction;
@@ -39,7 +41,7 @@ public final class TransactionAggregate {
 			// and other tools that treat messages starting with 00 byte as "plain text"
 			final byte[] prefixed = ArrayHelpers.concat(new byte[1], messageBytes);
 
-			final TransferTransactionV1Descriptor descriptor = new TransferTransactionV1Descriptor(recipientAddress, /* mosaics */ null, prefixed);
+			final TransferTransactionV1Descriptor descriptor = new TransferTransactionV1Descriptor(recipientAddress, (List<UnresolvedMosaicDescriptor>) null, prefixed);
 			final EmbeddedTransferTransactionV1 embeddedTransaction = (EmbeddedTransferTransactionV1) facade
 					.createEmbeddedTransactionFromTypedDescriptor(descriptor, publicKey);
 
@@ -65,7 +67,7 @@ public final class TransactionAggregate {
 		final CryptoTypes.Hash256 merkleHash = SymbolFacade.hashEmbeddedTransactions(embeddedTransactions);
 
 		final AggregateCompleteTransactionV3Descriptor aggregateDescriptor = new AggregateCompleteTransactionV3Descriptor(merkleHash,
-				embeddedTransactions, /* cosignatures */ null);
+				embeddedTransactions, (List<Cosignature>) null);
 		// pin deterministic header values in the descriptor (like the JS / Python examples) so the output stays comparable
 		final Map<String, Object> aggregateMap = aggregateDescriptor.toMap();
 		aggregateMap.put("signerPublicKey", keyPair.getPublicKey());

--- a/sdk/java/examples/src/main/java/org/symbol/examples/TransactionAggregate.java
+++ b/sdk/java/examples/src/main/java/org/symbol/examples/TransactionAggregate.java
@@ -39,7 +39,7 @@ public final class TransactionAggregate {
 			// and other tools that treat messages starting with 00 byte as "plain text"
 			final byte[] prefixed = ArrayHelpers.concat(new byte[1], messageBytes);
 
-			final TransferTransactionV1Descriptor descriptor = new TransferTransactionV1Descriptor(recipientAddress).message(prefixed);
+			final TransferTransactionV1Descriptor descriptor = new TransferTransactionV1Descriptor(recipientAddress, /* mosaics */ null, prefixed);
 			final EmbeddedTransferTransactionV1 embeddedTransaction = (EmbeddedTransferTransactionV1) facade
 					.createEmbeddedTransactionFromTypedDescriptor(descriptor, publicKey);
 
@@ -64,8 +64,8 @@ public final class TransactionAggregate {
 		final List<EmbeddedTransaction> embeddedTransactions = addEmbeddedTransfers(facade, keyPair.getPublicKey(), partFiles);
 		final CryptoTypes.Hash256 merkleHash = SymbolFacade.hashEmbeddedTransactions(embeddedTransactions);
 
-		final AggregateCompleteTransactionV3Descriptor aggregateDescriptor = new AggregateCompleteTransactionV3Descriptor(merkleHash)
-				.transactions(embeddedTransactions);
+		final AggregateCompleteTransactionV3Descriptor aggregateDescriptor = new AggregateCompleteTransactionV3Descriptor(merkleHash,
+				embeddedTransactions, /* cosignatures */ null);
 		// pin deterministic header values in the descriptor (like the JS / Python examples) so the output stays comparable
 		final Map<String, Object> aggregateMap = aggregateDescriptor.toMap();
 		aggregateMap.put("signerPublicKey", keyPair.getPublicKey());

--- a/sdk/java/examples/src/main/java/org/symbol/examples/TransactionMultisig.java
+++ b/sdk/java/examples/src/main/java/org/symbol/examples/TransactionMultisig.java
@@ -42,12 +42,12 @@ public final class TransactionMultisig {
 			addressAdditions.add(facade.network.publicKeyToAddress(cosigner.getPublicKey()));
 
 		final MultisigAccountModificationTransactionV1Descriptor embeddedDescriptor = new MultisigAccountModificationTransactionV1Descriptor(
-				1, 1, addressAdditions, /* addressDeletions */ null);
+				1, 1, addressAdditions, (List<Address>) null);
 		final List<EmbeddedTransaction> embeddedTransactions = List
 				.of(facade.createEmbeddedTransactionFromTypedDescriptor(embeddedDescriptor, multisigKeyPair.getPublicKey()));
 
 		final AggregateCompleteTransactionV3Descriptor aggregateDescriptor = new AggregateCompleteTransactionV3Descriptor(
-				SymbolFacade.hashEmbeddedTransactions(embeddedTransactions), embeddedTransactions, /* cosignatures */ null);
+				SymbolFacade.hashEmbeddedTransactions(embeddedTransactions), embeddedTransactions, (List<Cosignature>) null);
 
 		// pin deterministic header values in the descriptor (like the JS / Python examples) so the output stays comparable
 		final Map<String, Object> aggregateMap = aggregateDescriptor.toMap();

--- a/sdk/java/examples/src/main/java/org/symbol/examples/TransactionMultisig.java
+++ b/sdk/java/examples/src/main/java/org/symbol/examples/TransactionMultisig.java
@@ -42,12 +42,12 @@ public final class TransactionMultisig {
 			addressAdditions.add(facade.network.publicKeyToAddress(cosigner.getPublicKey()));
 
 		final MultisigAccountModificationTransactionV1Descriptor embeddedDescriptor = new MultisigAccountModificationTransactionV1Descriptor(
-				1, 1).addressAdditions(addressAdditions);
+				1, 1, addressAdditions, /* addressDeletions */ null);
 		final List<EmbeddedTransaction> embeddedTransactions = List
 				.of(facade.createEmbeddedTransactionFromTypedDescriptor(embeddedDescriptor, multisigKeyPair.getPublicKey()));
 
 		final AggregateCompleteTransactionV3Descriptor aggregateDescriptor = new AggregateCompleteTransactionV3Descriptor(
-				SymbolFacade.hashEmbeddedTransactions(embeddedTransactions)).transactions(embeddedTransactions);
+				SymbolFacade.hashEmbeddedTransactions(embeddedTransactions), embeddedTransactions, /* cosignatures */ null);
 
 		// pin deterministic header values in the descriptor (like the JS / Python examples) so the output stays comparable
 		final Map<String, Object> aggregateMap = aggregateDescriptor.toMap();

--- a/sdk/java/examples/src/main/java/org/symbol/examples/readme/Nem.java
+++ b/sdk/java/examples/src/main/java/org/symbol/examples/readme/Nem.java
@@ -3,15 +3,19 @@
 
 package org.symbol.examples.readme;
 
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.symbol.sdk.CryptoTypes;
 import org.symbol.sdk.facade.NemFacade;
+import org.symbol.sdk.nem.Address;
 import org.symbol.sdk.nem.KeyPair;
 import org.symbol.sdk.nem.NemTransactionFactory;
 import org.symbol.sdk.nem.descriptors.MessageDescriptor;
 import org.symbol.sdk.nem.descriptors.TransferTransactionV1Descriptor;
+import org.symbol.sdk.nem.models.Amount;
+import org.symbol.sdk.nem.models.MessageType;
 import org.symbol.sdk.nem.models.Transaction;
 
 public final class Nem {
@@ -34,11 +38,10 @@ public final class Nem {
 
 	private static void typedDescriptorExample(final NemFacade facade, final CryptoTypes.PublicKey signerPublicKey) {
 		System.out.println("*** EXAMPLE CONSTRUCTION FROM TYPED DESCRIPTOR ***");
-		// required fields are constructor args; optional fields are fluent setters. The string
-		// overloads parse canonical forms: base32 addresses, enum names, UTF-8 text fields.
+		// every field is a constructor argument
 		final TransferTransactionV1Descriptor typedDescriptor = new TransferTransactionV1Descriptor(
-			"TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW", "5100000")
-			.message(new MessageDescriptor("plain").message("hello nem"));
+			new Address("TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW"), new Amount(5100000L),
+			new MessageDescriptor(MessageType.PLAIN, "hello nem".getBytes(StandardCharsets.UTF_8)));
 
 		final long fee = 0x186A0L;
 		final long deadlineSeconds = 60L * 60L * 24L;

--- a/sdk/java/examples/src/main/java/org/symbol/examples/readme/Symbol.java
+++ b/sdk/java/examples/src/main/java/org/symbol/examples/readme/Symbol.java
@@ -3,18 +3,22 @@
 
 package org.symbol.examples.readme;
 
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.symbol.sdk.CryptoTypes;
 import org.symbol.sdk.facade.SymbolFacade;
+import org.symbol.sdk.symbol.Address;
 import org.symbol.sdk.symbol.KeyPair;
 import org.symbol.sdk.symbol.SymbolTransactionFactory;
 import org.symbol.sdk.symbol.descriptors.TransferTransactionV1Descriptor;
 import org.symbol.sdk.symbol.descriptors.UnresolvedMosaicDescriptor;
+import org.symbol.sdk.symbol.models.Amount;
 import org.symbol.sdk.symbol.models.EmbeddedTransaction;
 import org.symbol.sdk.symbol.models.Transaction;
+import org.symbol.sdk.symbol.models.UnresolvedMosaicId;
 
 public final class Symbol {
 	private Symbol() {
@@ -46,15 +50,13 @@ public final class Symbol {
 
 	private static void typedDescriptorExample(final SymbolFacade facade, final CryptoTypes.PublicKey signerPublicKey) {
 		System.out.println("*** EXAMPLE CONSTRUCTION FROM TYPED DESCRIPTOR ***");
-		// required fields are constructor args; optional fields are fluent setters. The string
-		// overloads parse canonical forms (base32 addresses, UTF-8 text, 0x-hex or decimal ids), and
-		// the array setter takes varargs — here two mosaics.
+		// every field is a constructor argument
 		final TransferTransactionV1Descriptor typedDescriptor = new TransferTransactionV1Descriptor(
-			"TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I")
-			.mosaics(
-				new UnresolvedMosaicDescriptor("0x7CDF3B117A3C40CC", "1000000"),
-				new UnresolvedMosaicDescriptor("0x1F031D8D3905B931", "5"))
-			.message("hello symbol");
+			new Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"),
+			List.of(
+				new UnresolvedMosaicDescriptor(new UnresolvedMosaicId(0x7CDF3B117A3C40CCL), new Amount(1000000L)),
+				new UnresolvedMosaicDescriptor(new UnresolvedMosaicId(0x1F031D8D3905B931L), new Amount(5L))),
+			"hello symbol".getBytes(StandardCharsets.UTF_8));
 
 		final Transaction typedTransaction = facade.createTransactionFromTypedDescriptor(
 			typedDescriptor, signerPublicKey, FEE_MULTIPLIER, DEADLINE_SECONDS);

--- a/sdk/java/generator/DescriptorStructTypeFormatter.py
+++ b/sdk/java/generator/DescriptorStructTypeFormatter.py
@@ -131,17 +131,6 @@ class DescriptorField:
 		"""Java expression stored into the descriptor map for this field."""
 		return f'{self.name}{self._unwrap}'
 
-	def convert_expression(self):
-		"""Expression converting this field's String parameter to its typed form (scalar fields only)."""
-		return self.string_conversion.format(value=self.name)
-
-	def guarded_convert_expression(self):
-		"""Like :meth:`convert_expression`, but optional fields pass ``null`` through unconverted."""
-		if not self.is_optional:
-			return self.convert_expression()
-
-		return f'null == {self.name} ? null : {self.convert_expression()}'
-
 
 class StructFormatter:
 	"""Renders a single ``XxxDescriptor`` Java class (sans package/imports header)."""
@@ -198,32 +187,14 @@ class StructFormatter:
 		return javadoc(lines, prefix='')
 
 	def _render_constructors(self, required, optional):
-		"""Required-only constructor(s) followed by one fluent setter per optional field."""
-		methods = [self._render_required_ctor(required)]
-		methods.extend(self._render_string_required_ctor(required))
-		for field in optional:
-			methods.append(self._render_typed_setter(field))
-			methods.extend(self._render_setter_overloads(field))
+		"""The single all-args typed constructor (mirrors the JS models_ts shape)."""
+		return [self._render_ctor(required, optional)]
 
-		return methods
-
-	@staticmethod
-	def _string_variant_signature(fields):
-		"""Parameter / argument lists for a string-form overload, or None when no field converts."""
-		if not any(field.string_conversion for field in fields):
-			return None
-
-		params = ', '.join(
-			f'final String {field.name}' if field.string_conversion else f'final {field.parameter_type()} {field.name}' for field in fields
-		)
-		args = ', '.join(field.guarded_convert_expression() if field.string_conversion else field.name for field in fields)
-		return params, args
-
-	def _render_required_ctor(self, required):
-		"""Typed constructor taking only the required fields; optionals are populated via fluent setters."""
+	def _render_ctor(self, required, optional):
+		"""Typed constructor taking every field; a null optional leaves its key out of the map."""
 		doc = [f'Creates a descriptor for {self.struct.name}.', '']
-		doc.extend(self._param_docs(required))
-		params = ', '.join(f'final {field.parameter_type()} {field.name}' for field in required)
+		doc.extend(StructFormatter._param_docs(required, optional))
+		params = ', '.join(f'final {field.parameter_type()} {field.name}' for field in required + optional)
 
 		body_lines = ['\t\trawDescriptor = new java.util.LinkedHashMap<>();']
 		if self.struct.factory_type:
@@ -232,58 +203,14 @@ class StructFormatter:
 		for field in required:
 			body_lines.append(f'\t\trawDescriptor.put("{field.name}", {field.store_expression()});')
 
+		# a null optional must leave its key ABSENT (TransactionDescriptorProcessor.copyTo iterates present keys)
+		for field in optional:
+			body_lines.append('')
+			body_lines.append(f'\t\tif (null != {field.name})')
+			body_lines.append(f'\t\t\trawDescriptor.put("{field.name}", {field.store_expression()});')
+
 		body = '\n'.join(body_lines) + '\n'
 		return method(doc, f'\tpublic {self.typename}({params})', body)
-
-	def _render_string_required_ctor(self, required):
-		"""String-form overload of the required constructor (every string-convertible field takes a ``String``)."""
-		signature = StructFormatter._string_variant_signature(required)
-		if signature is None:
-			return []
-
-		params, args = signature
-		doc = [f'Creates a descriptor for {self.struct.name} from string-form values.', '']
-		doc.extend(self._param_docs(required))
-		return [method(doc, f'\tpublic {self.typename}({params})', f'\t\tthis({args});\n')]
-
-	def _render_typed_setter(self, field):
-		"""Fluent setter for one optional field, storing the typed value into the descriptor map."""
-		signature = f'\tpublic {self.typename} {field.name}(final {field.parameter_type()} {field.name})'
-		body = (
-			f'\t\tif (null != {field.name})\n'
-			f'\t\t\trawDescriptor.put("{field.name}", {field.store_expression()});\n'
-			f'\t\treturn this;\n')
-		return method(self._setter_doc(field), signature, body)
-
-	def _render_setter_overloads(self, field):
-		"""String / varargs convenience overloads that convert and delegate to the typed setter."""
-		doc = self._setter_doc(field)
-		signature = f'\tpublic {self.typename} {field.name}'
-		if field.string_conversion:
-			body = f'\t\treturn {field.name}({field.guarded_convert_expression()});\n'
-			return [method(doc, f'{signature}(final String {field.name})', body)]
-
-		if field.element_string_conversion:
-			element_expression = field.element_string_conversion.format(value='value')
-			body = (
-				f'\t\treturn {field.name}(null == {field.name} ? null : java.util.Arrays.stream({field.name})'
-				f'.map(value -> {element_expression}).collect(java.util.stream.Collectors.toList()));\n')
-			return [method(doc, f'{signature}(final String... {field.name})', body)]
-
-		if field.descriptor_element_type:
-			body = f'\t\treturn {field.name}(null == {field.name} ? null : java.util.Arrays.asList({field.name}));\n'
-			return [method(doc, f'{signature}(final {field.descriptor_element_type}... {field.name})', body)]
-
-		return []
-
-	@staticmethod
-	def _setter_doc(field):
-		return [
-			f'Sets the {field.name} field.',
-			'',
-			f'@param {field.name} {field.comment or field.name}',
-			'@return This descriptor for chaining.',
-		]
 
 	@staticmethod
 	def _render_to_map():
@@ -296,10 +223,12 @@ class StructFormatter:
 		return method(doc, '\t@Override\n\tpublic java.util.Map<String, Object> toMap()', body)
 
 	@staticmethod
-	def _param_docs(fields):
+	def _param_docs(required, optional):
 		docs = []
-		for field in fields:
-			comment = field.comment or field.name
-			docs.append(f'@param {field.name} {comment}')
+		for field in required:
+			docs.append(f'@param {field.name} {field.comment or field.name}')
+
+		for field in optional:
+			docs.append(f'@param {field.name} {field.comment or field.name} (field is omitted when null)')
 
 		return docs

--- a/sdk/java/generator/DescriptorSweepTestFormatter.py
+++ b/sdk/java/generator/DescriptorSweepTestFormatter.py
@@ -35,8 +35,6 @@ class _FieldSample:
 		self._raw_field = raw_field
 		self._context = context
 		self._type_info = type_info
-		self.string_literal = None
-		self.element_string_literal = None
 		self.element_typed_expr = None
 		# model-struct samples are fresh instances without value equality; their asserts degrade to non-null
 		self.is_model_struct = False
@@ -67,12 +65,11 @@ class _FieldSample:
 		resolved = self.resolved
 		if 'byte[]' == resolved.java_type:
 			# the field's own name doubles as a distinct payload
-			self.string_literal = self.name
 			return f'"{self.name}".getBytes(java.nio.charset.StandardCharsets.UTF_8)'
 
 		if resolved.string_conversion:
-			self.string_literal = self._sample_string_for(str(self._raw_field.field_type))
-			return resolved.string_conversion.format(value=f'"{self.string_literal}"')
+			sample = self._sample_string_for(str(self._raw_field.field_type))
+			return resolved.string_conversion.format(value=f'"{sample}"')
 
 		if resolved.descriptor_element_type:
 			element = resolved.descriptor_element_type
@@ -80,8 +77,7 @@ class _FieldSample:
 
 		if resolved.element_string_conversion:
 			element_name = str(self._raw_field.field_type.element_type)
-			self.element_string_literal = self._sample_string_for(element_name)
-			self.element_typed_expr = resolved.element_string_conversion.format(value=f'"{self.element_string_literal}"')
+			self.element_typed_expr = resolved.element_string_conversion.format(value=f'"{self._sample_string_for(element_name)}"')
 			return f'java.util.List.of({self.element_typed_expr})'
 
 		if resolved.java_type.startswith('java.util.List<'):
@@ -217,16 +213,23 @@ class SweepTestFormatter:
 	def _helper_name(typename):
 		return f'sweepNew{typename}'
 
-	def _render_helper(self, typename, required):
-		arguments = ', '.join(sample.typed_expr for sample in required)
+	def _render_helper(self, typename, required, optional):
+		arguments = ', '.join([sample.typed_expr for sample in required] + ['null' for _ in optional])
+		doc = 'distinct sample required arguments and null optionals' if optional else 'distinct sample required arguments'
 		return (
-			f'\t/** Constructs a {typename} with distinct sample required arguments. */\n'
+			f'\t/** Constructs a {typename} with {doc}. */\n'
 			f'\tprivate static {typename} {self._helper_name(typename)}() {{\n'
 			f'\t\treturn new {typename}({arguments});\n'
 			'\t}\n')
 
 	@staticmethod
-	def _render_construction_asserts(ast_model, required):
+	def _full_ctor_expr(typename, required, optional):
+		"""All-args constructor expression with every field populated by its sample."""
+		args = ', '.join(sample.typed_expr for sample in required + optional)
+		return f'new {typename}({args})'
+
+	@staticmethod
+	def _render_construction_asserts(ast_model, required, optional):
 		lines = []
 		if ast_model.factory_type:
 			lines.append(f'\t\tassertThat(built.get("type"), equalTo("{underline_name(ast_model.name)}"));')
@@ -237,97 +240,31 @@ class SweepTestFormatter:
 			else:
 				lines.append(f'\t\tassertThat(built.get("{sample.name}"), equalTo({sample.map_expected_expr()}));')
 
+		for sample in optional:
+			lines.append(f'\t\tassertThat(built.containsKey("{sample.name}"), equalTo(false));')
+
 		lines.append(f'\t\tassertThat(built.size(), equalTo({len(required) + (1 if ast_model.factory_type else 0)}));')
 		return lines
 
-	def _render_string_ctor_test(self, ast_model, typename, required):
-		if not any(sample.resolved.string_conversion for sample in required):
-			return None
+	def _render_full_ctor_asserts(self, ast_model, typename, required, optional):
+		"""Asserts the all-args constructor stores every optional field (the required half is covered above)."""
+		if not optional:
+			return []
 
-		args = ', '.join(
-			f'"{sample.string_literal}"' if sample.resolved.string_conversion else sample.typed_expr for sample in required)
-		lines = [
-			'\t\t// Arrange:',
-			f'\t\tfinal java.util.Map<String, Object> built = {self._helper_name(typename)}().toMap();',
-			'',
-			'\t\t// Act:',
-			f'\t\tfinal java.util.Map<String, Object> stringBuilt = new {typename}({args}).toMap();',
-			'',
-			'\t\t// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)',
-			'\t\tassertThat(stringBuilt.size(), equalTo(built.size()));',
-		]
-		if ast_model.factory_type:
-			lines.append('\t\tassertThat(stringBuilt.get("type"), equalTo(built.get("type")));')
-
-		for sample in required:
-			if sample.is_model_struct:
-				lines.append(f'\t\tassertThat(stringBuilt.get("{sample.name}"), notNullValue());')
-			else:
-				lines.append(f'\t\tassertThat(stringBuilt.get("{sample.name}"), equalTo(built.get("{sample.name}")));')
-
-		body = '\n'.join(lines)
-		return (
-			'\t@Test\n'
-			f'\tvoid {uncapitalize(typename)}StringFormConstructor() {{\n'
-			f'{body}\n'
-			'\t}\n')
-
-	def _render_setter_asserts(self, typename, optional):
-		lines = []
-		helper = self._helper_name(typename)
+		lines = [f'\t\tfinal java.util.Map<String, Object> fullBuilt = {self._full_ctor_expr(typename, required, optional)}.toMap();']
 		for sample in optional:
-			lines.append('')
-			lines.append(f'\t\t// optional field: {sample.name}')
-			lines.append(f'\t\tassertThat(built.containsKey("{sample.name}"), equalTo(false));')
-			# a null argument must leave the key absent (the setter's null guard)
-			lines.append(
-				f'\t\tassertThat({helper}().{sample.name}(({sample.resolved.parameter_type()}) null).toMap()'
-				f'.containsKey("{sample.name}"), equalTo(false));')
-			if sample.resolved.string_conversion:
-				lines.append(
-					f'\t\tassertThat({helper}().{sample.name}((String) null).toMap()'
-					f'.containsKey("{sample.name}"), equalTo(false));')
-			lines.append(f'\t\tfinal {typename} with{capitalize(sample.name)} = {helper}();')
-			lines.append(
-				f'\t\tassertThat(with{capitalize(sample.name)}.{sample.name}({sample.typed_expr}),'
-				f' sameInstance(with{capitalize(sample.name)}));')
 			if sample.is_model_struct:
-				lines.append(f'\t\tassertThat(with{capitalize(sample.name)}.toMap().get("{sample.name}"), notNullValue());')
+				lines.append(f'\t\tassertThat(fullBuilt.get("{sample.name}"), notNullValue());')
 			elif sample.is_struct_element_list:
 				# struct elements have no value equality; the one-element size distinguishes the stored
 				# list from an empty default
-				lines.append(
-					f'\t\tassertThat(((java.util.List<?>) with{capitalize(sample.name)}.toMap()'
-					f'.get("{sample.name}")).size(), equalTo(1));')
+				lines.append(f'\t\tassertThat(((java.util.List<?>) fullBuilt.get("{sample.name}")).size(), equalTo(1));')
 			else:
-				lines.append(
-					f'\t\tassertThat(with{capitalize(sample.name)}.toMap().get("{sample.name}"),'
-					f' equalTo({sample.map_expected_expr()}));')
-			overload_expr = self._setter_overload_expr(sample)
-			if overload_expr is not None:
-				# compare only the key being set: whole-map equality would trip over byte[] identity
-				# semantics and over sibling fields without value equality
-				lines.append(
-					f'\t\tassertThat({helper}().{sample.name}({overload_expr}).toMap().get("{sample.name}"),'
-					f' equalTo(with{capitalize(sample.name)}.toMap().get("{sample.name}")));')
+				lines.append(f'\t\tassertThat(fullBuilt.get("{sample.name}"), equalTo({sample.map_expected_expr()}));')
 
+		total = len(required) + len(optional) + (1 if ast_model.factory_type else 0)
+		lines.append(f'\t\tassertThat(fullBuilt.size(), equalTo({total}));')
 		return lines
-
-	@staticmethod
-	def _setter_overload_expr(sample):
-		"""Argument for the convenience overload (String / String... / Descriptor...), or None."""
-		resolved = sample.resolved
-		if resolved.string_conversion:
-			return f'"{sample.string_literal}"'
-
-		if resolved.element_string_conversion:
-			return f'"{sample.element_string_literal}"'
-
-		if resolved.descriptor_element_type:
-			element = resolved.descriptor_element_type
-			return f'sweepNew{element[:-len("Descriptor")]}Descriptor()'
-
-		return None
 
 	def _render_factory_round_trip_test(self, ast_model, typename, required, optional):
 		"""Standalone factory round-trip test: the fully-populated map creates a model whose fields echo the samples."""
@@ -338,17 +275,18 @@ class SweepTestFormatter:
 		# struct-element lists get a held element local so the created model can be asserted to carry
 		# the exact same instance (the pipeline has no conversion rule for these element types)
 		element_locals = {}
-		descriptor_expr = self._helper_name(typename) + '()'
+		arguments = [sample.typed_expr for sample in required]
 		for sample in optional:
 			if sample.is_struct_element_list:
 				local = f'sweep{capitalize(sample.name)}Element'
 				element_locals[sample.name] = local
-				descriptor_expr += f'.{sample.name}(java.util.List.of({local}))'
+				arguments.append(f'java.util.List.of({local})')
 			else:
-				descriptor_expr += f'.{sample.name}({sample.typed_expr})'
+				arguments.append(sample.typed_expr)
 
+		descriptor_expr = f'new {typename}({", ".join(arguments)})'
 		concrete_model = f'{self.context.models_package}.{ast_model.name}'
-		lines = ['\t\t// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer']
+		lines = ['\t\t// Arrange: the sample descriptor with every field populated, plus the signer']
 		for sample in optional:
 			if sample.name in element_locals:
 				lines.append(
@@ -404,6 +342,10 @@ class SweepTestFormatter:
 		typename = formatter.typename
 		required, optional = self._field_samples(ast_model, factory_ast_model)
 
+		assert_comment = '\t\t// Assert: exact required contents'
+		if optional:
+			assert_comment += '; null optional arguments leave their keys absent'
+
 		body_lines = [
 			'\t\t// Arrange:',
 			f'\t\tfinal {typename} descriptor = {self._helper_name(typename)}();',
@@ -411,27 +353,23 @@ class SweepTestFormatter:
 			'\t\t// Act:',
 			'\t\tfinal java.util.Map<String, Object> built = descriptor.toMap();',
 			'',
-			'\t\t// Assert: exact required contents',
+			assert_comment,
 		]
-		body_lines.extend(SweepTestFormatter._render_construction_asserts(ast_model, required))
-		setter_lines = self._render_setter_asserts(typename, optional)
-		if setter_lines:
+		body_lines.extend(SweepTestFormatter._render_construction_asserts(ast_model, required, optional))
+		full_ctor_lines = self._render_full_ctor_asserts(ast_model, typename, required, optional)
+		if full_ctor_lines:
 			body_lines.append('')
-			body_lines.append('\t\t// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)')
-			body_lines.extend(setter_lines)
+			body_lines.append('\t\t// Act + Assert: the all-args constructor stores every optional field')
+			body_lines.extend(full_ctor_lines)
 
 		body = '\n'.join(body_lines)
 		parts = [
-			f'{self._render_helper(typename, required)}\n'
+			f'{self._render_helper(typename, required, optional)}\n'
 			'\t@Test\n'
 			f'\tvoid {uncapitalize(typename)}() {{\n'
 			f'{body}\n'
 			'\t}\n'
 		]
-		string_ctor_test = self._render_string_ctor_test(ast_model, typename, required)
-		if string_ctor_test is not None:
-			parts.append(string_ctor_test)
-
 		round_trip_test = self._render_factory_round_trip_test(ast_model, typename, required, optional)
 		if round_trip_test is not None:
 			parts.append(round_trip_test)
@@ -447,9 +385,9 @@ class SweepTestFormatter:
 			for ast_model, factory_ast_model, formatter in self.struct_entries)
 		return (
 			'/**\n'
-			' * Generated per-descriptor sweep: construction with distinct sample values, exact {@code toMap()} contents,\n'
-			' * string-form constructor equivalence, every optional fluent setter, and (for transaction descriptors) a\n'
-			' * factory round-trip verifying each created-model field via {@code getField}.\n'
+			' * Generated per-descriptor sweep: construction with distinct sample values, exact {@code toMap()} contents\n'
+			' * (null optional arguments leave their keys absent), all-args constructor storage of every field, and\n'
+			' * (for transaction descriptors) a factory round-trip verifying each created-model field via {@code getField}.\n'
 			' */\n'
 			'final class DescriptorsSweepTest {\n'
 			'\tprivate static final org.symbol.sdk.CryptoTypes.PublicKey SWEEP_SIGNER_PUBLIC_KEY ='

--- a/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/AccountKeyLinkTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/AccountKeyLinkTransactionV1Descriptor.java
@@ -31,16 +31,6 @@ public final class AccountKeyLinkTransactionV1Descriptor implements NemTransacti
 	}
 
 	/**
-	 * Creates a descriptor for AccountKeyLinkTransactionV1 from string-form values.
-	 *
-	 * @param linkAction link action
-	 * @param remotePublicKey public key of remote account to which importance should be transferred
-	 */
-	public AccountKeyLinkTransactionV1Descriptor(final String linkAction, final String remotePublicKey) {
-		this(LinkAction.parse(linkAction), new CryptoTypes.PublicKey(remotePublicKey));
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/CosignatureV1BodyDescriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/CosignatureV1BodyDescriptor.java
@@ -30,16 +30,6 @@ public final class CosignatureV1BodyDescriptor implements NemTypedDescriptor {
 	}
 
 	/**
-	 * Creates a descriptor for CosignatureV1Body from string-form values.
-	 *
-	 * @param otherTransactionHash other transaction hash
-	 * @param multisigAccountAddress multisig account address
-	 */
-	public CosignatureV1BodyDescriptor(final String otherTransactionHash, final String multisigAccountAddress) {
-		this(new CryptoTypes.Hash256(otherTransactionHash), new Address(multisigAccountAddress));
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/CosignatureV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/CosignatureV1Descriptor.java
@@ -31,16 +31,6 @@ public final class CosignatureV1Descriptor implements NemTransactionDescriptor {
 	}
 
 	/**
-	 * Creates a descriptor for CosignatureV1 from string-form values.
-	 *
-	 * @param otherTransactionHash other transaction hash
-	 * @param multisigAccountAddress multisig account address
-	 */
-	public CosignatureV1Descriptor(final String otherTransactionHash, final String multisigAccountAddress) {
-		this(new CryptoTypes.Hash256(otherTransactionHash), new Address(multisigAccountAddress));
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MessageDescriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MessageDescriptor.java
@@ -3,7 +3,6 @@
 
 package org.symbol.sdk.nem.descriptors;
 
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -21,42 +20,14 @@ public final class MessageDescriptor implements NemTypedDescriptor {
 	 * Creates a descriptor for Message.
 	 *
 	 * @param messageType message type
+	 * @param message message payload (field is omitted when null)
 	 */
-	public MessageDescriptor(final MessageType messageType) {
+	public MessageDescriptor(final MessageType messageType, final byte[] message) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("messageType", messageType);
-	}
 
-	/**
-	 * Creates a descriptor for Message from string-form values.
-	 *
-	 * @param messageType message type
-	 */
-	public MessageDescriptor(final String messageType) {
-		this(MessageType.parse(messageType));
-	}
-
-	/**
-	 * Sets the message field.
-	 *
-	 * @param message message payload
-	 * @return This descriptor for chaining.
-	 */
-	public MessageDescriptor message(final byte[] message) {
 		if (null != message)
 			rawDescriptor.put("message", message);
-
-		return this;
-	}
-
-	/**
-	 * Sets the message field.
-	 *
-	 * @param message message payload
-	 * @return This descriptor for chaining.
-	 */
-	public MessageDescriptor message(final String message) {
-		return message(null == message ? null : message.getBytes(StandardCharsets.UTF_8));
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MosaicDefinitionDescriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MosaicDefinitionDescriptor.java
@@ -3,8 +3,6 @@
 
 package org.symbol.sdk.nem.descriptors;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,81 +23,25 @@ public final class MosaicDefinitionDescriptor implements NemTypedDescriptor {
 	 *
 	 * @param ownerPublicKey owner public key
 	 * @param id mosaic id referenced by this definition
+	 * @param description description (field is omitted when null)
+	 * @param properties properties (field is omitted when null)
+	 * @param levy optional levy that is applied to transfers of this mosaic (field is omitted when null)
 	 */
-	public MosaicDefinitionDescriptor(final CryptoTypes.PublicKey ownerPublicKey, final MosaicIdDescriptor id) {
+	public MosaicDefinitionDescriptor(final CryptoTypes.PublicKey ownerPublicKey, final MosaicIdDescriptor id, final byte[] description,
+			final List<SizePrefixedMosaicPropertyDescriptor> properties, final MosaicLevyDescriptor levy) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("ownerPublicKey", ownerPublicKey);
 		rawDescriptor.put("id", id.toMap());
-	}
 
-	/**
-	 * Creates a descriptor for MosaicDefinition from string-form values.
-	 *
-	 * @param ownerPublicKey owner public key
-	 * @param id mosaic id referenced by this definition
-	 */
-	public MosaicDefinitionDescriptor(final String ownerPublicKey, final MosaicIdDescriptor id) {
-		this(new CryptoTypes.PublicKey(ownerPublicKey), id);
-	}
-
-	/**
-	 * Sets the description field.
-	 *
-	 * @param description description
-	 * @return This descriptor for chaining.
-	 */
-	public MosaicDefinitionDescriptor description(final byte[] description) {
 		if (null != description)
 			rawDescriptor.put("description", description);
 
-		return this;
-	}
-
-	/**
-	 * Sets the description field.
-	 *
-	 * @param description description
-	 * @return This descriptor for chaining.
-	 */
-	public MosaicDefinitionDescriptor description(final String description) {
-		return description(null == description ? null : description.getBytes(StandardCharsets.UTF_8));
-	}
-
-	/**
-	 * Sets the properties field.
-	 *
-	 * @param properties properties
-	 * @return This descriptor for chaining.
-	 */
-	public MosaicDefinitionDescriptor properties(final List<SizePrefixedMosaicPropertyDescriptor> properties) {
 		if (null != properties)
 			rawDescriptor.put("properties",
 					properties.stream().map(SizePrefixedMosaicPropertyDescriptor::toMap).collect(Collectors.toList()));
 
-		return this;
-	}
-
-	/**
-	 * Sets the properties field.
-	 *
-	 * @param properties properties
-	 * @return This descriptor for chaining.
-	 */
-	public MosaicDefinitionDescriptor properties(final SizePrefixedMosaicPropertyDescriptor... properties) {
-		return properties(null == properties ? null : Arrays.asList(properties));
-	}
-
-	/**
-	 * Sets the levy field.
-	 *
-	 * @param levy optional levy that is applied to transfers of this mosaic
-	 * @return This descriptor for chaining.
-	 */
-	public MosaicDefinitionDescriptor levy(final MosaicLevyDescriptor levy) {
 		if (null != levy)
 			rawDescriptor.put("levy", levy.toMap());
-
-		return this;
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MosaicDefinitionTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MosaicDefinitionTransactionV1Descriptor.java
@@ -34,18 +34,6 @@ public final class MosaicDefinitionTransactionV1Descriptor implements NemTransac
 	}
 
 	/**
-	 * Creates a descriptor for MosaicDefinitionTransactionV1 from string-form values.
-	 *
-	 * @param mosaicDefinition mosaic definition
-	 * @param rentalFeeSink mosaic rental fee sink public key
-	 * @param rentalFee mosaic rental fee
-	 */
-	public MosaicDefinitionTransactionV1Descriptor(final MosaicDefinitionDescriptor mosaicDefinition, final String rentalFeeSink,
-			final String rentalFee) {
-		this(mosaicDefinition, new Address(rentalFeeSink), Amount.parse(rentalFee));
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MosaicDescriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MosaicDescriptor.java
@@ -29,16 +29,6 @@ public final class MosaicDescriptor implements NemTypedDescriptor {
 	}
 
 	/**
-	 * Creates a descriptor for Mosaic from string-form values.
-	 *
-	 * @param mosaicId mosaic id
-	 * @param amount quantity
-	 */
-	public MosaicDescriptor(final MosaicIdDescriptor mosaicId, final String amount) {
-		this(mosaicId, Amount.parse(amount));
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MosaicIdDescriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MosaicIdDescriptor.java
@@ -3,7 +3,6 @@
 
 package org.symbol.sdk.nem.descriptors;
 
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -19,33 +18,14 @@ public final class MosaicIdDescriptor implements NemTypedDescriptor {
 	 * Creates a descriptor for MosaicId.
 	 *
 	 * @param namespaceId namespace id
+	 * @param name name (field is omitted when null)
 	 */
-	public MosaicIdDescriptor(final NamespaceIdDescriptor namespaceId) {
+	public MosaicIdDescriptor(final NamespaceIdDescriptor namespaceId, final byte[] name) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("namespaceId", namespaceId.toMap());
-	}
 
-	/**
-	 * Sets the name field.
-	 *
-	 * @param name name
-	 * @return This descriptor for chaining.
-	 */
-	public MosaicIdDescriptor name(final byte[] name) {
 		if (null != name)
 			rawDescriptor.put("name", name);
-
-		return this;
-	}
-
-	/**
-	 * Sets the name field.
-	 *
-	 * @param name name
-	 * @return This descriptor for chaining.
-	 */
-	public MosaicIdDescriptor name(final String name) {
-		return name(null == name ? null : name.getBytes(StandardCharsets.UTF_8));
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MosaicLevyDescriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MosaicLevyDescriptor.java
@@ -36,19 +36,6 @@ public final class MosaicLevyDescriptor implements NemTypedDescriptor {
 	}
 
 	/**
-	 * Creates a descriptor for MosaicLevy from string-form values.
-	 *
-	 * @param transferFeeType mosaic fee type
-	 * @param recipientAddress recipient address
-	 * @param mosaicId levy mosaic id
-	 * @param fee amount of levy mosaic to transfer
-	 */
-	public MosaicLevyDescriptor(final String transferFeeType, final String recipientAddress, final MosaicIdDescriptor mosaicId,
-			final String fee) {
-		this(MosaicTransferFeeType.parse(transferFeeType), new Address(recipientAddress), mosaicId, Amount.parse(fee));
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MosaicPropertyDescriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MosaicPropertyDescriptor.java
@@ -3,7 +3,6 @@
 
 package org.symbol.sdk.nem.descriptors;
 
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -18,55 +17,17 @@ public final class MosaicPropertyDescriptor implements NemTypedDescriptor {
 	/**
 	 * Creates a descriptor for MosaicProperty.
 	 *
+	 * @param name property name (field is omitted when null)
+	 * @param value property value (field is omitted when null)
 	 */
-	public MosaicPropertyDescriptor() {
+	public MosaicPropertyDescriptor(final byte[] name, final byte[] value) {
 		rawDescriptor = new LinkedHashMap<>();
-	}
 
-	/**
-	 * Sets the name field.
-	 *
-	 * @param name property name
-	 * @return This descriptor for chaining.
-	 */
-	public MosaicPropertyDescriptor name(final byte[] name) {
 		if (null != name)
 			rawDescriptor.put("name", name);
 
-		return this;
-	}
-
-	/**
-	 * Sets the name field.
-	 *
-	 * @param name property name
-	 * @return This descriptor for chaining.
-	 */
-	public MosaicPropertyDescriptor name(final String name) {
-		return name(null == name ? null : name.getBytes(StandardCharsets.UTF_8));
-	}
-
-	/**
-	 * Sets the value field.
-	 *
-	 * @param value property value
-	 * @return This descriptor for chaining.
-	 */
-	public MosaicPropertyDescriptor value(final byte[] value) {
 		if (null != value)
 			rawDescriptor.put("value", value);
-
-		return this;
-	}
-
-	/**
-	 * Sets the value field.
-	 *
-	 * @param value property value
-	 * @return This descriptor for chaining.
-	 */
-	public MosaicPropertyDescriptor value(final String value) {
-		return value(null == value ? null : value.getBytes(StandardCharsets.UTF_8));
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MosaicSupplyChangeTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MosaicSupplyChangeTransactionV1Descriptor.java
@@ -34,17 +34,6 @@ public final class MosaicSupplyChangeTransactionV1Descriptor implements NemTrans
 	}
 
 	/**
-	 * Creates a descriptor for MosaicSupplyChangeTransactionV1 from string-form values.
-	 *
-	 * @param mosaicId mosaic id
-	 * @param action supply change action
-	 * @param delta change amount
-	 */
-	public MosaicSupplyChangeTransactionV1Descriptor(final MosaicIdDescriptor mosaicId, final String action, final String delta) {
-		this(mosaicId, MosaicSupplyChangeAction.parse(action), Amount.parse(delta));
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MultisigAccountModificationDescriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MultisigAccountModificationDescriptor.java
@@ -31,16 +31,6 @@ public final class MultisigAccountModificationDescriptor implements NemTypedDesc
 	}
 
 	/**
-	 * Creates a descriptor for MultisigAccountModification from string-form values.
-	 *
-	 * @param modificationType modification type
-	 * @param cosignatoryPublicKey cosignatory public key
-	 */
-	public MultisigAccountModificationDescriptor(final String modificationType, final String cosignatoryPublicKey) {
-		this(MultisigAccountModificationType.parse(modificationType), new CryptoTypes.PublicKey(cosignatoryPublicKey));
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MultisigAccountModificationTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MultisigAccountModificationTransactionV1Descriptor.java
@@ -3,7 +3,6 @@
 
 package org.symbol.sdk.nem.descriptors;
 
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,36 +19,15 @@ public final class MultisigAccountModificationTransactionV1Descriptor implements
 	/**
 	 * Creates a descriptor for MultisigAccountModificationTransactionV1.
 	 *
+	 * @param modifications multisig account modifications (field is omitted when null)
 	 */
-	public MultisigAccountModificationTransactionV1Descriptor() {
+	public MultisigAccountModificationTransactionV1Descriptor(final List<SizePrefixedMultisigAccountModificationDescriptor> modifications) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("type", "multisig_account_modification_transaction_v1");
-	}
 
-	/**
-	 * Sets the modifications field.
-	 *
-	 * @param modifications multisig account modifications
-	 * @return This descriptor for chaining.
-	 */
-	public MultisigAccountModificationTransactionV1Descriptor modifications(
-			final List<SizePrefixedMultisigAccountModificationDescriptor> modifications) {
 		if (null != modifications)
 			rawDescriptor.put("modifications",
 					modifications.stream().map(SizePrefixedMultisigAccountModificationDescriptor::toMap).collect(Collectors.toList()));
-
-		return this;
-	}
-
-	/**
-	 * Sets the modifications field.
-	 *
-	 * @param modifications multisig account modifications
-	 * @return This descriptor for chaining.
-	 */
-	public MultisigAccountModificationTransactionV1Descriptor modifications(
-			final SizePrefixedMultisigAccountModificationDescriptor... modifications) {
-		return modifications(null == modifications ? null : Arrays.asList(modifications));
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MultisigAccountModificationTransactionV2Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MultisigAccountModificationTransactionV2Descriptor.java
@@ -3,7 +3,6 @@
 
 package org.symbol.sdk.nem.descriptors;
 
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,37 +20,17 @@ public final class MultisigAccountModificationTransactionV2Descriptor implements
 	 * Creates a descriptor for MultisigAccountModificationTransactionV2.
 	 *
 	 * @param minApprovalDelta relative change of the minimal number of cosignatories required when approving a transaction
+	 * @param modifications multisig account modifications (field is omitted when null)
 	 */
-	public MultisigAccountModificationTransactionV2Descriptor(final int minApprovalDelta) {
+	public MultisigAccountModificationTransactionV2Descriptor(final int minApprovalDelta,
+			final List<SizePrefixedMultisigAccountModificationDescriptor> modifications) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("type", "multisig_account_modification_transaction_v2");
 		rawDescriptor.put("minApprovalDelta", minApprovalDelta);
-	}
 
-	/**
-	 * Sets the modifications field.
-	 *
-	 * @param modifications multisig account modifications
-	 * @return This descriptor for chaining.
-	 */
-	public MultisigAccountModificationTransactionV2Descriptor modifications(
-			final List<SizePrefixedMultisigAccountModificationDescriptor> modifications) {
 		if (null != modifications)
 			rawDescriptor.put("modifications",
 					modifications.stream().map(SizePrefixedMultisigAccountModificationDescriptor::toMap).collect(Collectors.toList()));
-
-		return this;
-	}
-
-	/**
-	 * Sets the modifications field.
-	 *
-	 * @param modifications multisig account modifications
-	 * @return This descriptor for chaining.
-	 */
-	public MultisigAccountModificationTransactionV2Descriptor modifications(
-			final SizePrefixedMultisigAccountModificationDescriptor... modifications) {
-		return modifications(null == modifications ? null : Arrays.asList(modifications));
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MultisigTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/MultisigTransactionV1Descriptor.java
@@ -3,7 +3,6 @@
 
 package org.symbol.sdk.nem.descriptors;
 
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,35 +22,17 @@ public final class MultisigTransactionV1Descriptor implements NemTransactionDesc
 	 * Creates a descriptor for MultisigTransactionV1.
 	 *
 	 * @param innerTransaction inner transaction
+	 * @param cosignatures cosignatures (field is omitted when null)
 	 */
-	public MultisigTransactionV1Descriptor(final NonVerifiableTransaction innerTransaction) {
+	public MultisigTransactionV1Descriptor(final NonVerifiableTransaction innerTransaction,
+			final List<SizePrefixedCosignatureV1Descriptor> cosignatures) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("type", "multisig_transaction_v1");
 		rawDescriptor.put("innerTransaction", innerTransaction);
-	}
 
-	/**
-	 * Sets the cosignatures field.
-	 *
-	 * @param cosignatures cosignatures
-	 * @return This descriptor for chaining.
-	 */
-	public MultisigTransactionV1Descriptor cosignatures(final List<SizePrefixedCosignatureV1Descriptor> cosignatures) {
 		if (null != cosignatures)
 			rawDescriptor.put("cosignatures",
 					cosignatures.stream().map(SizePrefixedCosignatureV1Descriptor::toMap).collect(Collectors.toList()));
-
-		return this;
-	}
-
-	/**
-	 * Sets the cosignatures field.
-	 *
-	 * @param cosignatures cosignatures
-	 * @return This descriptor for chaining.
-	 */
-	public MultisigTransactionV1Descriptor cosignatures(final SizePrefixedCosignatureV1Descriptor... cosignatures) {
-		return cosignatures(null == cosignatures ? null : Arrays.asList(cosignatures));
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/NamespaceIdDescriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/NamespaceIdDescriptor.java
@@ -3,7 +3,6 @@
 
 package org.symbol.sdk.nem.descriptors;
 
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -18,32 +17,13 @@ public final class NamespaceIdDescriptor implements NemTypedDescriptor {
 	/**
 	 * Creates a descriptor for NamespaceId.
 	 *
+	 * @param name name (field is omitted when null)
 	 */
-	public NamespaceIdDescriptor() {
+	public NamespaceIdDescriptor(final byte[] name) {
 		rawDescriptor = new LinkedHashMap<>();
-	}
 
-	/**
-	 * Sets the name field.
-	 *
-	 * @param name name
-	 * @return This descriptor for chaining.
-	 */
-	public NamespaceIdDescriptor name(final byte[] name) {
 		if (null != name)
 			rawDescriptor.put("name", name);
-
-		return this;
-	}
-
-	/**
-	 * Sets the name field.
-	 *
-	 * @param name name
-	 * @return This descriptor for chaining.
-	 */
-	public NamespaceIdDescriptor name(final String name) {
-		return name(null == name ? null : name.getBytes(StandardCharsets.UTF_8));
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/NamespaceRegistrationTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/NamespaceRegistrationTransactionV1Descriptor.java
@@ -3,7 +3,6 @@
 
 package org.symbol.sdk.nem.descriptors;
 
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -23,68 +22,21 @@ public final class NamespaceRegistrationTransactionV1Descriptor implements NemTr
 	 *
 	 * @param rentalFeeSink mosaic rental fee sink public key
 	 * @param rentalFee mosaic rental fee
+	 * @param name new namespace name (field is omitted when null)
+	 * @param parentName parent namespace name (field is omitted when null)
 	 */
-	public NamespaceRegistrationTransactionV1Descriptor(final Address rentalFeeSink, final Amount rentalFee) {
+	public NamespaceRegistrationTransactionV1Descriptor(final Address rentalFeeSink, final Amount rentalFee, final byte[] name,
+			final byte[] parentName) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("type", "namespace_registration_transaction_v1");
 		rawDescriptor.put("rentalFeeSink", rentalFeeSink);
 		rawDescriptor.put("rentalFee", rentalFee);
-	}
 
-	/**
-	 * Creates a descriptor for NamespaceRegistrationTransactionV1 from string-form values.
-	 *
-	 * @param rentalFeeSink mosaic rental fee sink public key
-	 * @param rentalFee mosaic rental fee
-	 */
-	public NamespaceRegistrationTransactionV1Descriptor(final String rentalFeeSink, final String rentalFee) {
-		this(new Address(rentalFeeSink), Amount.parse(rentalFee));
-	}
-
-	/**
-	 * Sets the name field.
-	 *
-	 * @param name new namespace name
-	 * @return This descriptor for chaining.
-	 */
-	public NamespaceRegistrationTransactionV1Descriptor name(final byte[] name) {
 		if (null != name)
 			rawDescriptor.put("name", name);
 
-		return this;
-	}
-
-	/**
-	 * Sets the name field.
-	 *
-	 * @param name new namespace name
-	 * @return This descriptor for chaining.
-	 */
-	public NamespaceRegistrationTransactionV1Descriptor name(final String name) {
-		return name(null == name ? null : name.getBytes(StandardCharsets.UTF_8));
-	}
-
-	/**
-	 * Sets the parentName field.
-	 *
-	 * @param parentName parent namespace name
-	 * @return This descriptor for chaining.
-	 */
-	public NamespaceRegistrationTransactionV1Descriptor parentName(final byte[] parentName) {
 		if (null != parentName)
 			rawDescriptor.put("parentName", parentName);
-
-		return this;
-	}
-
-	/**
-	 * Sets the parentName field.
-	 *
-	 * @param parentName parent namespace name
-	 * @return This descriptor for chaining.
-	 */
-	public NamespaceRegistrationTransactionV1Descriptor parentName(final String parentName) {
-		return parentName(null == parentName ? null : parentName.getBytes(StandardCharsets.UTF_8));
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/TransferTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/TransferTransactionV1Descriptor.java
@@ -22,35 +22,16 @@ public final class TransferTransactionV1Descriptor implements NemTransactionDesc
 	 *
 	 * @param recipientAddress recipient address
 	 * @param amount XEM amount
+	 * @param message optional message (field is omitted when null)
 	 */
-	public TransferTransactionV1Descriptor(final Address recipientAddress, final Amount amount) {
+	public TransferTransactionV1Descriptor(final Address recipientAddress, final Amount amount, final MessageDescriptor message) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("type", "transfer_transaction_v1");
 		rawDescriptor.put("recipientAddress", recipientAddress);
 		rawDescriptor.put("amount", amount);
-	}
 
-	/**
-	 * Creates a descriptor for TransferTransactionV1 from string-form values.
-	 *
-	 * @param recipientAddress recipient address
-	 * @param amount XEM amount
-	 */
-	public TransferTransactionV1Descriptor(final String recipientAddress, final String amount) {
-		this(new Address(recipientAddress), Amount.parse(amount));
-	}
-
-	/**
-	 * Sets the message field.
-	 *
-	 * @param message optional message
-	 * @return This descriptor for chaining.
-	 */
-	public TransferTransactionV1Descriptor message(final MessageDescriptor message) {
 		if (null != message)
 			rawDescriptor.put("message", message.toMap());
-
-		return this;
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/TransferTransactionV2Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/nem/descriptors/TransferTransactionV2Descriptor.java
@@ -3,7 +3,6 @@
 
 package org.symbol.sdk.nem.descriptors;
 
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,58 +24,22 @@ public final class TransferTransactionV2Descriptor implements NemTransactionDesc
 	 *
 	 * @param recipientAddress recipient address
 	 * @param amount XEM amount
+	 * @param message optional message (field is omitted when null)
+	 * @param mosaics attached mosaics notice that mosaic amount is multipled by transfer amount to get effective amount (field is omitted
+	 *            when null)
 	 */
-	public TransferTransactionV2Descriptor(final Address recipientAddress, final Amount amount) {
+	public TransferTransactionV2Descriptor(final Address recipientAddress, final Amount amount, final MessageDescriptor message,
+			final List<SizePrefixedMosaicDescriptor> mosaics) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("type", "transfer_transaction_v2");
 		rawDescriptor.put("recipientAddress", recipientAddress);
 		rawDescriptor.put("amount", amount);
-	}
 
-	/**
-	 * Creates a descriptor for TransferTransactionV2 from string-form values.
-	 *
-	 * @param recipientAddress recipient address
-	 * @param amount XEM amount
-	 */
-	public TransferTransactionV2Descriptor(final String recipientAddress, final String amount) {
-		this(new Address(recipientAddress), Amount.parse(amount));
-	}
-
-	/**
-	 * Sets the message field.
-	 *
-	 * @param message optional message
-	 * @return This descriptor for chaining.
-	 */
-	public TransferTransactionV2Descriptor message(final MessageDescriptor message) {
 		if (null != message)
 			rawDescriptor.put("message", message.toMap());
 
-		return this;
-	}
-
-	/**
-	 * Sets the mosaics field.
-	 *
-	 * @param mosaics attached mosaics notice that mosaic amount is multipled by transfer amount to get effective amount
-	 * @return This descriptor for chaining.
-	 */
-	public TransferTransactionV2Descriptor mosaics(final List<SizePrefixedMosaicDescriptor> mosaics) {
 		if (null != mosaics)
 			rawDescriptor.put("mosaics", mosaics.stream().map(SizePrefixedMosaicDescriptor::toMap).collect(Collectors.toList()));
-
-		return this;
-	}
-
-	/**
-	 * Sets the mosaics field.
-	 *
-	 * @param mosaics attached mosaics notice that mosaic amount is multipled by transfer amount to get effective amount
-	 * @return This descriptor for chaining.
-	 */
-	public TransferTransactionV2Descriptor mosaics(final SizePrefixedMosaicDescriptor... mosaics) {
-		return mosaics(null == mosaics ? null : Arrays.asList(mosaics));
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AccountAddressRestrictionTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AccountAddressRestrictionTransactionV1Descriptor.java
@@ -3,11 +3,9 @@
 
 package org.symbol.sdk.symbol.descriptors;
 
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.symbol.sdk.symbol.Address;
 import org.symbol.sdk.symbol.models.AccountRestrictionFlags;
@@ -24,70 +22,20 @@ public final class AccountAddressRestrictionTransactionV1Descriptor implements S
 	 * Creates a descriptor for AccountAddressRestrictionTransactionV1.
 	 *
 	 * @param restrictionFlags Type of restriction being applied to the listed addresses.
+	 * @param restrictionAdditions Array of account addresses being added to the restricted list. (field is omitted when null)
+	 * @param restrictionDeletions Array of account addresses being removed from the restricted list. (field is omitted when null)
 	 */
-	public AccountAddressRestrictionTransactionV1Descriptor(final AccountRestrictionFlags restrictionFlags) {
+	public AccountAddressRestrictionTransactionV1Descriptor(final AccountRestrictionFlags restrictionFlags,
+			final List<Address> restrictionAdditions, final List<Address> restrictionDeletions) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("type", "account_address_restriction_transaction_v1");
 		rawDescriptor.put("restrictionFlags", restrictionFlags);
-	}
 
-	/**
-	 * Creates a descriptor for AccountAddressRestrictionTransactionV1 from string-form values.
-	 *
-	 * @param restrictionFlags Type of restriction being applied to the listed addresses.
-	 */
-	public AccountAddressRestrictionTransactionV1Descriptor(final String restrictionFlags) {
-		this(AccountRestrictionFlags.parse(restrictionFlags));
-	}
-
-	/**
-	 * Sets the restrictionAdditions field.
-	 *
-	 * @param restrictionAdditions Array of account addresses being added to the restricted list.
-	 * @return This descriptor for chaining.
-	 */
-	public AccountAddressRestrictionTransactionV1Descriptor restrictionAdditions(final List<Address> restrictionAdditions) {
 		if (null != restrictionAdditions)
 			rawDescriptor.put("restrictionAdditions", restrictionAdditions);
 
-		return this;
-	}
-
-	/**
-	 * Sets the restrictionAdditions field.
-	 *
-	 * @param restrictionAdditions Array of account addresses being added to the restricted list.
-	 * @return This descriptor for chaining.
-	 */
-	public AccountAddressRestrictionTransactionV1Descriptor restrictionAdditions(final String... restrictionAdditions) {
-		return restrictionAdditions(null == restrictionAdditions
-				? null
-				: Arrays.stream(restrictionAdditions).map(value -> new Address(value)).collect(Collectors.toList()));
-	}
-
-	/**
-	 * Sets the restrictionDeletions field.
-	 *
-	 * @param restrictionDeletions Array of account addresses being removed from the restricted list.
-	 * @return This descriptor for chaining.
-	 */
-	public AccountAddressRestrictionTransactionV1Descriptor restrictionDeletions(final List<Address> restrictionDeletions) {
 		if (null != restrictionDeletions)
 			rawDescriptor.put("restrictionDeletions", restrictionDeletions);
-
-		return this;
-	}
-
-	/**
-	 * Sets the restrictionDeletions field.
-	 *
-	 * @param restrictionDeletions Array of account addresses being removed from the restricted list.
-	 * @return This descriptor for chaining.
-	 */
-	public AccountAddressRestrictionTransactionV1Descriptor restrictionDeletions(final String... restrictionDeletions) {
-		return restrictionDeletions(null == restrictionDeletions
-				? null
-				: Arrays.stream(restrictionDeletions).map(value -> new Address(value)).collect(Collectors.toList()));
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AccountKeyLinkTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AccountKeyLinkTransactionV1Descriptor.java
@@ -32,16 +32,6 @@ public final class AccountKeyLinkTransactionV1Descriptor implements SymbolTransa
 	}
 
 	/**
-	 * Creates a descriptor for AccountKeyLinkTransactionV1 from string-form values.
-	 *
-	 * @param linkedPublicKey Linked public key.
-	 * @param linkAction Account link action.
-	 */
-	public AccountKeyLinkTransactionV1Descriptor(final String linkedPublicKey, final String linkAction) {
-		this(new CryptoTypes.PublicKey(linkedPublicKey), LinkAction.parse(linkAction));
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AccountMetadataTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AccountMetadataTransactionV1Descriptor.java
@@ -3,7 +3,6 @@
 
 package org.symbol.sdk.symbol.descriptors;
 
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -25,51 +24,20 @@ public final class AccountMetadataTransactionV1Descriptor implements SymbolTrans
 	 * @param targetAddress Account whose metadata should be modified.
 	 * @param scopedMetadataKey Metadata key scoped to source, target and type.
 	 * @param valueSizeDelta Change in value size in bytes, compared to previous size.
+	 * @param value Difference between existing value and new value. \note When there is no existing value, this array is directly used and
+	 *            `value_size_delta`==`value_size`. \note When there is an existing value, the new value is the byte-wise XOR of the
+	 *            previous value and this array. (field is omitted when null)
 	 */
-	public AccountMetadataTransactionV1Descriptor(final Address targetAddress, final long scopedMetadataKey, final int valueSizeDelta) {
+	public AccountMetadataTransactionV1Descriptor(final Address targetAddress, final long scopedMetadataKey, final int valueSizeDelta,
+			final byte[] value) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("type", "account_metadata_transaction_v1");
 		rawDescriptor.put("targetAddress", targetAddress);
 		rawDescriptor.put("scopedMetadataKey", scopedMetadataKey);
 		rawDescriptor.put("valueSizeDelta", valueSizeDelta);
-	}
 
-	/**
-	 * Creates a descriptor for AccountMetadataTransactionV1 from string-form values.
-	 *
-	 * @param targetAddress Account whose metadata should be modified.
-	 * @param scopedMetadataKey Metadata key scoped to source, target and type.
-	 * @param valueSizeDelta Change in value size in bytes, compared to previous size.
-	 */
-	public AccountMetadataTransactionV1Descriptor(final String targetAddress, final long scopedMetadataKey, final int valueSizeDelta) {
-		this(new Address(targetAddress), scopedMetadataKey, valueSizeDelta);
-	}
-
-	/**
-	 * Sets the value field.
-	 *
-	 * @param value Difference between existing value and new value. \note When there is no existing value, this array is directly used and
-	 *            `value_size_delta`==`value_size`. \note When there is an existing value, the new value is the byte-wise XOR of the
-	 *            previous value and this array.
-	 * @return This descriptor for chaining.
-	 */
-	public AccountMetadataTransactionV1Descriptor value(final byte[] value) {
 		if (null != value)
 			rawDescriptor.put("value", value);
-
-		return this;
-	}
-
-	/**
-	 * Sets the value field.
-	 *
-	 * @param value Difference between existing value and new value. \note When there is no existing value, this array is directly used and
-	 *            `value_size_delta`==`value_size`. \note When there is an existing value, the new value is the byte-wise XOR of the
-	 *            previous value and this array.
-	 * @return This descriptor for chaining.
-	 */
-	public AccountMetadataTransactionV1Descriptor value(final String value) {
-		return value(null == value ? null : value.getBytes(StandardCharsets.UTF_8));
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AccountMosaicRestrictionTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AccountMosaicRestrictionTransactionV1Descriptor.java
@@ -3,11 +3,9 @@
 
 package org.symbol.sdk.symbol.descriptors;
 
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.symbol.sdk.symbol.models.AccountRestrictionFlags;
 import org.symbol.sdk.symbol.models.UnresolvedMosaicId;
@@ -24,70 +22,20 @@ public final class AccountMosaicRestrictionTransactionV1Descriptor implements Sy
 	 * Creates a descriptor for AccountMosaicRestrictionTransactionV1.
 	 *
 	 * @param restrictionFlags Type of restriction being applied to the listed mosaics.
+	 * @param restrictionAdditions Array of mosaics being added to the restricted list. (field is omitted when null)
+	 * @param restrictionDeletions Array of mosaics being removed from the restricted list. (field is omitted when null)
 	 */
-	public AccountMosaicRestrictionTransactionV1Descriptor(final AccountRestrictionFlags restrictionFlags) {
+	public AccountMosaicRestrictionTransactionV1Descriptor(final AccountRestrictionFlags restrictionFlags,
+			final List<UnresolvedMosaicId> restrictionAdditions, final List<UnresolvedMosaicId> restrictionDeletions) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("type", "account_mosaic_restriction_transaction_v1");
 		rawDescriptor.put("restrictionFlags", restrictionFlags);
-	}
 
-	/**
-	 * Creates a descriptor for AccountMosaicRestrictionTransactionV1 from string-form values.
-	 *
-	 * @param restrictionFlags Type of restriction being applied to the listed mosaics.
-	 */
-	public AccountMosaicRestrictionTransactionV1Descriptor(final String restrictionFlags) {
-		this(AccountRestrictionFlags.parse(restrictionFlags));
-	}
-
-	/**
-	 * Sets the restrictionAdditions field.
-	 *
-	 * @param restrictionAdditions Array of mosaics being added to the restricted list.
-	 * @return This descriptor for chaining.
-	 */
-	public AccountMosaicRestrictionTransactionV1Descriptor restrictionAdditions(final List<UnresolvedMosaicId> restrictionAdditions) {
 		if (null != restrictionAdditions)
 			rawDescriptor.put("restrictionAdditions", restrictionAdditions);
 
-		return this;
-	}
-
-	/**
-	 * Sets the restrictionAdditions field.
-	 *
-	 * @param restrictionAdditions Array of mosaics being added to the restricted list.
-	 * @return This descriptor for chaining.
-	 */
-	public AccountMosaicRestrictionTransactionV1Descriptor restrictionAdditions(final String... restrictionAdditions) {
-		return restrictionAdditions(null == restrictionAdditions
-				? null
-				: Arrays.stream(restrictionAdditions).map(value -> UnresolvedMosaicId.parse(value)).collect(Collectors.toList()));
-	}
-
-	/**
-	 * Sets the restrictionDeletions field.
-	 *
-	 * @param restrictionDeletions Array of mosaics being removed from the restricted list.
-	 * @return This descriptor for chaining.
-	 */
-	public AccountMosaicRestrictionTransactionV1Descriptor restrictionDeletions(final List<UnresolvedMosaicId> restrictionDeletions) {
 		if (null != restrictionDeletions)
 			rawDescriptor.put("restrictionDeletions", restrictionDeletions);
-
-		return this;
-	}
-
-	/**
-	 * Sets the restrictionDeletions field.
-	 *
-	 * @param restrictionDeletions Array of mosaics being removed from the restricted list.
-	 * @return This descriptor for chaining.
-	 */
-	public AccountMosaicRestrictionTransactionV1Descriptor restrictionDeletions(final String... restrictionDeletions) {
-		return restrictionDeletions(null == restrictionDeletions
-				? null
-				: Arrays.stream(restrictionDeletions).map(value -> UnresolvedMosaicId.parse(value)).collect(Collectors.toList()));
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AccountOperationRestrictionTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AccountOperationRestrictionTransactionV1Descriptor.java
@@ -3,11 +3,9 @@
 
 package org.symbol.sdk.symbol.descriptors;
 
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.symbol.sdk.symbol.models.AccountRestrictionFlags;
 import org.symbol.sdk.symbol.models.TransactionType;
@@ -24,70 +22,20 @@ public final class AccountOperationRestrictionTransactionV1Descriptor implements
 	 * Creates a descriptor for AccountOperationRestrictionTransactionV1.
 	 *
 	 * @param restrictionFlags Type of restriction being applied to the listed transaction types.
+	 * @param restrictionAdditions Array of transaction types being added to the restricted list. (field is omitted when null)
+	 * @param restrictionDeletions Array of transaction types being rtemoved from the restricted list. (field is omitted when null)
 	 */
-	public AccountOperationRestrictionTransactionV1Descriptor(final AccountRestrictionFlags restrictionFlags) {
+	public AccountOperationRestrictionTransactionV1Descriptor(final AccountRestrictionFlags restrictionFlags,
+			final List<TransactionType> restrictionAdditions, final List<TransactionType> restrictionDeletions) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("type", "account_operation_restriction_transaction_v1");
 		rawDescriptor.put("restrictionFlags", restrictionFlags);
-	}
 
-	/**
-	 * Creates a descriptor for AccountOperationRestrictionTransactionV1 from string-form values.
-	 *
-	 * @param restrictionFlags Type of restriction being applied to the listed transaction types.
-	 */
-	public AccountOperationRestrictionTransactionV1Descriptor(final String restrictionFlags) {
-		this(AccountRestrictionFlags.parse(restrictionFlags));
-	}
-
-	/**
-	 * Sets the restrictionAdditions field.
-	 *
-	 * @param restrictionAdditions Array of transaction types being added to the restricted list.
-	 * @return This descriptor for chaining.
-	 */
-	public AccountOperationRestrictionTransactionV1Descriptor restrictionAdditions(final List<TransactionType> restrictionAdditions) {
 		if (null != restrictionAdditions)
 			rawDescriptor.put("restrictionAdditions", restrictionAdditions);
 
-		return this;
-	}
-
-	/**
-	 * Sets the restrictionAdditions field.
-	 *
-	 * @param restrictionAdditions Array of transaction types being added to the restricted list.
-	 * @return This descriptor for chaining.
-	 */
-	public AccountOperationRestrictionTransactionV1Descriptor restrictionAdditions(final String... restrictionAdditions) {
-		return restrictionAdditions(null == restrictionAdditions
-				? null
-				: Arrays.stream(restrictionAdditions).map(value -> TransactionType.parse(value)).collect(Collectors.toList()));
-	}
-
-	/**
-	 * Sets the restrictionDeletions field.
-	 *
-	 * @param restrictionDeletions Array of transaction types being rtemoved from the restricted list.
-	 * @return This descriptor for chaining.
-	 */
-	public AccountOperationRestrictionTransactionV1Descriptor restrictionDeletions(final List<TransactionType> restrictionDeletions) {
 		if (null != restrictionDeletions)
 			rawDescriptor.put("restrictionDeletions", restrictionDeletions);
-
-		return this;
-	}
-
-	/**
-	 * Sets the restrictionDeletions field.
-	 *
-	 * @param restrictionDeletions Array of transaction types being rtemoved from the restricted list.
-	 * @return This descriptor for chaining.
-	 */
-	public AccountOperationRestrictionTransactionV1Descriptor restrictionDeletions(final String... restrictionDeletions) {
-		return restrictionDeletions(null == restrictionDeletions
-				? null
-				: Arrays.stream(restrictionDeletions).map(value -> TransactionType.parse(value)).collect(Collectors.toList()));
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AddressAliasTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AddressAliasTransactionV1Descriptor.java
@@ -35,17 +35,6 @@ public final class AddressAliasTransactionV1Descriptor implements SymbolTransact
 	}
 
 	/**
-	 * Creates a descriptor for AddressAliasTransactionV1 from string-form values.
-	 *
-	 * @param namespaceId Identifier of the namespace that will become (or stop being) an alias for the address.
-	 * @param address Aliased address.
-	 * @param aliasAction Alias action.
-	 */
-	public AddressAliasTransactionV1Descriptor(final String namespaceId, final String address, final String aliasAction) {
-		this(NamespaceId.parse(namespaceId), new Address(address), AliasAction.parse(aliasAction));
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AggregateBondedTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AggregateBondedTransactionV1Descriptor.java
@@ -25,47 +25,21 @@ public final class AggregateBondedTransactionV1Descriptor implements SymbolTrans
 	 * Creates a descriptor for AggregateBondedTransactionV1.
 	 *
 	 * @param transactionsHash Hash of the aggregate's transaction.
+	 * @param transactions Embedded transaction data. Transactions are variable-sized and the total payload size is in bytes. Embedded
+	 *            transactions cannot be aggregates. (field is omitted when null)
+	 * @param cosignatures Cosignatures data. Fills up remaining body space after transactions. (field is omitted when null)
 	 */
-	public AggregateBondedTransactionV1Descriptor(final CryptoTypes.Hash256 transactionsHash) {
+	public AggregateBondedTransactionV1Descriptor(final CryptoTypes.Hash256 transactionsHash, final List<EmbeddedTransaction> transactions,
+			final List<Cosignature> cosignatures) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("type", "aggregate_bonded_transaction_v1");
 		rawDescriptor.put("transactionsHash", transactionsHash);
-	}
 
-	/**
-	 * Creates a descriptor for AggregateBondedTransactionV1 from string-form values.
-	 *
-	 * @param transactionsHash Hash of the aggregate's transaction.
-	 */
-	public AggregateBondedTransactionV1Descriptor(final String transactionsHash) {
-		this(new CryptoTypes.Hash256(transactionsHash));
-	}
-
-	/**
-	 * Sets the transactions field.
-	 *
-	 * @param transactions Embedded transaction data. Transactions are variable-sized and the total payload size is in bytes. Embedded
-	 *            transactions cannot be aggregates.
-	 * @return This descriptor for chaining.
-	 */
-	public AggregateBondedTransactionV1Descriptor transactions(final List<EmbeddedTransaction> transactions) {
 		if (null != transactions)
 			rawDescriptor.put("transactions", transactions);
 
-		return this;
-	}
-
-	/**
-	 * Sets the cosignatures field.
-	 *
-	 * @param cosignatures Cosignatures data. Fills up remaining body space after transactions.
-	 * @return This descriptor for chaining.
-	 */
-	public AggregateBondedTransactionV1Descriptor cosignatures(final List<Cosignature> cosignatures) {
 		if (null != cosignatures)
 			rawDescriptor.put("cosignatures", cosignatures);
-
-		return this;
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AggregateBondedTransactionV2Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AggregateBondedTransactionV2Descriptor.java
@@ -25,47 +25,21 @@ public final class AggregateBondedTransactionV2Descriptor implements SymbolTrans
 	 * Creates a descriptor for AggregateBondedTransactionV2.
 	 *
 	 * @param transactionsHash Hash of the aggregate's transaction.
+	 * @param transactions Embedded transaction data. Transactions are variable-sized and the total payload size is in bytes. Embedded
+	 *            transactions cannot be aggregates. (field is omitted when null)
+	 * @param cosignatures Cosignatures data. Fills up remaining body space after transactions. (field is omitted when null)
 	 */
-	public AggregateBondedTransactionV2Descriptor(final CryptoTypes.Hash256 transactionsHash) {
+	public AggregateBondedTransactionV2Descriptor(final CryptoTypes.Hash256 transactionsHash, final List<EmbeddedTransaction> transactions,
+			final List<Cosignature> cosignatures) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("type", "aggregate_bonded_transaction_v2");
 		rawDescriptor.put("transactionsHash", transactionsHash);
-	}
 
-	/**
-	 * Creates a descriptor for AggregateBondedTransactionV2 from string-form values.
-	 *
-	 * @param transactionsHash Hash of the aggregate's transaction.
-	 */
-	public AggregateBondedTransactionV2Descriptor(final String transactionsHash) {
-		this(new CryptoTypes.Hash256(transactionsHash));
-	}
-
-	/**
-	 * Sets the transactions field.
-	 *
-	 * @param transactions Embedded transaction data. Transactions are variable-sized and the total payload size is in bytes. Embedded
-	 *            transactions cannot be aggregates.
-	 * @return This descriptor for chaining.
-	 */
-	public AggregateBondedTransactionV2Descriptor transactions(final List<EmbeddedTransaction> transactions) {
 		if (null != transactions)
 			rawDescriptor.put("transactions", transactions);
 
-		return this;
-	}
-
-	/**
-	 * Sets the cosignatures field.
-	 *
-	 * @param cosignatures Cosignatures data. Fills up remaining body space after transactions.
-	 * @return This descriptor for chaining.
-	 */
-	public AggregateBondedTransactionV2Descriptor cosignatures(final List<Cosignature> cosignatures) {
 		if (null != cosignatures)
 			rawDescriptor.put("cosignatures", cosignatures);
-
-		return this;
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AggregateBondedTransactionV3Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AggregateBondedTransactionV3Descriptor.java
@@ -25,47 +25,21 @@ public final class AggregateBondedTransactionV3Descriptor implements SymbolTrans
 	 * Creates a descriptor for AggregateBondedTransactionV3.
 	 *
 	 * @param transactionsHash Hash of the aggregate's transaction.
+	 * @param transactions Embedded transaction data. Transactions are variable-sized and the total payload size is in bytes. Embedded
+	 *            transactions cannot be aggregates. (field is omitted when null)
+	 * @param cosignatures Cosignatures data. Fills up remaining body space after transactions. (field is omitted when null)
 	 */
-	public AggregateBondedTransactionV3Descriptor(final CryptoTypes.Hash256 transactionsHash) {
+	public AggregateBondedTransactionV3Descriptor(final CryptoTypes.Hash256 transactionsHash, final List<EmbeddedTransaction> transactions,
+			final List<Cosignature> cosignatures) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("type", "aggregate_bonded_transaction_v3");
 		rawDescriptor.put("transactionsHash", transactionsHash);
-	}
 
-	/**
-	 * Creates a descriptor for AggregateBondedTransactionV3 from string-form values.
-	 *
-	 * @param transactionsHash Hash of the aggregate's transaction.
-	 */
-	public AggregateBondedTransactionV3Descriptor(final String transactionsHash) {
-		this(new CryptoTypes.Hash256(transactionsHash));
-	}
-
-	/**
-	 * Sets the transactions field.
-	 *
-	 * @param transactions Embedded transaction data. Transactions are variable-sized and the total payload size is in bytes. Embedded
-	 *            transactions cannot be aggregates.
-	 * @return This descriptor for chaining.
-	 */
-	public AggregateBondedTransactionV3Descriptor transactions(final List<EmbeddedTransaction> transactions) {
 		if (null != transactions)
 			rawDescriptor.put("transactions", transactions);
 
-		return this;
-	}
-
-	/**
-	 * Sets the cosignatures field.
-	 *
-	 * @param cosignatures Cosignatures data. Fills up remaining body space after transactions.
-	 * @return This descriptor for chaining.
-	 */
-	public AggregateBondedTransactionV3Descriptor cosignatures(final List<Cosignature> cosignatures) {
 		if (null != cosignatures)
 			rawDescriptor.put("cosignatures", cosignatures);
-
-		return this;
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AggregateCompleteTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AggregateCompleteTransactionV1Descriptor.java
@@ -24,47 +24,21 @@ public final class AggregateCompleteTransactionV1Descriptor implements SymbolTra
 	 * Creates a descriptor for AggregateCompleteTransactionV1.
 	 *
 	 * @param transactionsHash Hash of the aggregate's transaction.
+	 * @param transactions Embedded transaction data. Transactions are variable-sized and the total payload size is in bytes. Embedded
+	 *            transactions cannot be aggregates. (field is omitted when null)
+	 * @param cosignatures Cosignatures data. Fills up remaining body space after transactions. (field is omitted when null)
 	 */
-	public AggregateCompleteTransactionV1Descriptor(final CryptoTypes.Hash256 transactionsHash) {
+	public AggregateCompleteTransactionV1Descriptor(final CryptoTypes.Hash256 transactionsHash,
+			final List<EmbeddedTransaction> transactions, final List<Cosignature> cosignatures) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("type", "aggregate_complete_transaction_v1");
 		rawDescriptor.put("transactionsHash", transactionsHash);
-	}
 
-	/**
-	 * Creates a descriptor for AggregateCompleteTransactionV1 from string-form values.
-	 *
-	 * @param transactionsHash Hash of the aggregate's transaction.
-	 */
-	public AggregateCompleteTransactionV1Descriptor(final String transactionsHash) {
-		this(new CryptoTypes.Hash256(transactionsHash));
-	}
-
-	/**
-	 * Sets the transactions field.
-	 *
-	 * @param transactions Embedded transaction data. Transactions are variable-sized and the total payload size is in bytes. Embedded
-	 *            transactions cannot be aggregates.
-	 * @return This descriptor for chaining.
-	 */
-	public AggregateCompleteTransactionV1Descriptor transactions(final List<EmbeddedTransaction> transactions) {
 		if (null != transactions)
 			rawDescriptor.put("transactions", transactions);
 
-		return this;
-	}
-
-	/**
-	 * Sets the cosignatures field.
-	 *
-	 * @param cosignatures Cosignatures data. Fills up remaining body space after transactions.
-	 * @return This descriptor for chaining.
-	 */
-	public AggregateCompleteTransactionV1Descriptor cosignatures(final List<Cosignature> cosignatures) {
 		if (null != cosignatures)
 			rawDescriptor.put("cosignatures", cosignatures);
-
-		return this;
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AggregateCompleteTransactionV2Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AggregateCompleteTransactionV2Descriptor.java
@@ -24,47 +24,21 @@ public final class AggregateCompleteTransactionV2Descriptor implements SymbolTra
 	 * Creates a descriptor for AggregateCompleteTransactionV2.
 	 *
 	 * @param transactionsHash Hash of the aggregate's transaction.
+	 * @param transactions Embedded transaction data. Transactions are variable-sized and the total payload size is in bytes. Embedded
+	 *            transactions cannot be aggregates. (field is omitted when null)
+	 * @param cosignatures Cosignatures data. Fills up remaining body space after transactions. (field is omitted when null)
 	 */
-	public AggregateCompleteTransactionV2Descriptor(final CryptoTypes.Hash256 transactionsHash) {
+	public AggregateCompleteTransactionV2Descriptor(final CryptoTypes.Hash256 transactionsHash,
+			final List<EmbeddedTransaction> transactions, final List<Cosignature> cosignatures) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("type", "aggregate_complete_transaction_v2");
 		rawDescriptor.put("transactionsHash", transactionsHash);
-	}
 
-	/**
-	 * Creates a descriptor for AggregateCompleteTransactionV2 from string-form values.
-	 *
-	 * @param transactionsHash Hash of the aggregate's transaction.
-	 */
-	public AggregateCompleteTransactionV2Descriptor(final String transactionsHash) {
-		this(new CryptoTypes.Hash256(transactionsHash));
-	}
-
-	/**
-	 * Sets the transactions field.
-	 *
-	 * @param transactions Embedded transaction data. Transactions are variable-sized and the total payload size is in bytes. Embedded
-	 *            transactions cannot be aggregates.
-	 * @return This descriptor for chaining.
-	 */
-	public AggregateCompleteTransactionV2Descriptor transactions(final List<EmbeddedTransaction> transactions) {
 		if (null != transactions)
 			rawDescriptor.put("transactions", transactions);
 
-		return this;
-	}
-
-	/**
-	 * Sets the cosignatures field.
-	 *
-	 * @param cosignatures Cosignatures data. Fills up remaining body space after transactions.
-	 * @return This descriptor for chaining.
-	 */
-	public AggregateCompleteTransactionV2Descriptor cosignatures(final List<Cosignature> cosignatures) {
 		if (null != cosignatures)
 			rawDescriptor.put("cosignatures", cosignatures);
-
-		return this;
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AggregateCompleteTransactionV3Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/AggregateCompleteTransactionV3Descriptor.java
@@ -24,47 +24,21 @@ public final class AggregateCompleteTransactionV3Descriptor implements SymbolTra
 	 * Creates a descriptor for AggregateCompleteTransactionV3.
 	 *
 	 * @param transactionsHash Hash of the aggregate's transaction.
+	 * @param transactions Embedded transaction data. Transactions are variable-sized and the total payload size is in bytes. Embedded
+	 *            transactions cannot be aggregates. (field is omitted when null)
+	 * @param cosignatures Cosignatures data. Fills up remaining body space after transactions. (field is omitted when null)
 	 */
-	public AggregateCompleteTransactionV3Descriptor(final CryptoTypes.Hash256 transactionsHash) {
+	public AggregateCompleteTransactionV3Descriptor(final CryptoTypes.Hash256 transactionsHash,
+			final List<EmbeddedTransaction> transactions, final List<Cosignature> cosignatures) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("type", "aggregate_complete_transaction_v3");
 		rawDescriptor.put("transactionsHash", transactionsHash);
-	}
 
-	/**
-	 * Creates a descriptor for AggregateCompleteTransactionV3 from string-form values.
-	 *
-	 * @param transactionsHash Hash of the aggregate's transaction.
-	 */
-	public AggregateCompleteTransactionV3Descriptor(final String transactionsHash) {
-		this(new CryptoTypes.Hash256(transactionsHash));
-	}
-
-	/**
-	 * Sets the transactions field.
-	 *
-	 * @param transactions Embedded transaction data. Transactions are variable-sized and the total payload size is in bytes. Embedded
-	 *            transactions cannot be aggregates.
-	 * @return This descriptor for chaining.
-	 */
-	public AggregateCompleteTransactionV3Descriptor transactions(final List<EmbeddedTransaction> transactions) {
 		if (null != transactions)
 			rawDescriptor.put("transactions", transactions);
 
-		return this;
-	}
-
-	/**
-	 * Sets the cosignatures field.
-	 *
-	 * @param cosignatures Cosignatures data. Fills up remaining body space after transactions.
-	 * @return This descriptor for chaining.
-	 */
-	public AggregateCompleteTransactionV3Descriptor cosignatures(final List<Cosignature> cosignatures) {
 		if (null != cosignatures)
 			rawDescriptor.put("cosignatures", cosignatures);
-
-		return this;
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/CosignatureDescriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/CosignatureDescriptor.java
@@ -32,17 +32,6 @@ public final class CosignatureDescriptor implements SymbolTypedDescriptor {
 	}
 
 	/**
-	 * Creates a descriptor for Cosignature from string-form values.
-	 *
-	 * @param version Version.
-	 * @param signerPublicKey Cosigner public key.
-	 * @param signature Transaction signature.
-	 */
-	public CosignatureDescriptor(final long version, final String signerPublicKey, final String signature) {
-		this(version, new CryptoTypes.PublicKey(signerPublicKey), Signature.parse(signature));
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/DetachedCosignatureDescriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/DetachedCosignatureDescriptor.java
@@ -35,19 +35,6 @@ public final class DetachedCosignatureDescriptor implements SymbolTypedDescripto
 	}
 
 	/**
-	 * Creates a descriptor for DetachedCosignature from string-form values.
-	 *
-	 * @param version Version.
-	 * @param signerPublicKey Cosigner public key.
-	 * @param signature Transaction signature.
-	 * @param parentHash Hash of the AggregateBondedTransaction that is signed by this cosignature.
-	 */
-	public DetachedCosignatureDescriptor(final long version, final String signerPublicKey, final String signature,
-			final String parentHash) {
-		this(version, new CryptoTypes.PublicKey(signerPublicKey), Signature.parse(signature), new CryptoTypes.Hash256(parentHash));
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/HashLockTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/HashLockTransactionV1Descriptor.java
@@ -43,18 +43,6 @@ public final class HashLockTransactionV1Descriptor implements SymbolTransactionD
 	}
 
 	/**
-	 * Creates a descriptor for HashLockTransactionV1 from string-form values.
-	 *
-	 * @param mosaic Locked mosaic.
-	 * @param duration Number of blocks for which a lock should be valid. The default maximum is 48h (See the `maxHashLockDuration` network
-	 *            property).
-	 * @param hash Hash of the AggregateBondedTransaction to be confirmed before unlocking the mosaics.
-	 */
-	public HashLockTransactionV1Descriptor(final UnresolvedMosaicDescriptor mosaic, final String duration, final String hash) {
-		this(mosaic, BlockDuration.parse(duration), new CryptoTypes.Hash256(hash));
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/MosaicAddressRestrictionTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/MosaicAddressRestrictionTransactionV1Descriptor.java
@@ -39,21 +39,6 @@ public final class MosaicAddressRestrictionTransactionV1Descriptor implements Sy
 	}
 
 	/**
-	 * Creates a descriptor for MosaicAddressRestrictionTransactionV1 from string-form values.
-	 *
-	 * @param mosaicId Identifier of the mosaic to which the restriction applies.
-	 * @param restrictionKey Restriction key.
-	 * @param previousRestrictionValue Previous restriction value. Set `previousRestrictionValue` to `FFFFFFFFFFFFFFFF` if the target
-	 *            address does not have a previous restriction value for this mosaic id and restriction key.
-	 * @param newRestrictionValue New restriction value.
-	 * @param targetAddress Address being restricted.
-	 */
-	public MosaicAddressRestrictionTransactionV1Descriptor(final String mosaicId, final long restrictionKey,
-			final long previousRestrictionValue, final long newRestrictionValue, final String targetAddress) {
-		this(UnresolvedMosaicId.parse(mosaicId), restrictionKey, previousRestrictionValue, newRestrictionValue, new Address(targetAddress));
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/MosaicAliasTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/MosaicAliasTransactionV1Descriptor.java
@@ -35,17 +35,6 @@ public final class MosaicAliasTransactionV1Descriptor implements SymbolTransacti
 	}
 
 	/**
-	 * Creates a descriptor for MosaicAliasTransactionV1 from string-form values.
-	 *
-	 * @param namespaceId Identifier of the namespace that will become (or stop being) an alias for the Mosaic.
-	 * @param mosaicId Aliased mosaic identifier.
-	 * @param aliasAction Alias action.
-	 */
-	public MosaicAliasTransactionV1Descriptor(final String namespaceId, final String mosaicId, final String aliasAction) {
-		this(NamespaceId.parse(namespaceId), MosaicId.parse(mosaicId), AliasAction.parse(aliasAction));
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/MosaicDefinitionTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/MosaicDefinitionTransactionV1Descriptor.java
@@ -41,21 +41,6 @@ public final class MosaicDefinitionTransactionV1Descriptor implements SymbolTran
 	}
 
 	/**
-	 * Creates a descriptor for MosaicDefinitionTransactionV1 from string-form values.
-	 *
-	 * @param id Unique mosaic identifier obtained from the generator account's public key and the `nonce`. The SDK's can take care of
-	 *            generating this ID for you.
-	 * @param duration Mosaic duration expressed in blocks. If set to 0, the mosaic never expires.
-	 * @param nonce Random nonce used to generate the mosaic id.
-	 * @param flags Mosaic flags.
-	 * @param divisibility Mosaic divisibility.
-	 */
-	public MosaicDefinitionTransactionV1Descriptor(final String id, final String duration, final String nonce, final String flags,
-			final int divisibility) {
-		this(MosaicId.parse(id), BlockDuration.parse(duration), MosaicNonce.parse(nonce), MosaicFlags.parse(flags), divisibility);
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/MosaicDescriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/MosaicDescriptor.java
@@ -30,16 +30,6 @@ public final class MosaicDescriptor implements SymbolTypedDescriptor {
 	}
 
 	/**
-	 * Creates a descriptor for Mosaic from string-form values.
-	 *
-	 * @param mosaicId Mosaic identifier.
-	 * @param amount Mosaic amount.
-	 */
-	public MosaicDescriptor(final String mosaicId, final String amount) {
-		this(MosaicId.parse(mosaicId), Amount.parse(amount));
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/MosaicGlobalRestrictionTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/MosaicGlobalRestrictionTransactionV1Descriptor.java
@@ -45,26 +45,6 @@ public final class MosaicGlobalRestrictionTransactionV1Descriptor implements Sym
 	}
 
 	/**
-	 * Creates a descriptor for MosaicGlobalRestrictionTransactionV1 from string-form values.
-	 *
-	 * @param mosaicId Identifier of the mosaic being restricted. The mosaic creator must be the signer of the transaction.
-	 * @param referenceMosaicId Identifier of the mosaic providing the restriction key. The mosaic global restriction for the mosaic
-	 *            identifier depends on global restrictions set on the reference mosaic. Set `reference_mosaic_id` to **0** if the mosaic
-	 *            giving the restriction equals the `mosaic_id`.
-	 * @param restrictionKey Restriction key relative to the reference mosaic identifier.
-	 * @param previousRestrictionValue Previous restriction value.
-	 * @param newRestrictionValue New restriction value.
-	 * @param previousRestrictionType Previous restriction type.
-	 * @param newRestrictionType New restriction type.
-	 */
-	public MosaicGlobalRestrictionTransactionV1Descriptor(final String mosaicId, final String referenceMosaicId, final long restrictionKey,
-			final long previousRestrictionValue, final long newRestrictionValue, final String previousRestrictionType,
-			final String newRestrictionType) {
-		this(UnresolvedMosaicId.parse(mosaicId), UnresolvedMosaicId.parse(referenceMosaicId), restrictionKey, previousRestrictionValue,
-				newRestrictionValue, MosaicRestrictionType.parse(previousRestrictionType), MosaicRestrictionType.parse(newRestrictionType));
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/MosaicMetadataTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/MosaicMetadataTransactionV1Descriptor.java
@@ -3,7 +3,6 @@
 
 package org.symbol.sdk.symbol.descriptors;
 
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -26,55 +25,21 @@ public final class MosaicMetadataTransactionV1Descriptor implements SymbolTransa
 	 * @param scopedMetadataKey Metadata key scoped to source, target and type.
 	 * @param targetMosaicId Mosaic whose metadata should be modified.
 	 * @param valueSizeDelta Change in value size in bytes, compared to previous size.
+	 * @param value Difference between existing value and new value. \note When there is no existing value, this array is directly used and
+	 *            `value_size_delta`==`value_size`. \note When there is an existing value, the new value is the byte-wise XOR of the
+	 *            previous value and this array. (field is omitted when null)
 	 */
 	public MosaicMetadataTransactionV1Descriptor(final Address targetAddress, final long scopedMetadataKey,
-			final UnresolvedMosaicId targetMosaicId, final int valueSizeDelta) {
+			final UnresolvedMosaicId targetMosaicId, final int valueSizeDelta, final byte[] value) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("type", "mosaic_metadata_transaction_v1");
 		rawDescriptor.put("targetAddress", targetAddress);
 		rawDescriptor.put("scopedMetadataKey", scopedMetadataKey);
 		rawDescriptor.put("targetMosaicId", targetMosaicId);
 		rawDescriptor.put("valueSizeDelta", valueSizeDelta);
-	}
 
-	/**
-	 * Creates a descriptor for MosaicMetadataTransactionV1 from string-form values.
-	 *
-	 * @param targetAddress Account owning the mosaic whose metadata should be modified.
-	 * @param scopedMetadataKey Metadata key scoped to source, target and type.
-	 * @param targetMosaicId Mosaic whose metadata should be modified.
-	 * @param valueSizeDelta Change in value size in bytes, compared to previous size.
-	 */
-	public MosaicMetadataTransactionV1Descriptor(final String targetAddress, final long scopedMetadataKey, final String targetMosaicId,
-			final int valueSizeDelta) {
-		this(new Address(targetAddress), scopedMetadataKey, UnresolvedMosaicId.parse(targetMosaicId), valueSizeDelta);
-	}
-
-	/**
-	 * Sets the value field.
-	 *
-	 * @param value Difference between existing value and new value. \note When there is no existing value, this array is directly used and
-	 *            `value_size_delta`==`value_size`. \note When there is an existing value, the new value is the byte-wise XOR of the
-	 *            previous value and this array.
-	 * @return This descriptor for chaining.
-	 */
-	public MosaicMetadataTransactionV1Descriptor value(final byte[] value) {
 		if (null != value)
 			rawDescriptor.put("value", value);
-
-		return this;
-	}
-
-	/**
-	 * Sets the value field.
-	 *
-	 * @param value Difference between existing value and new value. \note When there is no existing value, this array is directly used and
-	 *            `value_size_delta`==`value_size`. \note When there is an existing value, the new value is the byte-wise XOR of the
-	 *            previous value and this array.
-	 * @return This descriptor for chaining.
-	 */
-	public MosaicMetadataTransactionV1Descriptor value(final String value) {
-		return value(null == value ? null : value.getBytes(StandardCharsets.UTF_8));
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/MosaicSupplyChangeTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/MosaicSupplyChangeTransactionV1Descriptor.java
@@ -36,18 +36,6 @@ public final class MosaicSupplyChangeTransactionV1Descriptor implements SymbolTr
 	}
 
 	/**
-	 * Creates a descriptor for MosaicSupplyChangeTransactionV1 from string-form values.
-	 *
-	 * @param mosaicId Affected mosaic identifier.
-	 * @param delta Change amount. It cannot be negative, use the `action` field to indicate if this amount should be **added** or
-	 *            **subtracted** from the current supply.
-	 * @param action Supply change action.
-	 */
-	public MosaicSupplyChangeTransactionV1Descriptor(final String mosaicId, final String delta, final String action) {
-		this(UnresolvedMosaicId.parse(mosaicId), Amount.parse(delta), MosaicSupplyChangeAction.parse(action));
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/MosaicSupplyRevocationTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/MosaicSupplyRevocationTransactionV1Descriptor.java
@@ -30,16 +30,6 @@ public final class MosaicSupplyRevocationTransactionV1Descriptor implements Symb
 	}
 
 	/**
-	 * Creates a descriptor for MosaicSupplyRevocationTransactionV1 from string-form values.
-	 *
-	 * @param sourceAddress Address from which tokens should be revoked.
-	 * @param mosaic Revoked mosaic and amount.
-	 */
-	public MosaicSupplyRevocationTransactionV1Descriptor(final String sourceAddress, final UnresolvedMosaicDescriptor mosaic) {
-		this(new Address(sourceAddress), mosaic);
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/MultisigAccountModificationTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/MultisigAccountModificationTransactionV1Descriptor.java
@@ -3,11 +3,9 @@
 
 package org.symbol.sdk.symbol.descriptors;
 
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 import org.symbol.sdk.symbol.Address;
 
@@ -30,70 +28,25 @@ public final class MultisigAccountModificationTransactionV1Descriptor implements
 	 * @param minApprovalDelta Relative change to the **minimum** number of cosignatures required when **approving a transaction**. E.g.,
 	 *            when moving from 0 to 2 cosignatures this number would be **2**. When moving from 4 to 3 cosignatures, the number would be
 	 *            **-1**.
+	 * @param addressAdditions Cosignatory address additions. All accounts in this list will be able to cosign transactions on behalf of the
+	 *            multisig account. The number of required cosignatures depends on the configured minimum approval and minimum removal
+	 *            values. (field is omitted when null)
+	 * @param addressDeletions Cosignatory address deletions. All accounts in this list will stop being able to cosign transactions on
+	 *            behalf of the multisig account. A transaction containing **any** address in this array requires a number of cosignatures
+	 *            at least equal to the minimum removal value. (field is omitted when null)
 	 */
-	public MultisigAccountModificationTransactionV1Descriptor(final int minRemovalDelta, final int minApprovalDelta) {
+	public MultisigAccountModificationTransactionV1Descriptor(final int minRemovalDelta, final int minApprovalDelta,
+			final List<Address> addressAdditions, final List<Address> addressDeletions) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("type", "multisig_account_modification_transaction_v1");
 		rawDescriptor.put("minRemovalDelta", minRemovalDelta);
 		rawDescriptor.put("minApprovalDelta", minApprovalDelta);
-	}
 
-	/**
-	 * Sets the addressAdditions field.
-	 *
-	 * @param addressAdditions Cosignatory address additions. All accounts in this list will be able to cosign transactions on behalf of the
-	 *            multisig account. The number of required cosignatures depends on the configured minimum approval and minimum removal
-	 *            values.
-	 * @return This descriptor for chaining.
-	 */
-	public MultisigAccountModificationTransactionV1Descriptor addressAdditions(final List<Address> addressAdditions) {
 		if (null != addressAdditions)
 			rawDescriptor.put("addressAdditions", addressAdditions);
 
-		return this;
-	}
-
-	/**
-	 * Sets the addressAdditions field.
-	 *
-	 * @param addressAdditions Cosignatory address additions. All accounts in this list will be able to cosign transactions on behalf of the
-	 *            multisig account. The number of required cosignatures depends on the configured minimum approval and minimum removal
-	 *            values.
-	 * @return This descriptor for chaining.
-	 */
-	public MultisigAccountModificationTransactionV1Descriptor addressAdditions(final String... addressAdditions) {
-		return addressAdditions(null == addressAdditions
-				? null
-				: Arrays.stream(addressAdditions).map(value -> new Address(value)).collect(Collectors.toList()));
-	}
-
-	/**
-	 * Sets the addressDeletions field.
-	 *
-	 * @param addressDeletions Cosignatory address deletions. All accounts in this list will stop being able to cosign transactions on
-	 *            behalf of the multisig account. A transaction containing **any** address in this array requires a number of cosignatures
-	 *            at least equal to the minimum removal value.
-	 * @return This descriptor for chaining.
-	 */
-	public MultisigAccountModificationTransactionV1Descriptor addressDeletions(final List<Address> addressDeletions) {
 		if (null != addressDeletions)
 			rawDescriptor.put("addressDeletions", addressDeletions);
-
-		return this;
-	}
-
-	/**
-	 * Sets the addressDeletions field.
-	 *
-	 * @param addressDeletions Cosignatory address deletions. All accounts in this list will stop being able to cosign transactions on
-	 *            behalf of the multisig account. A transaction containing **any** address in this array requires a number of cosignatures
-	 *            at least equal to the minimum removal value.
-	 * @return This descriptor for chaining.
-	 */
-	public MultisigAccountModificationTransactionV1Descriptor addressDeletions(final String... addressDeletions) {
-		return addressDeletions(null == addressDeletions
-				? null
-				: Arrays.stream(addressDeletions).map(value -> new Address(value)).collect(Collectors.toList()));
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/NamespaceMetadataTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/NamespaceMetadataTransactionV1Descriptor.java
@@ -3,7 +3,6 @@
 
 package org.symbol.sdk.symbol.descriptors;
 
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -26,55 +25,21 @@ public final class NamespaceMetadataTransactionV1Descriptor implements SymbolTra
 	 * @param scopedMetadataKey Metadata key scoped to source, target and type.
 	 * @param targetNamespaceId Namespace whose metadata should be modified.
 	 * @param valueSizeDelta Change in value size in bytes, compared to previous size.
+	 * @param value Difference between existing value and new value. \note When there is no existing value, this array is directly used and
+	 *            `value_size_delta`==`value_size`. \note When there is an existing value, the new value is the byte-wise XOR of the
+	 *            previous value and this array. (field is omitted when null)
 	 */
 	public NamespaceMetadataTransactionV1Descriptor(final Address targetAddress, final long scopedMetadataKey,
-			final NamespaceId targetNamespaceId, final int valueSizeDelta) {
+			final NamespaceId targetNamespaceId, final int valueSizeDelta, final byte[] value) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("type", "namespace_metadata_transaction_v1");
 		rawDescriptor.put("targetAddress", targetAddress);
 		rawDescriptor.put("scopedMetadataKey", scopedMetadataKey);
 		rawDescriptor.put("targetNamespaceId", targetNamespaceId);
 		rawDescriptor.put("valueSizeDelta", valueSizeDelta);
-	}
 
-	/**
-	 * Creates a descriptor for NamespaceMetadataTransactionV1 from string-form values.
-	 *
-	 * @param targetAddress Account owning the namespace whose metadata should be modified.
-	 * @param scopedMetadataKey Metadata key scoped to source, target and type.
-	 * @param targetNamespaceId Namespace whose metadata should be modified.
-	 * @param valueSizeDelta Change in value size in bytes, compared to previous size.
-	 */
-	public NamespaceMetadataTransactionV1Descriptor(final String targetAddress, final long scopedMetadataKey,
-			final String targetNamespaceId, final int valueSizeDelta) {
-		this(new Address(targetAddress), scopedMetadataKey, NamespaceId.parse(targetNamespaceId), valueSizeDelta);
-	}
-
-	/**
-	 * Sets the value field.
-	 *
-	 * @param value Difference between existing value and new value. \note When there is no existing value, this array is directly used and
-	 *            `value_size_delta`==`value_size`. \note When there is an existing value, the new value is the byte-wise XOR of the
-	 *            previous value and this array.
-	 * @return This descriptor for chaining.
-	 */
-	public NamespaceMetadataTransactionV1Descriptor value(final byte[] value) {
 		if (null != value)
 			rawDescriptor.put("value", value);
-
-		return this;
-	}
-
-	/**
-	 * Sets the value field.
-	 *
-	 * @param value Difference between existing value and new value. \note When there is no existing value, this array is directly used and
-	 *            `value_size_delta`==`value_size`. \note When there is an existing value, the new value is the byte-wise XOR of the
-	 *            previous value and this array.
-	 * @return This descriptor for chaining.
-	 */
-	public NamespaceMetadataTransactionV1Descriptor value(final String value) {
-		return value(null == value ? null : value.getBytes(StandardCharsets.UTF_8));
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/NamespaceRegistrationTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/NamespaceRegistrationTransactionV1Descriptor.java
@@ -3,7 +3,6 @@
 
 package org.symbol.sdk.symbol.descriptors;
 
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -24,91 +23,26 @@ public final class NamespaceRegistrationTransactionV1Descriptor implements Symbo
 	 *
 	 * @param id Namespace identifier.
 	 * @param registrationType Namespace registration type.
+	 * @param duration Number of confirmed blocks you would like to rent the namespace for. Required for root namespaces. (field is omitted
+	 *            when null)
+	 * @param parentId Parent namespace identifier. Required for sub-namespaces. (field is omitted when null)
+	 * @param name Namespace name. (field is omitted when null)
 	 */
-	public NamespaceRegistrationTransactionV1Descriptor(final NamespaceId id, final NamespaceRegistrationType registrationType) {
+	public NamespaceRegistrationTransactionV1Descriptor(final NamespaceId id, final NamespaceRegistrationType registrationType,
+			final BlockDuration duration, final NamespaceId parentId, final byte[] name) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("type", "namespace_registration_transaction_v1");
 		rawDescriptor.put("id", id);
 		rawDescriptor.put("registrationType", registrationType);
-	}
 
-	/**
-	 * Creates a descriptor for NamespaceRegistrationTransactionV1 from string-form values.
-	 *
-	 * @param id Namespace identifier.
-	 * @param registrationType Namespace registration type.
-	 */
-	public NamespaceRegistrationTransactionV1Descriptor(final String id, final String registrationType) {
-		this(NamespaceId.parse(id), NamespaceRegistrationType.parse(registrationType));
-	}
-
-	/**
-	 * Sets the duration field.
-	 *
-	 * @param duration Number of confirmed blocks you would like to rent the namespace for. Required for root namespaces.
-	 * @return This descriptor for chaining.
-	 */
-	public NamespaceRegistrationTransactionV1Descriptor duration(final BlockDuration duration) {
 		if (null != duration)
 			rawDescriptor.put("duration", duration);
 
-		return this;
-	}
-
-	/**
-	 * Sets the duration field.
-	 *
-	 * @param duration Number of confirmed blocks you would like to rent the namespace for. Required for root namespaces.
-	 * @return This descriptor for chaining.
-	 */
-	public NamespaceRegistrationTransactionV1Descriptor duration(final String duration) {
-		return duration(null == duration ? null : BlockDuration.parse(duration));
-	}
-
-	/**
-	 * Sets the parentId field.
-	 *
-	 * @param parentId Parent namespace identifier. Required for sub-namespaces.
-	 * @return This descriptor for chaining.
-	 */
-	public NamespaceRegistrationTransactionV1Descriptor parentId(final NamespaceId parentId) {
 		if (null != parentId)
 			rawDescriptor.put("parentId", parentId);
 
-		return this;
-	}
-
-	/**
-	 * Sets the parentId field.
-	 *
-	 * @param parentId Parent namespace identifier. Required for sub-namespaces.
-	 * @return This descriptor for chaining.
-	 */
-	public NamespaceRegistrationTransactionV1Descriptor parentId(final String parentId) {
-		return parentId(null == parentId ? null : NamespaceId.parse(parentId));
-	}
-
-	/**
-	 * Sets the name field.
-	 *
-	 * @param name Namespace name.
-	 * @return This descriptor for chaining.
-	 */
-	public NamespaceRegistrationTransactionV1Descriptor name(final byte[] name) {
 		if (null != name)
 			rawDescriptor.put("name", name);
-
-		return this;
-	}
-
-	/**
-	 * Sets the name field.
-	 *
-	 * @param name Namespace name.
-	 * @return This descriptor for chaining.
-	 */
-	public NamespaceRegistrationTransactionV1Descriptor name(final String name) {
-		return name(null == name ? null : name.getBytes(StandardCharsets.UTF_8));
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/NodeKeyLinkTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/NodeKeyLinkTransactionV1Descriptor.java
@@ -32,16 +32,6 @@ public final class NodeKeyLinkTransactionV1Descriptor implements SymbolTransacti
 	}
 
 	/**
-	 * Creates a descriptor for NodeKeyLinkTransactionV1 from string-form values.
-	 *
-	 * @param linkedPublicKey Linked public key.
-	 * @param linkAction Account link action.
-	 */
-	public NodeKeyLinkTransactionV1Descriptor(final String linkedPublicKey, final String linkAction) {
-		this(new CryptoTypes.PublicKey(linkedPublicKey), LinkAction.parse(linkAction));
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/SecretLockTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/SecretLockTransactionV1Descriptor.java
@@ -43,21 +43,6 @@ public final class SecretLockTransactionV1Descriptor implements SymbolTransactio
 	}
 
 	/**
-	 * Creates a descriptor for SecretLockTransactionV1 from string-form values.
-	 *
-	 * @param recipientAddress Address that receives the funds once successfully unlocked by a SecretProofTransaction.
-	 * @param secret Hashed proof.
-	 * @param mosaic Locked mosaics.
-	 * @param duration Number of blocks to wait for the SecretProofTransaction.
-	 * @param hashAlgorithm Algorithm used to hash the proof.
-	 */
-	public SecretLockTransactionV1Descriptor(final String recipientAddress, final String secret, final UnresolvedMosaicDescriptor mosaic,
-			final String duration, final String hashAlgorithm) {
-		this(new Address(recipientAddress), new CryptoTypes.Hash256(secret), mosaic, BlockDuration.parse(duration),
-				LockHashAlgorithm.parse(hashAlgorithm));
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/SecretProofTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/SecretProofTransactionV1Descriptor.java
@@ -3,7 +3,6 @@
 
 package org.symbol.sdk.symbol.descriptors;
 
-import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -26,48 +25,18 @@ public final class SecretProofTransactionV1Descriptor implements SymbolTransacti
 	 * @param recipientAddress Address that receives the funds once unlocked.
 	 * @param secret Hashed proof.
 	 * @param hashAlgorithm Algorithm used to hash the proof.
+	 * @param proof Original random set of bytes that were hashed. (field is omitted when null)
 	 */
 	public SecretProofTransactionV1Descriptor(final Address recipientAddress, final CryptoTypes.Hash256 secret,
-			final LockHashAlgorithm hashAlgorithm) {
+			final LockHashAlgorithm hashAlgorithm, final byte[] proof) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("type", "secret_proof_transaction_v1");
 		rawDescriptor.put("recipientAddress", recipientAddress);
 		rawDescriptor.put("secret", secret);
 		rawDescriptor.put("hashAlgorithm", hashAlgorithm);
-	}
 
-	/**
-	 * Creates a descriptor for SecretProofTransactionV1 from string-form values.
-	 *
-	 * @param recipientAddress Address that receives the funds once unlocked.
-	 * @param secret Hashed proof.
-	 * @param hashAlgorithm Algorithm used to hash the proof.
-	 */
-	public SecretProofTransactionV1Descriptor(final String recipientAddress, final String secret, final String hashAlgorithm) {
-		this(new Address(recipientAddress), new CryptoTypes.Hash256(secret), LockHashAlgorithm.parse(hashAlgorithm));
-	}
-
-	/**
-	 * Sets the proof field.
-	 *
-	 * @param proof Original random set of bytes that were hashed.
-	 * @return This descriptor for chaining.
-	 */
-	public SecretProofTransactionV1Descriptor proof(final byte[] proof) {
 		if (null != proof)
 			rawDescriptor.put("proof", proof);
-
-		return this;
-	}
-
-	/**
-	 * Sets the proof field.
-	 *
-	 * @param proof Original random set of bytes that were hashed.
-	 * @return This descriptor for chaining.
-	 */
-	public SecretProofTransactionV1Descriptor proof(final String proof) {
-		return proof(null == proof ? null : proof.getBytes(StandardCharsets.UTF_8));
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/TransferTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/TransferTransactionV1Descriptor.java
@@ -3,8 +3,6 @@
 
 package org.symbol.sdk.symbol.descriptors;
 
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,66 +22,20 @@ public final class TransferTransactionV1Descriptor implements SymbolTransactionD
 	 * Creates a descriptor for TransferTransactionV1.
 	 *
 	 * @param recipientAddress recipient address
+	 * @param mosaics attached mosaics (field is omitted when null)
+	 * @param message attached message (field is omitted when null)
 	 */
-	public TransferTransactionV1Descriptor(final Address recipientAddress) {
+	public TransferTransactionV1Descriptor(final Address recipientAddress, final List<UnresolvedMosaicDescriptor> mosaics,
+			final byte[] message) {
 		rawDescriptor = new LinkedHashMap<>();
 		rawDescriptor.put("type", "transfer_transaction_v1");
 		rawDescriptor.put("recipientAddress", recipientAddress);
-	}
 
-	/**
-	 * Creates a descriptor for TransferTransactionV1 from string-form values.
-	 *
-	 * @param recipientAddress recipient address
-	 */
-	public TransferTransactionV1Descriptor(final String recipientAddress) {
-		this(new Address(recipientAddress));
-	}
-
-	/**
-	 * Sets the mosaics field.
-	 *
-	 * @param mosaics attached mosaics
-	 * @return This descriptor for chaining.
-	 */
-	public TransferTransactionV1Descriptor mosaics(final List<UnresolvedMosaicDescriptor> mosaics) {
 		if (null != mosaics)
 			rawDescriptor.put("mosaics", mosaics.stream().map(UnresolvedMosaicDescriptor::toMap).collect(Collectors.toList()));
 
-		return this;
-	}
-
-	/**
-	 * Sets the mosaics field.
-	 *
-	 * @param mosaics attached mosaics
-	 * @return This descriptor for chaining.
-	 */
-	public TransferTransactionV1Descriptor mosaics(final UnresolvedMosaicDescriptor... mosaics) {
-		return mosaics(null == mosaics ? null : Arrays.asList(mosaics));
-	}
-
-	/**
-	 * Sets the message field.
-	 *
-	 * @param message attached message
-	 * @return This descriptor for chaining.
-	 */
-	public TransferTransactionV1Descriptor message(final byte[] message) {
 		if (null != message)
 			rawDescriptor.put("message", message);
-
-		return this;
-	}
-
-	/**
-	 * Sets the message field.
-	 *
-	 * @param message attached message
-	 * @return This descriptor for chaining.
-	 */
-	public TransferTransactionV1Descriptor message(final String message) {
-		return message(null == message ? null : message.getBytes(StandardCharsets.UTF_8));
 	}
 
 	/**

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/UnresolvedMosaicDescriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/UnresolvedMosaicDescriptor.java
@@ -30,16 +30,6 @@ public final class UnresolvedMosaicDescriptor implements SymbolTypedDescriptor {
 	}
 
 	/**
-	 * Creates a descriptor for UnresolvedMosaic from string-form values.
-	 *
-	 * @param mosaicId Unresolved mosaic identifier.
-	 * @param amount Mosaic amount.
-	 */
-	public UnresolvedMosaicDescriptor(final String mosaicId, final String amount) {
-		this(UnresolvedMosaicId.parse(mosaicId), Amount.parse(amount));
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/VotingKeyLinkTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/VotingKeyLinkTransactionV1Descriptor.java
@@ -42,20 +42,6 @@ public final class VotingKeyLinkTransactionV1Descriptor implements SymbolTransac
 	}
 
 	/**
-	 * Creates a descriptor for VotingKeyLinkTransactionV1 from string-form values.
-	 *
-	 * @param linkedPublicKey Linked voting public key.
-	 * @param startEpoch Starting finalization epoch.
-	 * @param endEpoch Ending finalization epoch.
-	 * @param linkAction Account link action.
-	 */
-	public VotingKeyLinkTransactionV1Descriptor(final String linkedPublicKey, final String startEpoch, final String endEpoch,
-			final String linkAction) {
-		this(new CryptoTypes.PublicKey(linkedPublicKey), FinalizationEpoch.parse(startEpoch), FinalizationEpoch.parse(endEpoch),
-				LinkAction.parse(linkAction));
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/VrfKeyLinkTransactionV1Descriptor.java
+++ b/sdk/java/src/main/java/org/symbol/sdk/symbol/descriptors/VrfKeyLinkTransactionV1Descriptor.java
@@ -33,16 +33,6 @@ public final class VrfKeyLinkTransactionV1Descriptor implements SymbolTransactio
 	}
 
 	/**
-	 * Creates a descriptor for VrfKeyLinkTransactionV1 from string-form values.
-	 *
-	 * @param linkedPublicKey Linked VRF public key.
-	 * @param linkAction Account link action.
-	 */
-	public VrfKeyLinkTransactionV1Descriptor(final String linkedPublicKey, final String linkAction) {
-		this(new CryptoTypes.PublicKey(linkedPublicKey), LinkAction.parse(linkAction));
-	}
-
-	/**
 	 * Builds a representation of this descriptor that can be passed to a factory function.
 	 *
 	 * @return Descriptor map that can be passed to a transaction factory.

--- a/sdk/java/src/test/java/org/symbol/sdk/facade/NemFacadeTest.java
+++ b/sdk/java/src/test/java/org/symbol/sdk/facade/NemFacadeTest.java
@@ -423,7 +423,7 @@ final class NemFacadeTest {
 			// Act: required fields only.
 			final Address recipient = new Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C");
 			final Amount amount = new Amount(5L);
-			final Map<String, Object> map = new TransferTransactionV1Descriptor(recipient, amount).toMap();
+			final Map<String, Object> map = new TransferTransactionV1Descriptor(recipient, amount, /* message */ null).toMap();
 
 			// Assert: discriminator baked in; null optional message field is omitted.
 			assertThat(map.get("type"), is(equalTo("transfer_transaction_v1")));
@@ -433,10 +433,11 @@ final class NemFacadeTest {
 		}
 
 		@Test
-		void nullOptionalSetterOmitsField() {
-			// Act: root-namespace registration — passing null to the optional parentName setter omits it.
+		void nullOptionalConstructorArgOmitsField() {
+			// Act: root-namespace registration — passing null for the optional parentName omits it.
 			final NamespaceRegistrationTransactionV1Descriptor descriptor = new NamespaceRegistrationTransactionV1Descriptor(
-					"TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C", "50000").name("roger").parentName((String) null);
+					new Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C"), new Amount(50000L),
+					"roger".getBytes(java.nio.charset.StandardCharsets.UTF_8), /* parentName */ null);
 
 			// Assert: name converted, parentName omitted (not NPE, not a null entry).
 			final Map<String, Object> rawDescriptor = descriptor.toMap();
@@ -450,13 +451,14 @@ final class NemFacadeTest {
 			final NemFacade facade = new NemFacade(Network.TESTNET);
 			final KeyPair keyPair = new KeyPair(TEST_PRIVATE_KEY);
 			final Transaction inner = facade.createTransactionFromTypedDescriptor(
-					new TransferTransactionV1Descriptor("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C", "5000000"), keyPair.getPublicKey(), FEE,
-					60L);
+					new TransferTransactionV1Descriptor(new Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C"), new Amount(5000000L),
+							/* message */ null),
+					keyPair.getPublicKey(), FEE, 60L);
 			final MultisigTransactionV1Descriptor descriptor = new MultisigTransactionV1Descriptor(
-					NemTransactionFactory.toNonVerifiableTransaction(inner))
-					.cosignatures(new SizePrefixedCosignatureV1Descriptor(
-							new CosignatureV1Descriptor("E9B3AEDE9A57C2B8C3D78DB9805D12AB0D983B63CE8F89D8DFE108D0FF08D23C",
-									"TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C")));
+					NemTransactionFactory.toNonVerifiableTransaction(inner),
+					List.of(new SizePrefixedCosignatureV1Descriptor(new CosignatureV1Descriptor(
+							new CryptoTypes.Hash256("E9B3AEDE9A57C2B8C3D78DB9805D12AB0D983B63CE8F89D8DFE108D0FF08D23C"),
+							new Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C")))));
 
 			// Act: the cosignatures array must flow through the struct/array rules (previously unregistered).
 			final Transaction transaction = facade.createTransactionFromTypedDescriptor(descriptor, keyPair.getPublicKey(), FEE, 60L);
@@ -482,8 +484,8 @@ final class NemFacadeTest {
 			final CryptoTypes.PublicKey signerPublicKey = new CryptoTypes.PublicKey(
 					"87DA603E7BE5656C45692D5FC7F6D0EF8F24BB7A5C10ED5FDA8C5CFBC49FCBC8");
 			final NemTransactionDescriptor typedDescriptor = new TransferTransactionV1Descriptor(
-					new Address("TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW"), new Amount(1000000L))
-					.message(new MessageDescriptor(MessageType.PLAIN).message("hello nem"));
+					new Address("TALICE5VF6J5FYMTCB7A3QG6OIRDRUXDWJGFVXNW"), new Amount(1000000L),
+					new MessageDescriptor(MessageType.PLAIN, "hello nem".getBytes(java.nio.charset.StandardCharsets.UTF_8)));
 
 			// Act:
 			final TransferTransactionV1 transaction = (TransferTransactionV1) facade.createTransactionFromTypedDescriptor(typedDescriptor,
@@ -517,7 +519,7 @@ final class NemFacadeTest {
 			final NemFacade facade = new NemFacade(Network.TESTNET);
 			final KeyPair keyPair = new KeyPair(TEST_PRIVATE_KEY);
 			final NemTransactionDescriptor typedDescriptor = new TransferTransactionV1Descriptor(
-					new Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C"), new Amount(5L));
+					new Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C"), new Amount(5L), /* message */ null);
 
 			// Act:
 			final Transaction typed = facade.createTransactionFromTypedDescriptor(typedDescriptor, keyPair.getPublicKey(), FEE, 60L);

--- a/sdk/java/src/test/java/org/symbol/sdk/facade/NemFacadeTest.java
+++ b/sdk/java/src/test/java/org/symbol/sdk/facade/NemFacadeTest.java
@@ -423,7 +423,7 @@ final class NemFacadeTest {
 			// Act: required fields only.
 			final Address recipient = new Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C");
 			final Amount amount = new Amount(5L);
-			final Map<String, Object> map = new TransferTransactionV1Descriptor(recipient, amount, /* message */ null).toMap();
+			final Map<String, Object> map = new TransferTransactionV1Descriptor(recipient, amount, (MessageDescriptor) null).toMap();
 
 			// Assert: discriminator baked in; null optional message field is omitted.
 			assertThat(map.get("type"), is(equalTo("transfer_transaction_v1")));
@@ -437,7 +437,7 @@ final class NemFacadeTest {
 			// Act: root-namespace registration — passing null for the optional parentName omits it.
 			final NamespaceRegistrationTransactionV1Descriptor descriptor = new NamespaceRegistrationTransactionV1Descriptor(
 					new Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C"), new Amount(50000L),
-					"roger".getBytes(java.nio.charset.StandardCharsets.UTF_8), /* parentName */ null);
+					"roger".getBytes(java.nio.charset.StandardCharsets.UTF_8), (byte[]) null);
 
 			// Assert: name converted, parentName omitted (not NPE, not a null entry).
 			final Map<String, Object> rawDescriptor = descriptor.toMap();
@@ -452,7 +452,7 @@ final class NemFacadeTest {
 			final KeyPair keyPair = new KeyPair(TEST_PRIVATE_KEY);
 			final Transaction inner = facade.createTransactionFromTypedDescriptor(
 					new TransferTransactionV1Descriptor(new Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C"), new Amount(5000000L),
-							/* message */ null),
+							(MessageDescriptor) null),
 					keyPair.getPublicKey(), FEE, 60L);
 			final MultisigTransactionV1Descriptor descriptor = new MultisigTransactionV1Descriptor(
 					NemTransactionFactory.toNonVerifiableTransaction(inner),
@@ -519,7 +519,7 @@ final class NemFacadeTest {
 			final NemFacade facade = new NemFacade(Network.TESTNET);
 			final KeyPair keyPair = new KeyPair(TEST_PRIVATE_KEY);
 			final NemTransactionDescriptor typedDescriptor = new TransferTransactionV1Descriptor(
-					new Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C"), new Amount(5L), /* message */ null);
+					new Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C"), new Amount(5L), (MessageDescriptor) null);
 
 			// Act:
 			final Transaction typed = facade.createTransactionFromTypedDescriptor(typedDescriptor, keyPair.getPublicKey(), FEE, 60L);

--- a/sdk/java/src/test/java/org/symbol/sdk/facade/SymbolFacadeTest.java
+++ b/sdk/java/src/test/java/org/symbol/sdk/facade/SymbolFacadeTest.java
@@ -720,7 +720,7 @@ final class SymbolFacadeTest {
 		void toMapInjectsTypeAndOmitsNullOptionalFields() {
 			// Act: only the required recipientAddress is supplied.
 			final Address recipient = new Address("AEBAGBAFAYDQQCIKBMGA2DQPCAIREEYUCULBOGA");
-			final Map<String, Object> map = new TransferTransactionV1Descriptor(recipient, /* mosaics */ null, /* message */ null).toMap();
+			final Map<String, Object> map = new TransferTransactionV1Descriptor(recipient, (List<UnresolvedMosaicDescriptor>) null, (byte[]) null).toMap();
 
 			// Assert: discriminator baked in; null optional fields are not present.
 			assertThat(map.get("type"), is(equalTo("transfer_transaction_v1")));
@@ -756,8 +756,8 @@ final class SymbolFacadeTest {
 			final SymbolFacade facade = new SymbolFacade(Network.TESTNET);
 			final KeyPair keyPair = new KeyPair(TEST_PRIVATE_KEY);
 			final Address recipient = new Address("AEBAGBAFAYDQQCIKBMGA2DQPCAIREEYUCULBOGA");
-			final SymbolTransactionDescriptor typedDescriptor = new TransferTransactionV1Descriptor(recipient, /* mosaics */ null,
-					/* message */ null);
+			final SymbolTransactionDescriptor typedDescriptor = new TransferTransactionV1Descriptor(recipient, (List<UnresolvedMosaicDescriptor>) null,
+					(byte[]) null);
 
 			// Act:
 			final Transaction typed = facade.createTransactionFromTypedDescriptor(typedDescriptor, keyPair.getPublicKey(), 100L, 60L);
@@ -775,7 +775,7 @@ final class SymbolFacadeTest {
 			final SymbolFacade facade = new SymbolFacade(Network.TESTNET);
 			final KeyPair keyPair = new KeyPair(TEST_PRIVATE_KEY);
 			final SymbolTransactionDescriptor typedDescriptor = new TransferTransactionV1Descriptor(
-					new Address("AEBAGBAFAYDQQCIKBMGA2DQPCAIREEYUCULBOGA"), /* mosaics */ null, /* message */ null);
+					new Address("AEBAGBAFAYDQQCIKBMGA2DQPCAIREEYUCULBOGA"), (List<UnresolvedMosaicDescriptor>) null, (byte[]) null);
 
 			// Act:
 			final Transaction txNoCos = facade.createTransactionFromTypedDescriptor(typedDescriptor, keyPair.getPublicKey(), 100L, 60L, 0);

--- a/sdk/java/src/test/java/org/symbol/sdk/facade/SymbolFacadeTest.java
+++ b/sdk/java/src/test/java/org/symbol/sdk/facade/SymbolFacadeTest.java
@@ -720,7 +720,8 @@ final class SymbolFacadeTest {
 		void toMapInjectsTypeAndOmitsNullOptionalFields() {
 			// Act: only the required recipientAddress is supplied.
 			final Address recipient = new Address("AEBAGBAFAYDQQCIKBMGA2DQPCAIREEYUCULBOGA");
-			final Map<String, Object> map = new TransferTransactionV1Descriptor(recipient, (List<UnresolvedMosaicDescriptor>) null, (byte[]) null).toMap();
+			final Map<String, Object> map = new TransferTransactionV1Descriptor(recipient, (List<UnresolvedMosaicDescriptor>) null,
+					(byte[]) null).toMap();
 
 			// Assert: discriminator baked in; null optional fields are not present.
 			assertThat(map.get("type"), is(equalTo("transfer_transaction_v1")));
@@ -756,8 +757,8 @@ final class SymbolFacadeTest {
 			final SymbolFacade facade = new SymbolFacade(Network.TESTNET);
 			final KeyPair keyPair = new KeyPair(TEST_PRIVATE_KEY);
 			final Address recipient = new Address("AEBAGBAFAYDQQCIKBMGA2DQPCAIREEYUCULBOGA");
-			final SymbolTransactionDescriptor typedDescriptor = new TransferTransactionV1Descriptor(recipient, (List<UnresolvedMosaicDescriptor>) null,
-					(byte[]) null);
+			final SymbolTransactionDescriptor typedDescriptor = new TransferTransactionV1Descriptor(recipient,
+					(List<UnresolvedMosaicDescriptor>) null, (byte[]) null);
 
 			// Act:
 			final Transaction typed = facade.createTransactionFromTypedDescriptor(typedDescriptor, keyPair.getPublicKey(), 100L, 60L);

--- a/sdk/java/src/test/java/org/symbol/sdk/facade/SymbolFacadeTest.java
+++ b/sdk/java/src/test/java/org/symbol/sdk/facade/SymbolFacadeTest.java
@@ -720,7 +720,7 @@ final class SymbolFacadeTest {
 		void toMapInjectsTypeAndOmitsNullOptionalFields() {
 			// Act: only the required recipientAddress is supplied.
 			final Address recipient = new Address("AEBAGBAFAYDQQCIKBMGA2DQPCAIREEYUCULBOGA");
-			final Map<String, Object> map = new TransferTransactionV1Descriptor(recipient).toMap();
+			final Map<String, Object> map = new TransferTransactionV1Descriptor(recipient, /* mosaics */ null, /* message */ null).toMap();
 
 			// Assert: discriminator baked in; null optional fields are not present.
 			assertThat(map.get("type"), is(equalTo("transfer_transaction_v1")));
@@ -738,8 +738,7 @@ final class SymbolFacadeTest {
 			final byte[] message = "Hello, world!".getBytes();
 
 			// Act:
-			final Map<String, Object> map = new TransferTransactionV1Descriptor(recipient).mosaics(List.of(mosaic)).message(message)
-					.toMap();
+			final Map<String, Object> map = new TransferTransactionV1Descriptor(recipient, List.of(mosaic), message).toMap();
 
 			// Assert: mosaics is a list of raw descriptor maps (not descriptor objects).
 			assertThat(map.get("message"), is(sameInstance(message)));
@@ -752,37 +751,13 @@ final class SymbolFacadeTest {
 		}
 
 		@Test
-		void stringFormConstructorMatchesTypedConstructor() {
-			// Act: same descriptor built from typed values and from their string forms.
-			final TransferTransactionV1Descriptor typed = new TransferTransactionV1Descriptor(
-					new Address("AEBAGBAFAYDQQCIKBMGA2DQPCAIREEYUCULBOGA"));
-			final TransferTransactionV1Descriptor stringForm = new TransferTransactionV1Descriptor(
-					"AEBAGBAFAYDQQCIKBMGA2DQPCAIREEYUCULBOGA");
-
-			// Assert:
-			assertThat(stringForm.toMap(), is(equalTo(typed.toMap())));
-		}
-
-		@Test
-		void stringFormMessageMatchesTypedMessage() {
-			// Act: message set as a String vs the equivalent UTF-8 bytes.
-			final Address recipient = new Address("AEBAGBAFAYDQQCIKBMGA2DQPCAIREEYUCULBOGA");
-			final byte[] typedMessage = (byte[]) new TransferTransactionV1Descriptor(recipient)
-					.message("hello symbol".getBytes(java.nio.charset.StandardCharsets.UTF_8)).toMap().get("message");
-			final byte[] stringMessage = (byte[]) new TransferTransactionV1Descriptor(recipient.toString()).message("hello symbol").toMap()
-					.get("message");
-
-			// Assert:
-			assertThat(stringMessage, is(equalTo(typedMessage)));
-		}
-
-		@Test
 		void createTransactionFromTypedDescriptorMatchesUntypedPath() {
 			// Arrange: a typed descriptor and the equivalent untyped descriptor map.
 			final SymbolFacade facade = new SymbolFacade(Network.TESTNET);
 			final KeyPair keyPair = new KeyPair(TEST_PRIVATE_KEY);
 			final Address recipient = new Address("AEBAGBAFAYDQQCIKBMGA2DQPCAIREEYUCULBOGA");
-			final SymbolTransactionDescriptor typedDescriptor = new TransferTransactionV1Descriptor(recipient);
+			final SymbolTransactionDescriptor typedDescriptor = new TransferTransactionV1Descriptor(recipient, /* mosaics */ null,
+					/* message */ null);
 
 			// Act:
 			final Transaction typed = facade.createTransactionFromTypedDescriptor(typedDescriptor, keyPair.getPublicKey(), 100L, 60L);
@@ -800,7 +775,7 @@ final class SymbolFacadeTest {
 			final SymbolFacade facade = new SymbolFacade(Network.TESTNET);
 			final KeyPair keyPair = new KeyPair(TEST_PRIVATE_KEY);
 			final SymbolTransactionDescriptor typedDescriptor = new TransferTransactionV1Descriptor(
-					new Address("AEBAGBAFAYDQQCIKBMGA2DQPCAIREEYUCULBOGA"));
+					new Address("AEBAGBAFAYDQQCIKBMGA2DQPCAIREEYUCULBOGA"), /* mosaics */ null, /* message */ null);
 
 			// Act:
 			final Transaction txNoCos = facade.createTransactionFromTypedDescriptor(typedDescriptor, keyPair.getPublicKey(), 100L, 60L, 0);
@@ -818,9 +793,9 @@ final class SymbolFacadeTest {
 
 			final CryptoTypes.PublicKey signerPublicKey = new CryptoTypes.PublicKey(REAL_SIGNER_HEX);
 			final SymbolTransactionDescriptor typedDescriptor = new TransferTransactionV1Descriptor(
-					new Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"))
-					.mosaics(new UnresolvedMosaicDescriptor(new UnresolvedMosaicId(0x7CDF3B117A3C40CCL), new Amount(1000000L)))
-					.message("hello symbol");
+					new Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"),
+					List.of(new UnresolvedMosaicDescriptor(new UnresolvedMosaicId(0x7CDF3B117A3C40CCL), new Amount(1000000L))),
+					"hello symbol".getBytes(java.nio.charset.StandardCharsets.UTF_8));
 
 			// Act:
 			final TransferTransactionV1 transaction = (TransferTransactionV1) facade.createTransactionFromTypedDescriptor(typedDescriptor,
@@ -847,15 +822,14 @@ final class SymbolFacadeTest {
 			final SymbolFacade facade = new SymbolFacade(Network.TESTNET);
 
 			final CryptoTypes.PublicKey signerPublicKey = new CryptoTypes.PublicKey(REAL_SIGNER_HEX);
-			final AggregateCompleteTransactionV1Descriptor typedDescriptor = new AggregateCompleteTransactionV1Descriptor(
-					"157D3C15A677030DBD106C0C16556E305F3796B66F684715E0C18FC178DC8026").transactions(List.of());
-			if (0 != descriptorCosignatureCount) {
-				final List<Cosignature> cosignatures = new ArrayList<>();
-				for (int i = 0; i < descriptorCosignatureCount; ++i)
-					cosignatures.add(new Cosignature());
+			final List<Cosignature> cosignatures = new ArrayList<>();
+			for (int i = 0; i < descriptorCosignatureCount; ++i)
+				cosignatures.add(new Cosignature());
 
-				typedDescriptor.cosignatures(cosignatures);
-			}
+			// a zero count passes null so the cosignatures key stays absent, like the old unset state
+			final AggregateCompleteTransactionV1Descriptor typedDescriptor = new AggregateCompleteTransactionV1Descriptor(
+					new CryptoTypes.Hash256("157D3C15A677030DBD106C0C16556E305F3796B66F684715E0C18FC178DC8026"), List.of(),
+					0 == descriptorCosignatureCount ? null : cosignatures);
 
 			// Act:
 			final Transaction transaction = facade.createTransactionFromTypedDescriptor(typedDescriptor, signerPublicKey, 100L, 60L * 60L,
@@ -891,9 +865,9 @@ final class SymbolFacadeTest {
 
 			final CryptoTypes.PublicKey signerPublicKey = new CryptoTypes.PublicKey(REAL_SIGNER_HEX);
 			final SymbolTransactionDescriptor typedDescriptor = new TransferTransactionV1Descriptor(
-					new Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"))
-					.mosaics(new UnresolvedMosaicDescriptor(new UnresolvedMosaicId(0x7CDF3B117A3C40CCL), new Amount(1000000L)))
-					.message("hello symbol");
+					new Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"),
+					List.of(new UnresolvedMosaicDescriptor(new UnresolvedMosaicId(0x7CDF3B117A3C40CCL), new Amount(1000000L))),
+					"hello symbol".getBytes(java.nio.charset.StandardCharsets.UTF_8));
 
 			// Act:
 			final EmbeddedTransferTransactionV1 transaction = (EmbeddedTransferTransactionV1) facade

--- a/sdk/java/src/test/java/org/symbol/sdk/nem/descriptors/DescriptorsSweepTest.java
+++ b/sdk/java/src/test/java/org/symbol/sdk/nem/descriptors/DescriptorsSweepTest.java
@@ -6,7 +6,6 @@ package org.symbol.sdk.nem.descriptors;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.sameInstance;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
@@ -38,9 +37,9 @@ import org.symbol.sdk.nem.models.TransferTransactionV1;
 import org.symbol.sdk.nem.models.TransferTransactionV2;
 
 /**
- * Generated per-descriptor sweep: construction with distinct sample values, exact {@code toMap()} contents, string-form constructor
- * equivalence, every optional fluent setter, and (for transaction descriptors) a factory round-trip verifying each created-model field via
- * {@code getField}.
+ * Generated per-descriptor sweep: construction with distinct sample values, exact {@code toMap()} contents (null optional arguments leave
+ * their keys absent), all-args constructor storage of every field, and (for transaction descriptors) a factory round-trip verifying each
+ * created-model field via {@code getField}.
  */
 final class DescriptorsSweepTest {
 	private static final CryptoTypes.PublicKey SWEEP_SIGNER_PUBLIC_KEY = new CryptoTypes.PublicKey(
@@ -81,25 +80,10 @@ final class DescriptorsSweepTest {
 	}
 
 	@Test
-	void accountKeyLinkTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewAccountKeyLinkTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new AccountKeyLinkTransactionV1Descriptor("link",
-				"0303030303030303030303030303030303030303030303030303030303030303").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("linkAction"), equalTo(built.get("linkAction")));
-		assertThat(stringBuilt.get("remotePublicKey"), equalTo(built.get("remotePublicKey")));
-	}
-
-	@Test
 	void accountKeyLinkTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewAccountKeyLinkTransactionV1Descriptor());
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(new AccountKeyLinkTransactionV1Descriptor(LinkAction.parse("link"),
+				new CryptoTypes.PublicKey("0303030303030303030303030303030303030303030303030303030303030303")));
 
 		// Act:
 		final AccountKeyLinkTransactionV1 transaction = (AccountKeyLinkTransactionV1) FACTORY.create(createMap);
@@ -115,9 +99,9 @@ final class DescriptorsSweepTest {
 		assertThat(NemTransactionFactory.deserialize(payload).serialize(), equalTo(payload));
 	}
 
-	/** Constructs a NamespaceIdDescriptor with distinct sample required arguments. */
+	/** Constructs a NamespaceIdDescriptor with distinct sample required arguments and null optionals. */
 	private static NamespaceIdDescriptor sweepNewNamespaceIdDescriptor() {
-		return new NamespaceIdDescriptor();
+		return new NamespaceIdDescriptor(null);
 	}
 
 	@Test
@@ -128,24 +112,19 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
+		assertThat(built.containsKey("name"), equalTo(false));
 		assertThat(built.size(), equalTo(0));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: name
-		assertThat(built.containsKey("name"), equalTo(false));
-		assertThat(sweepNewNamespaceIdDescriptor().name((byte[]) null).toMap().containsKey("name"), equalTo(false));
-		assertThat(sweepNewNamespaceIdDescriptor().name((String) null).toMap().containsKey("name"), equalTo(false));
-		final NamespaceIdDescriptor withName = sweepNewNamespaceIdDescriptor();
-		assertThat(withName.name("name".getBytes(StandardCharsets.UTF_8)), sameInstance(withName));
-		assertThat(withName.toMap().get("name"), equalTo("name".getBytes(StandardCharsets.UTF_8)));
-		assertThat(sweepNewNamespaceIdDescriptor().name("name").toMap().get("name"), equalTo(withName.toMap().get("name")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new NamespaceIdDescriptor("name".getBytes(StandardCharsets.UTF_8)).toMap();
+		assertThat(fullBuilt.get("name"), equalTo("name".getBytes(StandardCharsets.UTF_8)));
+		assertThat(fullBuilt.size(), equalTo(1));
 	}
 
-	/** Constructs a MosaicIdDescriptor with distinct sample required arguments. */
+	/** Constructs a MosaicIdDescriptor with distinct sample required arguments and null optionals. */
 	private static MosaicIdDescriptor sweepNewMosaicIdDescriptor() {
-		return new MosaicIdDescriptor(sweepNewNamespaceIdDescriptor());
+		return new MosaicIdDescriptor(sweepNewNamespaceIdDescriptor(), null);
 	}
 
 	@Test
@@ -156,20 +135,16 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("namespaceId"), equalTo(sweepNewNamespaceIdDescriptor().toMap()));
+		assertThat(built.containsKey("name"), equalTo(false));
 		assertThat(built.size(), equalTo(1));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: name
-		assertThat(built.containsKey("name"), equalTo(false));
-		assertThat(sweepNewMosaicIdDescriptor().name((byte[]) null).toMap().containsKey("name"), equalTo(false));
-		assertThat(sweepNewMosaicIdDescriptor().name((String) null).toMap().containsKey("name"), equalTo(false));
-		final MosaicIdDescriptor withName = sweepNewMosaicIdDescriptor();
-		assertThat(withName.name("name".getBytes(StandardCharsets.UTF_8)), sameInstance(withName));
-		assertThat(withName.toMap().get("name"), equalTo("name".getBytes(StandardCharsets.UTF_8)));
-		assertThat(sweepNewMosaicIdDescriptor().name("name").toMap().get("name"), equalTo(withName.toMap().get("name")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new MosaicIdDescriptor(sweepNewNamespaceIdDescriptor(),
+				"name".getBytes(StandardCharsets.UTF_8)).toMap();
+		assertThat(fullBuilt.get("name"), equalTo("name".getBytes(StandardCharsets.UTF_8)));
+		assertThat(fullBuilt.size(), equalTo(2));
 	}
 
 	/** Constructs a MosaicDescriptor with distinct sample required arguments. */
@@ -189,20 +164,6 @@ final class DescriptorsSweepTest {
 		assertThat(built.get("mosaicId"), equalTo(sweepNewMosaicIdDescriptor().toMap()));
 		assertThat(built.get("amount"), equalTo(Amount.parse("2")));
 		assertThat(built.size(), equalTo(2));
-	}
-
-	@Test
-	void mosaicDescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewMosaicDescriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new MosaicDescriptor(sweepNewMosaicIdDescriptor(), "2").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("mosaicId"), equalTo(built.get("mosaicId")));
-		assertThat(stringBuilt.get("amount"), equalTo(built.get("amount")));
 	}
 
 	/** Constructs a SizePrefixedMosaicDescriptor with distinct sample required arguments. */
@@ -246,26 +207,9 @@ final class DescriptorsSweepTest {
 		assertThat(built.size(), equalTo(4));
 	}
 
-	@Test
-	void mosaicLevyDescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewMosaicLevyDescriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new MosaicLevyDescriptor("absolute", "TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C",
-				sweepNewMosaicIdDescriptor(), "4").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("transferFeeType"), equalTo(built.get("transferFeeType")));
-		assertThat(stringBuilt.get("recipientAddress"), equalTo(built.get("recipientAddress")));
-		assertThat(stringBuilt.get("mosaicId"), equalTo(built.get("mosaicId")));
-		assertThat(stringBuilt.get("fee"), equalTo(built.get("fee")));
-	}
-
-	/** Constructs a MosaicPropertyDescriptor with distinct sample required arguments. */
+	/** Constructs a MosaicPropertyDescriptor with distinct sample required arguments and null optionals. */
 	private static MosaicPropertyDescriptor sweepNewMosaicPropertyDescriptor() {
-		return new MosaicPropertyDescriptor();
+		return new MosaicPropertyDescriptor(null, null);
 	}
 
 	@Test
@@ -276,28 +220,17 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
+		assertThat(built.containsKey("name"), equalTo(false));
+		assertThat(built.containsKey("value"), equalTo(false));
 		assertThat(built.size(), equalTo(0));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: name
-		assertThat(built.containsKey("name"), equalTo(false));
-		assertThat(sweepNewMosaicPropertyDescriptor().name((byte[]) null).toMap().containsKey("name"), equalTo(false));
-		assertThat(sweepNewMosaicPropertyDescriptor().name((String) null).toMap().containsKey("name"), equalTo(false));
-		final MosaicPropertyDescriptor withName = sweepNewMosaicPropertyDescriptor();
-		assertThat(withName.name("name".getBytes(StandardCharsets.UTF_8)), sameInstance(withName));
-		assertThat(withName.toMap().get("name"), equalTo("name".getBytes(StandardCharsets.UTF_8)));
-		assertThat(sweepNewMosaicPropertyDescriptor().name("name").toMap().get("name"), equalTo(withName.toMap().get("name")));
-
-		// optional field: value
-		assertThat(built.containsKey("value"), equalTo(false));
-		assertThat(sweepNewMosaicPropertyDescriptor().value((byte[]) null).toMap().containsKey("value"), equalTo(false));
-		assertThat(sweepNewMosaicPropertyDescriptor().value((String) null).toMap().containsKey("value"), equalTo(false));
-		final MosaicPropertyDescriptor withValue = sweepNewMosaicPropertyDescriptor();
-		assertThat(withValue.value("value".getBytes(StandardCharsets.UTF_8)), sameInstance(withValue));
-		assertThat(withValue.toMap().get("value"), equalTo("value".getBytes(StandardCharsets.UTF_8)));
-		assertThat(sweepNewMosaicPropertyDescriptor().value("value").toMap().get("value"), equalTo(withValue.toMap().get("value")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new MosaicPropertyDescriptor("name".getBytes(StandardCharsets.UTF_8),
+				"value".getBytes(StandardCharsets.UTF_8)).toMap();
+		assertThat(fullBuilt.get("name"), equalTo("name".getBytes(StandardCharsets.UTF_8)));
+		assertThat(fullBuilt.get("value"), equalTo("value".getBytes(StandardCharsets.UTF_8)));
+		assertThat(fullBuilt.size(), equalTo(2));
 	}
 
 	/** Constructs a SizePrefixedMosaicPropertyDescriptor with distinct sample required arguments. */
@@ -318,10 +251,10 @@ final class DescriptorsSweepTest {
 		assertThat(built.size(), equalTo(1));
 	}
 
-	/** Constructs a MosaicDefinitionDescriptor with distinct sample required arguments. */
+	/** Constructs a MosaicDefinitionDescriptor with distinct sample required arguments and null optionals. */
 	private static MosaicDefinitionDescriptor sweepNewMosaicDefinitionDescriptor() {
 		return new MosaicDefinitionDescriptor(new CryptoTypes.PublicKey("0202020202020202020202020202020202020202020202020202020202020202"),
-				sweepNewMosaicIdDescriptor());
+				sweepNewMosaicIdDescriptor(), null, null, null);
 	}
 
 	@Test
@@ -332,56 +265,24 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("ownerPublicKey"),
 				equalTo(new CryptoTypes.PublicKey("0202020202020202020202020202020202020202020202020202020202020202")));
 		assertThat(built.get("id"), equalTo(sweepNewMosaicIdDescriptor().toMap()));
+		assertThat(built.containsKey("description"), equalTo(false));
+		assertThat(built.containsKey("properties"), equalTo(false));
+		assertThat(built.containsKey("levy"), equalTo(false));
 		assertThat(built.size(), equalTo(2));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: description
-		assertThat(built.containsKey("description"), equalTo(false));
-		assertThat(sweepNewMosaicDefinitionDescriptor().description((byte[]) null).toMap().containsKey("description"), equalTo(false));
-		assertThat(sweepNewMosaicDefinitionDescriptor().description((String) null).toMap().containsKey("description"), equalTo(false));
-		final MosaicDefinitionDescriptor withDescription = sweepNewMosaicDefinitionDescriptor();
-		assertThat(withDescription.description("description".getBytes(StandardCharsets.UTF_8)), sameInstance(withDescription));
-		assertThat(withDescription.toMap().get("description"), equalTo("description".getBytes(StandardCharsets.UTF_8)));
-		assertThat(sweepNewMosaicDefinitionDescriptor().description("description").toMap().get("description"),
-				equalTo(withDescription.toMap().get("description")));
-
-		// optional field: properties
-		assertThat(built.containsKey("properties"), equalTo(false));
-		assertThat(sweepNewMosaicDefinitionDescriptor().properties((List<SizePrefixedMosaicPropertyDescriptor>) null).toMap()
-				.containsKey("properties"), equalTo(false));
-		final MosaicDefinitionDescriptor withProperties = sweepNewMosaicDefinitionDescriptor();
-		assertThat(withProperties.properties(List.of(sweepNewSizePrefixedMosaicPropertyDescriptor())), sameInstance(withProperties));
-		assertThat(withProperties.toMap().get("properties"), equalTo(List.of(sweepNewSizePrefixedMosaicPropertyDescriptor().toMap())));
-		assertThat(
-				sweepNewMosaicDefinitionDescriptor().properties(sweepNewSizePrefixedMosaicPropertyDescriptor()).toMap().get("properties"),
-				equalTo(withProperties.toMap().get("properties")));
-
-		// optional field: levy
-		assertThat(built.containsKey("levy"), equalTo(false));
-		assertThat(sweepNewMosaicDefinitionDescriptor().levy((MosaicLevyDescriptor) null).toMap().containsKey("levy"), equalTo(false));
-		final MosaicDefinitionDescriptor withLevy = sweepNewMosaicDefinitionDescriptor();
-		assertThat(withLevy.levy(sweepNewMosaicLevyDescriptor()), sameInstance(withLevy));
-		assertThat(withLevy.toMap().get("levy"), equalTo(sweepNewMosaicLevyDescriptor().toMap()));
-	}
-
-	@Test
-	void mosaicDefinitionDescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewMosaicDefinitionDescriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new MosaicDefinitionDescriptor(
-				"0202020202020202020202020202020202020202020202020202020202020202", sweepNewMosaicIdDescriptor()).toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("ownerPublicKey"), equalTo(built.get("ownerPublicKey")));
-		assertThat(stringBuilt.get("id"), equalTo(built.get("id")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new MosaicDefinitionDescriptor(
+				new CryptoTypes.PublicKey("0202020202020202020202020202020202020202020202020202020202020202"), sweepNewMosaicIdDescriptor(),
+				"description".getBytes(StandardCharsets.UTF_8), List.of(sweepNewSizePrefixedMosaicPropertyDescriptor()),
+				sweepNewMosaicLevyDescriptor()).toMap();
+		assertThat(fullBuilt.get("description"), equalTo("description".getBytes(StandardCharsets.UTF_8)));
+		assertThat(fullBuilt.get("properties"), equalTo(List.of(sweepNewSizePrefixedMosaicPropertyDescriptor().toMap())));
+		assertThat(fullBuilt.get("levy"), equalTo(sweepNewMosaicLevyDescriptor().toMap()));
+		assertThat(fullBuilt.size(), equalTo(5));
 	}
 
 	/** Constructs a MosaicDefinitionTransactionV1Descriptor with distinct sample required arguments. */
@@ -407,26 +308,11 @@ final class DescriptorsSweepTest {
 	}
 
 	@Test
-	void mosaicDefinitionTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewMosaicDefinitionTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new MosaicDefinitionTransactionV1Descriptor(sweepNewMosaicDefinitionDescriptor(),
-				"TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C", "3").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("mosaicDefinition"), equalTo(built.get("mosaicDefinition")));
-		assertThat(stringBuilt.get("rentalFeeSink"), equalTo(built.get("rentalFeeSink")));
-		assertThat(stringBuilt.get("rentalFee"), equalTo(built.get("rentalFee")));
-	}
-
-	@Test
 	void mosaicDefinitionTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewMosaicDefinitionTransactionV1Descriptor());
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(
+				new MosaicDefinitionTransactionV1Descriptor(sweepNewMosaicDefinitionDescriptor(),
+						new org.symbol.sdk.nem.Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C"), Amount.parse("3")));
 
 		// Act:
 		final MosaicDefinitionTransactionV1 transaction = (MosaicDefinitionTransactionV1) FACTORY.create(createMap);
@@ -466,26 +352,10 @@ final class DescriptorsSweepTest {
 	}
 
 	@Test
-	void mosaicSupplyChangeTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewMosaicSupplyChangeTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new MosaicSupplyChangeTransactionV1Descriptor(sweepNewMosaicIdDescriptor(), "decrease", "3")
-				.toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("mosaicId"), equalTo(built.get("mosaicId")));
-		assertThat(stringBuilt.get("action"), equalTo(built.get("action")));
-		assertThat(stringBuilt.get("delta"), equalTo(built.get("delta")));
-	}
-
-	@Test
 	void mosaicSupplyChangeTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewMosaicSupplyChangeTransactionV1Descriptor());
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(new MosaicSupplyChangeTransactionV1Descriptor(sweepNewMosaicIdDescriptor(),
+				MosaicSupplyChangeAction.parse("decrease"), Amount.parse("3")));
 
 		// Act:
 		final MosaicSupplyChangeTransactionV1 transaction = (MosaicSupplyChangeTransactionV1) FACTORY.create(createMap);
@@ -522,21 +392,6 @@ final class DescriptorsSweepTest {
 		assertThat(built.size(), equalTo(2));
 	}
 
-	@Test
-	void multisigAccountModificationDescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewMultisigAccountModificationDescriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new MultisigAccountModificationDescriptor("add_cosignatory",
-				"0303030303030303030303030303030303030303030303030303030303030303").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("modificationType"), equalTo(built.get("modificationType")));
-		assertThat(stringBuilt.get("cosignatoryPublicKey"), equalTo(built.get("cosignatoryPublicKey")));
-	}
-
 	/** Constructs a SizePrefixedMultisigAccountModificationDescriptor with distinct sample required arguments. */
 	private static SizePrefixedMultisigAccountModificationDescriptor sweepNewSizePrefixedMultisigAccountModificationDescriptor() {
 		return new SizePrefixedMultisigAccountModificationDescriptor(sweepNewMultisigAccountModificationDescriptor());
@@ -555,9 +410,9 @@ final class DescriptorsSweepTest {
 		assertThat(built.size(), equalTo(1));
 	}
 
-	/** Constructs a MultisigAccountModificationTransactionV1Descriptor with distinct sample required arguments. */
+	/** Constructs a MultisigAccountModificationTransactionV1Descriptor with distinct sample required arguments and null optionals. */
 	private static MultisigAccountModificationTransactionV1Descriptor sweepNewMultisigAccountModificationTransactionV1Descriptor() {
-		return new MultisigAccountModificationTransactionV1Descriptor();
+		return new MultisigAccountModificationTransactionV1Descriptor(null);
 	}
 
 	@Test
@@ -568,34 +423,23 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("type"), equalTo("multisig_account_modification_transaction_v1"));
+		assertThat(built.containsKey("modifications"), equalTo(false));
 		assertThat(built.size(), equalTo(1));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: modifications
-		assertThat(built.containsKey("modifications"), equalTo(false));
-		assertThat(
-				sweepNewMultisigAccountModificationTransactionV1Descriptor()
-						.modifications((List<SizePrefixedMultisigAccountModificationDescriptor>) null).toMap().containsKey("modifications"),
-				equalTo(false));
-		final MultisigAccountModificationTransactionV1Descriptor withModifications = sweepNewMultisigAccountModificationTransactionV1Descriptor();
-		assertThat(withModifications.modifications(List.of(sweepNewSizePrefixedMultisigAccountModificationDescriptor())),
-				sameInstance(withModifications));
-		assertThat(withModifications.toMap().get("modifications"),
-				equalTo(List.of(sweepNewSizePrefixedMultisigAccountModificationDescriptor().toMap())));
-		assertThat(
-				sweepNewMultisigAccountModificationTransactionV1Descriptor()
-						.modifications(sweepNewSizePrefixedMultisigAccountModificationDescriptor()).toMap().get("modifications"),
-				equalTo(withModifications.toMap().get("modifications")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new MultisigAccountModificationTransactionV1Descriptor(
+				List.of(sweepNewSizePrefixedMultisigAccountModificationDescriptor())).toMap();
+		assertThat(fullBuilt.get("modifications"), equalTo(List.of(sweepNewSizePrefixedMultisigAccountModificationDescriptor().toMap())));
+		assertThat(fullBuilt.size(), equalTo(2));
 	}
 
 	@Test
 	void multisigAccountModificationTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewMultisigAccountModificationTransactionV1Descriptor()
-				.modifications(List.of(sweepNewSizePrefixedMultisigAccountModificationDescriptor())));
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(new MultisigAccountModificationTransactionV1Descriptor(
+				List.of(sweepNewSizePrefixedMultisigAccountModificationDescriptor())));
 
 		// Act:
 		final MultisigAccountModificationTransactionV1 transaction = (MultisigAccountModificationTransactionV1) FACTORY.create(createMap);
@@ -609,9 +453,9 @@ final class DescriptorsSweepTest {
 		assertThat(NemTransactionFactory.deserialize(payload).serialize(), equalTo(payload));
 	}
 
-	/** Constructs a MultisigAccountModificationTransactionV2Descriptor with distinct sample required arguments. */
+	/** Constructs a MultisigAccountModificationTransactionV2Descriptor with distinct sample required arguments and null optionals. */
 	private static MultisigAccountModificationTransactionV2Descriptor sweepNewMultisigAccountModificationTransactionV2Descriptor() {
-		return new MultisigAccountModificationTransactionV2Descriptor(2);
+		return new MultisigAccountModificationTransactionV2Descriptor(2, null);
 	}
 
 	@Test
@@ -622,35 +466,24 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("type"), equalTo("multisig_account_modification_transaction_v2"));
 		assertThat(built.get("minApprovalDelta"), equalTo(2));
+		assertThat(built.containsKey("modifications"), equalTo(false));
 		assertThat(built.size(), equalTo(2));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: modifications
-		assertThat(built.containsKey("modifications"), equalTo(false));
-		assertThat(
-				sweepNewMultisigAccountModificationTransactionV2Descriptor()
-						.modifications((List<SizePrefixedMultisigAccountModificationDescriptor>) null).toMap().containsKey("modifications"),
-				equalTo(false));
-		final MultisigAccountModificationTransactionV2Descriptor withModifications = sweepNewMultisigAccountModificationTransactionV2Descriptor();
-		assertThat(withModifications.modifications(List.of(sweepNewSizePrefixedMultisigAccountModificationDescriptor())),
-				sameInstance(withModifications));
-		assertThat(withModifications.toMap().get("modifications"),
-				equalTo(List.of(sweepNewSizePrefixedMultisigAccountModificationDescriptor().toMap())));
-		assertThat(
-				sweepNewMultisigAccountModificationTransactionV2Descriptor()
-						.modifications(sweepNewSizePrefixedMultisigAccountModificationDescriptor()).toMap().get("modifications"),
-				equalTo(withModifications.toMap().get("modifications")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new MultisigAccountModificationTransactionV2Descriptor(2,
+				List.of(sweepNewSizePrefixedMultisigAccountModificationDescriptor())).toMap();
+		assertThat(fullBuilt.get("modifications"), equalTo(List.of(sweepNewSizePrefixedMultisigAccountModificationDescriptor().toMap())));
+		assertThat(fullBuilt.size(), equalTo(3));
 	}
 
 	@Test
 	void multisigAccountModificationTransactionV2DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewMultisigAccountModificationTransactionV2Descriptor()
-				.modifications(List.of(sweepNewSizePrefixedMultisigAccountModificationDescriptor())));
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(new MultisigAccountModificationTransactionV2Descriptor(2,
+				List.of(sweepNewSizePrefixedMultisigAccountModificationDescriptor())));
 
 		// Act:
 		final MultisigAccountModificationTransactionV2 transaction = (MultisigAccountModificationTransactionV2) FACTORY.create(createMap);
@@ -687,21 +520,6 @@ final class DescriptorsSweepTest {
 		assertThat(built.size(), equalTo(2));
 	}
 
-	@Test
-	void cosignatureV1BodyDescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewCosignatureV1BodyDescriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new CosignatureV1BodyDescriptor(
-				"0202020202020202020202020202020202020202020202020202020202020202", "TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("otherTransactionHash"), equalTo(built.get("otherTransactionHash")));
-		assertThat(stringBuilt.get("multisigAccountAddress"), equalTo(built.get("multisigAccountAddress")));
-	}
-
 	/** Constructs a CosignatureV1Descriptor with distinct sample required arguments. */
 	private static CosignatureV1Descriptor sweepNewCosignatureV1Descriptor() {
 		return new CosignatureV1Descriptor(new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"),
@@ -726,25 +544,11 @@ final class DescriptorsSweepTest {
 	}
 
 	@Test
-	void cosignatureV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewCosignatureV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new CosignatureV1Descriptor(
-				"0202020202020202020202020202020202020202020202020202020202020202", "TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("otherTransactionHash"), equalTo(built.get("otherTransactionHash")));
-		assertThat(stringBuilt.get("multisigAccountAddress"), equalTo(built.get("multisigAccountAddress")));
-	}
-
-	@Test
 	void cosignatureV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewCosignatureV1Descriptor());
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(
+				new CosignatureV1Descriptor(new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"),
+						new org.symbol.sdk.nem.Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C")));
 
 		// Act:
 		final CosignatureV1 transaction = (CosignatureV1) FACTORY.create(createMap);
@@ -779,9 +583,9 @@ final class DescriptorsSweepTest {
 		assertThat(built.size(), equalTo(1));
 	}
 
-	/** Constructs a MultisigTransactionV1Descriptor with distinct sample required arguments. */
+	/** Constructs a MultisigTransactionV1Descriptor with distinct sample required arguments and null optionals. */
 	private static MultisigTransactionV1Descriptor sweepNewMultisigTransactionV1Descriptor() {
-		return new MultisigTransactionV1Descriptor(new NonVerifiableAccountKeyLinkTransactionV1());
+		return new MultisigTransactionV1Descriptor(new NonVerifiableAccountKeyLinkTransactionV1(), null);
 	}
 
 	@Test
@@ -792,29 +596,24 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("type"), equalTo("multisig_transaction_v1"));
 		assertThat(built.get("innerTransaction"), notNullValue());
+		assertThat(built.containsKey("cosignatures"), equalTo(false));
 		assertThat(built.size(), equalTo(2));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: cosignatures
-		assertThat(built.containsKey("cosignatures"), equalTo(false));
-		assertThat(sweepNewMultisigTransactionV1Descriptor().cosignatures((List<SizePrefixedCosignatureV1Descriptor>) null).toMap()
-				.containsKey("cosignatures"), equalTo(false));
-		final MultisigTransactionV1Descriptor withCosignatures = sweepNewMultisigTransactionV1Descriptor();
-		assertThat(withCosignatures.cosignatures(List.of(sweepNewSizePrefixedCosignatureV1Descriptor())), sameInstance(withCosignatures));
-		assertThat(withCosignatures.toMap().get("cosignatures"), equalTo(List.of(sweepNewSizePrefixedCosignatureV1Descriptor().toMap())));
-		assertThat(sweepNewMultisigTransactionV1Descriptor().cosignatures(sweepNewSizePrefixedCosignatureV1Descriptor()).toMap()
-				.get("cosignatures"), equalTo(withCosignatures.toMap().get("cosignatures")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new MultisigTransactionV1Descriptor(new NonVerifiableAccountKeyLinkTransactionV1(),
+				List.of(sweepNewSizePrefixedCosignatureV1Descriptor())).toMap();
+		assertThat(fullBuilt.get("cosignatures"), equalTo(List.of(sweepNewSizePrefixedCosignatureV1Descriptor().toMap())));
+		assertThat(fullBuilt.size(), equalTo(3));
 	}
 
 	@Test
 	void multisigTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(
-				sweepNewMultisigTransactionV1Descriptor().cosignatures(List.of(sweepNewSizePrefixedCosignatureV1Descriptor())));
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(new MultisigTransactionV1Descriptor(
+				new NonVerifiableAccountKeyLinkTransactionV1(), List.of(sweepNewSizePrefixedCosignatureV1Descriptor())));
 
 		// Act:
 		final MultisigTransactionV1 transaction = (MultisigTransactionV1) FACTORY.create(createMap);
@@ -829,10 +628,10 @@ final class DescriptorsSweepTest {
 		assertThat(NemTransactionFactory.deserialize(payload).serialize(), equalTo(payload));
 	}
 
-	/** Constructs a NamespaceRegistrationTransactionV1Descriptor with distinct sample required arguments. */
+	/** Constructs a NamespaceRegistrationTransactionV1Descriptor with distinct sample required arguments and null optionals. */
 	private static NamespaceRegistrationTransactionV1Descriptor sweepNewNamespaceRegistrationTransactionV1Descriptor() {
 		return new NamespaceRegistrationTransactionV1Descriptor(new org.symbol.sdk.nem.Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C"),
-				Amount.parse("2"));
+				Amount.parse("2"), null, null);
 	}
 
 	@Test
@@ -843,58 +642,29 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("type"), equalTo("namespace_registration_transaction_v1"));
 		assertThat(built.get("rentalFeeSink"), equalTo(new org.symbol.sdk.nem.Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C")));
 		assertThat(built.get("rentalFee"), equalTo(Amount.parse("2")));
+		assertThat(built.containsKey("name"), equalTo(false));
+		assertThat(built.containsKey("parentName"), equalTo(false));
 		assertThat(built.size(), equalTo(3));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: name
-		assertThat(built.containsKey("name"), equalTo(false));
-		assertThat(sweepNewNamespaceRegistrationTransactionV1Descriptor().name((byte[]) null).toMap().containsKey("name"), equalTo(false));
-		assertThat(sweepNewNamespaceRegistrationTransactionV1Descriptor().name((String) null).toMap().containsKey("name"), equalTo(false));
-		final NamespaceRegistrationTransactionV1Descriptor withName = sweepNewNamespaceRegistrationTransactionV1Descriptor();
-		assertThat(withName.name("name".getBytes(StandardCharsets.UTF_8)), sameInstance(withName));
-		assertThat(withName.toMap().get("name"), equalTo("name".getBytes(StandardCharsets.UTF_8)));
-		assertThat(sweepNewNamespaceRegistrationTransactionV1Descriptor().name("name").toMap().get("name"),
-				equalTo(withName.toMap().get("name")));
-
-		// optional field: parentName
-		assertThat(built.containsKey("parentName"), equalTo(false));
-		assertThat(sweepNewNamespaceRegistrationTransactionV1Descriptor().parentName((byte[]) null).toMap().containsKey("parentName"),
-				equalTo(false));
-		assertThat(sweepNewNamespaceRegistrationTransactionV1Descriptor().parentName((String) null).toMap().containsKey("parentName"),
-				equalTo(false));
-		final NamespaceRegistrationTransactionV1Descriptor withParentName = sweepNewNamespaceRegistrationTransactionV1Descriptor();
-		assertThat(withParentName.parentName("parentName".getBytes(StandardCharsets.UTF_8)), sameInstance(withParentName));
-		assertThat(withParentName.toMap().get("parentName"), equalTo("parentName".getBytes(StandardCharsets.UTF_8)));
-		assertThat(sweepNewNamespaceRegistrationTransactionV1Descriptor().parentName("parentName").toMap().get("parentName"),
-				equalTo(withParentName.toMap().get("parentName")));
-	}
-
-	@Test
-	void namespaceRegistrationTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewNamespaceRegistrationTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new NamespaceRegistrationTransactionV1Descriptor("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C",
-				"2").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("rentalFeeSink"), equalTo(built.get("rentalFeeSink")));
-		assertThat(stringBuilt.get("rentalFee"), equalTo(built.get("rentalFee")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new NamespaceRegistrationTransactionV1Descriptor(
+				new org.symbol.sdk.nem.Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C"), Amount.parse("2"),
+				"name".getBytes(StandardCharsets.UTF_8), "parentName".getBytes(StandardCharsets.UTF_8)).toMap();
+		assertThat(fullBuilt.get("name"), equalTo("name".getBytes(StandardCharsets.UTF_8)));
+		assertThat(fullBuilt.get("parentName"), equalTo("parentName".getBytes(StandardCharsets.UTF_8)));
+		assertThat(fullBuilt.size(), equalTo(5));
 	}
 
 	@Test
 	void namespaceRegistrationTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewNamespaceRegistrationTransactionV1Descriptor()
-				.name("name".getBytes(StandardCharsets.UTF_8)).parentName("parentName".getBytes(StandardCharsets.UTF_8)));
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(
+				new NamespaceRegistrationTransactionV1Descriptor(new org.symbol.sdk.nem.Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C"),
+						Amount.parse("2"), "name".getBytes(StandardCharsets.UTF_8), "parentName".getBytes(StandardCharsets.UTF_8)));
 
 		// Act:
 		final NamespaceRegistrationTransactionV1 transaction = (NamespaceRegistrationTransactionV1) FACTORY.create(createMap);
@@ -912,9 +682,9 @@ final class DescriptorsSweepTest {
 		assertThat(NemTransactionFactory.deserialize(payload).serialize(), equalTo(payload));
 	}
 
-	/** Constructs a MessageDescriptor with distinct sample required arguments. */
+	/** Constructs a MessageDescriptor with distinct sample required arguments and null optionals. */
 	private static MessageDescriptor sweepNewMessageDescriptor() {
-		return new MessageDescriptor(MessageType.parse("plain"));
+		return new MessageDescriptor(MessageType.parse("plain"), null);
 	}
 
 	@Test
@@ -925,39 +695,22 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("messageType"), equalTo(MessageType.parse("plain")));
+		assertThat(built.containsKey("message"), equalTo(false));
 		assertThat(built.size(), equalTo(1));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: message
-		assertThat(built.containsKey("message"), equalTo(false));
-		assertThat(sweepNewMessageDescriptor().message((byte[]) null).toMap().containsKey("message"), equalTo(false));
-		assertThat(sweepNewMessageDescriptor().message((String) null).toMap().containsKey("message"), equalTo(false));
-		final MessageDescriptor withMessage = sweepNewMessageDescriptor();
-		assertThat(withMessage.message("message".getBytes(StandardCharsets.UTF_8)), sameInstance(withMessage));
-		assertThat(withMessage.toMap().get("message"), equalTo("message".getBytes(StandardCharsets.UTF_8)));
-		assertThat(sweepNewMessageDescriptor().message("message").toMap().get("message"), equalTo(withMessage.toMap().get("message")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new MessageDescriptor(MessageType.parse("plain"), "message".getBytes(StandardCharsets.UTF_8))
+				.toMap();
+		assertThat(fullBuilt.get("message"), equalTo("message".getBytes(StandardCharsets.UTF_8)));
+		assertThat(fullBuilt.size(), equalTo(2));
 	}
 
-	@Test
-	void messageDescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewMessageDescriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new MessageDescriptor("plain").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("messageType"), equalTo(built.get("messageType")));
-	}
-
-	/** Constructs a TransferTransactionV1Descriptor with distinct sample required arguments. */
+	/** Constructs a TransferTransactionV1Descriptor with distinct sample required arguments and null optionals. */
 	private static TransferTransactionV1Descriptor sweepNewTransferTransactionV1Descriptor() {
 		return new TransferTransactionV1Descriptor(new org.symbol.sdk.nem.Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C"),
-				Amount.parse("2"));
+				Amount.parse("2"), null);
 	}
 
 	@Test
@@ -968,44 +721,27 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("type"), equalTo("transfer_transaction_v1"));
 		assertThat(built.get("recipientAddress"), equalTo(new org.symbol.sdk.nem.Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C")));
 		assertThat(built.get("amount"), equalTo(Amount.parse("2")));
+		assertThat(built.containsKey("message"), equalTo(false));
 		assertThat(built.size(), equalTo(3));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: message
-		assertThat(built.containsKey("message"), equalTo(false));
-		assertThat(sweepNewTransferTransactionV1Descriptor().message((MessageDescriptor) null).toMap().containsKey("message"),
-				equalTo(false));
-		final TransferTransactionV1Descriptor withMessage = sweepNewTransferTransactionV1Descriptor();
-		assertThat(withMessage.message(sweepNewMessageDescriptor()), sameInstance(withMessage));
-		assertThat(withMessage.toMap().get("message"), equalTo(sweepNewMessageDescriptor().toMap()));
-	}
-
-	@Test
-	void transferTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewTransferTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new TransferTransactionV1Descriptor("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C", "2")
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new TransferTransactionV1Descriptor(
+				new org.symbol.sdk.nem.Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C"), Amount.parse("2"), sweepNewMessageDescriptor())
 				.toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("recipientAddress"), equalTo(built.get("recipientAddress")));
-		assertThat(stringBuilt.get("amount"), equalTo(built.get("amount")));
+		assertThat(fullBuilt.get("message"), equalTo(sweepNewMessageDescriptor().toMap()));
+		assertThat(fullBuilt.size(), equalTo(4));
 	}
 
 	@Test
 	void transferTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
+		// Arrange: the sample descriptor with every field populated, plus the signer
 		final Map<String, Object> createMap = sweepCreateMap(
-				sweepNewTransferTransactionV1Descriptor().message(sweepNewMessageDescriptor()));
+				new TransferTransactionV1Descriptor(new org.symbol.sdk.nem.Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C"),
+						Amount.parse("2"), sweepNewMessageDescriptor()));
 
 		// Act:
 		final TransferTransactionV1 transaction = (TransferTransactionV1) FACTORY.create(createMap);
@@ -1022,10 +758,10 @@ final class DescriptorsSweepTest {
 		assertThat(NemTransactionFactory.deserialize(payload).serialize(), equalTo(payload));
 	}
 
-	/** Constructs a TransferTransactionV2Descriptor with distinct sample required arguments. */
+	/** Constructs a TransferTransactionV2Descriptor with distinct sample required arguments and null optionals. */
 	private static TransferTransactionV2Descriptor sweepNewTransferTransactionV2Descriptor() {
 		return new TransferTransactionV2Descriptor(new org.symbol.sdk.nem.Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C"),
-				Amount.parse("2"));
+				Amount.parse("2"), null, null);
 	}
 
 	@Test
@@ -1036,55 +772,29 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("type"), equalTo("transfer_transaction_v2"));
 		assertThat(built.get("recipientAddress"), equalTo(new org.symbol.sdk.nem.Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C")));
 		assertThat(built.get("amount"), equalTo(Amount.parse("2")));
+		assertThat(built.containsKey("message"), equalTo(false));
+		assertThat(built.containsKey("mosaics"), equalTo(false));
 		assertThat(built.size(), equalTo(3));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: message
-		assertThat(built.containsKey("message"), equalTo(false));
-		assertThat(sweepNewTransferTransactionV2Descriptor().message((MessageDescriptor) null).toMap().containsKey("message"),
-				equalTo(false));
-		final TransferTransactionV2Descriptor withMessage = sweepNewTransferTransactionV2Descriptor();
-		assertThat(withMessage.message(sweepNewMessageDescriptor()), sameInstance(withMessage));
-		assertThat(withMessage.toMap().get("message"), equalTo(sweepNewMessageDescriptor().toMap()));
-
-		// optional field: mosaics
-		assertThat(built.containsKey("mosaics"), equalTo(false));
-		assertThat(
-				sweepNewTransferTransactionV2Descriptor().mosaics((List<SizePrefixedMosaicDescriptor>) null).toMap().containsKey("mosaics"),
-				equalTo(false));
-		final TransferTransactionV2Descriptor withMosaics = sweepNewTransferTransactionV2Descriptor();
-		assertThat(withMosaics.mosaics(List.of(sweepNewSizePrefixedMosaicDescriptor())), sameInstance(withMosaics));
-		assertThat(withMosaics.toMap().get("mosaics"), equalTo(List.of(sweepNewSizePrefixedMosaicDescriptor().toMap())));
-		assertThat(sweepNewTransferTransactionV2Descriptor().mosaics(sweepNewSizePrefixedMosaicDescriptor()).toMap().get("mosaics"),
-				equalTo(withMosaics.toMap().get("mosaics")));
-	}
-
-	@Test
-	void transferTransactionV2DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewTransferTransactionV2Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new TransferTransactionV2Descriptor("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C", "2")
-				.toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("recipientAddress"), equalTo(built.get("recipientAddress")));
-		assertThat(stringBuilt.get("amount"), equalTo(built.get("amount")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new TransferTransactionV2Descriptor(
+				new org.symbol.sdk.nem.Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C"), Amount.parse("2"), sweepNewMessageDescriptor(),
+				List.of(sweepNewSizePrefixedMosaicDescriptor())).toMap();
+		assertThat(fullBuilt.get("message"), equalTo(sweepNewMessageDescriptor().toMap()));
+		assertThat(fullBuilt.get("mosaics"), equalTo(List.of(sweepNewSizePrefixedMosaicDescriptor().toMap())));
+		assertThat(fullBuilt.size(), equalTo(5));
 	}
 
 	@Test
 	void transferTransactionV2DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewTransferTransactionV2Descriptor().message(sweepNewMessageDescriptor())
-				.mosaics(List.of(sweepNewSizePrefixedMosaicDescriptor())));
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(
+				new TransferTransactionV2Descriptor(new org.symbol.sdk.nem.Address("TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C"),
+						Amount.parse("2"), sweepNewMessageDescriptor(), List.of(sweepNewSizePrefixedMosaicDescriptor())));
 
 		// Act:
 		final TransferTransactionV2 transaction = (TransferTransactionV2) FACTORY.create(createMap);

--- a/sdk/java/src/test/java/org/symbol/sdk/symbol/descriptors/DescriptorsSweepTest.java
+++ b/sdk/java/src/test/java/org/symbol/sdk/symbol/descriptors/DescriptorsSweepTest.java
@@ -35,7 +35,6 @@ import org.symbol.sdk.symbol.models.Amount;
 import org.symbol.sdk.symbol.models.BlockDuration;
 import org.symbol.sdk.symbol.models.Cosignature;
 import org.symbol.sdk.symbol.models.EmbeddedAccountKeyLinkTransactionV1;
-import org.symbol.sdk.symbol.models.EmbeddedTransaction;
 import org.symbol.sdk.symbol.models.FinalizationEpoch;
 import org.symbol.sdk.symbol.models.Hash256;
 import org.symbol.sdk.symbol.models.HashLockTransactionV1;
@@ -72,9 +71,9 @@ import org.symbol.sdk.symbol.models.VotingPublicKey;
 import org.symbol.sdk.symbol.models.VrfKeyLinkTransactionV1;
 
 /**
- * Generated per-descriptor sweep: construction with distinct sample values, exact {@code toMap()} contents, string-form constructor
- * equivalence, every optional fluent setter, and (for transaction descriptors) a factory round-trip verifying each created-model field via
- * {@code getField}.
+ * Generated per-descriptor sweep: construction with distinct sample values, exact {@code toMap()} contents (null optional arguments leave
+ * their keys absent), all-args constructor storage of every field, and (for transaction descriptors) a factory round-trip verifying each
+ * created-model field via {@code getField}.
  */
 final class DescriptorsSweepTest {
 	private static final CryptoTypes.PublicKey SWEEP_SIGNER_PUBLIC_KEY = new CryptoTypes.PublicKey(
@@ -111,20 +110,6 @@ final class DescriptorsSweepTest {
 		assertThat(built.size(), equalTo(2));
 	}
 
-	@Test
-	void mosaicDescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewMosaicDescriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new MosaicDescriptor("1", "2").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("mosaicId"), equalTo(built.get("mosaicId")));
-		assertThat(stringBuilt.get("amount"), equalTo(built.get("amount")));
-	}
-
 	/** Constructs a UnresolvedMosaicDescriptor with distinct sample required arguments. */
 	private static UnresolvedMosaicDescriptor sweepNewUnresolvedMosaicDescriptor() {
 		return new UnresolvedMosaicDescriptor(UnresolvedMosaicId.parse("1"), Amount.parse("2"));
@@ -142,20 +127,6 @@ final class DescriptorsSweepTest {
 		assertThat(built.get("mosaicId"), equalTo(UnresolvedMosaicId.parse("1")));
 		assertThat(built.get("amount"), equalTo(Amount.parse("2")));
 		assertThat(built.size(), equalTo(2));
-	}
-
-	@Test
-	void unresolvedMosaicDescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewUnresolvedMosaicDescriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new UnresolvedMosaicDescriptor("1", "2").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("mosaicId"), equalTo(built.get("mosaicId")));
-		assertThat(stringBuilt.get("amount"), equalTo(built.get("amount")));
 	}
 
 	/** Constructs a AccountKeyLinkTransactionV1Descriptor with distinct sample required arguments. */
@@ -181,25 +152,10 @@ final class DescriptorsSweepTest {
 	}
 
 	@Test
-	void accountKeyLinkTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewAccountKeyLinkTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new AccountKeyLinkTransactionV1Descriptor(
-				"0202020202020202020202020202020202020202020202020202020202020202", "link").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("linkedPublicKey"), equalTo(built.get("linkedPublicKey")));
-		assertThat(stringBuilt.get("linkAction"), equalTo(built.get("linkAction")));
-	}
-
-	@Test
 	void accountKeyLinkTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewAccountKeyLinkTransactionV1Descriptor());
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(new AccountKeyLinkTransactionV1Descriptor(
+				new CryptoTypes.PublicKey("0202020202020202020202020202020202020202020202020202020202020202"), LinkAction.parse("link")));
 
 		// Act:
 		final AccountKeyLinkTransactionV1 transaction = (AccountKeyLinkTransactionV1) FACTORY.create(createMap);
@@ -238,25 +194,10 @@ final class DescriptorsSweepTest {
 	}
 
 	@Test
-	void nodeKeyLinkTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewNodeKeyLinkTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new NodeKeyLinkTransactionV1Descriptor(
-				"0202020202020202020202020202020202020202020202020202020202020202", "link").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("linkedPublicKey"), equalTo(built.get("linkedPublicKey")));
-		assertThat(stringBuilt.get("linkAction"), equalTo(built.get("linkAction")));
-	}
-
-	@Test
 	void nodeKeyLinkTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewNodeKeyLinkTransactionV1Descriptor());
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(new NodeKeyLinkTransactionV1Descriptor(
+				new CryptoTypes.PublicKey("0202020202020202020202020202020202020202020202020202020202020202"), LinkAction.parse("link")));
 
 		// Act:
 		final NodeKeyLinkTransactionV1 transaction = (NodeKeyLinkTransactionV1) FACTORY.create(createMap);
@@ -296,24 +237,6 @@ final class DescriptorsSweepTest {
 		assertThat(built.size(), equalTo(3));
 	}
 
-	@Test
-	void cosignatureDescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewCosignatureDescriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new CosignatureDescriptor(1L,
-				"0303030303030303030303030303030303030303030303030303030303030303",
-				"04040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404")
-				.toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("version"), equalTo(built.get("version")));
-		assertThat(stringBuilt.get("signerPublicKey"), equalTo(built.get("signerPublicKey")));
-		assertThat(stringBuilt.get("signature"), equalTo(built.get("signature")));
-	}
-
 	/** Constructs a DetachedCosignatureDescriptor with distinct sample required arguments. */
 	private static DetachedCosignatureDescriptor sweepNewDetachedCosignatureDescriptor() {
 		return new DetachedCosignatureDescriptor(1L,
@@ -342,29 +265,10 @@ final class DescriptorsSweepTest {
 		assertThat(built.size(), equalTo(4));
 	}
 
-	@Test
-	void detachedCosignatureDescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewDetachedCosignatureDescriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new DetachedCosignatureDescriptor(1L,
-				"0303030303030303030303030303030303030303030303030303030303030303",
-				"04040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404040404",
-				"0505050505050505050505050505050505050505050505050505050505050505").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("version"), equalTo(built.get("version")));
-		assertThat(stringBuilt.get("signerPublicKey"), equalTo(built.get("signerPublicKey")));
-		assertThat(stringBuilt.get("signature"), equalTo(built.get("signature")));
-		assertThat(stringBuilt.get("parentHash"), equalTo(built.get("parentHash")));
-	}
-
-	/** Constructs a AggregateCompleteTransactionV1Descriptor with distinct sample required arguments. */
+	/** Constructs a AggregateCompleteTransactionV1Descriptor with distinct sample required arguments and null optionals. */
 	private static AggregateCompleteTransactionV1Descriptor sweepNewAggregateCompleteTransactionV1Descriptor() {
 		return new AggregateCompleteTransactionV1Descriptor(
-				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"));
+				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"), null, null);
 	}
 
 	@Test
@@ -375,53 +279,31 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("type"), equalTo("aggregate_complete_transaction_v1"));
 		assertThat(built.get("transactionsHash"),
 				equalTo(new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202")));
+		assertThat(built.containsKey("transactions"), equalTo(false));
+		assertThat(built.containsKey("cosignatures"), equalTo(false));
 		assertThat(built.size(), equalTo(2));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: transactions
-		assertThat(built.containsKey("transactions"), equalTo(false));
-		assertThat(sweepNewAggregateCompleteTransactionV1Descriptor().transactions((List<EmbeddedTransaction>) null).toMap()
-				.containsKey("transactions"), equalTo(false));
-		final AggregateCompleteTransactionV1Descriptor withTransactions = sweepNewAggregateCompleteTransactionV1Descriptor();
-		assertThat(withTransactions.transactions(List.of(new EmbeddedAccountKeyLinkTransactionV1())), sameInstance(withTransactions));
-		assertThat(((List<?>) withTransactions.toMap().get("transactions")).size(), equalTo(1));
-
-		// optional field: cosignatures
-		assertThat(built.containsKey("cosignatures"), equalTo(false));
-		assertThat(sweepNewAggregateCompleteTransactionV1Descriptor().cosignatures((List<Cosignature>) null).toMap()
-				.containsKey("cosignatures"), equalTo(false));
-		final AggregateCompleteTransactionV1Descriptor withCosignatures = sweepNewAggregateCompleteTransactionV1Descriptor();
-		assertThat(withCosignatures.cosignatures(List.of(new Cosignature())), sameInstance(withCosignatures));
-		assertThat(((List<?>) withCosignatures.toMap().get("cosignatures")).size(), equalTo(1));
-	}
-
-	@Test
-	void aggregateCompleteTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewAggregateCompleteTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new AggregateCompleteTransactionV1Descriptor(
-				"0202020202020202020202020202020202020202020202020202020202020202").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("transactionsHash"), equalTo(built.get("transactionsHash")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new AggregateCompleteTransactionV1Descriptor(
+				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"),
+				List.of(new EmbeddedAccountKeyLinkTransactionV1()), List.of(new Cosignature())).toMap();
+		assertThat(((List<?>) fullBuilt.get("transactions")).size(), equalTo(1));
+		assertThat(((List<?>) fullBuilt.get("cosignatures")).size(), equalTo(1));
+		assertThat(fullBuilt.size(), equalTo(4));
 	}
 
 	@Test
 	void aggregateCompleteTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
+		// Arrange: the sample descriptor with every field populated, plus the signer
 		final EmbeddedAccountKeyLinkTransactionV1 sweepTransactionsElement = new EmbeddedAccountKeyLinkTransactionV1();
 		final Cosignature sweepCosignaturesElement = new Cosignature();
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewAggregateCompleteTransactionV1Descriptor()
-				.transactions(List.of(sweepTransactionsElement)).cosignatures(List.of(sweepCosignaturesElement)));
+		final Map<String, Object> createMap = sweepCreateMap(new AggregateCompleteTransactionV1Descriptor(
+				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"),
+				List.of(sweepTransactionsElement), List.of(sweepCosignaturesElement)));
 
 		// Act:
 		final AggregateCompleteTransactionV1 transaction = (AggregateCompleteTransactionV1) FACTORY.create(createMap);
@@ -440,10 +322,10 @@ final class DescriptorsSweepTest {
 		assertThat(SymbolTransactionFactory.deserialize(payload).serialize(), equalTo(payload));
 	}
 
-	/** Constructs a AggregateCompleteTransactionV2Descriptor with distinct sample required arguments. */
+	/** Constructs a AggregateCompleteTransactionV2Descriptor with distinct sample required arguments and null optionals. */
 	private static AggregateCompleteTransactionV2Descriptor sweepNewAggregateCompleteTransactionV2Descriptor() {
 		return new AggregateCompleteTransactionV2Descriptor(
-				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"));
+				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"), null, null);
 	}
 
 	@Test
@@ -454,53 +336,31 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("type"), equalTo("aggregate_complete_transaction_v2"));
 		assertThat(built.get("transactionsHash"),
 				equalTo(new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202")));
+		assertThat(built.containsKey("transactions"), equalTo(false));
+		assertThat(built.containsKey("cosignatures"), equalTo(false));
 		assertThat(built.size(), equalTo(2));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: transactions
-		assertThat(built.containsKey("transactions"), equalTo(false));
-		assertThat(sweepNewAggregateCompleteTransactionV2Descriptor().transactions((List<EmbeddedTransaction>) null).toMap()
-				.containsKey("transactions"), equalTo(false));
-		final AggregateCompleteTransactionV2Descriptor withTransactions = sweepNewAggregateCompleteTransactionV2Descriptor();
-		assertThat(withTransactions.transactions(List.of(new EmbeddedAccountKeyLinkTransactionV1())), sameInstance(withTransactions));
-		assertThat(((List<?>) withTransactions.toMap().get("transactions")).size(), equalTo(1));
-
-		// optional field: cosignatures
-		assertThat(built.containsKey("cosignatures"), equalTo(false));
-		assertThat(sweepNewAggregateCompleteTransactionV2Descriptor().cosignatures((List<Cosignature>) null).toMap()
-				.containsKey("cosignatures"), equalTo(false));
-		final AggregateCompleteTransactionV2Descriptor withCosignatures = sweepNewAggregateCompleteTransactionV2Descriptor();
-		assertThat(withCosignatures.cosignatures(List.of(new Cosignature())), sameInstance(withCosignatures));
-		assertThat(((List<?>) withCosignatures.toMap().get("cosignatures")).size(), equalTo(1));
-	}
-
-	@Test
-	void aggregateCompleteTransactionV2DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewAggregateCompleteTransactionV2Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new AggregateCompleteTransactionV2Descriptor(
-				"0202020202020202020202020202020202020202020202020202020202020202").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("transactionsHash"), equalTo(built.get("transactionsHash")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new AggregateCompleteTransactionV2Descriptor(
+				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"),
+				List.of(new EmbeddedAccountKeyLinkTransactionV1()), List.of(new Cosignature())).toMap();
+		assertThat(((List<?>) fullBuilt.get("transactions")).size(), equalTo(1));
+		assertThat(((List<?>) fullBuilt.get("cosignatures")).size(), equalTo(1));
+		assertThat(fullBuilt.size(), equalTo(4));
 	}
 
 	@Test
 	void aggregateCompleteTransactionV2DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
+		// Arrange: the sample descriptor with every field populated, plus the signer
 		final EmbeddedAccountKeyLinkTransactionV1 sweepTransactionsElement = new EmbeddedAccountKeyLinkTransactionV1();
 		final Cosignature sweepCosignaturesElement = new Cosignature();
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewAggregateCompleteTransactionV2Descriptor()
-				.transactions(List.of(sweepTransactionsElement)).cosignatures(List.of(sweepCosignaturesElement)));
+		final Map<String, Object> createMap = sweepCreateMap(new AggregateCompleteTransactionV2Descriptor(
+				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"),
+				List.of(sweepTransactionsElement), List.of(sweepCosignaturesElement)));
 
 		// Act:
 		final AggregateCompleteTransactionV2 transaction = (AggregateCompleteTransactionV2) FACTORY.create(createMap);
@@ -519,10 +379,10 @@ final class DescriptorsSweepTest {
 		assertThat(SymbolTransactionFactory.deserialize(payload).serialize(), equalTo(payload));
 	}
 
-	/** Constructs a AggregateCompleteTransactionV3Descriptor with distinct sample required arguments. */
+	/** Constructs a AggregateCompleteTransactionV3Descriptor with distinct sample required arguments and null optionals. */
 	private static AggregateCompleteTransactionV3Descriptor sweepNewAggregateCompleteTransactionV3Descriptor() {
 		return new AggregateCompleteTransactionV3Descriptor(
-				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"));
+				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"), null, null);
 	}
 
 	@Test
@@ -533,53 +393,31 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("type"), equalTo("aggregate_complete_transaction_v3"));
 		assertThat(built.get("transactionsHash"),
 				equalTo(new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202")));
+		assertThat(built.containsKey("transactions"), equalTo(false));
+		assertThat(built.containsKey("cosignatures"), equalTo(false));
 		assertThat(built.size(), equalTo(2));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: transactions
-		assertThat(built.containsKey("transactions"), equalTo(false));
-		assertThat(sweepNewAggregateCompleteTransactionV3Descriptor().transactions((List<EmbeddedTransaction>) null).toMap()
-				.containsKey("transactions"), equalTo(false));
-		final AggregateCompleteTransactionV3Descriptor withTransactions = sweepNewAggregateCompleteTransactionV3Descriptor();
-		assertThat(withTransactions.transactions(List.of(new EmbeddedAccountKeyLinkTransactionV1())), sameInstance(withTransactions));
-		assertThat(((List<?>) withTransactions.toMap().get("transactions")).size(), equalTo(1));
-
-		// optional field: cosignatures
-		assertThat(built.containsKey("cosignatures"), equalTo(false));
-		assertThat(sweepNewAggregateCompleteTransactionV3Descriptor().cosignatures((List<Cosignature>) null).toMap()
-				.containsKey("cosignatures"), equalTo(false));
-		final AggregateCompleteTransactionV3Descriptor withCosignatures = sweepNewAggregateCompleteTransactionV3Descriptor();
-		assertThat(withCosignatures.cosignatures(List.of(new Cosignature())), sameInstance(withCosignatures));
-		assertThat(((List<?>) withCosignatures.toMap().get("cosignatures")).size(), equalTo(1));
-	}
-
-	@Test
-	void aggregateCompleteTransactionV3DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewAggregateCompleteTransactionV3Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new AggregateCompleteTransactionV3Descriptor(
-				"0202020202020202020202020202020202020202020202020202020202020202").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("transactionsHash"), equalTo(built.get("transactionsHash")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new AggregateCompleteTransactionV3Descriptor(
+				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"),
+				List.of(new EmbeddedAccountKeyLinkTransactionV1()), List.of(new Cosignature())).toMap();
+		assertThat(((List<?>) fullBuilt.get("transactions")).size(), equalTo(1));
+		assertThat(((List<?>) fullBuilt.get("cosignatures")).size(), equalTo(1));
+		assertThat(fullBuilt.size(), equalTo(4));
 	}
 
 	@Test
 	void aggregateCompleteTransactionV3DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
+		// Arrange: the sample descriptor with every field populated, plus the signer
 		final EmbeddedAccountKeyLinkTransactionV1 sweepTransactionsElement = new EmbeddedAccountKeyLinkTransactionV1();
 		final Cosignature sweepCosignaturesElement = new Cosignature();
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewAggregateCompleteTransactionV3Descriptor()
-				.transactions(List.of(sweepTransactionsElement)).cosignatures(List.of(sweepCosignaturesElement)));
+		final Map<String, Object> createMap = sweepCreateMap(new AggregateCompleteTransactionV3Descriptor(
+				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"),
+				List.of(sweepTransactionsElement), List.of(sweepCosignaturesElement)));
 
 		// Act:
 		final AggregateCompleteTransactionV3 transaction = (AggregateCompleteTransactionV3) FACTORY.create(createMap);
@@ -598,10 +436,10 @@ final class DescriptorsSweepTest {
 		assertThat(SymbolTransactionFactory.deserialize(payload).serialize(), equalTo(payload));
 	}
 
-	/** Constructs a AggregateBondedTransactionV1Descriptor with distinct sample required arguments. */
+	/** Constructs a AggregateBondedTransactionV1Descriptor with distinct sample required arguments and null optionals. */
 	private static AggregateBondedTransactionV1Descriptor sweepNewAggregateBondedTransactionV1Descriptor() {
 		return new AggregateBondedTransactionV1Descriptor(
-				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"));
+				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"), null, null);
 	}
 
 	@Test
@@ -612,54 +450,31 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("type"), equalTo("aggregate_bonded_transaction_v1"));
 		assertThat(built.get("transactionsHash"),
 				equalTo(new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202")));
+		assertThat(built.containsKey("transactions"), equalTo(false));
+		assertThat(built.containsKey("cosignatures"), equalTo(false));
 		assertThat(built.size(), equalTo(2));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: transactions
-		assertThat(built.containsKey("transactions"), equalTo(false));
-		assertThat(sweepNewAggregateBondedTransactionV1Descriptor().transactions((List<EmbeddedTransaction>) null).toMap()
-				.containsKey("transactions"), equalTo(false));
-		final AggregateBondedTransactionV1Descriptor withTransactions = sweepNewAggregateBondedTransactionV1Descriptor();
-		assertThat(withTransactions.transactions(List.of(new EmbeddedAccountKeyLinkTransactionV1())), sameInstance(withTransactions));
-		assertThat(((List<?>) withTransactions.toMap().get("transactions")).size(), equalTo(1));
-
-		// optional field: cosignatures
-		assertThat(built.containsKey("cosignatures"), equalTo(false));
-		assertThat(
-				sweepNewAggregateBondedTransactionV1Descriptor().cosignatures((List<Cosignature>) null).toMap().containsKey("cosignatures"),
-				equalTo(false));
-		final AggregateBondedTransactionV1Descriptor withCosignatures = sweepNewAggregateBondedTransactionV1Descriptor();
-		assertThat(withCosignatures.cosignatures(List.of(new Cosignature())), sameInstance(withCosignatures));
-		assertThat(((List<?>) withCosignatures.toMap().get("cosignatures")).size(), equalTo(1));
-	}
-
-	@Test
-	void aggregateBondedTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewAggregateBondedTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new AggregateBondedTransactionV1Descriptor(
-				"0202020202020202020202020202020202020202020202020202020202020202").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("transactionsHash"), equalTo(built.get("transactionsHash")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new AggregateBondedTransactionV1Descriptor(
+				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"),
+				List.of(new EmbeddedAccountKeyLinkTransactionV1()), List.of(new Cosignature())).toMap();
+		assertThat(((List<?>) fullBuilt.get("transactions")).size(), equalTo(1));
+		assertThat(((List<?>) fullBuilt.get("cosignatures")).size(), equalTo(1));
+		assertThat(fullBuilt.size(), equalTo(4));
 	}
 
 	@Test
 	void aggregateBondedTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
+		// Arrange: the sample descriptor with every field populated, plus the signer
 		final EmbeddedAccountKeyLinkTransactionV1 sweepTransactionsElement = new EmbeddedAccountKeyLinkTransactionV1();
 		final Cosignature sweepCosignaturesElement = new Cosignature();
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewAggregateBondedTransactionV1Descriptor()
-				.transactions(List.of(sweepTransactionsElement)).cosignatures(List.of(sweepCosignaturesElement)));
+		final Map<String, Object> createMap = sweepCreateMap(new AggregateBondedTransactionV1Descriptor(
+				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"),
+				List.of(sweepTransactionsElement), List.of(sweepCosignaturesElement)));
 
 		// Act:
 		final AggregateBondedTransactionV1 transaction = (AggregateBondedTransactionV1) FACTORY.create(createMap);
@@ -678,10 +493,10 @@ final class DescriptorsSweepTest {
 		assertThat(SymbolTransactionFactory.deserialize(payload).serialize(), equalTo(payload));
 	}
 
-	/** Constructs a AggregateBondedTransactionV2Descriptor with distinct sample required arguments. */
+	/** Constructs a AggregateBondedTransactionV2Descriptor with distinct sample required arguments and null optionals. */
 	private static AggregateBondedTransactionV2Descriptor sweepNewAggregateBondedTransactionV2Descriptor() {
 		return new AggregateBondedTransactionV2Descriptor(
-				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"));
+				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"), null, null);
 	}
 
 	@Test
@@ -692,54 +507,31 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("type"), equalTo("aggregate_bonded_transaction_v2"));
 		assertThat(built.get("transactionsHash"),
 				equalTo(new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202")));
+		assertThat(built.containsKey("transactions"), equalTo(false));
+		assertThat(built.containsKey("cosignatures"), equalTo(false));
 		assertThat(built.size(), equalTo(2));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: transactions
-		assertThat(built.containsKey("transactions"), equalTo(false));
-		assertThat(sweepNewAggregateBondedTransactionV2Descriptor().transactions((List<EmbeddedTransaction>) null).toMap()
-				.containsKey("transactions"), equalTo(false));
-		final AggregateBondedTransactionV2Descriptor withTransactions = sweepNewAggregateBondedTransactionV2Descriptor();
-		assertThat(withTransactions.transactions(List.of(new EmbeddedAccountKeyLinkTransactionV1())), sameInstance(withTransactions));
-		assertThat(((List<?>) withTransactions.toMap().get("transactions")).size(), equalTo(1));
-
-		// optional field: cosignatures
-		assertThat(built.containsKey("cosignatures"), equalTo(false));
-		assertThat(
-				sweepNewAggregateBondedTransactionV2Descriptor().cosignatures((List<Cosignature>) null).toMap().containsKey("cosignatures"),
-				equalTo(false));
-		final AggregateBondedTransactionV2Descriptor withCosignatures = sweepNewAggregateBondedTransactionV2Descriptor();
-		assertThat(withCosignatures.cosignatures(List.of(new Cosignature())), sameInstance(withCosignatures));
-		assertThat(((List<?>) withCosignatures.toMap().get("cosignatures")).size(), equalTo(1));
-	}
-
-	@Test
-	void aggregateBondedTransactionV2DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewAggregateBondedTransactionV2Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new AggregateBondedTransactionV2Descriptor(
-				"0202020202020202020202020202020202020202020202020202020202020202").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("transactionsHash"), equalTo(built.get("transactionsHash")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new AggregateBondedTransactionV2Descriptor(
+				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"),
+				List.of(new EmbeddedAccountKeyLinkTransactionV1()), List.of(new Cosignature())).toMap();
+		assertThat(((List<?>) fullBuilt.get("transactions")).size(), equalTo(1));
+		assertThat(((List<?>) fullBuilt.get("cosignatures")).size(), equalTo(1));
+		assertThat(fullBuilt.size(), equalTo(4));
 	}
 
 	@Test
 	void aggregateBondedTransactionV2DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
+		// Arrange: the sample descriptor with every field populated, plus the signer
 		final EmbeddedAccountKeyLinkTransactionV1 sweepTransactionsElement = new EmbeddedAccountKeyLinkTransactionV1();
 		final Cosignature sweepCosignaturesElement = new Cosignature();
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewAggregateBondedTransactionV2Descriptor()
-				.transactions(List.of(sweepTransactionsElement)).cosignatures(List.of(sweepCosignaturesElement)));
+		final Map<String, Object> createMap = sweepCreateMap(new AggregateBondedTransactionV2Descriptor(
+				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"),
+				List.of(sweepTransactionsElement), List.of(sweepCosignaturesElement)));
 
 		// Act:
 		final AggregateBondedTransactionV2 transaction = (AggregateBondedTransactionV2) FACTORY.create(createMap);
@@ -758,10 +550,10 @@ final class DescriptorsSweepTest {
 		assertThat(SymbolTransactionFactory.deserialize(payload).serialize(), equalTo(payload));
 	}
 
-	/** Constructs a AggregateBondedTransactionV3Descriptor with distinct sample required arguments. */
+	/** Constructs a AggregateBondedTransactionV3Descriptor with distinct sample required arguments and null optionals. */
 	private static AggregateBondedTransactionV3Descriptor sweepNewAggregateBondedTransactionV3Descriptor() {
 		return new AggregateBondedTransactionV3Descriptor(
-				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"));
+				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"), null, null);
 	}
 
 	@Test
@@ -772,54 +564,31 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("type"), equalTo("aggregate_bonded_transaction_v3"));
 		assertThat(built.get("transactionsHash"),
 				equalTo(new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202")));
+		assertThat(built.containsKey("transactions"), equalTo(false));
+		assertThat(built.containsKey("cosignatures"), equalTo(false));
 		assertThat(built.size(), equalTo(2));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: transactions
-		assertThat(built.containsKey("transactions"), equalTo(false));
-		assertThat(sweepNewAggregateBondedTransactionV3Descriptor().transactions((List<EmbeddedTransaction>) null).toMap()
-				.containsKey("transactions"), equalTo(false));
-		final AggregateBondedTransactionV3Descriptor withTransactions = sweepNewAggregateBondedTransactionV3Descriptor();
-		assertThat(withTransactions.transactions(List.of(new EmbeddedAccountKeyLinkTransactionV1())), sameInstance(withTransactions));
-		assertThat(((List<?>) withTransactions.toMap().get("transactions")).size(), equalTo(1));
-
-		// optional field: cosignatures
-		assertThat(built.containsKey("cosignatures"), equalTo(false));
-		assertThat(
-				sweepNewAggregateBondedTransactionV3Descriptor().cosignatures((List<Cosignature>) null).toMap().containsKey("cosignatures"),
-				equalTo(false));
-		final AggregateBondedTransactionV3Descriptor withCosignatures = sweepNewAggregateBondedTransactionV3Descriptor();
-		assertThat(withCosignatures.cosignatures(List.of(new Cosignature())), sameInstance(withCosignatures));
-		assertThat(((List<?>) withCosignatures.toMap().get("cosignatures")).size(), equalTo(1));
-	}
-
-	@Test
-	void aggregateBondedTransactionV3DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewAggregateBondedTransactionV3Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new AggregateBondedTransactionV3Descriptor(
-				"0202020202020202020202020202020202020202020202020202020202020202").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("transactionsHash"), equalTo(built.get("transactionsHash")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new AggregateBondedTransactionV3Descriptor(
+				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"),
+				List.of(new EmbeddedAccountKeyLinkTransactionV1()), List.of(new Cosignature())).toMap();
+		assertThat(((List<?>) fullBuilt.get("transactions")).size(), equalTo(1));
+		assertThat(((List<?>) fullBuilt.get("cosignatures")).size(), equalTo(1));
+		assertThat(fullBuilt.size(), equalTo(4));
 	}
 
 	@Test
 	void aggregateBondedTransactionV3DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
+		// Arrange: the sample descriptor with every field populated, plus the signer
 		final EmbeddedAccountKeyLinkTransactionV1 sweepTransactionsElement = new EmbeddedAccountKeyLinkTransactionV1();
 		final Cosignature sweepCosignaturesElement = new Cosignature();
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewAggregateBondedTransactionV3Descriptor()
-				.transactions(List.of(sweepTransactionsElement)).cosignatures(List.of(sweepCosignaturesElement)));
+		final Map<String, Object> createMap = sweepCreateMap(new AggregateBondedTransactionV3Descriptor(
+				new CryptoTypes.Hash256("0202020202020202020202020202020202020202020202020202020202020202"),
+				List.of(sweepTransactionsElement), List.of(sweepCosignaturesElement)));
 
 		// Act:
 		final AggregateBondedTransactionV3 transaction = (AggregateBondedTransactionV3) FACTORY.create(createMap);
@@ -864,27 +633,11 @@ final class DescriptorsSweepTest {
 	}
 
 	@Test
-	void votingKeyLinkTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewVotingKeyLinkTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new VotingKeyLinkTransactionV1Descriptor(
-				"0202020202020202020202020202020202020202020202020202020202020202", "2", "3", "link").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("linkedPublicKey"), equalTo(built.get("linkedPublicKey")));
-		assertThat(stringBuilt.get("startEpoch"), equalTo(built.get("startEpoch")));
-		assertThat(stringBuilt.get("endEpoch"), equalTo(built.get("endEpoch")));
-		assertThat(stringBuilt.get("linkAction"), equalTo(built.get("linkAction")));
-	}
-
-	@Test
 	void votingKeyLinkTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewVotingKeyLinkTransactionV1Descriptor());
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(new VotingKeyLinkTransactionV1Descriptor(
+				new CryptoTypes.PublicKey("0202020202020202020202020202020202020202020202020202020202020202"), FinalizationEpoch.parse("2"),
+				FinalizationEpoch.parse("3"), LinkAction.parse("link")));
 
 		// Act:
 		final VotingKeyLinkTransactionV1 transaction = (VotingKeyLinkTransactionV1) FACTORY.create(createMap);
@@ -925,25 +678,10 @@ final class DescriptorsSweepTest {
 	}
 
 	@Test
-	void vrfKeyLinkTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewVrfKeyLinkTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new VrfKeyLinkTransactionV1Descriptor(
-				"0202020202020202020202020202020202020202020202020202020202020202", "link").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("linkedPublicKey"), equalTo(built.get("linkedPublicKey")));
-		assertThat(stringBuilt.get("linkAction"), equalTo(built.get("linkAction")));
-	}
-
-	@Test
 	void vrfKeyLinkTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewVrfKeyLinkTransactionV1Descriptor());
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(new VrfKeyLinkTransactionV1Descriptor(
+				new CryptoTypes.PublicKey("0202020202020202020202020202020202020202020202020202020202020202"), LinkAction.parse("link")));
 
 		// Act:
 		final VrfKeyLinkTransactionV1 transaction = (VrfKeyLinkTransactionV1) FACTORY.create(createMap);
@@ -982,26 +720,10 @@ final class DescriptorsSweepTest {
 	}
 
 	@Test
-	void hashLockTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewHashLockTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new HashLockTransactionV1Descriptor(sweepNewUnresolvedMosaicDescriptor(), "2",
-				"0404040404040404040404040404040404040404040404040404040404040404").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("mosaic"), equalTo(built.get("mosaic")));
-		assertThat(stringBuilt.get("duration"), equalTo(built.get("duration")));
-		assertThat(stringBuilt.get("hash"), equalTo(built.get("hash")));
-	}
-
-	@Test
 	void hashLockTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewHashLockTransactionV1Descriptor());
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(new HashLockTransactionV1Descriptor(sweepNewUnresolvedMosaicDescriptor(),
+				BlockDuration.parse("2"), new CryptoTypes.Hash256("0404040404040404040404040404040404040404040404040404040404040404")));
 
 		// Act:
 		final HashLockTransactionV1 transaction = (HashLockTransactionV1) FACTORY.create(createMap);
@@ -1045,29 +767,12 @@ final class DescriptorsSweepTest {
 	}
 
 	@Test
-	void secretLockTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewSecretLockTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new SecretLockTransactionV1Descriptor("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I",
-				"0303030303030303030303030303030303030303030303030303030303030303", sweepNewUnresolvedMosaicDescriptor(), "4", "hash_160")
-				.toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("recipientAddress"), equalTo(built.get("recipientAddress")));
-		assertThat(stringBuilt.get("secret"), equalTo(built.get("secret")));
-		assertThat(stringBuilt.get("mosaic"), equalTo(built.get("mosaic")));
-		assertThat(stringBuilt.get("duration"), equalTo(built.get("duration")));
-		assertThat(stringBuilt.get("hashAlgorithm"), equalTo(built.get("hashAlgorithm")));
-	}
-
-	@Test
 	void secretLockTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewSecretLockTransactionV1Descriptor());
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(
+				new SecretLockTransactionV1Descriptor(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"),
+						new CryptoTypes.Hash256("0303030303030303030303030303030303030303030303030303030303030303"),
+						sweepNewUnresolvedMosaicDescriptor(), BlockDuration.parse("4"), LockHashAlgorithm.parse("hash_160")));
 
 		// Act:
 		final SecretLockTransactionV1 transaction = (SecretLockTransactionV1) FACTORY.create(createMap);
@@ -1087,11 +792,11 @@ final class DescriptorsSweepTest {
 		assertThat(SymbolTransactionFactory.deserialize(payload).serialize(), equalTo(payload));
 	}
 
-	/** Constructs a SecretProofTransactionV1Descriptor with distinct sample required arguments. */
+	/** Constructs a SecretProofTransactionV1Descriptor with distinct sample required arguments and null optionals. */
 	private static SecretProofTransactionV1Descriptor sweepNewSecretProofTransactionV1Descriptor() {
 		return new SecretProofTransactionV1Descriptor(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"),
 				new CryptoTypes.Hash256("0303030303030303030303030303030303030303030303030303030303030303"),
-				LockHashAlgorithm.parse("hash_256"));
+				LockHashAlgorithm.parse("hash_256"), null);
 	}
 
 	@Test
@@ -1102,49 +807,31 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("type"), equalTo("secret_proof_transaction_v1"));
 		assertThat(built.get("recipientAddress"), equalTo(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I")));
 		assertThat(built.get("secret"),
 				equalTo(new CryptoTypes.Hash256("0303030303030303030303030303030303030303030303030303030303030303")));
 		assertThat(built.get("hashAlgorithm"), equalTo(LockHashAlgorithm.parse("hash_256")));
+		assertThat(built.containsKey("proof"), equalTo(false));
 		assertThat(built.size(), equalTo(4));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: proof
-		assertThat(built.containsKey("proof"), equalTo(false));
-		assertThat(sweepNewSecretProofTransactionV1Descriptor().proof((byte[]) null).toMap().containsKey("proof"), equalTo(false));
-		assertThat(sweepNewSecretProofTransactionV1Descriptor().proof((String) null).toMap().containsKey("proof"), equalTo(false));
-		final SecretProofTransactionV1Descriptor withProof = sweepNewSecretProofTransactionV1Descriptor();
-		assertThat(withProof.proof("proof".getBytes(StandardCharsets.UTF_8)), sameInstance(withProof));
-		assertThat(withProof.toMap().get("proof"), equalTo("proof".getBytes(StandardCharsets.UTF_8)));
-		assertThat(sweepNewSecretProofTransactionV1Descriptor().proof("proof").toMap().get("proof"),
-				equalTo(withProof.toMap().get("proof")));
-	}
-
-	@Test
-	void secretProofTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewSecretProofTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new SecretProofTransactionV1Descriptor("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I",
-				"0303030303030303030303030303030303030303030303030303030303030303", "hash_256").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("recipientAddress"), equalTo(built.get("recipientAddress")));
-		assertThat(stringBuilt.get("secret"), equalTo(built.get("secret")));
-		assertThat(stringBuilt.get("hashAlgorithm"), equalTo(built.get("hashAlgorithm")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new SecretProofTransactionV1Descriptor(
+				new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"),
+				new CryptoTypes.Hash256("0303030303030303030303030303030303030303030303030303030303030303"),
+				LockHashAlgorithm.parse("hash_256"), "proof".getBytes(StandardCharsets.UTF_8)).toMap();
+		assertThat(fullBuilt.get("proof"), equalTo("proof".getBytes(StandardCharsets.UTF_8)));
+		assertThat(fullBuilt.size(), equalTo(5));
 	}
 
 	@Test
 	void secretProofTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
+		// Arrange: the sample descriptor with every field populated, plus the signer
 		final Map<String, Object> createMap = sweepCreateMap(
-				sweepNewSecretProofTransactionV1Descriptor().proof("proof".getBytes(StandardCharsets.UTF_8)));
+				new SecretProofTransactionV1Descriptor(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"),
+						new CryptoTypes.Hash256("0303030303030303030303030303030303030303030303030303030303030303"),
+						LockHashAlgorithm.parse("hash_256"), "proof".getBytes(StandardCharsets.UTF_8)));
 
 		// Act:
 		final SecretProofTransactionV1 transaction = (SecretProofTransactionV1) FACTORY.create(createMap);
@@ -1163,10 +850,10 @@ final class DescriptorsSweepTest {
 		assertThat(SymbolTransactionFactory.deserialize(payload).serialize(), equalTo(payload));
 	}
 
-	/** Constructs a AccountMetadataTransactionV1Descriptor with distinct sample required arguments. */
+	/** Constructs a AccountMetadataTransactionV1Descriptor with distinct sample required arguments and null optionals. */
 	private static AccountMetadataTransactionV1Descriptor sweepNewAccountMetadataTransactionV1Descriptor() {
 		return new AccountMetadataTransactionV1Descriptor(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"), 2L,
-				3);
+				3, null);
 	}
 
 	@Test
@@ -1177,48 +864,28 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("type"), equalTo("account_metadata_transaction_v1"));
 		assertThat(built.get("targetAddress"), equalTo(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I")));
 		assertThat(built.get("scopedMetadataKey"), equalTo(2L));
 		assertThat(built.get("valueSizeDelta"), equalTo(3));
+		assertThat(built.containsKey("value"), equalTo(false));
 		assertThat(built.size(), equalTo(4));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: value
-		assertThat(built.containsKey("value"), equalTo(false));
-		assertThat(sweepNewAccountMetadataTransactionV1Descriptor().value((byte[]) null).toMap().containsKey("value"), equalTo(false));
-		assertThat(sweepNewAccountMetadataTransactionV1Descriptor().value((String) null).toMap().containsKey("value"), equalTo(false));
-		final AccountMetadataTransactionV1Descriptor withValue = sweepNewAccountMetadataTransactionV1Descriptor();
-		assertThat(withValue.value("value".getBytes(StandardCharsets.UTF_8)), sameInstance(withValue));
-		assertThat(withValue.toMap().get("value"), equalTo("value".getBytes(StandardCharsets.UTF_8)));
-		assertThat(sweepNewAccountMetadataTransactionV1Descriptor().value("value").toMap().get("value"),
-				equalTo(withValue.toMap().get("value")));
-	}
-
-	@Test
-	void accountMetadataTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewAccountMetadataTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new AccountMetadataTransactionV1Descriptor("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I", 2L, 3)
-				.toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("targetAddress"), equalTo(built.get("targetAddress")));
-		assertThat(stringBuilt.get("scopedMetadataKey"), equalTo(built.get("scopedMetadataKey")));
-		assertThat(stringBuilt.get("valueSizeDelta"), equalTo(built.get("valueSizeDelta")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new AccountMetadataTransactionV1Descriptor(
+				new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"), 2L, 3,
+				"value".getBytes(StandardCharsets.UTF_8)).toMap();
+		assertThat(fullBuilt.get("value"), equalTo("value".getBytes(StandardCharsets.UTF_8)));
+		assertThat(fullBuilt.size(), equalTo(5));
 	}
 
 	@Test
 	void accountMetadataTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
+		// Arrange: the sample descriptor with every field populated, plus the signer
 		final Map<String, Object> createMap = sweepCreateMap(
-				sweepNewAccountMetadataTransactionV1Descriptor().value("value".getBytes(StandardCharsets.UTF_8)));
+				new AccountMetadataTransactionV1Descriptor(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"), 2L,
+						3, "value".getBytes(StandardCharsets.UTF_8)));
 
 		// Act:
 		final AccountMetadataTransactionV1 transaction = (AccountMetadataTransactionV1) FACTORY.create(createMap);
@@ -1236,10 +903,10 @@ final class DescriptorsSweepTest {
 		assertThat(SymbolTransactionFactory.deserialize(payload).serialize(), equalTo(payload));
 	}
 
-	/** Constructs a MosaicMetadataTransactionV1Descriptor with distinct sample required arguments. */
+	/** Constructs a MosaicMetadataTransactionV1Descriptor with distinct sample required arguments and null optionals. */
 	private static MosaicMetadataTransactionV1Descriptor sweepNewMosaicMetadataTransactionV1Descriptor() {
 		return new MosaicMetadataTransactionV1Descriptor(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"), 2L,
-				UnresolvedMosaicId.parse("3"), 4);
+				UnresolvedMosaicId.parse("3"), 4, null);
 	}
 
 	@Test
@@ -1250,50 +917,29 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("type"), equalTo("mosaic_metadata_transaction_v1"));
 		assertThat(built.get("targetAddress"), equalTo(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I")));
 		assertThat(built.get("scopedMetadataKey"), equalTo(2L));
 		assertThat(built.get("targetMosaicId"), equalTo(UnresolvedMosaicId.parse("3")));
 		assertThat(built.get("valueSizeDelta"), equalTo(4));
+		assertThat(built.containsKey("value"), equalTo(false));
 		assertThat(built.size(), equalTo(5));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: value
-		assertThat(built.containsKey("value"), equalTo(false));
-		assertThat(sweepNewMosaicMetadataTransactionV1Descriptor().value((byte[]) null).toMap().containsKey("value"), equalTo(false));
-		assertThat(sweepNewMosaicMetadataTransactionV1Descriptor().value((String) null).toMap().containsKey("value"), equalTo(false));
-		final MosaicMetadataTransactionV1Descriptor withValue = sweepNewMosaicMetadataTransactionV1Descriptor();
-		assertThat(withValue.value("value".getBytes(StandardCharsets.UTF_8)), sameInstance(withValue));
-		assertThat(withValue.toMap().get("value"), equalTo("value".getBytes(StandardCharsets.UTF_8)));
-		assertThat(sweepNewMosaicMetadataTransactionV1Descriptor().value("value").toMap().get("value"),
-				equalTo(withValue.toMap().get("value")));
-	}
-
-	@Test
-	void mosaicMetadataTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewMosaicMetadataTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new MosaicMetadataTransactionV1Descriptor("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I", 2L,
-				"3", 4).toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("targetAddress"), equalTo(built.get("targetAddress")));
-		assertThat(stringBuilt.get("scopedMetadataKey"), equalTo(built.get("scopedMetadataKey")));
-		assertThat(stringBuilt.get("targetMosaicId"), equalTo(built.get("targetMosaicId")));
-		assertThat(stringBuilt.get("valueSizeDelta"), equalTo(built.get("valueSizeDelta")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new MosaicMetadataTransactionV1Descriptor(
+				new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"), 2L, UnresolvedMosaicId.parse("3"), 4,
+				"value".getBytes(StandardCharsets.UTF_8)).toMap();
+		assertThat(fullBuilt.get("value"), equalTo("value".getBytes(StandardCharsets.UTF_8)));
+		assertThat(fullBuilt.size(), equalTo(6));
 	}
 
 	@Test
 	void mosaicMetadataTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
+		// Arrange: the sample descriptor with every field populated, plus the signer
 		final Map<String, Object> createMap = sweepCreateMap(
-				sweepNewMosaicMetadataTransactionV1Descriptor().value("value".getBytes(StandardCharsets.UTF_8)));
+				new MosaicMetadataTransactionV1Descriptor(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"), 2L,
+						UnresolvedMosaicId.parse("3"), 4, "value".getBytes(StandardCharsets.UTF_8)));
 
 		// Act:
 		final MosaicMetadataTransactionV1 transaction = (MosaicMetadataTransactionV1) FACTORY.create(createMap);
@@ -1312,10 +958,10 @@ final class DescriptorsSweepTest {
 		assertThat(SymbolTransactionFactory.deserialize(payload).serialize(), equalTo(payload));
 	}
 
-	/** Constructs a NamespaceMetadataTransactionV1Descriptor with distinct sample required arguments. */
+	/** Constructs a NamespaceMetadataTransactionV1Descriptor with distinct sample required arguments and null optionals. */
 	private static NamespaceMetadataTransactionV1Descriptor sweepNewNamespaceMetadataTransactionV1Descriptor() {
 		return new NamespaceMetadataTransactionV1Descriptor(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"),
-				2L, NamespaceId.parse("3"), 4);
+				2L, NamespaceId.parse("3"), 4, null);
 	}
 
 	@Test
@@ -1326,50 +972,29 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("type"), equalTo("namespace_metadata_transaction_v1"));
 		assertThat(built.get("targetAddress"), equalTo(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I")));
 		assertThat(built.get("scopedMetadataKey"), equalTo(2L));
 		assertThat(built.get("targetNamespaceId"), equalTo(NamespaceId.parse("3")));
 		assertThat(built.get("valueSizeDelta"), equalTo(4));
+		assertThat(built.containsKey("value"), equalTo(false));
 		assertThat(built.size(), equalTo(5));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: value
-		assertThat(built.containsKey("value"), equalTo(false));
-		assertThat(sweepNewNamespaceMetadataTransactionV1Descriptor().value((byte[]) null).toMap().containsKey("value"), equalTo(false));
-		assertThat(sweepNewNamespaceMetadataTransactionV1Descriptor().value((String) null).toMap().containsKey("value"), equalTo(false));
-		final NamespaceMetadataTransactionV1Descriptor withValue = sweepNewNamespaceMetadataTransactionV1Descriptor();
-		assertThat(withValue.value("value".getBytes(StandardCharsets.UTF_8)), sameInstance(withValue));
-		assertThat(withValue.toMap().get("value"), equalTo("value".getBytes(StandardCharsets.UTF_8)));
-		assertThat(sweepNewNamespaceMetadataTransactionV1Descriptor().value("value").toMap().get("value"),
-				equalTo(withValue.toMap().get("value")));
-	}
-
-	@Test
-	void namespaceMetadataTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewNamespaceMetadataTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new NamespaceMetadataTransactionV1Descriptor("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I", 2L,
-				"3", 4).toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("targetAddress"), equalTo(built.get("targetAddress")));
-		assertThat(stringBuilt.get("scopedMetadataKey"), equalTo(built.get("scopedMetadataKey")));
-		assertThat(stringBuilt.get("targetNamespaceId"), equalTo(built.get("targetNamespaceId")));
-		assertThat(stringBuilt.get("valueSizeDelta"), equalTo(built.get("valueSizeDelta")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new NamespaceMetadataTransactionV1Descriptor(
+				new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"), 2L, NamespaceId.parse("3"), 4,
+				"value".getBytes(StandardCharsets.UTF_8)).toMap();
+		assertThat(fullBuilt.get("value"), equalTo("value".getBytes(StandardCharsets.UTF_8)));
+		assertThat(fullBuilt.size(), equalTo(6));
 	}
 
 	@Test
 	void namespaceMetadataTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
+		// Arrange: the sample descriptor with every field populated, plus the signer
 		final Map<String, Object> createMap = sweepCreateMap(
-				sweepNewNamespaceMetadataTransactionV1Descriptor().value("value".getBytes(StandardCharsets.UTF_8)));
+				new NamespaceMetadataTransactionV1Descriptor(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"),
+						2L, NamespaceId.parse("3"), 4, "value".getBytes(StandardCharsets.UTF_8)));
 
 		// Act:
 		final NamespaceMetadataTransactionV1 transaction = (NamespaceMetadataTransactionV1) FACTORY.create(createMap);
@@ -1413,27 +1038,10 @@ final class DescriptorsSweepTest {
 	}
 
 	@Test
-	void mosaicDefinitionTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewMosaicDefinitionTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new MosaicDefinitionTransactionV1Descriptor("1", "2", "3", "restrictable", 5).toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("id"), equalTo(built.get("id")));
-		assertThat(stringBuilt.get("duration"), equalTo(built.get("duration")));
-		assertThat(stringBuilt.get("nonce"), equalTo(built.get("nonce")));
-		assertThat(stringBuilt.get("flags"), equalTo(built.get("flags")));
-		assertThat(stringBuilt.get("divisibility"), equalTo(built.get("divisibility")));
-	}
-
-	@Test
 	void mosaicDefinitionTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewMosaicDefinitionTransactionV1Descriptor());
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(new MosaicDefinitionTransactionV1Descriptor(MosaicId.parse("1"),
+				BlockDuration.parse("2"), MosaicNonce.parse("3"), MosaicFlags.parse("restrictable"), 5));
 
 		// Act:
 		final MosaicDefinitionTransactionV1 transaction = (MosaicDefinitionTransactionV1) FACTORY.create(createMap);
@@ -1474,25 +1082,10 @@ final class DescriptorsSweepTest {
 	}
 
 	@Test
-	void mosaicSupplyChangeTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewMosaicSupplyChangeTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new MosaicSupplyChangeTransactionV1Descriptor("1", "2", "decrease").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("mosaicId"), equalTo(built.get("mosaicId")));
-		assertThat(stringBuilt.get("delta"), equalTo(built.get("delta")));
-		assertThat(stringBuilt.get("action"), equalTo(built.get("action")));
-	}
-
-	@Test
 	void mosaicSupplyChangeTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewMosaicSupplyChangeTransactionV1Descriptor());
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(new MosaicSupplyChangeTransactionV1Descriptor(UnresolvedMosaicId.parse("1"),
+				Amount.parse("2"), MosaicSupplyChangeAction.parse("decrease")));
 
 		// Act:
 		final MosaicSupplyChangeTransactionV1 transaction = (MosaicSupplyChangeTransactionV1) FACTORY.create(createMap);
@@ -1530,25 +1123,10 @@ final class DescriptorsSweepTest {
 	}
 
 	@Test
-	void mosaicSupplyRevocationTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewMosaicSupplyRevocationTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new MosaicSupplyRevocationTransactionV1Descriptor("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I",
-				sweepNewUnresolvedMosaicDescriptor()).toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("sourceAddress"), equalTo(built.get("sourceAddress")));
-		assertThat(stringBuilt.get("mosaic"), equalTo(built.get("mosaic")));
-	}
-
-	@Test
 	void mosaicSupplyRevocationTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewMosaicSupplyRevocationTransactionV1Descriptor());
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(new MosaicSupplyRevocationTransactionV1Descriptor(
+				new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"), sweepNewUnresolvedMosaicDescriptor()));
 
 		// Act:
 		final MosaicSupplyRevocationTransactionV1 transaction = (MosaicSupplyRevocationTransactionV1) FACTORY.create(createMap);
@@ -1564,9 +1142,9 @@ final class DescriptorsSweepTest {
 		assertThat(SymbolTransactionFactory.deserialize(payload).serialize(), equalTo(payload));
 	}
 
-	/** Constructs a MultisigAccountModificationTransactionV1Descriptor with distinct sample required arguments. */
+	/** Constructs a MultisigAccountModificationTransactionV1Descriptor with distinct sample required arguments and null optionals. */
 	private static MultisigAccountModificationTransactionV1Descriptor sweepNewMultisigAccountModificationTransactionV1Descriptor() {
-		return new MultisigAccountModificationTransactionV1Descriptor(1, 2);
+		return new MultisigAccountModificationTransactionV1Descriptor(1, 2, null, null);
 	}
 
 	@Test
@@ -1577,49 +1155,31 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("type"), equalTo("multisig_account_modification_transaction_v1"));
 		assertThat(built.get("minRemovalDelta"), equalTo(1));
 		assertThat(built.get("minApprovalDelta"), equalTo(2));
+		assertThat(built.containsKey("addressAdditions"), equalTo(false));
+		assertThat(built.containsKey("addressDeletions"), equalTo(false));
 		assertThat(built.size(), equalTo(3));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: addressAdditions
-		assertThat(built.containsKey("addressAdditions"), equalTo(false));
-		assertThat(sweepNewMultisigAccountModificationTransactionV1Descriptor().addressAdditions((List<org.symbol.sdk.symbol.Address>) null)
-				.toMap().containsKey("addressAdditions"), equalTo(false));
-		final MultisigAccountModificationTransactionV1Descriptor withAddressAdditions = sweepNewMultisigAccountModificationTransactionV1Descriptor();
-		assertThat(
-				withAddressAdditions
-						.addressAdditions(List.of(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"))),
-				sameInstance(withAddressAdditions));
-		assertThat(withAddressAdditions.toMap().get("addressAdditions"),
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new MultisigAccountModificationTransactionV1Descriptor(1, 2,
+				List.of(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I")),
+				List.of(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"))).toMap();
+		assertThat(fullBuilt.get("addressAdditions"),
 				equalTo(List.of(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"))));
-		assertThat(sweepNewMultisigAccountModificationTransactionV1Descriptor().addressAdditions("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I")
-				.toMap().get("addressAdditions"), equalTo(withAddressAdditions.toMap().get("addressAdditions")));
-
-		// optional field: addressDeletions
-		assertThat(built.containsKey("addressDeletions"), equalTo(false));
-		assertThat(sweepNewMultisigAccountModificationTransactionV1Descriptor().addressDeletions((List<org.symbol.sdk.symbol.Address>) null)
-				.toMap().containsKey("addressDeletions"), equalTo(false));
-		final MultisigAccountModificationTransactionV1Descriptor withAddressDeletions = sweepNewMultisigAccountModificationTransactionV1Descriptor();
-		assertThat(
-				withAddressDeletions
-						.addressDeletions(List.of(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"))),
-				sameInstance(withAddressDeletions));
-		assertThat(withAddressDeletions.toMap().get("addressDeletions"),
+		assertThat(fullBuilt.get("addressDeletions"),
 				equalTo(List.of(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"))));
-		assertThat(sweepNewMultisigAccountModificationTransactionV1Descriptor().addressDeletions("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I")
-				.toMap().get("addressDeletions"), equalTo(withAddressDeletions.toMap().get("addressDeletions")));
+		assertThat(fullBuilt.size(), equalTo(5));
 	}
 
 	@Test
 	void multisigAccountModificationTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewMultisigAccountModificationTransactionV1Descriptor()
-				.addressAdditions(List.of(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I")))
-				.addressDeletions(List.of(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"))));
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(new MultisigAccountModificationTransactionV1Descriptor(1, 2,
+				List.of(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I")),
+				List.of(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"))));
 
 		// Act:
 		final MultisigAccountModificationTransactionV1 transaction = (MultisigAccountModificationTransactionV1) FACTORY.create(createMap);
@@ -1661,26 +1221,10 @@ final class DescriptorsSweepTest {
 	}
 
 	@Test
-	void addressAliasTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewAddressAliasTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new AddressAliasTransactionV1Descriptor("1", "TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I",
-				"unlink").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("namespaceId"), equalTo(built.get("namespaceId")));
-		assertThat(stringBuilt.get("address"), equalTo(built.get("address")));
-		assertThat(stringBuilt.get("aliasAction"), equalTo(built.get("aliasAction")));
-	}
-
-	@Test
 	void addressAliasTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewAddressAliasTransactionV1Descriptor());
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(new AddressAliasTransactionV1Descriptor(NamespaceId.parse("1"),
+				new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"), AliasAction.parse("unlink")));
 
 		// Act:
 		final AddressAliasTransactionV1 transaction = (AddressAliasTransactionV1) FACTORY.create(createMap);
@@ -1719,25 +1263,10 @@ final class DescriptorsSweepTest {
 	}
 
 	@Test
-	void mosaicAliasTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewMosaicAliasTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new MosaicAliasTransactionV1Descriptor("1", "2", "unlink").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("namespaceId"), equalTo(built.get("namespaceId")));
-		assertThat(stringBuilt.get("mosaicId"), equalTo(built.get("mosaicId")));
-		assertThat(stringBuilt.get("aliasAction"), equalTo(built.get("aliasAction")));
-	}
-
-	@Test
 	void mosaicAliasTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewMosaicAliasTransactionV1Descriptor());
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(
+				new MosaicAliasTransactionV1Descriptor(NamespaceId.parse("1"), MosaicId.parse("2"), AliasAction.parse("unlink")));
 
 		// Act:
 		final MosaicAliasTransactionV1 transaction = (MosaicAliasTransactionV1) FACTORY.create(createMap);
@@ -1753,9 +1282,10 @@ final class DescriptorsSweepTest {
 		assertThat(SymbolTransactionFactory.deserialize(payload).serialize(), equalTo(payload));
 	}
 
-	/** Constructs a NamespaceRegistrationTransactionV1Descriptor with distinct sample required arguments. */
+	/** Constructs a NamespaceRegistrationTransactionV1Descriptor with distinct sample required arguments and null optionals. */
 	private static NamespaceRegistrationTransactionV1Descriptor sweepNewNamespaceRegistrationTransactionV1Descriptor() {
-		return new NamespaceRegistrationTransactionV1Descriptor(NamespaceId.parse("3"), NamespaceRegistrationType.parse("child"));
+		return new NamespaceRegistrationTransactionV1Descriptor(NamespaceId.parse("3"), NamespaceRegistrationType.parse("child"), null,
+				null, null);
 	}
 
 	@Test
@@ -1766,69 +1296,31 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("type"), equalTo("namespace_registration_transaction_v1"));
 		assertThat(built.get("id"), equalTo(NamespaceId.parse("3")));
 		assertThat(built.get("registrationType"), equalTo(NamespaceRegistrationType.parse("child")));
+		assertThat(built.containsKey("duration"), equalTo(false));
+		assertThat(built.containsKey("parentId"), equalTo(false));
+		assertThat(built.containsKey("name"), equalTo(false));
 		assertThat(built.size(), equalTo(3));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: duration
-		assertThat(built.containsKey("duration"), equalTo(false));
-		assertThat(sweepNewNamespaceRegistrationTransactionV1Descriptor().duration((BlockDuration) null).toMap().containsKey("duration"),
-				equalTo(false));
-		assertThat(sweepNewNamespaceRegistrationTransactionV1Descriptor().duration((String) null).toMap().containsKey("duration"),
-				equalTo(false));
-		final NamespaceRegistrationTransactionV1Descriptor withDuration = sweepNewNamespaceRegistrationTransactionV1Descriptor();
-		assertThat(withDuration.duration(BlockDuration.parse("1")), sameInstance(withDuration));
-		assertThat(withDuration.toMap().get("duration"), equalTo(BlockDuration.parse("1")));
-		assertThat(sweepNewNamespaceRegistrationTransactionV1Descriptor().duration("1").toMap().get("duration"),
-				equalTo(withDuration.toMap().get("duration")));
-
-		// optional field: parentId
-		assertThat(built.containsKey("parentId"), equalTo(false));
-		assertThat(sweepNewNamespaceRegistrationTransactionV1Descriptor().parentId((NamespaceId) null).toMap().containsKey("parentId"),
-				equalTo(false));
-		assertThat(sweepNewNamespaceRegistrationTransactionV1Descriptor().parentId((String) null).toMap().containsKey("parentId"),
-				equalTo(false));
-		final NamespaceRegistrationTransactionV1Descriptor withParentId = sweepNewNamespaceRegistrationTransactionV1Descriptor();
-		assertThat(withParentId.parentId(NamespaceId.parse("2")), sameInstance(withParentId));
-		assertThat(withParentId.toMap().get("parentId"), equalTo(NamespaceId.parse("2")));
-		assertThat(sweepNewNamespaceRegistrationTransactionV1Descriptor().parentId("2").toMap().get("parentId"),
-				equalTo(withParentId.toMap().get("parentId")));
-
-		// optional field: name
-		assertThat(built.containsKey("name"), equalTo(false));
-		assertThat(sweepNewNamespaceRegistrationTransactionV1Descriptor().name((byte[]) null).toMap().containsKey("name"), equalTo(false));
-		assertThat(sweepNewNamespaceRegistrationTransactionV1Descriptor().name((String) null).toMap().containsKey("name"), equalTo(false));
-		final NamespaceRegistrationTransactionV1Descriptor withName = sweepNewNamespaceRegistrationTransactionV1Descriptor();
-		assertThat(withName.name("name".getBytes(StandardCharsets.UTF_8)), sameInstance(withName));
-		assertThat(withName.toMap().get("name"), equalTo("name".getBytes(StandardCharsets.UTF_8)));
-		assertThat(sweepNewNamespaceRegistrationTransactionV1Descriptor().name("name").toMap().get("name"),
-				equalTo(withName.toMap().get("name")));
-	}
-
-	@Test
-	void namespaceRegistrationTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewNamespaceRegistrationTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new NamespaceRegistrationTransactionV1Descriptor("3", "child").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("id"), equalTo(built.get("id")));
-		assertThat(stringBuilt.get("registrationType"), equalTo(built.get("registrationType")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new NamespaceRegistrationTransactionV1Descriptor(NamespaceId.parse("3"),
+				NamespaceRegistrationType.parse("child"), BlockDuration.parse("1"), NamespaceId.parse("2"),
+				"name".getBytes(StandardCharsets.UTF_8)).toMap();
+		assertThat(fullBuilt.get("duration"), equalTo(BlockDuration.parse("1")));
+		assertThat(fullBuilt.get("parentId"), equalTo(NamespaceId.parse("2")));
+		assertThat(fullBuilt.get("name"), equalTo("name".getBytes(StandardCharsets.UTF_8)));
+		assertThat(fullBuilt.size(), equalTo(6));
 	}
 
 	@Test
 	void namespaceRegistrationTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewNamespaceRegistrationTransactionV1Descriptor()
-				.duration(BlockDuration.parse("1")).parentId(NamespaceId.parse("2")).name("name".getBytes(StandardCharsets.UTF_8)));
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(
+				new NamespaceRegistrationTransactionV1Descriptor(NamespaceId.parse("3"), NamespaceRegistrationType.parse("child"),
+						BlockDuration.parse("1"), NamespaceId.parse("2"), "name".getBytes(StandardCharsets.UTF_8)));
 
 		// Act:
 		final NamespaceRegistrationTransactionV1 transaction = (NamespaceRegistrationTransactionV1) FACTORY.create(createMap);
@@ -1846,9 +1338,9 @@ final class DescriptorsSweepTest {
 		assertThat(SymbolTransactionFactory.deserialize(payload).serialize(), equalTo(payload));
 	}
 
-	/** Constructs a AccountAddressRestrictionTransactionV1Descriptor with distinct sample required arguments. */
+	/** Constructs a AccountAddressRestrictionTransactionV1Descriptor with distinct sample required arguments and null optionals. */
 	private static AccountAddressRestrictionTransactionV1Descriptor sweepNewAccountAddressRestrictionTransactionV1Descriptor() {
-		return new AccountAddressRestrictionTransactionV1Descriptor(AccountRestrictionFlags.parse("address"));
+		return new AccountAddressRestrictionTransactionV1Descriptor(AccountRestrictionFlags.parse("address"), null, null);
 	}
 
 	@Test
@@ -1859,66 +1351,31 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("type"), equalTo("account_address_restriction_transaction_v1"));
 		assertThat(built.get("restrictionFlags"), equalTo(AccountRestrictionFlags.parse("address")));
+		assertThat(built.containsKey("restrictionAdditions"), equalTo(false));
+		assertThat(built.containsKey("restrictionDeletions"), equalTo(false));
 		assertThat(built.size(), equalTo(2));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: restrictionAdditions
-		assertThat(built.containsKey("restrictionAdditions"), equalTo(false));
-		assertThat(sweepNewAccountAddressRestrictionTransactionV1Descriptor()
-				.restrictionAdditions((List<org.symbol.sdk.symbol.Address>) null).toMap().containsKey("restrictionAdditions"),
-				equalTo(false));
-		final AccountAddressRestrictionTransactionV1Descriptor withRestrictionAdditions = sweepNewAccountAddressRestrictionTransactionV1Descriptor();
-		assertThat(
-				withRestrictionAdditions
-						.restrictionAdditions(List.of(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"))),
-				sameInstance(withRestrictionAdditions));
-		assertThat(withRestrictionAdditions.toMap().get("restrictionAdditions"),
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new AccountAddressRestrictionTransactionV1Descriptor(AccountRestrictionFlags.parse("address"),
+				List.of(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I")),
+				List.of(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"))).toMap();
+		assertThat(fullBuilt.get("restrictionAdditions"),
 				equalTo(List.of(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"))));
-		assertThat(sweepNewAccountAddressRestrictionTransactionV1Descriptor()
-				.restrictionAdditions("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I").toMap().get("restrictionAdditions"),
-				equalTo(withRestrictionAdditions.toMap().get("restrictionAdditions")));
-
-		// optional field: restrictionDeletions
-		assertThat(built.containsKey("restrictionDeletions"), equalTo(false));
-		assertThat(sweepNewAccountAddressRestrictionTransactionV1Descriptor()
-				.restrictionDeletions((List<org.symbol.sdk.symbol.Address>) null).toMap().containsKey("restrictionDeletions"),
-				equalTo(false));
-		final AccountAddressRestrictionTransactionV1Descriptor withRestrictionDeletions = sweepNewAccountAddressRestrictionTransactionV1Descriptor();
-		assertThat(
-				withRestrictionDeletions
-						.restrictionDeletions(List.of(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"))),
-				sameInstance(withRestrictionDeletions));
-		assertThat(withRestrictionDeletions.toMap().get("restrictionDeletions"),
+		assertThat(fullBuilt.get("restrictionDeletions"),
 				equalTo(List.of(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"))));
-		assertThat(sweepNewAccountAddressRestrictionTransactionV1Descriptor()
-				.restrictionDeletions("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I").toMap().get("restrictionDeletions"),
-				equalTo(withRestrictionDeletions.toMap().get("restrictionDeletions")));
-	}
-
-	@Test
-	void accountAddressRestrictionTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewAccountAddressRestrictionTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new AccountAddressRestrictionTransactionV1Descriptor("address").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("restrictionFlags"), equalTo(built.get("restrictionFlags")));
+		assertThat(fullBuilt.size(), equalTo(4));
 	}
 
 	@Test
 	void accountAddressRestrictionTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewAccountAddressRestrictionTransactionV1Descriptor()
-				.restrictionAdditions(List.of(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I")))
-				.restrictionDeletions(List.of(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"))));
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(
+				new AccountAddressRestrictionTransactionV1Descriptor(AccountRestrictionFlags.parse("address"),
+						List.of(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I")),
+						List.of(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"))));
 
 		// Act:
 		final AccountAddressRestrictionTransactionV1 transaction = (AccountAddressRestrictionTransactionV1) FACTORY.create(createMap);
@@ -1936,9 +1393,9 @@ final class DescriptorsSweepTest {
 		assertThat(SymbolTransactionFactory.deserialize(payload).serialize(), equalTo(payload));
 	}
 
-	/** Constructs a AccountMosaicRestrictionTransactionV1Descriptor with distinct sample required arguments. */
+	/** Constructs a AccountMosaicRestrictionTransactionV1Descriptor with distinct sample required arguments and null optionals. */
 	private static AccountMosaicRestrictionTransactionV1Descriptor sweepNewAccountMosaicRestrictionTransactionV1Descriptor() {
-		return new AccountMosaicRestrictionTransactionV1Descriptor(AccountRestrictionFlags.parse("address"));
+		return new AccountMosaicRestrictionTransactionV1Descriptor(AccountRestrictionFlags.parse("address"), null, null);
 	}
 
 	@Test
@@ -1949,55 +1406,26 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("type"), equalTo("account_mosaic_restriction_transaction_v1"));
 		assertThat(built.get("restrictionFlags"), equalTo(AccountRestrictionFlags.parse("address")));
+		assertThat(built.containsKey("restrictionAdditions"), equalTo(false));
+		assertThat(built.containsKey("restrictionDeletions"), equalTo(false));
 		assertThat(built.size(), equalTo(2));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: restrictionAdditions
-		assertThat(built.containsKey("restrictionAdditions"), equalTo(false));
-		assertThat(sweepNewAccountMosaicRestrictionTransactionV1Descriptor().restrictionAdditions((List<UnresolvedMosaicId>) null).toMap()
-				.containsKey("restrictionAdditions"), equalTo(false));
-		final AccountMosaicRestrictionTransactionV1Descriptor withRestrictionAdditions = sweepNewAccountMosaicRestrictionTransactionV1Descriptor();
-		assertThat(withRestrictionAdditions.restrictionAdditions(List.of(UnresolvedMosaicId.parse("2"))),
-				sameInstance(withRestrictionAdditions));
-		assertThat(withRestrictionAdditions.toMap().get("restrictionAdditions"), equalTo(List.of(UnresolvedMosaicId.parse("2"))));
-		assertThat(sweepNewAccountMosaicRestrictionTransactionV1Descriptor().restrictionAdditions("2").toMap().get("restrictionAdditions"),
-				equalTo(withRestrictionAdditions.toMap().get("restrictionAdditions")));
-
-		// optional field: restrictionDeletions
-		assertThat(built.containsKey("restrictionDeletions"), equalTo(false));
-		assertThat(sweepNewAccountMosaicRestrictionTransactionV1Descriptor().restrictionDeletions((List<UnresolvedMosaicId>) null).toMap()
-				.containsKey("restrictionDeletions"), equalTo(false));
-		final AccountMosaicRestrictionTransactionV1Descriptor withRestrictionDeletions = sweepNewAccountMosaicRestrictionTransactionV1Descriptor();
-		assertThat(withRestrictionDeletions.restrictionDeletions(List.of(UnresolvedMosaicId.parse("3"))),
-				sameInstance(withRestrictionDeletions));
-		assertThat(withRestrictionDeletions.toMap().get("restrictionDeletions"), equalTo(List.of(UnresolvedMosaicId.parse("3"))));
-		assertThat(sweepNewAccountMosaicRestrictionTransactionV1Descriptor().restrictionDeletions("3").toMap().get("restrictionDeletions"),
-				equalTo(withRestrictionDeletions.toMap().get("restrictionDeletions")));
-	}
-
-	@Test
-	void accountMosaicRestrictionTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewAccountMosaicRestrictionTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new AccountMosaicRestrictionTransactionV1Descriptor("address").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("restrictionFlags"), equalTo(built.get("restrictionFlags")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new AccountMosaicRestrictionTransactionV1Descriptor(AccountRestrictionFlags.parse("address"),
+				List.of(UnresolvedMosaicId.parse("2")), List.of(UnresolvedMosaicId.parse("3"))).toMap();
+		assertThat(fullBuilt.get("restrictionAdditions"), equalTo(List.of(UnresolvedMosaicId.parse("2"))));
+		assertThat(fullBuilt.get("restrictionDeletions"), equalTo(List.of(UnresolvedMosaicId.parse("3"))));
+		assertThat(fullBuilt.size(), equalTo(4));
 	}
 
 	@Test
 	void accountMosaicRestrictionTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewAccountMosaicRestrictionTransactionV1Descriptor()
-				.restrictionAdditions(List.of(UnresolvedMosaicId.parse("2"))).restrictionDeletions(List.of(UnresolvedMosaicId.parse("3"))));
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(new AccountMosaicRestrictionTransactionV1Descriptor(
+				AccountRestrictionFlags.parse("address"), List.of(UnresolvedMosaicId.parse("2")), List.of(UnresolvedMosaicId.parse("3"))));
 
 		// Act:
 		final AccountMosaicRestrictionTransactionV1 transaction = (AccountMosaicRestrictionTransactionV1) FACTORY.create(createMap);
@@ -2013,9 +1441,9 @@ final class DescriptorsSweepTest {
 		assertThat(SymbolTransactionFactory.deserialize(payload).serialize(), equalTo(payload));
 	}
 
-	/** Constructs a AccountOperationRestrictionTransactionV1Descriptor with distinct sample required arguments. */
+	/** Constructs a AccountOperationRestrictionTransactionV1Descriptor with distinct sample required arguments and null optionals. */
 	private static AccountOperationRestrictionTransactionV1Descriptor sweepNewAccountOperationRestrictionTransactionV1Descriptor() {
-		return new AccountOperationRestrictionTransactionV1Descriptor(AccountRestrictionFlags.parse("address"));
+		return new AccountOperationRestrictionTransactionV1Descriptor(AccountRestrictionFlags.parse("address"), null, null);
 	}
 
 	@Test
@@ -2026,57 +1454,28 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("type"), equalTo("account_operation_restriction_transaction_v1"));
 		assertThat(built.get("restrictionFlags"), equalTo(AccountRestrictionFlags.parse("address")));
+		assertThat(built.containsKey("restrictionAdditions"), equalTo(false));
+		assertThat(built.containsKey("restrictionDeletions"), equalTo(false));
 		assertThat(built.size(), equalTo(2));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: restrictionAdditions
-		assertThat(built.containsKey("restrictionAdditions"), equalTo(false));
-		assertThat(sweepNewAccountOperationRestrictionTransactionV1Descriptor().restrictionAdditions((List<TransactionType>) null).toMap()
-				.containsKey("restrictionAdditions"), equalTo(false));
-		final AccountOperationRestrictionTransactionV1Descriptor withRestrictionAdditions = sweepNewAccountOperationRestrictionTransactionV1Descriptor();
-		assertThat(withRestrictionAdditions.restrictionAdditions(List.of(TransactionType.parse("node_key_link"))),
-				sameInstance(withRestrictionAdditions));
-		assertThat(withRestrictionAdditions.toMap().get("restrictionAdditions"), equalTo(List.of(TransactionType.parse("node_key_link"))));
-		assertThat(sweepNewAccountOperationRestrictionTransactionV1Descriptor().restrictionAdditions("node_key_link").toMap()
-				.get("restrictionAdditions"), equalTo(withRestrictionAdditions.toMap().get("restrictionAdditions")));
-
-		// optional field: restrictionDeletions
-		assertThat(built.containsKey("restrictionDeletions"), equalTo(false));
-		assertThat(sweepNewAccountOperationRestrictionTransactionV1Descriptor().restrictionDeletions((List<TransactionType>) null).toMap()
-				.containsKey("restrictionDeletions"), equalTo(false));
-		final AccountOperationRestrictionTransactionV1Descriptor withRestrictionDeletions = sweepNewAccountOperationRestrictionTransactionV1Descriptor();
-		assertThat(withRestrictionDeletions.restrictionDeletions(List.of(TransactionType.parse("aggregate_complete"))),
-				sameInstance(withRestrictionDeletions));
-		assertThat(withRestrictionDeletions.toMap().get("restrictionDeletions"),
-				equalTo(List.of(TransactionType.parse("aggregate_complete"))));
-		assertThat(sweepNewAccountOperationRestrictionTransactionV1Descriptor().restrictionDeletions("aggregate_complete").toMap()
-				.get("restrictionDeletions"), equalTo(withRestrictionDeletions.toMap().get("restrictionDeletions")));
-	}
-
-	@Test
-	void accountOperationRestrictionTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewAccountOperationRestrictionTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new AccountOperationRestrictionTransactionV1Descriptor("address").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("restrictionFlags"), equalTo(built.get("restrictionFlags")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new AccountOperationRestrictionTransactionV1Descriptor(
+				AccountRestrictionFlags.parse("address"), List.of(TransactionType.parse("node_key_link")),
+				List.of(TransactionType.parse("aggregate_complete"))).toMap();
+		assertThat(fullBuilt.get("restrictionAdditions"), equalTo(List.of(TransactionType.parse("node_key_link"))));
+		assertThat(fullBuilt.get("restrictionDeletions"), equalTo(List.of(TransactionType.parse("aggregate_complete"))));
+		assertThat(fullBuilt.size(), equalTo(4));
 	}
 
 	@Test
 	void accountOperationRestrictionTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewAccountOperationRestrictionTransactionV1Descriptor()
-				.restrictionAdditions(List.of(TransactionType.parse("node_key_link")))
-				.restrictionDeletions(List.of(TransactionType.parse("aggregate_complete"))));
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(
+				new AccountOperationRestrictionTransactionV1Descriptor(AccountRestrictionFlags.parse("address"),
+						List.of(TransactionType.parse("node_key_link")), List.of(TransactionType.parse("aggregate_complete"))));
 
 		// Act:
 		final AccountOperationRestrictionTransactionV1 transaction = (AccountOperationRestrictionTransactionV1) FACTORY.create(createMap);
@@ -2117,28 +1516,10 @@ final class DescriptorsSweepTest {
 	}
 
 	@Test
-	void mosaicAddressRestrictionTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewMosaicAddressRestrictionTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new MosaicAddressRestrictionTransactionV1Descriptor("1", 2L, 3L, 4L,
-				"TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("mosaicId"), equalTo(built.get("mosaicId")));
-		assertThat(stringBuilt.get("restrictionKey"), equalTo(built.get("restrictionKey")));
-		assertThat(stringBuilt.get("previousRestrictionValue"), equalTo(built.get("previousRestrictionValue")));
-		assertThat(stringBuilt.get("newRestrictionValue"), equalTo(built.get("newRestrictionValue")));
-		assertThat(stringBuilt.get("targetAddress"), equalTo(built.get("targetAddress")));
-	}
-
-	@Test
 	void mosaicAddressRestrictionTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewMosaicAddressRestrictionTransactionV1Descriptor());
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(new MosaicAddressRestrictionTransactionV1Descriptor(
+				UnresolvedMosaicId.parse("1"), 2L, 3L, 4L, new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I")));
 
 		// Act:
 		final MosaicAddressRestrictionTransactionV1 transaction = (MosaicAddressRestrictionTransactionV1) FACTORY.create(createMap);
@@ -2184,30 +1565,11 @@ final class DescriptorsSweepTest {
 	}
 
 	@Test
-	void mosaicGlobalRestrictionTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewMosaicGlobalRestrictionTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new MosaicGlobalRestrictionTransactionV1Descriptor("1", "2", 3L, 4L, 5L, "gt", "ge")
-				.toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("mosaicId"), equalTo(built.get("mosaicId")));
-		assertThat(stringBuilt.get("referenceMosaicId"), equalTo(built.get("referenceMosaicId")));
-		assertThat(stringBuilt.get("restrictionKey"), equalTo(built.get("restrictionKey")));
-		assertThat(stringBuilt.get("previousRestrictionValue"), equalTo(built.get("previousRestrictionValue")));
-		assertThat(stringBuilt.get("newRestrictionValue"), equalTo(built.get("newRestrictionValue")));
-		assertThat(stringBuilt.get("previousRestrictionType"), equalTo(built.get("previousRestrictionType")));
-		assertThat(stringBuilt.get("newRestrictionType"), equalTo(built.get("newRestrictionType")));
-	}
-
-	@Test
 	void mosaicGlobalRestrictionTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewMosaicGlobalRestrictionTransactionV1Descriptor());
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(
+				new MosaicGlobalRestrictionTransactionV1Descriptor(UnresolvedMosaicId.parse("1"), UnresolvedMosaicId.parse("2"), 3L, 4L, 5L,
+						MosaicRestrictionType.parse("gt"), MosaicRestrictionType.parse("ge")));
 
 		// Act:
 		final MosaicGlobalRestrictionTransactionV1 transaction = (MosaicGlobalRestrictionTransactionV1) FACTORY.create(createMap);
@@ -2227,9 +1589,10 @@ final class DescriptorsSweepTest {
 		assertThat(SymbolTransactionFactory.deserialize(payload).serialize(), equalTo(payload));
 	}
 
-	/** Constructs a TransferTransactionV1Descriptor with distinct sample required arguments. */
+	/** Constructs a TransferTransactionV1Descriptor with distinct sample required arguments and null optionals. */
 	private static TransferTransactionV1Descriptor sweepNewTransferTransactionV1Descriptor() {
-		return new TransferTransactionV1Descriptor(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"));
+		return new TransferTransactionV1Descriptor(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"), null,
+				null);
 	}
 
 	@Test
@@ -2240,54 +1603,28 @@ final class DescriptorsSweepTest {
 		// Act:
 		final Map<String, Object> built = descriptor.toMap();
 
-		// Assert: exact required contents
+		// Assert: exact required contents; null optional arguments leave their keys absent
 		assertThat(built.get("type"), equalTo("transfer_transaction_v1"));
 		assertThat(built.get("recipientAddress"), equalTo(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I")));
+		assertThat(built.containsKey("mosaics"), equalTo(false));
+		assertThat(built.containsKey("message"), equalTo(false));
 		assertThat(built.size(), equalTo(2));
 
-		// Act + Assert: each optional fluent setter (typed form, chaining, stored value, overload)
-
-		// optional field: mosaics
-		assertThat(built.containsKey("mosaics"), equalTo(false));
-		assertThat(
-				sweepNewTransferTransactionV1Descriptor().mosaics((List<UnresolvedMosaicDescriptor>) null).toMap().containsKey("mosaics"),
-				equalTo(false));
-		final TransferTransactionV1Descriptor withMosaics = sweepNewTransferTransactionV1Descriptor();
-		assertThat(withMosaics.mosaics(List.of(sweepNewUnresolvedMosaicDescriptor())), sameInstance(withMosaics));
-		assertThat(withMosaics.toMap().get("mosaics"), equalTo(List.of(sweepNewUnresolvedMosaicDescriptor().toMap())));
-		assertThat(sweepNewTransferTransactionV1Descriptor().mosaics(sweepNewUnresolvedMosaicDescriptor()).toMap().get("mosaics"),
-				equalTo(withMosaics.toMap().get("mosaics")));
-
-		// optional field: message
-		assertThat(built.containsKey("message"), equalTo(false));
-		assertThat(sweepNewTransferTransactionV1Descriptor().message((byte[]) null).toMap().containsKey("message"), equalTo(false));
-		assertThat(sweepNewTransferTransactionV1Descriptor().message((String) null).toMap().containsKey("message"), equalTo(false));
-		final TransferTransactionV1Descriptor withMessage = sweepNewTransferTransactionV1Descriptor();
-		assertThat(withMessage.message("message".getBytes(StandardCharsets.UTF_8)), sameInstance(withMessage));
-		assertThat(withMessage.toMap().get("message"), equalTo("message".getBytes(StandardCharsets.UTF_8)));
-		assertThat(sweepNewTransferTransactionV1Descriptor().message("message").toMap().get("message"),
-				equalTo(withMessage.toMap().get("message")));
-	}
-
-	@Test
-	void transferTransactionV1DescriptorStringFormConstructor() {
-		// Arrange:
-		final Map<String, Object> built = sweepNewTransferTransactionV1Descriptor().toMap();
-
-		// Act:
-		final Map<String, Object> stringBuilt = new TransferTransactionV1Descriptor("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I").toMap();
-
-		// Assert: the string-form constructor parses into the same typed values (and no extra/missing keys)
-		assertThat(stringBuilt.size(), equalTo(built.size()));
-		assertThat(stringBuilt.get("type"), equalTo(built.get("type")));
-		assertThat(stringBuilt.get("recipientAddress"), equalTo(built.get("recipientAddress")));
+		// Act + Assert: the all-args constructor stores every optional field
+		final Map<String, Object> fullBuilt = new TransferTransactionV1Descriptor(
+				new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"), List.of(sweepNewUnresolvedMosaicDescriptor()),
+				"message".getBytes(StandardCharsets.UTF_8)).toMap();
+		assertThat(fullBuilt.get("mosaics"), equalTo(List.of(sweepNewUnresolvedMosaicDescriptor().toMap())));
+		assertThat(fullBuilt.get("message"), equalTo("message".getBytes(StandardCharsets.UTF_8)));
+		assertThat(fullBuilt.size(), equalTo(4));
 	}
 
 	@Test
 	void transferTransactionV1DescriptorFactoryRoundTrip() {
-		// Arrange: the sample descriptor, all optional fields populated via their setters, plus the signer
-		final Map<String, Object> createMap = sweepCreateMap(sweepNewTransferTransactionV1Descriptor()
-				.mosaics(List.of(sweepNewUnresolvedMosaicDescriptor())).message("message".getBytes(StandardCharsets.UTF_8)));
+		// Arrange: the sample descriptor with every field populated, plus the signer
+		final Map<String, Object> createMap = sweepCreateMap(
+				new TransferTransactionV1Descriptor(new org.symbol.sdk.symbol.Address("TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I"),
+						List.of(sweepNewUnresolvedMosaicDescriptor()), "message".getBytes(StandardCharsets.UTF_8)));
 
 		// Act:
 		final TransferTransactionV1 transaction = (TransferTransactionV1) FACTORY.create(createMap);

--- a/sdk/java/src/test/java/org/symbol/sdk/vectors/NemTypedDescriptorVectorsTest.java
+++ b/sdk/java/src/test/java/org/symbol/sdk/vectors/NemTypedDescriptorVectorsTest.java
@@ -14,28 +14,7 @@ import org.symbol.sdk.Serializer;
 import org.symbol.sdk.facade.NemFacade;
 import org.symbol.sdk.nem.Address;
 import org.symbol.sdk.nem.NemTransactionFactory;
-import org.symbol.sdk.nem.descriptors.AccountKeyLinkTransactionV1Descriptor;
-import org.symbol.sdk.nem.descriptors.CosignatureV1Descriptor;
-import org.symbol.sdk.nem.descriptors.MessageDescriptor;
-import org.symbol.sdk.nem.descriptors.MosaicDefinitionDescriptor;
-import org.symbol.sdk.nem.descriptors.MosaicDefinitionTransactionV1Descriptor;
-import org.symbol.sdk.nem.descriptors.MosaicDescriptor;
-import org.symbol.sdk.nem.descriptors.MosaicIdDescriptor;
-import org.symbol.sdk.nem.descriptors.MosaicLevyDescriptor;
-import org.symbol.sdk.nem.descriptors.MosaicPropertyDescriptor;
-import org.symbol.sdk.nem.descriptors.MosaicSupplyChangeTransactionV1Descriptor;
-import org.symbol.sdk.nem.descriptors.MultisigAccountModificationDescriptor;
-import org.symbol.sdk.nem.descriptors.MultisigAccountModificationTransactionV1Descriptor;
-import org.symbol.sdk.nem.descriptors.MultisigAccountModificationTransactionV2Descriptor;
-import org.symbol.sdk.nem.descriptors.MultisigTransactionV1Descriptor;
-import org.symbol.sdk.nem.descriptors.NamespaceIdDescriptor;
-import org.symbol.sdk.nem.descriptors.NamespaceRegistrationTransactionV1Descriptor;
-import org.symbol.sdk.nem.descriptors.NemTransactionDescriptor;
-import org.symbol.sdk.nem.descriptors.SizePrefixedMosaicDescriptor;
-import org.symbol.sdk.nem.descriptors.SizePrefixedMosaicPropertyDescriptor;
-import org.symbol.sdk.nem.descriptors.SizePrefixedMultisigAccountModificationDescriptor;
-import org.symbol.sdk.nem.descriptors.TransferTransactionV1Descriptor;
-import org.symbol.sdk.nem.descriptors.TransferTransactionV2Descriptor;
+import org.symbol.sdk.nem.descriptors.*;
 import org.symbol.sdk.nem.models.Amount;
 import org.symbol.sdk.nem.models.LinkAction;
 import org.symbol.sdk.nem.models.MessageType;
@@ -151,7 +130,7 @@ final class NemTypedDescriptorVectorsTest {
 
 				final NonVerifiableTransaction inner = NemTransactionFactory
 						.toNonVerifiableTransaction(facade.transactionFactory.create(innerDescriptor));
-				return new MultisigTransactionV1Descriptor(inner, /* cosignatures */ null);
+				return new MultisigTransactionV1Descriptor(inner, (List<SizePrefixedCosignatureV1Descriptor>) null);
 			}
 
 			default :

--- a/sdk/java/src/test/java/org/symbol/sdk/vectors/NemTypedDescriptorVectorsTest.java
+++ b/sdk/java/src/test/java/org/symbol/sdk/vectors/NemTypedDescriptorVectorsTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.TestFactory;
 
+import org.symbol.sdk.CryptoTypes;
 import org.symbol.sdk.Serializer;
 import org.symbol.sdk.facade.NemFacade;
 import org.symbol.sdk.nem.Address;
@@ -36,8 +37,11 @@ import org.symbol.sdk.nem.descriptors.SizePrefixedMultisigAccountModificationDes
 import org.symbol.sdk.nem.descriptors.TransferTransactionV1Descriptor;
 import org.symbol.sdk.nem.descriptors.TransferTransactionV2Descriptor;
 import org.symbol.sdk.nem.models.Amount;
+import org.symbol.sdk.nem.models.LinkAction;
+import org.symbol.sdk.nem.models.MessageType;
 import org.symbol.sdk.nem.models.MosaicSupplyChangeAction;
 import org.symbol.sdk.nem.models.MosaicTransferFeeType;
+import org.symbol.sdk.nem.models.MultisigAccountModificationType;
 import org.symbol.sdk.nem.models.NonVerifiableTransaction;
 import org.symbol.sdk.nem.models.SizePrefixedCosignatureV1;
 import org.symbol.sdk.utils.Converter;
@@ -50,8 +54,9 @@ import org.symbol.sdk.utils.Converter;
  * were rejected by design), and the header fields typed descriptors deliberately omit (signature, timestamp, signerPublicKey, fee) are
  * overlaid on the descriptor map — the analog of the JS rawDescriptor override.
  *
- * Values flow from the vector JSON as-is: strings feed the String constructor overloads, numbers feed the pod {@code parse} coercions (u64
- * values arrive as wrapped longs — stringifying a negative long would corrupt them), and the byte-carrying fields (message content, names,
+ * Values flow from the vector JSON as-is: strings feed the model constructors ({@code Address},
+ * {@code CryptoTypes.PublicKey}/{@code Hash256}) and enum {@code parse} calls, numbers feed the pod {@code parse} coercions (u64 values
+ * arrive as wrapped longs — stringifying a negative long would corrupt them), and the byte-carrying fields (message content, names,
  * descriptions, property name/value pairs — hex-encoded in the NEM vectors) go through {@link CatbufferDescriptorHelper#rawBytes}.
  */
 @Tag("catvectors")
@@ -98,7 +103,8 @@ final class NemTypedDescriptorVectorsTest {
 		final String type = (String) plain.get("type");
 		switch (type) {
 			case "account_key_link_transaction_v1":
-				return new AccountKeyLinkTransactionV1Descriptor((String) plain.get("linkAction"), (String) plain.get("remotePublicKey"));
+				return new AccountKeyLinkTransactionV1Descriptor(LinkAction.parse(plain.get("linkAction")),
+						new CryptoTypes.PublicKey((String) plain.get("remotePublicKey")));
 
 			case "mosaic_definition_transaction_v1":
 				return new MosaicDefinitionTransactionV1Descriptor(
@@ -110,55 +116,28 @@ final class NemTypedDescriptorVectorsTest {
 						MosaicSupplyChangeAction.parse(plain.get("action")), Amount.parse(plain.get("delta")));
 
 			case "multisig_account_modification_transaction_v1":
-				return new MultisigAccountModificationTransactionV1Descriptor().modifications(mapModifications(plain));
+				return new MultisigAccountModificationTransactionV1Descriptor(mapModifications(plain));
 
 			case "multisig_account_modification_transaction_v2":
-				return new MultisigAccountModificationTransactionV2Descriptor(Converter.toInt((Number) plain.get("minApprovalDelta")))
-						.modifications(mapModifications(plain));
+				return new MultisigAccountModificationTransactionV2Descriptor(Converter.toInt((Number) plain.get("minApprovalDelta")),
+						mapModifications(plain));
 
-			case "namespace_registration_transaction_v1": {
-				final NamespaceRegistrationTransactionV1Descriptor descriptor = new NamespaceRegistrationTransactionV1Descriptor(
-						new Address((String) plain.get("rentalFeeSink")), Amount.parse(plain.get("rentalFee")))
-						.name(CatbufferDescriptorHelper.rawBytes(plain.get("name")));
-				if (null != plain.get("parentName"))
-					descriptor.parentName(CatbufferDescriptorHelper.rawBytes(plain.get("parentName")));
+			case "namespace_registration_transaction_v1":
+				return new NamespaceRegistrationTransactionV1Descriptor(new Address((String) plain.get("rentalFeeSink")),
+						Amount.parse(plain.get("rentalFee")), CatbufferDescriptorHelper.rawBytes(plain.get("name")),
+						null == plain.get("parentName") ? null : CatbufferDescriptorHelper.rawBytes(plain.get("parentName")));
 
-				return descriptor;
-			}
+			case "transfer_transaction_v1":
+				return new TransferTransactionV1Descriptor(new Address((String) plain.get("recipientAddress")),
+						Amount.parse(plain.get("amount")), mapOptionalMessage(plain));
 
-			case "transfer_transaction_v1": {
-				final TransferTransactionV1Descriptor descriptor = new TransferTransactionV1Descriptor(
-						new Address((String) plain.get("recipientAddress")), Amount.parse(plain.get("amount")));
-				if (null != plain.get("message"))
-					descriptor.message(mapMessage(CatbufferVectorsHelper.toObjectMap(plain.get("message"))));
-
-				return descriptor;
-			}
-
-			case "transfer_transaction_v2": {
-				final TransferTransactionV2Descriptor descriptor = new TransferTransactionV2Descriptor(
-						new Address((String) plain.get("recipientAddress")), Amount.parse(plain.get("amount")));
-				if (null != plain.get("message"))
-					descriptor.message(mapMessage(CatbufferVectorsHelper.toObjectMap(plain.get("message"))));
-
-				if (null != plain.get("mosaics")) {
-					final List<SizePrefixedMosaicDescriptor> mosaics = new ArrayList<>();
-					for (final Object element : (List<?>) plain.get("mosaics")) {
-						final Map<String, Object> mosaic = extractNamedChild(element, "mosaic");
-						mosaics.add(new SizePrefixedMosaicDescriptor(
-								new MosaicDescriptor(mapMosaicId(CatbufferVectorsHelper.toObjectMap(mosaic.get("mosaicId"))),
-										Amount.parse(mosaic.get("amount")))));
-					}
-
-					descriptor.mosaics(mosaics);
-				}
-
-				return descriptor;
-			}
+			case "transfer_transaction_v2":
+				return new TransferTransactionV2Descriptor(new Address((String) plain.get("recipientAddress")),
+						Amount.parse(plain.get("amount")), mapOptionalMessage(plain), mapMosaicList(plain.get("mosaics")));
 
 			case "cosignature_v1":
-				return new CosignatureV1Descriptor((String) plain.get("otherTransactionHash"),
-						(String) plain.get("multisigAccountAddress"));
+				return new CosignatureV1Descriptor(new CryptoTypes.Hash256((String) plain.get("otherTransactionHash")),
+						new Address((String) plain.get("multisigAccountAddress")));
 
 			case "multisig_transaction_v1": {
 				final Map<String, Object> innerPlain = CatbufferVectorsHelper.toObjectMap(plain.get("innerTransaction"));
@@ -172,7 +151,7 @@ final class NemTypedDescriptorVectorsTest {
 
 				final NonVerifiableTransaction inner = NemTransactionFactory
 						.toNonVerifiableTransaction(facade.transactionFactory.create(innerDescriptor));
-				return new MultisigTransactionV1Descriptor(inner);
+				return new MultisigTransactionV1Descriptor(inner, /* cosignatures */ null);
 			}
 
 			default :
@@ -184,8 +163,9 @@ final class NemTypedDescriptorVectorsTest {
 		final List<SizePrefixedCosignatureV1> cosignatures = new ArrayList<>();
 		for (final Object element : (List<?>) plain.get("cosignatures")) {
 			final Map<String, Object> cosignature = extractNamedChild(element, "cosignature");
-			final CosignatureV1Descriptor typedCosignature = new CosignatureV1Descriptor((String) cosignature.get("otherTransactionHash"),
-					(String) cosignature.get("multisigAccountAddress"));
+			final CosignatureV1Descriptor typedCosignature = new CosignatureV1Descriptor(
+					new CryptoTypes.Hash256((String) cosignature.get("otherTransactionHash")),
+					new Address((String) cosignature.get("multisigAccountAddress")));
 
 			final Map<String, Object> cosignatureDescriptor = new LinkedHashMap<>(typedCosignature.toMap());
 			// override base transaction properties to get vectors to pass (the analog of the JS rawDescriptor override)
@@ -200,50 +180,75 @@ final class NemTypedDescriptorVectorsTest {
 		return cosignatures;
 	}
 
-	private static MessageDescriptor mapMessage(final Map<String, Object> message) {
-		return new MessageDescriptor((String) message.get("messageType"))
-				.message(CatbufferDescriptorHelper.rawBytes(message.get("message")));
+	// the optional-field mappers pass an absent vector field through as null, which the all-args constructors omit from the map
+
+	private static MessageDescriptor mapOptionalMessage(final Map<String, Object> plain) {
+		if (null == plain.get("message"))
+			return null;
+
+		final Map<String, Object> message = CatbufferVectorsHelper.toObjectMap(plain.get("message"));
+		return new MessageDescriptor(MessageType.parse(message.get("messageType")),
+				CatbufferDescriptorHelper.rawBytes(message.get("message")));
+	}
+
+	private static List<SizePrefixedMosaicDescriptor> mapMosaicList(final Object mosaics) {
+		if (null == mosaics)
+			return null;
+
+		final List<SizePrefixedMosaicDescriptor> result = new ArrayList<>();
+		for (final Object element : (List<?>) mosaics) {
+			final Map<String, Object> mosaic = extractNamedChild(element, "mosaic");
+			result.add(new SizePrefixedMosaicDescriptor(new MosaicDescriptor(
+					mapMosaicId(CatbufferVectorsHelper.toObjectMap(mosaic.get("mosaicId"))), Amount.parse(mosaic.get("amount")))));
+		}
+
+		return result;
 	}
 
 	private static MosaicIdDescriptor mapMosaicId(final Map<String, Object> mosaicId) {
 		final Map<String, Object> namespaceId = CatbufferVectorsHelper.toObjectMap(mosaicId.get("namespaceId"));
-		return new MosaicIdDescriptor(new NamespaceIdDescriptor().name(CatbufferDescriptorHelper.rawBytes(namespaceId.get("name"))))
-				.name(CatbufferDescriptorHelper.rawBytes(mosaicId.get("name")));
+		return new MosaicIdDescriptor(new NamespaceIdDescriptor(CatbufferDescriptorHelper.rawBytes(namespaceId.get("name"))),
+				CatbufferDescriptorHelper.rawBytes(mosaicId.get("name")));
 	}
 
 	private static MosaicDefinitionDescriptor mapMosaicDefinition(final Map<String, Object> definition) {
-		final MosaicDefinitionDescriptor descriptor = new MosaicDefinitionDescriptor((String) definition.get("ownerPublicKey"),
-				mapMosaicId(CatbufferVectorsHelper.toObjectMap(definition.get("id"))))
-				.description(CatbufferDescriptorHelper.rawBytes(definition.get("description")));
+		return new MosaicDefinitionDescriptor(new CryptoTypes.PublicKey((String) definition.get("ownerPublicKey")),
+				mapMosaicId(CatbufferVectorsHelper.toObjectMap(definition.get("id"))),
+				CatbufferDescriptorHelper.rawBytes(definition.get("description")), mapProperties(definition.get("properties")),
+				mapLevy(definition.get("levy")));
+	}
 
-		if (null != definition.get("properties")) {
-			final List<SizePrefixedMosaicPropertyDescriptor> properties = new ArrayList<>();
-			for (final Object element : (List<?>) definition.get("properties")) {
-				final Map<String, Object> property = extractNamedChild(element, "property");
-				properties.add(new SizePrefixedMosaicPropertyDescriptor(
-						new MosaicPropertyDescriptor().name(CatbufferDescriptorHelper.rawBytes(property.get("name")))
-								.value(CatbufferDescriptorHelper.rawBytes(property.get("value")))));
-			}
+	private static List<SizePrefixedMosaicPropertyDescriptor> mapProperties(final Object propertyList) {
+		if (null == propertyList)
+			return null;
 
-			descriptor.properties(properties);
+		final List<SizePrefixedMosaicPropertyDescriptor> properties = new ArrayList<>();
+		for (final Object element : (List<?>) propertyList) {
+			final Map<String, Object> property = extractNamedChild(element, "property");
+			properties.add(new SizePrefixedMosaicPropertyDescriptor(new MosaicPropertyDescriptor(
+					CatbufferDescriptorHelper.rawBytes(property.get("name")), CatbufferDescriptorHelper.rawBytes(property.get("value")))));
 		}
 
-		if (null != definition.get("levy")) {
-			final Map<String, Object> levy = CatbufferVectorsHelper.toObjectMap(definition.get("levy"));
-			descriptor.levy(new MosaicLevyDescriptor(MosaicTransferFeeType.parse(levy.get("transferFeeType")),
-					new Address((String) levy.get("recipientAddress")),
-					mapMosaicId(CatbufferVectorsHelper.toObjectMap(levy.get("mosaicId"))), Amount.parse(levy.get("fee"))));
-		}
+		return properties;
+	}
 
-		return descriptor;
+	private static MosaicLevyDescriptor mapLevy(final Object levyValue) {
+		if (null == levyValue)
+			return null;
+
+		final Map<String, Object> levy = CatbufferVectorsHelper.toObjectMap(levyValue);
+		return new MosaicLevyDescriptor(MosaicTransferFeeType.parse(levy.get("transferFeeType")),
+				new Address((String) levy.get("recipientAddress")), mapMosaicId(CatbufferVectorsHelper.toObjectMap(levy.get("mosaicId"))),
+				Amount.parse(levy.get("fee")));
 	}
 
 	private static List<SizePrefixedMultisigAccountModificationDescriptor> mapModifications(final Map<String, Object> plain) {
 		final List<SizePrefixedMultisigAccountModificationDescriptor> modifications = new ArrayList<>();
 		for (final Object element : (List<?>) plain.get("modifications")) {
 			final Map<String, Object> modification = extractNamedChild(element, "modification");
-			modifications.add(new SizePrefixedMultisigAccountModificationDescriptor(new MultisigAccountModificationDescriptor(
-					(String) modification.get("modificationType"), (String) modification.get("cosignatoryPublicKey"))));
+			modifications.add(new SizePrefixedMultisigAccountModificationDescriptor(
+					new MultisigAccountModificationDescriptor(MultisigAccountModificationType.parse(modification.get("modificationType")),
+							new CryptoTypes.PublicKey((String) modification.get("cosignatoryPublicKey")))));
 		}
 
 		return modifications;

--- a/sdk/java/src/test/java/org/symbol/sdk/vectors/SymbolTypedDescriptorVectorsTest.java
+++ b/sdk/java/src/test/java/org/symbol/sdk/vectors/SymbolTypedDescriptorVectorsTest.java
@@ -1,5 +1,6 @@
 package org.symbol.sdk.vectors;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -44,6 +45,7 @@ import org.symbol.sdk.symbol.descriptors.TransferTransactionV1Descriptor;
 import org.symbol.sdk.symbol.descriptors.UnresolvedMosaicDescriptor;
 import org.symbol.sdk.symbol.descriptors.VotingKeyLinkTransactionV1Descriptor;
 import org.symbol.sdk.symbol.descriptors.VrfKeyLinkTransactionV1Descriptor;
+import org.symbol.sdk.symbol.models.AccountRestrictionFlags;
 import org.symbol.sdk.symbol.models.AliasAction;
 import org.symbol.sdk.symbol.models.Amount;
 import org.symbol.sdk.symbol.models.BlockDuration;
@@ -59,6 +61,7 @@ import org.symbol.sdk.symbol.models.MosaicRestrictionType;
 import org.symbol.sdk.symbol.models.MosaicSupplyChangeAction;
 import org.symbol.sdk.symbol.models.NamespaceId;
 import org.symbol.sdk.symbol.models.NamespaceRegistrationType;
+import org.symbol.sdk.symbol.models.TransactionType;
 import org.symbol.sdk.symbol.models.UnresolvedMosaicId;
 import org.symbol.sdk.utils.Converter;
 
@@ -71,9 +74,10 @@ import org.symbol.sdk.utils.Converter;
  * typed descriptors deliberately omit (signature, signerPublicKey, fee, deadline) are overlaid on the descriptor map — the analog of the JS
  * rawDescriptor override.
  *
- * Values flow from the vector JSON as-is: strings feed the String constructor overloads, numbers feed the pod {@code parse} coercions (u64
- * values arrive as wrapped longs — stringifying a negative long would corrupt them), and the byte-carrying fields (message, metadata
- * values, proof) go through {@link CatbufferDescriptorHelper#rawBytes}.
+ * Values flow from the vector JSON as-is: strings feed the model constructors ({@code Address},
+ * {@code CryptoTypes.PublicKey}/{@code Hash256}) and enum {@code parse} calls, numbers feed the pod {@code parse} coercions (u64 values
+ * arrive as wrapped longs — stringifying a negative long would corrupt them), and the byte-carrying fields (message, metadata values,
+ * proof) go through {@link CatbufferDescriptorHelper#rawBytes}.
  */
 @Tag("catvectors")
 final class SymbolTypedDescriptorVectorsTest {
@@ -118,16 +122,13 @@ final class SymbolTypedDescriptorVectorsTest {
 				List<Cosignature> cosignatures);
 	}
 
-	// the six aggregate variants differ only in the constructor; the shared tail lives once in createTypedTransactionDescriptor
+	// the six aggregate variants differ only in the constructed type; the shared tail lives once in createTypedTransactionDescriptor
 	private static final Map<String, AggregateDescriptorFactory> AGGREGATE_FACTORIES = Map.of("aggregate_bonded_transaction_v1",
-			(h, t, c) -> new AggregateBondedTransactionV1Descriptor(h).transactions(t).cosignatures(c), "aggregate_bonded_transaction_v2",
-			(h, t, c) -> new AggregateBondedTransactionV2Descriptor(h).transactions(t).cosignatures(c), "aggregate_bonded_transaction_v3",
-			(h, t, c) -> new AggregateBondedTransactionV3Descriptor(h).transactions(t).cosignatures(c), "aggregate_complete_transaction_v1",
-			(h, t, c) -> new AggregateCompleteTransactionV1Descriptor(h).transactions(t).cosignatures(c),
-			"aggregate_complete_transaction_v2",
-			(h, t, c) -> new AggregateCompleteTransactionV2Descriptor(h).transactions(t).cosignatures(c),
-			"aggregate_complete_transaction_v3",
-			(h, t, c) -> new AggregateCompleteTransactionV3Descriptor(h).transactions(t).cosignatures(c));
+			AggregateBondedTransactionV1Descriptor::new, "aggregate_bonded_transaction_v2", AggregateBondedTransactionV2Descriptor::new,
+			"aggregate_bonded_transaction_v3", AggregateBondedTransactionV3Descriptor::new, "aggregate_complete_transaction_v1",
+			AggregateCompleteTransactionV1Descriptor::new, "aggregate_complete_transaction_v2",
+			AggregateCompleteTransactionV2Descriptor::new, "aggregate_complete_transaction_v3",
+			AggregateCompleteTransactionV3Descriptor::new);
 
 	private static SymbolTransactionDescriptor createTypedTransactionDescriptor(final Map<String, Object> plain,
 			final SymbolFacade facade) {
@@ -138,10 +139,12 @@ final class SymbolTypedDescriptorVectorsTest {
 
 		switch (type) {
 			case "account_key_link_transaction_v1":
-				return new AccountKeyLinkTransactionV1Descriptor((String) plain.get("linkedPublicKey"), (String) plain.get("linkAction"));
+				return new AccountKeyLinkTransactionV1Descriptor(new CryptoTypes.PublicKey((String) plain.get("linkedPublicKey")),
+						LinkAction.parse(plain.get("linkAction")));
 
 			case "node_key_link_transaction_v1":
-				return new NodeKeyLinkTransactionV1Descriptor((String) plain.get("linkedPublicKey"), (String) plain.get("linkAction"));
+				return new NodeKeyLinkTransactionV1Descriptor(new CryptoTypes.PublicKey((String) plain.get("linkedPublicKey")),
+						LinkAction.parse(plain.get("linkAction")));
 
 			case "voting_key_link_transaction_v1":
 				return new VotingKeyLinkTransactionV1Descriptor(new CryptoTypes.PublicKey((String) plain.get("linkedPublicKey")),
@@ -149,7 +152,8 @@ final class SymbolTypedDescriptorVectorsTest {
 						LinkAction.parse(plain.get("linkAction")));
 
 			case "vrf_key_link_transaction_v1":
-				return new VrfKeyLinkTransactionV1Descriptor((String) plain.get("linkedPublicKey"), (String) plain.get("linkAction"));
+				return new VrfKeyLinkTransactionV1Descriptor(new CryptoTypes.PublicKey((String) plain.get("linkedPublicKey")),
+						LinkAction.parse(plain.get("linkAction")));
 
 			case "hash_lock_transaction_v1":
 				return new HashLockTransactionV1Descriptor(mapUnresolvedMosaic(CatbufferVectorsHelper.toObjectMap(plain.get("mosaic"))),
@@ -162,25 +166,26 @@ final class SymbolTypedDescriptorVectorsTest {
 						BlockDuration.parse(plain.get("duration")), LockHashAlgorithm.parse(plain.get("hashAlgorithm")));
 
 			case "secret_proof_transaction_v1":
-				return new SecretProofTransactionV1Descriptor((String) plain.get("recipientAddress"), (String) plain.get("secret"),
-						(String) plain.get("hashAlgorithm")).proof(CatbufferDescriptorHelper.rawBytes(plain.get("proof")));
+				return new SecretProofTransactionV1Descriptor(new Address((String) plain.get("recipientAddress")),
+						new CryptoTypes.Hash256((String) plain.get("secret")), LockHashAlgorithm.parse(plain.get("hashAlgorithm")),
+						CatbufferDescriptorHelper.rawBytes(plain.get("proof")));
 
 			case "account_metadata_transaction_v1":
-				return new AccountMetadataTransactionV1Descriptor((String) plain.get("targetAddress"),
-						Converter.toLong((Number) plain.get("scopedMetadataKey")), Converter.toInt((Number) plain.get("valueSizeDelta")))
-						.value(CatbufferDescriptorHelper.rawBytes(plain.get("value")));
+				return new AccountMetadataTransactionV1Descriptor(new Address((String) plain.get("targetAddress")),
+						Converter.toLong((Number) plain.get("scopedMetadataKey")), Converter.toInt((Number) plain.get("valueSizeDelta")),
+						CatbufferDescriptorHelper.rawBytes(plain.get("value")));
 
 			case "mosaic_metadata_transaction_v1":
 				return new MosaicMetadataTransactionV1Descriptor(new Address((String) plain.get("targetAddress")),
 						Converter.toLong((Number) plain.get("scopedMetadataKey")), UnresolvedMosaicId.parse(plain.get("targetMosaicId")),
-						Converter.toInt((Number) plain.get("valueSizeDelta")))
-						.value(CatbufferDescriptorHelper.rawBytes(plain.get("value")));
+						Converter.toInt((Number) plain.get("valueSizeDelta")), CatbufferDescriptorHelper.rawBytes(plain.get("value")));
 
 			case "namespace_metadata_transaction_v1":
 				// deliberately plain text even when it looks like hex — see CatbufferDescriptorHelper.isPlainTextValue
 				return new NamespaceMetadataTransactionV1Descriptor(new Address((String) plain.get("targetAddress")),
 						Converter.toLong((Number) plain.get("scopedMetadataKey")), NamespaceId.parse(plain.get("targetNamespaceId")),
-						Converter.toInt((Number) plain.get("valueSizeDelta"))).value((String) plain.get("value"));
+						Converter.toInt((Number) plain.get("valueSizeDelta")),
+						((String) plain.get("value")).getBytes(StandardCharsets.UTF_8));
 
 			case "mosaic_definition_transaction_v1":
 				// placeholder id mirrors JS: the factory autogenerates the mosaic id from nonce + signer
@@ -193,17 +198,13 @@ final class SymbolTypedDescriptorVectorsTest {
 						Amount.parse(plain.get("delta")), MosaicSupplyChangeAction.parse(plain.get("action")));
 
 			case "mosaic_supply_revocation_transaction_v1":
-				return new MosaicSupplyRevocationTransactionV1Descriptor((String) plain.get("sourceAddress"),
+				return new MosaicSupplyRevocationTransactionV1Descriptor(new Address((String) plain.get("sourceAddress")),
 						mapUnresolvedMosaic(CatbufferVectorsHelper.toObjectMap(plain.get("mosaic"))));
 
-			case "multisig_account_modification_transaction_v1": {
-				final MultisigAccountModificationTransactionV1Descriptor descriptor = new MultisigAccountModificationTransactionV1Descriptor(
-						Converter.toInt((Number) plain.get("minRemovalDelta")), Converter.toInt((Number) plain.get("minApprovalDelta")));
-				applyIfPresent(plain, "addressAdditions", () -> descriptor.addressAdditions(toStringArray(plain.get("addressAdditions"))));
-				applyIfPresent(plain, "addressDeletions", () -> descriptor.addressDeletions(toStringArray(plain.get("addressDeletions"))));
-
-				return descriptor;
-			}
+			case "multisig_account_modification_transaction_v1":
+				return new MultisigAccountModificationTransactionV1Descriptor(Converter.toInt((Number) plain.get("minRemovalDelta")),
+						Converter.toInt((Number) plain.get("minApprovalDelta")), mapAddressList(plain.get("addressAdditions")),
+						mapAddressList(plain.get("addressDeletions")));
 
 			case "address_alias_transaction_v1":
 				return new AddressAliasTransactionV1Descriptor(NamespaceId.parse(plain.get("namespaceId")),
@@ -213,51 +214,27 @@ final class SymbolTypedDescriptorVectorsTest {
 				return new MosaicAliasTransactionV1Descriptor(NamespaceId.parse(plain.get("namespaceId")),
 						MosaicId.parse(plain.get("mosaicId")), AliasAction.parse(plain.get("aliasAction")));
 
-			case "namespace_registration_transaction_v1": {
-				// placeholder id mirrors JS: the factory autogenerates the namespace id from the name
-				final NamespaceRegistrationTransactionV1Descriptor descriptor = new NamespaceRegistrationTransactionV1Descriptor(
-						new NamespaceId(0L), NamespaceRegistrationType.parse(plain.get("registrationType")))
-						.name((String) plain.get("name"));
-				applyIfPresent(plain, "duration", () -> descriptor.duration(BlockDuration.parse(plain.get("duration")))); // only used for
-																															// 'root'
-				applyIfPresent(plain, "parentId", () -> descriptor.parentId(NamespaceId.parse(plain.get("parentId")))); // only used for
-																														// 'child'
+			case "namespace_registration_transaction_v1":
+				// placeholder id mirrors JS: the factory autogenerates the namespace id from the name;
+				// duration is only present for 'root' registrations and parentId only for 'child'
+				return new NamespaceRegistrationTransactionV1Descriptor(new NamespaceId(0L),
+						NamespaceRegistrationType.parse(plain.get("registrationType")),
+						null == plain.get("duration") ? null : BlockDuration.parse(plain.get("duration")),
+						null == plain.get("parentId") ? null : NamespaceId.parse(plain.get("parentId")),
+						((String) plain.get("name")).getBytes(StandardCharsets.UTF_8));
 
-				return descriptor;
-			}
+			case "account_address_restriction_transaction_v1":
+				return new AccountAddressRestrictionTransactionV1Descriptor(AccountRestrictionFlags.parse(plain.get("restrictionFlags")),
+						mapAddressList(plain.get("restrictionAdditions")), mapAddressList(plain.get("restrictionDeletions")));
 
-			case "account_address_restriction_transaction_v1": {
-				final AccountAddressRestrictionTransactionV1Descriptor descriptor = new AccountAddressRestrictionTransactionV1Descriptor(
-						(String) plain.get("restrictionFlags"));
-				applyIfPresent(plain, "restrictionAdditions",
-						() -> descriptor.restrictionAdditions(toStringArray(plain.get("restrictionAdditions"))));
-				applyIfPresent(plain, "restrictionDeletions",
-						() -> descriptor.restrictionDeletions(toStringArray(plain.get("restrictionDeletions"))));
+			case "account_mosaic_restriction_transaction_v1":
+				return new AccountMosaicRestrictionTransactionV1Descriptor(AccountRestrictionFlags.parse(plain.get("restrictionFlags")),
+						mapMosaicIdList(plain.get("restrictionAdditions")), mapMosaicIdList(plain.get("restrictionDeletions")));
 
-				return descriptor;
-			}
-
-			case "account_mosaic_restriction_transaction_v1": {
-				final AccountMosaicRestrictionTransactionV1Descriptor descriptor = new AccountMosaicRestrictionTransactionV1Descriptor(
-						(String) plain.get("restrictionFlags"));
-				applyIfPresent(plain, "restrictionAdditions",
-						() -> descriptor.restrictionAdditions(mapMosaicIdList(plain.get("restrictionAdditions"))));
-				applyIfPresent(plain, "restrictionDeletions",
-						() -> descriptor.restrictionDeletions(mapMosaicIdList(plain.get("restrictionDeletions"))));
-
-				return descriptor;
-			}
-
-			case "account_operation_restriction_transaction_v1": {
-				final AccountOperationRestrictionTransactionV1Descriptor descriptor = new AccountOperationRestrictionTransactionV1Descriptor(
-						(String) plain.get("restrictionFlags"));
-				applyIfPresent(plain, "restrictionAdditions",
-						() -> descriptor.restrictionAdditions(toStringArray(plain.get("restrictionAdditions"))));
-				applyIfPresent(plain, "restrictionDeletions",
-						() -> descriptor.restrictionDeletions(toStringArray(plain.get("restrictionDeletions"))));
-
-				return descriptor;
-			}
+			case "account_operation_restriction_transaction_v1":
+				return new AccountOperationRestrictionTransactionV1Descriptor(AccountRestrictionFlags.parse(plain.get("restrictionFlags")),
+						mapTransactionTypeList(plain.get("restrictionAdditions")),
+						mapTransactionTypeList(plain.get("restrictionDeletions")));
 
 			case "mosaic_address_restriction_transaction_v1":
 				return new MosaicAddressRestrictionTransactionV1Descriptor(UnresolvedMosaicId.parse(plain.get("mosaicId")),
@@ -273,22 +250,10 @@ final class SymbolTypedDescriptorVectorsTest {
 						MosaicRestrictionType.parse(plain.get("previousRestrictionType")),
 						MosaicRestrictionType.parse(plain.get("newRestrictionType")));
 
-			case "transfer_transaction_v1": {
-				final TransferTransactionV1Descriptor descriptor = new TransferTransactionV1Descriptor(
-						(String) plain.get("recipientAddress"));
-				if (null != plain.get("mosaics")) {
-					final List<UnresolvedMosaicDescriptor> mosaics = new ArrayList<>();
-					for (final Object element : (List<?>) plain.get("mosaics"))
-						mosaics.add(mapUnresolvedMosaic(CatbufferVectorsHelper.toObjectMap(element)));
-
-					descriptor.mosaics(mosaics);
-				}
-
-				if (null != plain.get("message"))
-					descriptor.message(CatbufferDescriptorHelper.rawBytes(plain.get("message")));
-
-				return descriptor;
-			}
+			case "transfer_transaction_v1":
+				return new TransferTransactionV1Descriptor(new Address((String) plain.get("recipientAddress")),
+						mapUnresolvedMosaicList(plain.get("mosaics")),
+						null == plain.get("message") ? null : CatbufferDescriptorHelper.rawBytes(plain.get("message")));
 
 			default :
 				throw new IllegalArgumentException("unknown transaction type " + type);
@@ -303,7 +268,45 @@ final class SymbolTypedDescriptorVectorsTest {
 		return new UnresolvedMosaicDescriptor(UnresolvedMosaicId.parse(mosaic.get("mosaicId")), Amount.parse(mosaic.get("amount")));
 	}
 
+	// the list mappers pass an absent vector field through as null, which the all-args constructors omit from the map
+
+	private static List<UnresolvedMosaicDescriptor> mapUnresolvedMosaicList(final Object mosaics) {
+		if (null == mosaics)
+			return null;
+
+		final List<UnresolvedMosaicDescriptor> result = new ArrayList<>();
+		for (final Object element : (List<?>) mosaics)
+			result.add(mapUnresolvedMosaic(CatbufferVectorsHelper.toObjectMap(element)));
+
+		return result;
+	}
+
+	private static List<Address> mapAddressList(final Object addresses) {
+		if (null == addresses)
+			return null;
+
+		final List<Address> result = new ArrayList<>();
+		for (final Object element : (List<?>) addresses)
+			result.add(new Address((String) element));
+
+		return result;
+	}
+
+	private static List<TransactionType> mapTransactionTypeList(final Object types) {
+		if (null == types)
+			return null;
+
+		final List<TransactionType> result = new ArrayList<>();
+		for (final Object element : (List<?>) types)
+			result.add(TransactionType.parse(element));
+
+		return result;
+	}
+
 	private static List<UnresolvedMosaicId> mapMosaicIdList(final Object mosaicIds) {
+		if (null == mosaicIds)
+			return null;
+
 		final List<UnresolvedMosaicId> result = new ArrayList<>();
 		for (final Object element : (List<?>) mosaicIds)
 			result.add(UnresolvedMosaicId.parse(element));
@@ -343,18 +346,8 @@ final class SymbolTypedDescriptorVectorsTest {
 
 	// region value helpers
 
-	private static String[] toStringArray(final Object values) {
-		final List<?> list = (List<?>) values;
-		return list.stream().map(String.class::cast).toArray(String[]::new);
-	}
-
 	private static CryptoTypes.Hash256 getTransactionsHash(final Map<String, Object> plain) {
 		return new CryptoTypes.Hash256((String) plain.get("transactionsHash"));
-	}
-
-	private static void applyIfPresent(final Map<String, Object> plain, final String field, final Runnable applier) {
-		if (null != plain.get(field))
-			applier.run();
 	}
 
 	// endregion


### PR DESCRIPTION
problem: descriptors have required values in the constructor and others in setters, which can be unclear
solution: create one constructor with all parameters