### PR TITLE
[jenkins] fix: increase docker openfile limit in Jenkins pipeline

### DIFF
--- a/jenkins/shared-library/vars/defaultCiPipeline.groovy
+++ b/jenkins/shared-library/vars/defaultCiPipeline.groovy
@@ -86,7 +86,8 @@ void call(Closure body) {
 				agent {
 					docker {
 						image jobHelper.resolveBuildImageName(params.CI_ENVIRONMENT ?: resolveCiEnvironment(jenkinsfileParams)[0])
-						args jenkinsfileParams.dockerArgs ?: ''
+
+						args "--ulimit nofile=65536:65536${jenkinsfileParams.dockerArgs ? ' ' + jenkinsfileParams.dockerArgs : ''}"
 
 						// using the same node and the same workspace mounted to the container
 						reuseNode true


### PR DESCRIPTION
problem: MongoDB is failing during the Rest and Catapult tests due to too many open files
solution: increase the open file limit in the Jenkins pipeline