### PR TITLE
[jenkins] fix: catapult base test image fails to build

### DIFF
--- a/jenkins/catapult/templates/UbuntuTestBaseImage.Dockerfile
+++ b/jenkins/catapult/templates/UbuntuTestBaseImage.Dockerfile
@@ -1,11 +1,12 @@
 # image name required as ARG
-ARG FROM_IMAGE='ubuntu:24.04'
+ARG FROM_IMAGE='ubuntu:26.04'
 ARG DEBIAN_FRONTEND=noninteractive
 
 FROM ${FROM_IMAGE}
 LABEL maintainer="Catapult Development Team"
 RUN apt-get -y update && apt-get install -y \
 	bison \
+	build-essential \
 	gdb \
 	git \
 	flex \
@@ -18,6 +19,7 @@ RUN apt-get -y update && apt-get install -y \
 	libelf-dev \
 	libiberty-dev \
 	libslang2-dev \
+	pkg-config \
 	&& \
 	rm -rf /var/lib/apt/lists/*
 
@@ -38,4 +40,3 @@ RUN python3 -m venv $VIRTUAL_ENV
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 RUN pip3 install -U colorama conan cryptography gitpython pycodestyle pylint ply PyYAML
-

--- a/jenkins/catapult/versions.properties
+++ b/jenkins/catapult/versions.properties
@@ -1,6 +1,6 @@
 [versions]
 
-ubuntu = 25.10
+ubuntu = 26.04
 fedora = 43
 debian = 13
 windows = 2022


### PR DESCRIPTION
problem: Linux perf tool fails to build due to missing dependencies
solution: add pkg-config and build-essential to the Docker image