### PR TITLE
[jenkins] fix: catapult tests failing on clang build

### DIFF
--- a/jenkins/catapult/environment.py
+++ b/jenkins/catapult/environment.py
@@ -95,14 +95,14 @@ class EnvironmentManager:
 
 	# region file copying
 
-	def copy_glob_with_symlinks(self, directory_path, pattern, destination):
+	def copy_glob_with_symlinks(self, directory_path, pattern, destination, follow_symlinks=False):
 		self._print_command('copy_glob', [directory_path, pattern, destination])
 
 		if self.dry_run:
 			return
 
 		for file in Path(directory_path).glob(pattern):
-			shutil.copy(file, destination, follow_symlinks=False)
+			shutil.copy(file, destination, follow_symlinks=follow_symlinks)
 
 	def copy_tree_with_symlinks(self, source, destination):
 		self._print_command('copy_tree', [source, destination])

--- a/jenkins/catapult/runDockerBuildInnerBuild.py
+++ b/jenkins/catapult/runDockerBuildInnerBuild.py
@@ -197,7 +197,7 @@ class BuildManager(BasicBuildManager):
 		for dependency_pattern in self.compiler.deps:
 			directory_path = os.path.dirname(dependency_pattern)
 			pattern = os.path.basename(dependency_pattern)
-			self.environment_manager.copy_glob_with_symlinks(directory_path, pattern, destination)
+			self.environment_manager.copy_glob_with_symlinks(directory_path, pattern, destination, True)
 
 	def copy_files(self, output_path):
 		deps_output_path = Path(f'{output_path}/deps').resolve()

--- a/jenkins/catapult/runDockerBuildInnerBuild.py
+++ b/jenkins/catapult/runDockerBuildInnerBuild.py
@@ -197,7 +197,7 @@ class BuildManager(BasicBuildManager):
 		for dependency_pattern in self.compiler.deps:
 			directory_path = os.path.dirname(dependency_pattern)
 			pattern = os.path.basename(dependency_pattern)
-			self.environment_manager.copy_glob_with_symlinks(directory_path, pattern, destination, True)
+			self.environment_manager.copy_glob_with_symlinks(directory_path, pattern, destination, self.compiler.c.startswith('clang'))
 
 	def copy_files(self, output_path):
 		deps_output_path = Path(f'{output_path}/deps').resolve()

--- a/jenkins/catapult/templates/RunTest.yaml
+++ b/jenkins/catapult/templates/RunTest.yaml
@@ -16,6 +16,10 @@ services:
       start_period: 5s
     volumes:
       - ./mongo/{{BUILD_NUMBER}}:/mongo:rw
+    ulimits:
+      nofile:
+        soft: 65536
+        hard: 65536
 
   test:
     image: {{IMAGE_NAME}}
@@ -32,6 +36,9 @@ services:
       - SYS_PTRACE
     ulimits:
       core: -1
+      nofile:
+        soft: 65536
+        hard: 65536
     command: >-
       python3 /scripts/runDockerTestsInnerTest.py
         --compiler-configuration /{{COMPILER_CONFIGURATION}}


### PR DESCRIPTION
problem: catapult tests are failing on clang builds to find libc++.
                This is due to symlinks for the compiler files not getting resolved.
solution: copy the actual compiler file instead of symlinks