### PR TITLE
[sdk/python]: add create_transaction_from_descriptor wrapper

### DIFF
--- a/sdk/python/symbolchain/facade/NemFacade.py
+++ b/sdk/python/symbolchain/facade/NemFacade.py
@@ -86,6 +86,17 @@ class NemFacade:
 		"""Creates a NEM account from a private key."""
 		return NemAccount(self, KeyPair(private_key))
 
+	def create_transaction_from_descriptor(self, descriptor, signer_public_key, fee, deadline_seconds):
+		"""Creates a transaction from a descriptor, adding signer, fee, timestamp and deadline to a copy of it."""
+		now = self.now()
+		return self.transaction_factory.create({
+			**descriptor,
+			'signer_public_key': signer_public_key,
+			'fee': fee,
+			'timestamp': now.timestamp,
+			'deadline': now.add_seconds(deadline_seconds).timestamp
+		})
+
 	@staticmethod
 	def hash_transaction(transaction):
 		"""Hashes a NEM transaction."""

--- a/sdk/python/symbolchain/facade/SymbolFacade.py
+++ b/sdk/python/symbolchain/facade/SymbolFacade.py
@@ -138,6 +138,10 @@ class SymbolFacade:
 		transaction.fee = sc.Amount(transaction_with_cosignatures_size * fee_multiplier)
 		return transaction
 
+	def create_embedded_transaction_from_descriptor(self, descriptor, signer_public_key):  # pylint: disable=invalid-name
+		"""Creates an embedded transaction from a descriptor, adding signer to a copy of it."""
+		return self.transaction_factory.create_embedded({**descriptor, 'signer_public_key': signer_public_key})
+
 	def hash_transaction(self, transaction):
 		"""Hashes a Symbol transaction."""
 		hasher = hashlib.sha3_256()

--- a/sdk/python/symbolchain/facade/SymbolFacade.py
+++ b/sdk/python/symbolchain/facade/SymbolFacade.py
@@ -115,6 +115,29 @@ class SymbolFacade:
 		"""Creates a Symbol account from a private key."""
 		return SymbolAccount(self, KeyPair(private_key))
 
+	def create_transaction_from_descriptor(self, descriptor, signer_public_key, fee_multiplier, deadline_seconds, cosignature_count=0):
+		"""
+		Creates a transaction from a descriptor, adding signer and deadline to a copy of it, with the fee computed as
+		(size + reserved cosignatures size) * fee_multiplier.
+		"""
+		raw_descriptor = {
+			**descriptor,
+			'signer_public_key': signer_public_key,
+			'deadline': self.now().add_seconds(deadline_seconds).timestamp
+		}
+		transaction = self.transaction_factory.create(raw_descriptor)
+
+		# if cosignatures are specified in the descriptor, use the max of them and cosignature_count
+		cosignature_count_adjustment = cosignature_count
+		explicit_cosignatures = raw_descriptor.get('cosignatures')
+		if isinstance(explicit_cosignatures, list):
+			explicit_count = len(explicit_cosignatures)
+			cosignature_count_adjustment = 0 if explicit_count > cosignature_count else cosignature_count - explicit_count
+
+		transaction_with_cosignatures_size = transaction.size + cosignature_count_adjustment * sc.Cosignature().size
+		transaction.fee = sc.Amount(transaction_with_cosignatures_size * fee_multiplier)
+		return transaction
+
 	def hash_transaction(self, transaction):
 		"""Hashes a Symbol transaction."""
 		hasher = hashlib.sha3_256()

--- a/sdk/python/tests/facade/test_NemFacade.py
+++ b/sdk/python/tests/facade/test_NemFacade.py
@@ -1,6 +1,7 @@
 import unittest
 from datetime import datetime, timezone
 
+from symbolchain import nc
 from symbolchain.AccountDescriptorRepository import AccountDescriptorRepository
 from symbolchain.Bip32 import Bip32
 from symbolchain.CryptoTypes import Hash256, PrivateKey, PublicKey, Signature
@@ -232,6 +233,40 @@ class NemFacadeTest(unittest.TestCase):
 
 		# Assert:
 		self.assertTrue(is_verified)
+
+	# endregion
+
+	# region create_transaction_from_descriptor
+
+	def test_can_create_transaction_from_descriptor(self):
+		# Arrange:
+		facade = NemFacade('testnet')
+		now_timestamp = facade.now()
+		signer_public_key = PublicKey('87DA603E7BE5656C45692D5FC7F6D0EF8F24BB7A5C10ED5FDA8C5CFBC49FCBC8')
+
+		# Act:
+		transaction = facade.create_transaction_from_descriptor({
+			'type': 'transfer_transaction_v1',
+			'recipient_address': 'TALICEROONSJCPHC63F52V6FY3SDMSVAEUGHMB7C',
+			'amount': 5000000
+		}, signer_public_key, 100000, 60 * 60)
+
+		# Assert:
+		self.assertEqual(nc.TransactionType.TRANSFER, transaction.type_)
+		self.assertEqual(nc.NetworkType.TESTNET, transaction.network)
+		self.assertEqual(signer_public_key.bytes, transaction.signer_public_key.bytes)
+		self.assertEqual(100000, transaction.fee.value)
+
+		# - check timestamp and deadline are in range (within 10s)
+		self.assertLessEqual(now_timestamp.timestamp, transaction.timestamp.value)
+		self.assertLessEqual(transaction.timestamp.value, now_timestamp.timestamp + 10)
+
+		min_raw_deadline = now_timestamp.timestamp + (60 * 60)
+		self.assertLessEqual(min_raw_deadline, transaction.deadline.value)
+		self.assertLessEqual(transaction.deadline.value, min_raw_deadline + 10)
+
+		# - both fields derive from one now() snapshot, so their difference is exactly deadline_seconds
+		self.assertEqual(60 * 60, transaction.deadline.value - transaction.timestamp.value)
 
 	# endregion
 

--- a/sdk/python/tests/facade/test_SymbolFacade.py
+++ b/sdk/python/tests/facade/test_SymbolFacade.py
@@ -382,6 +382,7 @@ class SymbolFacadeTest(unittest.TestCase):
 		# Assert:
 		self.assertEqual(sc.TransactionType.TRANSFER, transaction.type_)
 		self.assertEqual(sc.NetworkType.TESTNET, transaction.network)
+		self.assertEqual(1, transaction.version)
 		self.assertEqual(signer_public_key.bytes, transaction.signer_public_key.bytes)
 		self.assertEqual(transaction.size * 100, transaction.fee.value)
 
@@ -420,6 +421,23 @@ class SymbolFacadeTest(unittest.TestCase):
 		self._assert_aggregate_size_calculation(3, 4, 4)
 		self._assert_aggregate_size_calculation(4, 3, 4)
 		self._assert_aggregate_size_calculation(4, 4, 4)
+
+	def test_can_create_embedded_transaction_from_descriptor(self):
+		# Arrange:
+		facade = SymbolFacade('testnet')
+		signer_public_key = PublicKey('87DA603E7BE5656C45692D5FC7F6D0EF8F24BB7A5C10ED5FDA8C5CFBC49FCBC8')
+
+		# Act:
+		transaction = facade.create_embedded_transaction_from_descriptor({
+			'type': 'transfer_transaction_v1',
+			'recipient_address': 'TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I'
+		}, signer_public_key)
+
+		# Assert:
+		self.assertEqual(sc.TransactionType.TRANSFER, transaction.type_)
+		self.assertEqual(sc.NetworkType.TESTNET, transaction.network)
+		self.assertEqual(1, transaction.version)
+		self.assertEqual(signer_public_key.bytes, transaction.signer_public_key.bytes)
 
 	# endregion
 

--- a/sdk/python/tests/facade/test_SymbolFacade.py
+++ b/sdk/python/tests/facade/test_SymbolFacade.py
@@ -365,6 +365,64 @@ class SymbolFacadeTest(unittest.TestCase):
 
 	# endregion
 
+	# region create_transaction_from_descriptor
+
+	def test_can_create_transaction_from_descriptor(self):
+		# Arrange:
+		facade = SymbolFacade('testnet')
+		now_timestamp = facade.now()
+		signer_public_key = PublicKey('87DA603E7BE5656C45692D5FC7F6D0EF8F24BB7A5C10ED5FDA8C5CFBC49FCBC8')
+
+		# Act:
+		transaction = facade.create_transaction_from_descriptor({
+			'type': 'transfer_transaction_v1',
+			'recipient_address': 'TCHBDENCLKEBILBPWP3JPB2XNY64OE7PYHHE32I'
+		}, signer_public_key, 100, 60 * 60)
+
+		# Assert:
+		self.assertEqual(sc.TransactionType.TRANSFER, transaction.type_)
+		self.assertEqual(sc.NetworkType.TESTNET, transaction.network)
+		self.assertEqual(signer_public_key.bytes, transaction.signer_public_key.bytes)
+		self.assertEqual(transaction.size * 100, transaction.fee.value)
+
+		# - check deadline is in range (within 10s)
+		min_raw_deadline = now_timestamp.timestamp + (60 * 60 * 1000)
+		self.assertLessEqual(min_raw_deadline, transaction.deadline.value)
+		self.assertLessEqual(transaction.deadline.value, min_raw_deadline + 10000)
+
+	def _assert_aggregate_size_calculation(self, descriptor_cosignature_count, reserved_cosignature_count, expected_cosignature_count):
+		# Arrange:
+		facade = SymbolFacade('testnet')
+		signer_public_key = PublicKey('87DA603E7BE5656C45692D5FC7F6D0EF8F24BB7A5C10ED5FDA8C5CFBC49FCBC8')
+		descriptor = {
+			'type': 'aggregate_complete_transaction_v2',
+			'transactions_hash': '157D3C15A677030DBD106C0C16556E305F3796B66F684715E0C18FC178DC8026',
+			'transactions': []
+		}
+		if descriptor_cosignature_count:
+			descriptor['cosignatures'] = [sc.Cosignature() for _ in range(descriptor_cosignature_count)]
+
+		# Act:
+		transaction = facade.create_transaction_from_descriptor(descriptor, signer_public_key, 100, 60 * 60, reserved_cosignature_count)
+
+		# Assert: check size and fee
+		self.assertEqual(168 + 104 * descriptor_cosignature_count, transaction.size)
+		self.assertEqual((168 + 104 * expected_cosignature_count) * 100, transaction.fee.value)
+
+	def test_can_create_aggregate_transaction_from_descriptor_with_explicit_cosignatures(self):
+		self._assert_aggregate_size_calculation(3, 0, 3)
+
+	def test_can_create_aggregate_transaction_from_descriptor_with_implicit_cosignatures(self):
+		self._assert_aggregate_size_calculation(0, 4, 4)
+
+	def test_can_create_aggregate_transaction_from_descriptor_with_both_explicit_and_implicit_cosignatures(self):
+		# Assert: maximum of two values should be used in fee calculation
+		self._assert_aggregate_size_calculation(3, 4, 4)
+		self._assert_aggregate_size_calculation(4, 3, 4)
+		self._assert_aggregate_size_calculation(4, 4, 4)
+
+	# endregion
+
 	# region hash_transaction / sign_transaction
 
 	def _assert_can_hash_transaction(self, transaction_factory, expected_hash):


### PR DESCRIPTION
problem: Python SDK does not have type descriptors to match TS/Java
solution: add a wrapper(create_transaction_from_descriptor) that creates transaction from raw descriptor